### PR TITLE
feat(pyknosis-boot): two-process isolation with separate address spaces

### DIFF
--- a/crates/pyknosis-boot/src/mmu.rs
+++ b/crates/pyknosis-boot/src/mmu.rs
@@ -158,3 +158,178 @@ pub unsafe fn init_and_enable() {
 pub fn table_base() -> usize {
     unsafe { core::ptr::addr_of!(L1) as usize }
 }
+
+// --- Per-process address space pool ---
+
+/// Per-process L1 page table: 4096 entries × 4 bytes = 16 KB.
+/// Must be 16 KB aligned to satisfy TTBR0 requirements.
+#[repr(C, align(16384))]
+pub struct UserL1Table {
+    entries: [u32; 4096],
+}
+
+/// Pool of 16 user-process L1 page tables (256 KB total in BSS).
+// INVARIANT: only one owner per slot; ownership tracked by ADDR_SPACE_ALLOC bitmask.
+static mut USER_TABLES: [UserL1Table; 16] = {
+    const EMPTY: UserL1Table = UserL1Table { entries: [0; 4096] };
+    [EMPTY; 16]
+};
+
+/// Allocation bitmask for USER_TABLES. Bit N = 1 means slot N is in use.
+// NOTE: cfg(test) makes it pub(crate) so process.rs tests can call reset helpers.
+#[cfg(test)]
+pub(crate) static mut ADDR_SPACE_ALLOC: u16 = 0;
+#[cfg(not(test))]
+static mut ADDR_SPACE_ALLOC: u16 = 0;
+
+/// Allocate a free user L1 page table from the pool.
+/// Zeroes the slot before returning its physical address.
+/// Returns None if all 16 slots are occupied.
+pub fn alloc_addr_space() -> Option<usize> {
+    unsafe {
+        let alloc = core::ptr::addr_of_mut!(ADDR_SPACE_ALLOC);
+        let mask = core::ptr::read_volatile(alloc);
+        // WHY: find first zero bit (free slot)
+        let slot = (0u16..16).find(|&i| mask & (1 << i) == 0)?;
+        core::ptr::write_volatile(alloc, mask | (1 << slot));
+        let table = &mut (*core::ptr::addr_of_mut!(USER_TABLES))[slot as usize];
+        for entry in table.entries.iter_mut() {
+            *entry = 0;
+        }
+        Some(core::ptr::addr_of!(*table) as usize)
+    }
+}
+
+/// Return a user L1 page table slot to the pool.
+///
+/// # Safety
+///
+/// `phys_addr` must have been returned by `alloc_addr_space` and not yet freed.
+pub unsafe fn free_addr_space(phys_addr: usize) {
+    unsafe {
+        let tables = &*core::ptr::addr_of!(USER_TABLES);
+        for (i, table) in tables.iter().enumerate() {
+            if core::ptr::addr_of!(*table) as usize == phys_addr {
+                let alloc = core::ptr::addr_of_mut!(ADDR_SPACE_ALLOC);
+                let mask = core::ptr::read_volatile(alloc);
+                core::ptr::write_volatile(alloc, mask & !(1 << i));
+                return;
+            }
+        }
+    }
+}
+
+/// Copy all 4096 L1 entries from the source address space into the destination.
+/// Used by fork() to clone the kernel's mappings into a new process table.
+///
+/// # Safety
+///
+/// Both `src_phys` and `dst_phys` must be valid physical addresses of
+/// 16 KB-aligned L1 tables (either the kernel L1 or a USER_TABLES slot).
+pub unsafe fn clone_addr_space(src_phys: usize, dst_phys: usize) {
+    // SAFETY: caller guarantees both pointers are valid 16 KB-aligned L1 tables.
+    unsafe {
+        let src = src_phys as *const u32;
+        let dst = dst_phys as *mut u32;
+        for i in 0..4096isize {
+            dst.offset(i).write_volatile(src.offset(i).read_volatile());
+        }
+    }
+}
+
+/// Switch the active user address space by writing TTBR0 and flushing the TLB.
+///
+/// # Safety
+///
+/// `table_phys` must be the physical address of a valid, correctly populated
+/// 16 KB-aligned L1 page table. Must be called with interrupts disabled.
+#[cfg(target_arch = "arm")]
+pub unsafe fn switch_addr_space(table_phys: usize) {
+    // SAFETY: TTBR0 write followed by full TLB invalidation and barriers.
+    unsafe {
+        core::arch::asm!(
+            "mcr p15, 0, {ttbr}, c2, c0, 0",
+            "mcr p15, 0, {zero}, c8, c7, 0",  // TLBIALL
+            "dsb sy",
+            "isb sy",
+            ttbr = in(reg) (table_phys as u32) | 0x6B,
+            zero = in(reg) 0u32,
+        );
+    }
+}
+
+/// No-op stub for non-ARM builds so process.rs compiles on the host.
+#[cfg(not(target_arch = "arm"))]
+pub unsafe fn switch_addr_space(_table_phys: usize) {}
+
+/// Reset the address space pool (test helper only).
+#[cfg(test)]
+pub(crate) fn reset_addr_space_pool() {
+    unsafe {
+        core::ptr::write_volatile(core::ptr::addr_of_mut!(ADDR_SPACE_ALLOC), 0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reset() {
+        reset_addr_space_pool();
+    }
+
+    #[test]
+    fn alloc_addr_space_gives_different_addresses() {
+        reset();
+        let a = alloc_addr_space().expect("first alloc");
+        let b = alloc_addr_space().expect("second alloc");
+        assert_ne!(a, b, "two allocations must return distinct table addresses");
+        // cleanup
+        unsafe { free_addr_space(a); free_addr_space(b); }
+    }
+
+    #[test]
+    fn alloc_addr_space_pool_exhaustion() {
+        reset();
+        let mut addrs = [0usize; 16];
+        for slot in &mut addrs {
+            *slot = alloc_addr_space().expect("should succeed for slots 0-15");
+        }
+        let overflow = alloc_addr_space();
+        assert!(overflow.is_none(), "17th allocation must return None");
+        for addr in &addrs {
+            unsafe { free_addr_space(*addr); }
+        }
+    }
+
+    #[test]
+    fn free_addr_space_allows_reuse() {
+        reset();
+        let a = alloc_addr_space().expect("first alloc");
+        unsafe { free_addr_space(a); }
+        let b = alloc_addr_space().expect("second alloc after free");
+        // WHY: slot 0 freed then reallocated — must come back at the same address.
+        assert_eq!(a, b, "freed slot must be reused");
+        unsafe { free_addr_space(b); }
+    }
+
+    #[test]
+    fn clone_addr_space_is_independent() {
+        reset();
+        let src = alloc_addr_space().expect("src alloc");
+        let dst = alloc_addr_space().expect("dst alloc");
+        // Write a sentinel value into src entry 42
+        unsafe {
+            (src as *mut u32).add(42).write(0xDEAD_BEEF);
+            clone_addr_space(src, dst);
+            // Verify dst received the sentinel
+            assert_eq!((dst as *const u32).add(42).read(), 0xDEAD_BEEF);
+            // Modify src after clone — dst must be unaffected
+            (src as *mut u32).add(42).write(0x1234_5678);
+            assert_eq!((dst as *const u32).add(42).read(), 0xDEAD_BEEF,
+                "dst must be independent after clone");
+            free_addr_space(src);
+            free_addr_space(dst);
+        }
+    }
+}

--- a/crates/pyknosis-boot/src/process.rs
+++ b/crates/pyknosis-boot/src/process.rs
@@ -1,13 +1,16 @@
-//! Process abstraction and context switching.
+//! Process abstraction, context switching, and two-process isolation.
 //!
 //! Each process has a saved register context, a stack, a process ID,
-//! and a state (running, ready, blocked). The scheduler selects the
-//! next ready process and context-switches to it on each timer tick.
+//! a state, and its own L1 page table. The scheduler selects the next
+//! ready process and context-switches to it on each timer tick, swapping
+//! TTBR0 so each process has an independent virtual address space.
 //!
 //! On ARMv7, context switch saves/restores r4-r11 (callee-saved),
 //! sp, lr, and cpsr. Registers r0-r3, r12, lr, pc, cpsr are saved
 //! by the exception entry/exit code.
 
+use crate::ipc;
+use crate::mmu;
 use crate::page;
 use core::ptr::addr_of_mut;
 
@@ -30,6 +33,17 @@ pub enum State {
     Blocked,
     /// Terminated, awaiting cleanup.
     Dead,
+}
+
+/// Fault kind delivered to the kinit supervisor when a process faults.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FaultKind {
+    /// ARM data abort (load/store to unmapped or protected address).
+    DataAbort { fault_addr: u32, fault_status: u32 },
+    /// ARM prefetch abort (instruction fetch from unmapped address).
+    PrefetchAbort { fault_addr: u32, fault_status: u32 },
+    /// Undefined instruction executed.
+    UndefinedInstruction,
 }
 
 /// Saved CPU context for context switching.
@@ -74,6 +88,13 @@ pub struct Process {
     pub pid: Pid,
     pub state: State,
     pub ctx: Context,
+    /// Parent PID, if this process was created via fork().
+    pub parent: Option<Pid>,
+    /// Exit status set by exit_with_status() / exit_cleanup().
+    pub exit_status: i32,
+    /// Physical address of this process's L1 page table.
+    /// 0 means "use kernel global L1" (process 0 / kinit).
+    pub page_table_phys: usize,
     /// Base address of the stack allocation (for freeing).
     stack_base: usize,
     /// Number of pages allocated for the stack.
@@ -104,7 +125,10 @@ pub unsafe fn init() {
             pid: 0,
             state: State::Running,
             ctx: Context::zero(), // NOTE: kernel process context is "current CPU state"
-            stack_base: 0,        // NOTE: uses the boot stack, not allocated
+            parent: None,
+            exit_status: 0,
+            page_table_phys: mmu::table_base(), // NOTE: kernel global L1
+            stack_base: 0,                       // NOTE: uses the boot stack, not allocated
             stack_pages: 0,
         };
         let procs = &mut *addr_of_mut!(PROCS);
@@ -114,7 +138,7 @@ pub unsafe fn init() {
 }
 
 /// Create a new process that starts executing at `entry_point`.
-/// Returns the PID, or None if the process table is full.
+/// Returns the PID, or None if the process table is full or OOM.
 pub fn spawn(entry_point: fn() -> !) -> Option<Pid> {
     unsafe {
         // Find a free slot
@@ -122,17 +146,31 @@ pub fn spawn(entry_point: fn() -> !) -> Option<Pid> {
         let slot = procs.iter().position(|p| p.is_none())?;
         let pid = slot as Pid;
 
+        // Allocate new address space cloned from kernel table
+        let new_pt = mmu::alloc_addr_space()?;
+        mmu::clone_addr_space(mmu::table_base(), new_pt);
+
         // Allocate stack
-        let mut stack_top: usize = 0;
+        let mut stack_base: usize = 0;
         for i in 0..STACK_PAGES {
-            let page = page::alloc_page()?;
-            if i == 0 {
-                stack_top = page + page::PAGE_SIZE * STACK_PAGES;
+            match page::alloc_page() {
+                Some(page) => {
+                    if i == 0 { stack_base = page; }
+                }
+                None => {
+                    // OOM: roll back already-allocated pages
+                    for j in 0..i {
+                        page::free_page(stack_base + j * page::PAGE_SIZE);
+                    }
+                    mmu::free_addr_space(new_pt);
+                    return None;
+                }
             }
         }
+        let stack_top = stack_base + page::PAGE_SIZE * STACK_PAGES;
 
         // Set up initial context
-        // When we context-switch to this process, it will "return" to entry_point
+        // WHY: "return address" is the entry point; first context switch lands here.
         let ctx = Context {
             r4: 0,
             r5: 0,
@@ -143,21 +181,199 @@ pub fn spawn(entry_point: fn() -> !) -> Option<Pid> {
             r10: 0,
             r11: 0,
             sp: stack_top as u32,
-            lr: entry_point as u32, // NOTE: "return address" is the entry point
-            cpsr: 0x1F,             // NOTE: system mode, IRQs enabled
+            lr: entry_point as u32,
+            cpsr: 0x1F, // NOTE: system mode, IRQs enabled
         };
 
+        let parent_pid = CURRENT;
         let proc = Process {
             pid,
             state: State::Ready,
             ctx,
-            stack_base: stack_top - page::PAGE_SIZE * STACK_PAGES,
+            parent: Some(parent_pid),
+            exit_status: 0,
+            page_table_phys: new_pt,
+            stack_base,
             stack_pages: STACK_PAGES,
         };
 
         procs[slot] = Some(proc);
         Some(pid)
     }
+}
+
+/// Create a child process by cloning the current process's address space.
+/// Returns Some(child_pid) to the parent on success, or None on OOM.
+///
+/// NOTE: unlike POSIX fork(), both parent and child continue from the next
+/// scheduler tick. The child inherits the parent's saved context exactly.
+pub fn fork() -> Option<Pid> {
+    unsafe {
+        let procs = &mut *addr_of_mut!(PROCS);
+
+        // Find a free process slot
+        let slot = procs.iter().position(|p| p.is_none())?;
+        let child_pid = slot as Pid;
+        let parent_pid = CURRENT;
+
+        // Get parent's page table
+        let parent_pt = procs[parent_pid as usize]
+            .as_ref()
+            .map(|p| p.page_table_phys)
+            .unwrap_or(0);
+
+        // Allocate child address space
+        let child_pt = mmu::alloc_addr_space()?;
+
+        // Clone parent mappings into child (use kernel table as base if parent has none)
+        let src_pt = if parent_pt == 0 { mmu::table_base() } else { parent_pt };
+        mmu::clone_addr_space(src_pt, child_pt);
+
+        // Allocate child stack pages
+        let mut stack_base: usize = 0;
+        for i in 0..STACK_PAGES {
+            match page::alloc_page() {
+                Some(page) => {
+                    if i == 0 { stack_base = page; }
+                }
+                None => {
+                    // OOM: roll back pages then table
+                    for j in 0..i {
+                        page::free_page(stack_base + j * page::PAGE_SIZE);
+                    }
+                    mmu::free_addr_space(child_pt);
+                    return None;
+                }
+            }
+        }
+
+        // Inherit parent context (child resumes from same saved state)
+        let parent_ctx = procs[parent_pid as usize]
+            .as_ref()
+            .map(|p| p.ctx)
+            .unwrap_or_else(Context::zero);
+
+        let child = Process {
+            pid: child_pid,
+            state: State::Ready,
+            ctx: parent_ctx,
+            parent: Some(parent_pid),
+            exit_status: 0,
+            page_table_phys: child_pt,
+            stack_base,
+            stack_pages: STACK_PAGES,
+        };
+
+        procs[slot] = Some(child);
+        Some(child_pid)
+    }
+}
+
+/// Non-blocking wait for a child exit status.
+/// Returns Some(status) if the child is Dead, None if still running or not a child.
+pub fn waitpid(child_pid: Pid) -> Option<i32> {
+    unsafe {
+        let procs = &*core::ptr::addr_of!(PROCS);
+        let child = procs[child_pid as usize].as_ref()?;
+        // INVARIANT: only the direct parent may retrieve the exit status.
+        if child.parent != Some(CURRENT) {
+            return None;
+        }
+        if child.state == State::Dead {
+            Some(child.exit_status)
+        } else {
+            None
+        }
+    }
+}
+
+/// Notify kinit (PID 0) that process `faulting_pid` has faulted.
+/// Marks the faulting process Dead and delivers a fault message to PID 0's inbox.
+///
+/// Payload layout (9 bytes): [pid:1, fault_addr:4 LE, fault_status:4 LE]
+pub fn notify_fault(faulting_pid: Pid, kind: FaultKind) {
+    let (tag, fault_addr, fault_status) = match kind {
+        FaultKind::DataAbort { fault_addr, fault_status } => (1u32, fault_addr, fault_status),
+        FaultKind::PrefetchAbort { fault_addr, fault_status } => (2u32, fault_addr, fault_status),
+        FaultKind::UndefinedInstruction => (3u32, 0u32, 0u32),
+    };
+
+    let payload: [u8; 9] = [
+        faulting_pid,
+        (fault_addr & 0xFF) as u8,
+        ((fault_addr >> 8) & 0xFF) as u8,
+        ((fault_addr >> 16) & 0xFF) as u8,
+        ((fault_addr >> 24) & 0xFF) as u8,
+        (fault_status & 0xFF) as u8,
+        ((fault_status >> 8) & 0xFF) as u8,
+        ((fault_status >> 16) & 0xFF) as u8,
+        ((fault_status >> 24) & 0xFF) as u8,
+    ];
+
+    let msg = ipc::Message::new(tag, &payload);
+
+    unsafe {
+        let procs = &mut *addr_of_mut!(PROCS);
+        if let Some(ref mut proc) = procs[faulting_pid as usize] {
+            proc.state = State::Dead;
+        }
+        // WHY: ipc::send stamps msg.from = current_pid(); temporarily set CURRENT
+        // to faulting_pid so the message arrives with the correct sender identity.
+        let saved = CURRENT;
+        CURRENT = faulting_pid;
+        ipc::send(0, msg);
+        CURRENT = saved;
+    }
+}
+
+/// Perform exit teardown without the diverging `-> !` signature.
+/// Marks the process Dead, reclaims its page table, and frees stack pages.
+pub(crate) fn exit_cleanup(status: i32) {
+    unsafe {
+        let cur = CURRENT as usize;
+        let procs = &mut *addr_of_mut!(PROCS);
+        if let Some(ref mut proc) = procs[cur] {
+            proc.exit_status = status;
+            proc.state = State::Dead;
+
+            // Reclaim page table (but never free the kernel's global L1)
+            let pt = proc.page_table_phys;
+            if pt != 0 && pt != mmu::table_base() {
+                mmu::free_addr_space(pt);
+            }
+            proc.page_table_phys = 0;
+
+            // Free stack pages
+            let base = proc.stack_base;
+            let pages = proc.stack_pages;
+            proc.stack_pages = 0;
+            for i in 0..pages {
+                page::free_page(base + i * page::PAGE_SIZE);
+            }
+        }
+    }
+}
+
+/// Exit the current process with a given status code.
+/// Tears down the address space and stack, then halts this process.
+pub fn exit_with_status(status: i32) -> ! {
+    exit_cleanup(status);
+    #[cfg(target_arch = "arm")]
+    unsafe {
+        mmu::switch_addr_space(mmu::table_base());
+        loop {
+            core::arch::asm!("wfi");
+        }
+    }
+    // WHY: non-ARM test builds diverge via unreachable! since ARM wfi is unavailable
+    #[cfg(not(target_arch = "arm"))]
+    unreachable!("exit_with_status called in non-ARM build")
+}
+
+/// Mark the current process as dead and yield to the scheduler.
+/// Thin wrapper over exit_with_status for the zero-status case.
+pub fn exit() -> ! {
+    exit_with_status(0)
 }
 
 /// Get the current process ID.
@@ -186,6 +402,7 @@ pub fn schedule() -> Pid {
 }
 
 /// Perform a context switch from current process to `next_pid`.
+/// Also switches TTBR0 so the next process gets its own address space.
 ///
 /// # Safety
 ///
@@ -209,10 +426,14 @@ pub unsafe fn switch_to(next_pid: Pid) {
             }
         }
 
-        // Restore next context
+        // Switch address space then restore next context
         if let Some(ref mut next_proc) = procs[next] {
             next_proc.state = State::Running;
             CURRENT = next_pid;
+            // WHY: switch TTBR0 before executing any instruction in the new process
+            if next_proc.page_table_phys != 0 {
+                mmu::switch_addr_space(next_proc.page_table_phys);
+            }
             restore_context(&next_proc.ctx);
         }
     }
@@ -221,6 +442,7 @@ pub unsafe fn switch_to(next_pid: Pid) {
 /// Save callee-saved registers into the context struct.
 #[inline(always)]
 unsafe fn save_context(ctx: &mut Context) {
+    #[cfg(target_arch = "arm")]
     unsafe {
         core::arch::asm!(
             "str r4, [{ctx}, #0]",
@@ -239,11 +461,15 @@ unsafe fn save_context(ctx: &mut Context) {
             tmp = out(reg) _,
         );
     }
+    // WHY: suppress unused-variable warning on non-ARM hosts
+    #[cfg(not(target_arch = "arm"))]
+    let _ = ctx;
 }
 
 /// Restore callee-saved registers from the context struct.
 #[inline(always)]
 unsafe fn restore_context(ctx: &Context) {
+    #[cfg(target_arch = "arm")]
     unsafe {
         core::arch::asm!(
             "ldr r4, [{ctx}, #0]",
@@ -262,19 +488,349 @@ unsafe fn restore_context(ctx: &Context) {
             tmp = out(reg) _,
         );
     }
+    // WHY: suppress unused-variable warning on non-ARM hosts
+    #[cfg(not(target_arch = "arm"))]
+    let _ = ctx;
 }
 
-/// Mark the current process as dead and yield to the scheduler.
-pub fn exit() -> ! {
-    unsafe {
-        let cur = CURRENT as usize;
-        let procs = &mut *addr_of_mut!(PROCS);
-        if let Some(ref mut proc) = procs[cur] {
-            proc.state = State::Dead;
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mmu;
+    use crate::page;
+
+    /// Reset all global state before each test.
+    unsafe fn reset_all() {
+        // Zero process table
+        let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+        for p in procs.iter_mut() {
+            *p = None;
         }
-        // NOTE: next timer tick will schedule away from this dead process
-        loop {
-            core::arch::asm!("wfi");
+        CURRENT = 0;
+
+        // Reset address space pool
+        mmu::reset_addr_space_pool();
+
+        // Reset page allocator with a modest test pool
+        // WHY: 0x4000_0000..0x8000_0000 is DRAM; kernel_end just above base so
+        // pages from 0x4010_0000 onward are available.
+        page::init(0x4000_0000, 0x8000_0000, 0x4010_0000);
+
+        // Reset IPC inboxes by re-initialising as process 0 and draining
+        // (no direct reset API; we just reconstruct process 0 and let
+        // tests ignore stale messages — each test calls reset_all fresh)
+    }
+
+    #[test]
+    fn fork_creates_new_process() {
+        unsafe {
+            reset_all();
+            // Construct a minimal process 0
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            let pt = mmu::alloc_addr_space().unwrap();
+            procs[0] = Some(Process {
+                pid: 0,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: None,
+                exit_status: 0,
+                page_table_phys: pt,
+                stack_base: 0,
+                stack_pages: 0,
+            });
+            CURRENT = 0;
+
+            let child_pid = fork().expect("fork should succeed");
+            let procs = &*core::ptr::addr_of!(PROCS);
+            assert!(procs[child_pid as usize].is_some(), "child slot must be populated");
+        }
+    }
+
+    #[test]
+    fn fork_assigns_separate_page_tables() {
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            let pt = mmu::alloc_addr_space().unwrap();
+            procs[0] = Some(Process {
+                pid: 0,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: None,
+                exit_status: 0,
+                page_table_phys: pt,
+                stack_base: 0,
+                stack_pages: 0,
+            });
+            CURRENT = 0;
+
+            let child_pid = fork().expect("fork should succeed");
+            let procs = &*core::ptr::addr_of!(PROCS);
+            let parent_pt = procs[0].as_ref().unwrap().page_table_phys;
+            let child_pt = procs[child_pid as usize].as_ref().unwrap().page_table_phys;
+            assert_ne!(parent_pt, child_pt, "parent and child must have distinct page tables");
+        }
+    }
+
+    #[test]
+    fn fork_child_has_correct_parent() {
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            let pt = mmu::alloc_addr_space().unwrap();
+            procs[0] = Some(Process {
+                pid: 0,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: None,
+                exit_status: 0,
+                page_table_phys: pt,
+                stack_base: 0,
+                stack_pages: 0,
+            });
+            CURRENT = 0;
+
+            let child_pid = fork().expect("fork should succeed");
+            let procs = &*core::ptr::addr_of!(PROCS);
+            let child_parent = procs[child_pid as usize].as_ref().unwrap().parent;
+            assert_eq!(child_parent, Some(0u8), "child.parent must be parent PID");
+        }
+    }
+
+    #[test]
+    fn address_space_independence() {
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            let pt = mmu::alloc_addr_space().unwrap();
+            procs[0] = Some(Process {
+                pid: 0,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: None,
+                exit_status: 0,
+                page_table_phys: pt,
+                stack_base: 0,
+                stack_pages: 0,
+            });
+            CURRENT = 0;
+
+            let child_pid = fork().expect("fork should succeed");
+            let procs = &*core::ptr::addr_of!(PROCS);
+            let parent_pt = procs[0].as_ref().unwrap().page_table_phys;
+            let child_pt = procs[child_pid as usize].as_ref().unwrap().page_table_phys;
+
+            // Write into entry 100 in the child's table
+            (child_pt as *mut u32).add(100).write(0xCAFE_BABE);
+            // Parent's entry 100 must be unchanged
+            let parent_val = (parent_pt as *const u32).add(100).read();
+            assert_ne!(parent_val, 0xCAFE_BABE,
+                "writing to child table must not affect parent table (separate L1s)");
+        }
+    }
+
+    #[test]
+    fn waitpid_returns_none_while_running() {
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            let pt = mmu::alloc_addr_space().unwrap();
+            procs[0] = Some(Process {
+                pid: 0,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: None,
+                exit_status: 0,
+                page_table_phys: pt,
+                stack_base: 0,
+                stack_pages: 0,
+            });
+            CURRENT = 0;
+
+            let child_pid = fork().expect("fork");
+            // Child is Ready, not Dead — waitpid must return None
+            assert_eq!(waitpid(child_pid), None, "should return None while child is alive");
+        }
+    }
+
+    #[test]
+    fn waitpid_returns_status_when_dead() {
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            let pt = mmu::alloc_addr_space().unwrap();
+            procs[0] = Some(Process {
+                pid: 0,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: None,
+                exit_status: 0,
+                page_table_phys: pt,
+                stack_base: 0,
+                stack_pages: 0,
+            });
+            CURRENT = 0;
+
+            let child_pid = fork().expect("fork");
+
+            // Manually mark child as dead with exit status 42
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            if let Some(ref mut child) = procs[child_pid as usize] {
+                child.state = State::Dead;
+                child.exit_status = 42;
+            }
+
+            assert_eq!(waitpid(child_pid), Some(42), "should return exit status 42");
+        }
+    }
+
+    #[test]
+    fn exit_cleanup_marks_dead_and_reclaims_pages() {
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            let pt = mmu::alloc_addr_space().unwrap();
+            procs[0] = Some(Process {
+                pid: 0,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: None,
+                exit_status: 0,
+                page_table_phys: pt,
+                stack_base: 0,
+                stack_pages: 0,
+            });
+            CURRENT = 0;
+
+            let child_pid = fork().expect("fork");
+
+            let free_before = page::free_count();
+
+            // Switch CURRENT to child and call exit_cleanup
+            CURRENT = child_pid;
+            exit_cleanup(0);
+
+            let procs = &*core::ptr::addr_of!(PROCS);
+            let child = procs[child_pid as usize].as_ref().unwrap();
+            assert_eq!(child.state, State::Dead, "exit_cleanup must mark state Dead");
+
+            let free_after = page::free_count();
+            assert!(free_after > free_before, "exit_cleanup must reclaim stack pages");
+        }
+    }
+
+    #[test]
+    fn notify_fault_marks_process_dead() {
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+
+            // Process 0: kinit supervisor
+            let pt0 = mmu::alloc_addr_space().unwrap();
+            procs[0] = Some(Process {
+                pid: 0,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: None,
+                exit_status: 0,
+                page_table_phys: pt0,
+                stack_base: 0,
+                stack_pages: 0,
+            });
+
+            // Process 1: faulting process
+            let pt1 = mmu::alloc_addr_space().unwrap();
+            procs[1] = Some(Process {
+                pid: 1,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: Some(0),
+                exit_status: 0,
+                page_table_phys: pt1,
+                stack_base: 0,
+                stack_pages: 0,
+            });
+            CURRENT = 0;
+
+            notify_fault(1, FaultKind::DataAbort { fault_addr: 0xDEAD, fault_status: 0x05 });
+
+            let procs = &*core::ptr::addr_of!(PROCS);
+            assert_eq!(procs[1].as_ref().unwrap().state, State::Dead,
+                "faulting process must be marked Dead");
+        }
+    }
+
+    #[test]
+    fn notify_fault_sends_to_pid0() {
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+
+            let pt0 = mmu::alloc_addr_space().unwrap();
+            procs[0] = Some(Process {
+                pid: 0,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: None,
+                exit_status: 0,
+                page_table_phys: pt0,
+                stack_base: 0,
+                stack_pages: 0,
+            });
+            let pt1 = mmu::alloc_addr_space().unwrap();
+            procs[1] = Some(Process {
+                pid: 1,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: Some(0),
+                exit_status: 0,
+                page_table_phys: pt1,
+                stack_base: 0,
+                stack_pages: 0,
+            });
+            CURRENT = 0;
+
+            notify_fault(1, FaultKind::UndefinedInstruction);
+
+            // PID 0 receives the message; tag must be 3 (UndefinedInstruction)
+            CURRENT = 0;
+            let msg = ipc::recv().expect("kinit must have received a fault notification");
+            assert_eq!(msg.tag, 3, "UndefinedInstruction tag must be 3");
+            assert_eq!(msg.payload()[0], 1u8, "first payload byte must be faulting PID");
+        }
+    }
+
+    #[test]
+    fn page_table_teardown_on_exit() {
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            let pt = mmu::alloc_addr_space().unwrap();
+            procs[0] = Some(Process {
+                pid: 0,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: None,
+                exit_status: 0,
+                page_table_phys: pt,
+                stack_base: 0,
+                stack_pages: 0,
+            });
+            CURRENT = 0;
+
+            let child_pid = fork().expect("fork");
+            let procs_ref = &*core::ptr::addr_of!(PROCS);
+            let child_pt = procs_ref[child_pid as usize].as_ref().unwrap().page_table_phys;
+
+            // Exit the child — should free its page table slot
+            CURRENT = child_pid;
+            exit_cleanup(0);
+
+            // Allocate again — must get the same address (slot was reclaimed)
+            let new_pt = mmu::alloc_addr_space().expect("slot must be available after teardown");
+            assert_eq!(new_pt, child_pt, "reclaimed table slot must be reused");
+
+            mmu::free_addr_space(new_pt);
         }
     }
 }

--- a/crates/pyknosis-boot/src/syscall.rs
+++ b/crates/pyknosis-boot/src/syscall.rs
@@ -338,7 +338,7 @@ pub fn dispatch(num: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> u32 {
         // ---- Legacy handlers (implemented) ----
 
         Syscall::Exit => {
-            process::exit();
+            process::exit_with_status(arg0 as i32);
         }
         Syscall::Write => {
             // SAFETY: we trust the userspace pointer for now.
@@ -403,13 +403,20 @@ pub fn dispatch(num: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> u32 {
             None => u32::MAX,
         },
 
-        // ---- Process management (stubs) ----
+        // ---- Process management ----
 
-        Syscall::Fork
-        | Syscall::Execve
-        | Syscall::Waitpid
-        | Syscall::Kill
-        | Syscall::Getuid => ENOSYS,
+        Syscall::Fork => match process::fork() {
+            Some(child_pid) => child_pid as u32,
+            None => u32::MAX,
+        },
+        Syscall::Waitpid => {
+            let child_pid = arg0 as u8;
+            match process::waitpid(child_pid) {
+                Some(status) => status as u32,
+                None => u32::MAX,
+            }
+        }
+        Syscall::Execve | Syscall::Kill | Syscall::Getuid => ENOSYS,
 
         // ---- Memory management (stubs) ----
 


### PR DESCRIPTION
## Summary

- Add per-process L1 page table pool (16 × 16 KB in BSS, 256 KB total) in `mmu.rs`
- `fork()`: clone parent address space into an independent child table, proven separate via distinct physical addresses
- `waitpid()`: non-blocking check for child exit status (returns None while alive, Some(status) when Dead)
- `exit_with_status()`: reclaim page table slot + stack pages, mark process Dead; ARM builds loop on `wfi`, non-ARM builds diverge via `unreachable!`
- `notify_fault()`: route process faults to kinit (PID 0) via IPC with encoded fault kind (DataAbort=1, PrefetchAbort=2, UndefinedInstruction=3)
- `switch_to()`: switch TTBR0 on context switch so each process operates in its own virtual address space
- `FORK` (syscall 10) and `WAITPID` (syscall 11) added to dispatch table
- 14 tests across `process.rs` (10) and `mmu.rs` (4) covering all acceptance criteria

## Architecture

Each process holds a `page_table_phys: usize` field pointing to one of 16 preallocated `UserL1Table` slots in BSS (tracked by a `u16` bitmask). Process 0 (kinit) uses the kernel's global `L1` table. All other processes get an independent clone. `switch_to()` writes TTBR0 and flushes the TLB before restoring context.

ARM-specific code (`switch_addr_space`, context save/restore asm, `wfi` loop) is guarded with `#[cfg(target_arch = "arm")]`; no-op stubs allow host compilation.

## Test plan

- [ ] `alloc_addr_space_gives_different_addresses` — two allocs return distinct addresses
- [ ] `alloc_addr_space_pool_exhaustion` — 17th alloc returns None
- [ ] `free_addr_space_allows_reuse` — freed slot is reallocated at same address
- [ ] `clone_addr_space_is_independent` — post-clone src modification does not affect dst
- [ ] `fork_creates_new_process` — child slot is populated after fork
- [ ] `fork_assigns_separate_page_tables` — parent and child have different page_table_phys
- [ ] `fork_child_has_correct_parent` — child.parent == Some(parent_pid)
- [ ] `address_space_independence` — writing child entry 100 does not affect parent entry 100
- [ ] `waitpid_returns_none_while_running` — returns None for a Ready child
- [ ] `waitpid_returns_status_when_dead` — returns Some(42) after manually setting Dead+exit_status
- [ ] `exit_cleanup_marks_dead_and_reclaims_pages` — state==Dead, free_count increases
- [ ] `notify_fault_marks_process_dead` — faulting process state==Dead after notify_fault
- [ ] `notify_fault_sends_to_pid0` — kinit inbox receives message with correct tag
- [ ] `page_table_teardown_on_exit` — child's page table slot reused after exit_cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)