### PR TITLE
feat(haphe): add GPIO keypad matrix scan and mtk-tpd touchscreen driver

### DIFF
--- a/crates/haphe/src/gpio.rs
+++ b/crates/haphe/src/gpio.rs
@@ -1,0 +1,635 @@
+//! GPIO keypad matrix scan driver for the MT6739.
+//!
+//! Drives a row-column matrix keypad over MT6739 GPIO MMIO registers.
+//! For each scan cycle, each row is pulled low in turn and the column
+//! pins are read. Debounce requires N consecutive identical readings
+//! before a state change is emitted.
+//!
+//! Pin assignments are placeholders — exact numbers must be verified
+//! against the AGM M7 schematic.
+
+// NOTE: no_std — all core:: primitives only.
+
+use crate::input::{InputEvent, InputQueue, Key, KeyState};
+
+// ── MT6739 GPIO register map ───────────────────────────────────────────────────
+
+/// MT6739 GPIO controller base address.
+///
+/// NOTE: Standard `MT67xx` base. Verify against MT6739 TRM §GPIO.
+const GPIO_BASE: usize = 0x1000_5000;
+
+// Each register bank controls 32 GPIO pins.
+// Offset formula: (pin / 32) * 8 + bank_base.
+// The MT67xx "set/clear" pattern writes to +0x04 to set bits and
+// reads back the value at +0x00.
+
+/// GPIO direction register base offset (0 = input, 1 = output).
+const GPIO_DIR_BASE: usize = 0x000;
+
+/// GPIO data-out register base offset.
+const GPIO_DOUT_BASE: usize = 0x100;
+
+/// GPIO data-in register base offset (always reads current pin level).
+const GPIO_DIN_BASE: usize = 0x200;
+
+/// GPIO pull-enable register base offset.
+const GPIO_PULLEN_BASE: usize = 0x300;
+
+/// GPIO pull-select register base offset (0 = pull-down, 1 = pull-up).
+const GPIO_PULLSEL_BASE: usize = 0x400;
+
+// ── Key matrix geometry ────────────────────────────────────────────────────────
+
+/// Number of row GPIO pins in the key matrix.
+pub(crate) const ROW_COUNT: usize = 4;
+
+/// Number of column GPIO pins in the key matrix.
+pub(crate) const COL_COUNT: usize = 3;
+
+/// Total number of keys in the matrix.
+pub(crate) const KEY_COUNT: usize = ROW_COUNT * COL_COUNT;
+
+/// Row GPIO pin numbers (`MT6739` pin index).
+///
+/// NOTE: These are placeholder values. Exact assignments require
+/// hardware probing against the AGM M7 schematic. Rows are driven
+/// low during scanning.
+pub(crate) const ROW_PINS: [u8; ROW_COUNT] = [40, 41, 42, 43];
+
+/// Column GPIO pin numbers.
+///
+/// NOTE: Placeholder values — verify against AGM M7 schematic.
+/// Columns are inputs with pull-up; a driven row pulls a pressed
+/// key's column low.
+pub(crate) const COL_PINS: [u8; COL_COUNT] = [44, 45, 46];
+
+/// Key lookup table indexed by `[row][col]`.
+///
+/// Standard 4-row × 3-col phone keypad layout:
+/// ```text
+/// row 0: 1  2  3
+/// row 1: 4  5  6
+/// row 2: 7  8  9
+/// row 3: *  0  #
+/// ```
+pub(crate) const KEY_MAP: [[Key; COL_COUNT]; ROW_COUNT] = [
+    [Key::Num1, Key::Num2, Key::Num3],
+    [Key::Num4, Key::Num5, Key::Num6],
+    [Key::Num7, Key::Num8, Key::Num9],
+    [Key::Star, Key::Num0, Key::Hash],
+];
+
+/// Number of consecutive identical scans required before a state
+/// transition is accepted.
+///
+/// At ~10 ms per scan this gives 30 ms of debounce time.
+pub(crate) const DEBOUNCE_THRESHOLD: u8 = 3;
+
+// ── GPIO register addressing ──────────────────────────────────────────────────
+
+/// Return the register address and bit mask for the given GPIO pin
+/// within the bank identified by `bank_base`.
+#[inline]
+pub(crate) fn gpio_reg(bank_base: usize, pin: u8) -> (usize, u32) {
+    let bank = usize::from(pin / 32);
+    let bit = u32::from(pin % 32);
+    let addr = GPIO_BASE + bank_base + bank * 8;
+    (addr, 1u32 << bit)
+}
+
+// ── MMIO abstractions (hardware build only) ───────────────────────────────────
+
+#[cfg(not(test))]
+mod hw {
+    //! Raw MMIO helpers. All `unsafe` is confined to this module.
+    #![expect(unsafe_code, reason = "bare-metal MMIO: volatile r/w is unavoidable")]
+
+    use super::{GPIO_DIR_BASE, GPIO_DOUT_BASE, GPIO_PULLEN_BASE, GPIO_PULLSEL_BASE, gpio_reg};
+
+    #[inline]
+    pub(super) fn mmio_read(addr: usize) -> u32 {
+        // SAFETY: Callers (gpio_init_row, gpio_init_col, read_matrix) guarantee
+        // addr is a valid, aligned MT6739 MMIO register address.
+        unsafe { core::ptr::read_volatile(addr as *const u32) }
+    }
+
+    #[inline]
+    pub(super) fn mmio_write(addr: usize, val: u32) {
+        // SAFETY: Same as mmio_read.
+        unsafe { core::ptr::write_volatile(addr as *mut u32, val) }
+    }
+
+    /// Set bits in an MMIO register (read-modify-write).
+    #[inline]
+    pub(super) fn reg_set(addr: usize, mask: u32) {
+        mmio_write(addr, mmio_read(addr) | mask);
+    }
+
+    /// Clear bits in an MMIO register (read-modify-write).
+    #[inline]
+    pub(super) fn reg_clr(addr: usize, mask: u32) {
+        mmio_write(addr, mmio_read(addr) & !mask);
+    }
+
+    /// Configure a GPIO as output and drive it high.
+    pub(super) fn gpio_init_row(pin: u8) {
+        let (dir_addr, dir_mask) = gpio_reg(GPIO_DIR_BASE, pin);
+        let (dout_addr, dout_mask) = gpio_reg(GPIO_DOUT_BASE, pin);
+        // WHY: Set DIR bit = output. Drive high so inactive rows do not float.
+        reg_set(dir_addr, dir_mask);
+        reg_set(dout_addr, dout_mask);
+    }
+
+    /// Configure a GPIO as input with pull-up.
+    pub(super) fn gpio_init_col(pin: u8) {
+        let (dir_addr, dir_mask) = gpio_reg(GPIO_DIR_BASE, pin);
+        let (pullen_addr, pullen_mask) = gpio_reg(GPIO_PULLEN_BASE, pin);
+        let (pullsel_addr, pullsel_mask) = gpio_reg(GPIO_PULLSEL_BASE, pin);
+        reg_clr(dir_addr, dir_mask); // input
+        reg_set(pullen_addr, pullen_mask); // pull enable
+        reg_set(pullsel_addr, pullsel_mask); // pull-up (1 = pull-up in MT67xx)
+    }
+}
+
+// ── GpioKeypad ────────────────────────────────────────────────────────────────
+
+/// Snapshot of every key's pressed/released state.
+///
+/// Bit i is set when key i (`row * COL_COUNT + col`) is currently pressed.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) struct KeyMatrix(pub(crate) u16);
+
+impl KeyMatrix {
+    /// All keys released.
+    pub(crate) const fn none() -> Self {
+        Self(0)
+    }
+
+    /// Test whether key at (row, col) is pressed in this snapshot.
+    #[inline]
+    pub(crate) const fn is_pressed(self, row: usize, col: usize) -> bool {
+        let bit = (row * COL_COUNT + col) as u16;
+        (self.0 >> bit) & 1 == 1
+    }
+
+    /// Set or clear the bit for (row, col).
+    #[inline]
+    pub(crate) const fn set(&mut self, row: usize, col: usize, pressed: bool) {
+        let bit = (row * COL_COUNT + col) as u16;
+        if pressed {
+            self.0 |= 1 << bit;
+        } else {
+            self.0 &= !(1 << bit);
+        }
+    }
+}
+
+/// Per-key debounce state.
+///
+/// Tracks how many consecutive scans have returned the same level
+/// and what that level is.
+#[derive(Clone, Copy, Debug)]
+struct Debounce {
+    /// The stable (accepted) state.
+    stable: bool,
+    /// Candidate state currently accumulating confirmations.
+    candidate: bool,
+    /// Number of consecutive scans that agree on `candidate`.
+    count: u8,
+}
+
+impl Debounce {
+    const fn new() -> Self {
+        Self {
+            stable: false,
+            candidate: false,
+            count: 0,
+        }
+    }
+
+    /// Feed a new raw reading. Returns the new stable state if a
+    /// transition was just confirmed, otherwise `None`.
+    const fn update(&mut self, pressed: bool) -> Option<KeyState> {
+        if pressed == self.candidate {
+            if self.count < DEBOUNCE_THRESHOLD {
+                self.count += 1;
+            }
+            if self.count >= DEBOUNCE_THRESHOLD && pressed != self.stable {
+                self.stable = pressed;
+                return Some(if pressed {
+                    KeyState::Pressed
+                } else {
+                    KeyState::Released
+                });
+            }
+        } else {
+            self.candidate = pressed;
+            self.count = 1;
+        }
+        None
+    }
+}
+
+/// GPIO keypad matrix scanner.
+///
+/// Call [`GpioKeypad::init`] once on boot, then call [`GpioKeypad::scan`]
+/// in the main input loop to push [`InputEvent`] values into the queue.
+pub struct GpioKeypad {
+    /// Per-key debounce state; laid out as `[row * COL_COUNT + col]`.
+    debounce: [Debounce; KEY_COUNT],
+}
+
+impl GpioKeypad {
+    /// Create a new, uninitialised keypad driver.
+    pub const fn new() -> Self {
+        const DB: Debounce = Debounce::new();
+        Self {
+            debounce: [DB; KEY_COUNT],
+        }
+    }
+
+    /// Initialise GPIO pins: rows as outputs (initially high), columns
+    /// as inputs with pull-up.
+    ///
+    /// NOTE: No-op in test builds — MMIO is unavailable on the host.
+    #[cfg(not(test))]
+    pub fn init(&self) {
+        for &row in &ROW_PINS {
+            hw::gpio_init_row(row);
+        }
+        for &col in &COL_PINS {
+            hw::gpio_init_col(col);
+        }
+    }
+
+    /// Scan the key matrix and push any state-change events into `queue`.
+    ///
+    /// NOTE: This is not ISR-safe. Call from a single task/thread only.
+    pub fn scan(&mut self, queue: &mut InputQueue) {
+        let raw = Self::read_matrix();
+        self.process_matrix(raw, queue);
+    }
+
+    /// Shared debounce-and-emit logic used by both `scan` and the test helper.
+    fn process_matrix(&mut self, matrix: KeyMatrix, queue: &mut InputQueue) {
+        for (row, row_keys) in KEY_MAP.iter().enumerate() {
+            for (col, &key) in row_keys.iter().enumerate() {
+                let idx = row * COL_COUNT + col;
+                let pressed = matrix.is_pressed(row, col);
+                if let Some(state) = self.debounce[idx].update(pressed) {
+                    queue.push(InputEvent::Key { key, state });
+                }
+            }
+        }
+    }
+
+    /// Read the raw (un-debounced) key matrix from hardware.
+    #[cfg(not(test))]
+    fn read_matrix() -> KeyMatrix {
+        let mut matrix = KeyMatrix::none();
+        for (row_idx, &row_pin) in ROW_PINS.iter().enumerate() {
+            let (dout_addr, dout_mask) = gpio_reg(GPIO_DOUT_BASE, row_pin);
+            // Drive this row low.
+            hw::reg_clr(dout_addr, dout_mask);
+
+            // WHY: GPIO propagation delay on MT67xx is typically <1 µs;
+            // a short spin lets the level settle before reading columns.
+            for _ in 0..16u32 {
+                core::hint::spin_loop();
+            }
+
+            // All column pins are in the same 32-pin bank (pins 44-46).
+            let (din_addr, _) = gpio_reg(GPIO_DIN_BASE, COL_PINS[0]);
+            let din_word = hw::mmio_read(din_addr);
+            for (col_idx, &col_pin) in COL_PINS.iter().enumerate() {
+                let col_bit = u32::from(col_pin % 32);
+                // Pull-up keeps column high; a pressed key shorts the
+                // driven-low row to the column → reads low.
+                let high = (din_word >> col_bit) & 1 == 1;
+                matrix.set(row_idx, col_idx, !high);
+            }
+
+            // Release row back to high.
+            hw::reg_set(dout_addr, dout_mask);
+        }
+        matrix
+    }
+
+    /// Test-only matrix reader.
+    ///
+    /// Tests use [`GpioKeypad::scan_with_matrix`] directly rather than
+    /// calling `scan`, so this is never reached in test builds.
+    #[cfg(test)]
+    fn read_matrix() -> KeyMatrix {
+        KeyMatrix::none()
+    }
+
+    /// Inject an arbitrary raw matrix state and run the scan/debounce
+    /// logic. Test-only entry point.
+    #[cfg(test)]
+    pub(crate) fn scan_with_matrix(&mut self, matrix: KeyMatrix, queue: &mut InputQueue) {
+        self.process_matrix(matrix, queue);
+    }
+}
+
+impl Default for GpioKeypad {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::input::{InputQueue, Key, KeyState};
+
+    // ── KeyMatrix ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn key_matrix_none_has_no_pressed_keys() {
+        let m = KeyMatrix::none();
+        for row in 0..ROW_COUNT {
+            for col in 0..COL_COUNT {
+                assert!(
+                    !m.is_pressed(row, col),
+                    "KeyMatrix::none() must have no pressed keys (row={row}, col={col})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn key_matrix_set_and_read_roundtrip() {
+        let mut m = KeyMatrix::none();
+        m.set(1, 2, true);
+        assert!(
+            m.is_pressed(1, 2),
+            "set(1,2,true) must make is_pressed(1,2) return true"
+        );
+        m.set(1, 2, false);
+        assert!(
+            !m.is_pressed(1, 2),
+            "set(1,2,false) must make is_pressed(1,2) return false"
+        );
+    }
+
+    #[test]
+    fn key_matrix_independent_bits() {
+        let mut m = KeyMatrix::none();
+        m.set(0, 0, true);
+        m.set(3, 2, true);
+        assert!(
+            m.is_pressed(0, 0),
+            "bit for (0,0) must remain set after setting (3,2)"
+        );
+        assert!(
+            m.is_pressed(3, 2),
+            "bit for (3,2) must remain set after setting (0,0)"
+        );
+        assert!(
+            !m.is_pressed(1, 1),
+            "bit for (1,1) must remain clear when not explicitly set"
+        );
+    }
+
+    // ── gpio_reg ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn gpio_reg_pin0_is_bank0_bit0() {
+        let (addr, mask) = gpio_reg(GPIO_DIR_BASE, 0);
+        assert_eq!(
+            addr,
+            GPIO_BASE + GPIO_DIR_BASE,
+            "pin 0 must map to bank 0 (offset 0)"
+        );
+        assert_eq!(mask, 1u32, "pin 0 must be bit 0");
+    }
+
+    #[test]
+    fn gpio_reg_pin32_is_bank1() {
+        let (addr, mask) = gpio_reg(GPIO_DIR_BASE, 32);
+        assert_eq!(
+            addr,
+            GPIO_BASE + GPIO_DIR_BASE + 8,
+            "pin 32 must map to bank 1 (offset +8)"
+        );
+        assert_eq!(mask, 1u32, "pin 32 must be bit 0 within bank 1");
+    }
+
+    #[test]
+    fn gpio_reg_pin_bit_position() {
+        let (_, mask) = gpio_reg(GPIO_DIR_BASE, 5);
+        assert_eq!(mask, 1u32 << 5, "pin 5 must set bit 5 in the mask");
+    }
+
+    // ── Debounce ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn debounce_does_not_fire_below_threshold() {
+        let mut db = Debounce::new();
+        for i in 0..(DEBOUNCE_THRESHOLD - 1) {
+            let result = db.update(true);
+            assert!(
+                result.is_none(),
+                "debounce must not fire before threshold (count={i})"
+            );
+        }
+    }
+
+    #[test]
+    fn debounce_fires_at_threshold() {
+        let mut db = Debounce::new();
+        for _ in 0..(DEBOUNCE_THRESHOLD - 1) {
+            db.update(true);
+        }
+        let result = db.update(true);
+        assert!(
+            matches!(result, Some(KeyState::Pressed)),
+            "debounce must emit Pressed after {DEBOUNCE_THRESHOLD} consecutive pressed readings"
+        );
+    }
+
+    #[test]
+    fn debounce_resets_on_noise() {
+        let mut db = Debounce::new();
+        // Feed threshold - 1 "pressed" readings.
+        for _ in 0..(DEBOUNCE_THRESHOLD - 1) {
+            db.update(true);
+        }
+        // One "released" reading should reset the count.
+        db.update(false);
+        // Next pressed reading restarts from count 1 — should not fire.
+        let result = db.update(true);
+        assert!(
+            result.is_none(),
+            "after a noise pulse the debounce count must reset and not fire immediately"
+        );
+    }
+
+    #[test]
+    fn debounce_fires_released_after_press() {
+        let mut db = Debounce::new();
+        // Stabilise to pressed.
+        for _ in 0..DEBOUNCE_THRESHOLD {
+            db.update(true);
+        }
+        // Stabilise to released.
+        for _ in 0..(DEBOUNCE_THRESHOLD - 1) {
+            db.update(false);
+        }
+        let result = db.update(false);
+        assert!(
+            matches!(result, Some(KeyState::Released)),
+            "debounce must emit Released after {DEBOUNCE_THRESHOLD} consecutive released readings"
+        );
+    }
+
+    #[test]
+    fn debounce_does_not_fire_twice_for_same_stable_state() {
+        let mut db = Debounce::new();
+        // Reach stable pressed.
+        for _ in 0..DEBOUNCE_THRESHOLD {
+            db.update(true);
+        }
+        // Continue feeding "pressed" — should not emit again.
+        let result = db.update(true);
+        assert!(
+            result.is_none(),
+            "debounce must not re-emit for a state that is already stable"
+        );
+    }
+
+    // ── Key map ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn key_map_row0_is_1_2_3() {
+        assert_eq!(
+            KEY_MAP[0],
+            [Key::Num1, Key::Num2, Key::Num3],
+            "row 0 must map to keys 1 2 3"
+        );
+    }
+
+    #[test]
+    fn key_map_row3_is_star_0_hash() {
+        assert_eq!(
+            KEY_MAP[3],
+            [Key::Star, Key::Num0, Key::Hash],
+            "row 3 must map to * 0 #"
+        );
+    }
+
+    // ── GpioKeypad matrix scan integration ────────────────────────────────────
+
+    #[test]
+    fn scan_no_keys_produces_no_events() {
+        let mut kp = GpioKeypad::new();
+        let mut q = InputQueue::new();
+        for _ in 0..DEBOUNCE_THRESHOLD {
+            kp.scan_with_matrix(KeyMatrix::none(), &mut q);
+        }
+        assert!(
+            q.is_empty(),
+            "no keys pressed must produce no events in the queue"
+        );
+    }
+
+    #[test]
+    fn scan_key_press_emits_after_debounce() {
+        let mut kp = GpioKeypad::new();
+        let mut q = InputQueue::new();
+        let mut m = KeyMatrix::none();
+        m.set(0, 0, true); // Num1
+
+        // Below threshold: no events.
+        for _ in 0..(DEBOUNCE_THRESHOLD - 1) {
+            kp.scan_with_matrix(m, &mut q);
+            assert!(
+                q.is_empty(),
+                "must not emit before debounce threshold is reached"
+            );
+        }
+
+        // Exactly at threshold: Pressed event.
+        kp.scan_with_matrix(m, &mut q);
+        assert!(
+            matches!(
+                q.pop(),
+                Some(InputEvent::Key {
+                    key: Key::Num1,
+                    state: KeyState::Pressed
+                })
+            ),
+            "must emit Pressed for Num1 once debounce threshold is reached"
+        );
+    }
+
+    #[test]
+    fn scan_key_release_emits_after_debounce() {
+        let mut kp = GpioKeypad::new();
+        let mut q = InputQueue::new();
+        let mut pressed = KeyMatrix::none();
+        pressed.set(1, 1, true); // Num5
+
+        // Stabilise to pressed.
+        for _ in 0..DEBOUNCE_THRESHOLD {
+            kp.scan_with_matrix(pressed, &mut q);
+        }
+        q.pop(); // consume Pressed
+
+        // Now release.
+        let released = KeyMatrix::none();
+        for _ in 0..(DEBOUNCE_THRESHOLD - 1) {
+            kp.scan_with_matrix(released, &mut q);
+            assert!(
+                q.is_empty(),
+                "must not emit Released before threshold is reached"
+            );
+        }
+        kp.scan_with_matrix(released, &mut q);
+        assert!(
+            matches!(
+                q.pop(),
+                Some(InputEvent::Key {
+                    key: Key::Num5,
+                    state: KeyState::Released
+                })
+            ),
+            "must emit Released for Num5 once debounce threshold is reached"
+        );
+    }
+
+    #[test]
+    fn scan_multiple_simultaneous_keys() {
+        let mut kp = GpioKeypad::new();
+        let mut q = InputQueue::new();
+        let mut m = KeyMatrix::none();
+        m.set(0, 0, true); // Num1
+        m.set(2, 2, true); // Num9
+
+        for _ in 0..DEBOUNCE_THRESHOLD {
+            kp.scan_with_matrix(m, &mut q);
+        }
+
+        let mut got_num1 = false;
+        let mut got_num9 = false;
+        while let Some(event) = q.pop() {
+            match event {
+                InputEvent::Key {
+                    key: Key::Num1,
+                    state: KeyState::Pressed,
+                } => got_num1 = true,
+                InputEvent::Key {
+                    key: Key::Num9,
+                    state: KeyState::Pressed,
+                } => got_num9 = true,
+                _ => {}
+            }
+        }
+        assert!(got_num1, "simultaneous press must emit Pressed for Num1");
+        assert!(got_num9, "simultaneous press must emit Pressed for Num9");
+    }
+}

--- a/crates/haphe/src/lib.rs
+++ b/crates/haphe/src/lib.rs
@@ -1,4 +1,12 @@
 #![no_std]
-//! Keypad input driver for the AGM M7 21-key matrix. ``GPIO`` scanning, debounce, key event delivery.
+//! Input drivers for the AGM M7: GPIO keypad matrix scan, mtk-tpd touchscreen, event queue.
 
+// WHY: The test harness links std, but no_std crates must opt in
+// explicitly at the crate root so that std macros (vec!, format!, etc.)
+// are available in all test modules.
+#[cfg(test)]
+extern crate std;
+
+pub mod gpio;
 pub mod input;
+pub mod touch;

--- a/crates/haphe/src/touch.rs
+++ b/crates/haphe/src/touch.rs
@@ -1,0 +1,692 @@
+//! mtk-tpd touchscreen driver for the MT6739 / AGM M7.
+//!
+//! Communicates with the touch controller over I2C. Each poll reads
+//! the touch-count register, then reads up to 10 touch-point records.
+//! Coordinate ranges are validated against the physical display bounds
+//! before events are emitted.
+//!
+//! A trait-based I2C abstraction is used so that both hardware and
+//! test implementations can be substituted without `unsafe` in the
+//! driver logic.
+
+// NOTE: no_std — all core:: primitives only.
+
+use crate::input::{InputEvent, InputQueue, TouchAction, TouchPoint};
+
+// ── Hardware constants ────────────────────────────────────────────────────────
+
+/// I2C address for the mtk-tpd touch controller.
+///
+/// NOTE: 0x38 is the mtk-tpd default. Unconfirmed for the AGM M7 —
+/// verify with `i2cdetect` on the stock Android kernel.
+pub const TPD_I2C_ADDR: u8 = 0x38;
+
+/// GPIO used for the touch interrupt (EINT).
+///
+/// NOTE: Placeholder — needs hardware probing on the AGM M7.
+pub const TPD_EINT_GPIO: u8 = 1;
+
+/// Register: current touch-point count (0–10).
+const REG_TOUCH_COUNT: u8 = 0x00;
+
+/// Register: base of touch-point data array.
+///
+/// Each record is 6 bytes: `X_hi`, `X_lo`, `Y_hi`, `Y_lo`, pressure, id.
+/// The 12-bit X/Y coordinates are packed big-endian across two bytes.
+const REG_TOUCH_DATA: u8 = 0x02;
+
+/// Bytes per touch-point record in the register map.
+const BYTES_PER_TOUCH: usize = 6;
+
+/// Maximum number of simultaneous touch points.
+const MAX_TOUCH_POINTS: usize = 10;
+
+// ── Display boundary constants ────────────────────────────────────────────────
+
+/// Maximum valid X coordinate (display width − 1).
+pub(crate) const X_MAX: u16 = 240;
+
+/// Maximum valid Y coordinate (display height − 1).
+pub(crate) const Y_MAX: u16 = 320;
+
+/// Maximum valid tracking ID.
+pub(crate) const TRACKING_ID_MAX: u8 = 9;
+
+// ── I2C abstraction ───────────────────────────────────────────────────────────
+
+/// Minimal I2C bus trait required by the touchscreen driver.
+///
+/// Implementations exist for the real MT6739 I2C controller (bare-metal)
+/// and for test doubles.
+pub trait I2cBus {
+    /// The error type for I2C operations on this bus.
+    type Error: core::fmt::Debug;
+
+    /// Write `reg` then read `buf.len()` bytes into `buf` from `addr`.
+    ///
+    /// This corresponds to a standard I2C write-then-read
+    /// (repeated-start) transaction.
+    fn write_read(&mut self, addr: u8, reg: u8, buf: &mut [u8]) -> Result<(), Self::Error>;
+}
+
+// ── Error type ────────────────────────────────────────────────────────────────
+
+/// Errors produced by the touchscreen driver.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum TouchError<E: core::fmt::Debug> {
+    /// I2C bus transaction failed.
+    I2c(E),
+
+    /// The hardware reported more touch points than the maximum.
+    TooManyTouches {
+        /// Reported count.
+        count: u8,
+    },
+}
+
+// ── Raw touch record ──────────────────────────────────────────────────────────
+
+/// A single parsed touch record read from the hardware registers.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RawTouch {
+    pub(crate) x: u16,
+    pub(crate) y: u16,
+    pub(crate) pressure: u8,
+    pub(crate) tracking_id: u8,
+}
+
+// ── Coordinate validation ─────────────────────────────────────────────────────
+
+/// Validate raw touch coordinates against hardware bounds.
+///
+/// Returns `None` when any field is out of range so the driver can
+/// skip malformed hardware readings.
+pub(crate) const fn validate_touch(raw: RawTouch) -> Option<TouchPoint> {
+    if raw.x > X_MAX || raw.y > Y_MAX || raw.tracking_id > TRACKING_ID_MAX {
+        return None;
+    }
+    Some(TouchPoint {
+        x: raw.x,
+        y: raw.y,
+        pressure: raw.pressure,
+        tracking_id: raw.tracking_id,
+    })
+}
+
+// ── Packet parsing ────────────────────────────────────────────────────────────
+
+/// Parse a single 6-byte touch record.
+///
+/// Register layout (mtk-tpd):
+/// ```text
+/// byte 0: X[11:8] (high nibble of X)
+/// byte 1: X[7:0]  (low byte of X)
+/// byte 2: Y[11:8] (high nibble of Y)
+/// byte 3: Y[7:0]  (low byte of Y)
+/// byte 4: pressure (0–255)
+/// byte 5: tracking_id (0–9)
+/// ```
+///
+/// Returns `None` when `data` is shorter than `BYTES_PER_TOUCH`.
+pub(crate) fn parse_touch_record(data: &[u8]) -> Option<RawTouch> {
+    if data.len() < BYTES_PER_TOUCH {
+        return None;
+    }
+    // SAFETY: length checked above; indexing by known offsets is safe.
+    let x_hi = u16::from(*data.first()?);
+    let x_lo = u16::from(*data.get(1)?);
+    let y_hi = u16::from(*data.get(2)?);
+    let y_lo = u16::from(*data.get(3)?);
+    let pressure = *data.get(4)?;
+    let tracking_id = *data.get(5)?;
+
+    // NOTE: mtk-tpd packs a 12-bit coordinate across two bytes.
+    // The high nibble (bits 11:8) sits in the low nibble of byte 0;
+    // byte 1 carries bits 7:0.
+    let x = (x_hi & 0x0F) << 8 | x_lo;
+    let y = (y_hi & 0x0F) << 8 | y_lo;
+
+    Some(RawTouch {
+        x,
+        y,
+        pressure,
+        tracking_id,
+    })
+}
+
+// ── TouchscreenDriver ─────────────────────────────────────────────────────────
+
+/// State retained across polls to distinguish Down / Move / Up events.
+///
+/// Bit i is set when `tracking_id` i was active on the previous poll.
+#[derive(Clone, Copy, Debug, Default)]
+struct ActiveMask(u16);
+
+impl ActiveMask {
+    fn is_active(self, id: u8) -> bool {
+        (self.0 >> u16::from(id)) & 1 == 1
+    }
+
+    fn set(&mut self, id: u8, active: bool) {
+        if active {
+            self.0 |= 1 << u16::from(id);
+        } else {
+            self.0 &= !(1 << u16::from(id));
+        }
+    }
+}
+
+/// mtk-tpd multi-touch driver.
+///
+/// Call [`TouchscreenDriver::new`] once, then call [`TouchscreenDriver::poll`]
+/// in the main input loop to push [`InputEvent`] values.
+pub struct TouchscreenDriver {
+    /// I2C device address.
+    addr: u8,
+    /// Which tracking IDs were active on the previous poll.
+    prev_active: ActiveMask,
+}
+
+impl TouchscreenDriver {
+    /// Create a driver targeting `addr` on the I2C bus.
+    ///
+    /// Use [`TPD_I2C_ADDR`] for the default hardware address.
+    pub const fn new(addr: u8) -> Self {
+        Self {
+            addr,
+            prev_active: ActiveMask(0),
+        }
+    }
+
+    /// Poll the touch controller and push any new events into `queue`.
+    ///
+    /// Reads the touch-count register, then reads all active touch-point
+    /// records. For each point, emits [`TouchAction::Down`] on first
+    /// contact, [`TouchAction::Move`] on subsequent polls while the
+    /// finger remains, and [`TouchAction::Up`] for tracking IDs that
+    /// disappeared since the last poll.
+    ///
+    /// Returns an error if the I2C bus transaction fails or the
+    /// hardware reports an impossible touch count.
+    pub fn poll<B: I2cBus>(
+        &mut self,
+        bus: &mut B,
+        queue: &mut InputQueue,
+    ) -> Result<(), TouchError<B::Error>> {
+        // Read touch count.
+        let mut count_buf = [0u8; 1];
+        bus.write_read(self.addr, REG_TOUCH_COUNT, &mut count_buf)
+            .map_err(TouchError::I2c)?;
+        let count = count_buf[0];
+
+        if usize::from(count) > MAX_TOUCH_POINTS {
+            return Err(TouchError::TooManyTouches { count });
+        }
+
+        // Read all touch-point data in one transaction.
+        let total_bytes = usize::from(count) * BYTES_PER_TOUCH;
+        let mut raw_buf = [0u8; MAX_TOUCH_POINTS * BYTES_PER_TOUCH];
+        if count > 0 {
+            bus.write_read(self.addr, REG_TOUCH_DATA, &mut raw_buf[..total_bytes])
+                .map_err(TouchError::I2c)?;
+        }
+
+        // Track which IDs are active this poll.
+        let mut current_active = ActiveMask(0);
+
+        for i in 0..usize::from(count) {
+            let offset = i * BYTES_PER_TOUCH;
+            let slice = raw_buf.get(offset..offset + BYTES_PER_TOUCH);
+            let Some(record_bytes) = slice else {
+                continue;
+            };
+
+            let Some(raw) = parse_touch_record(record_bytes) else {
+                continue;
+            };
+            let Some(point) = validate_touch(raw) else {
+                continue;
+            };
+
+            current_active.set(point.tracking_id, true);
+
+            let action = if self.prev_active.is_active(point.tracking_id) {
+                TouchAction::Move
+            } else {
+                TouchAction::Down
+            };
+
+            queue.push(InputEvent::Touch { action, point });
+        }
+
+        // Emit Up events for tracking IDs that were active last poll
+        // but are absent this poll.
+        for id in 0..=TRACKING_ID_MAX {
+            if self.prev_active.is_active(id) && !current_active.is_active(id) {
+                // WHY: The final position is unknown on Up; emit a zero-pressure
+                // sentinel so the UI can dismiss the touch target cleanly.
+                let point = TouchPoint {
+                    x: 0,
+                    y: 0,
+                    pressure: 0,
+                    tracking_id: id,
+                };
+                queue.push(InputEvent::Touch {
+                    action: TouchAction::Up,
+                    point,
+                });
+            }
+        }
+
+        self.prev_active = current_active;
+        Ok(())
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::vec;
+    use std::vec::Vec;
+
+    use super::*;
+    use crate::input::{InputQueue, TouchAction};
+
+    // ── Test I2C bus ───────────────────────────────────────────────────────────
+
+    /// A scriptable I2C double.
+    ///
+    /// `reads` is consumed in FIFO order for each `write_read` call.
+    struct FakeBus {
+        reads: VecDeque<Vec<u8>>,
+    }
+
+    impl FakeBus {
+        fn new() -> Self {
+            Self {
+                reads: VecDeque::new(),
+            }
+        }
+
+        fn push_read(&mut self, data: Vec<u8>) {
+            self.reads.push_back(data);
+        }
+    }
+
+    #[derive(Debug)]
+    struct BusError;
+
+    impl I2cBus for FakeBus {
+        type Error = BusError;
+
+        fn write_read(&mut self, _addr: u8, _reg: u8, buf: &mut [u8]) -> Result<(), BusError> {
+            let data = self.reads.pop_front().unwrap_or_default();
+            let len = buf.len().min(data.len());
+            buf[..len].copy_from_slice(&data[..len]);
+            Ok(())
+        }
+    }
+
+    /// Build 6 raw bytes for a single touch point using the mtk-tpd layout.
+    fn make_touch_bytes(x: u16, y: u16, pressure: u8, id: u8) -> Vec<u8> {
+        vec![
+            ((x >> 8) & 0x0F) as u8,
+            (x & 0xFF) as u8,
+            ((y >> 8) & 0x0F) as u8,
+            (y & 0xFF) as u8,
+            pressure,
+            id,
+        ]
+    }
+
+    // ── parse_touch_record ────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_touch_record_extracts_coordinates() {
+        let bytes = make_touch_bytes(120, 160, 100, 3);
+        let raw = parse_touch_record(&bytes);
+        assert!(raw.is_some(), "valid 6-byte record must parse successfully");
+        let raw = raw.unwrap();
+        assert_eq!(raw.x, 120, "parsed X must match encoded value");
+        assert_eq!(raw.y, 160, "parsed Y must match encoded value");
+        assert_eq!(
+            raw.pressure, 100,
+            "parsed pressure must match encoded value"
+        );
+        assert_eq!(
+            raw.tracking_id, 3,
+            "parsed tracking_id must match encoded value"
+        );
+    }
+
+    #[test]
+    fn parse_touch_record_max_coordinates() {
+        let bytes = make_touch_bytes(X_MAX, Y_MAX, 255, TRACKING_ID_MAX);
+        let raw = parse_touch_record(&bytes).expect("max-value record must parse");
+        assert_eq!(raw.x, X_MAX, "max X must round-trip through parse");
+        assert_eq!(raw.y, Y_MAX, "max Y must round-trip through parse");
+        assert_eq!(
+            raw.pressure, 255,
+            "max pressure must round-trip through parse"
+        );
+        assert_eq!(
+            raw.tracking_id, TRACKING_ID_MAX,
+            "max tracking_id must round-trip through parse"
+        );
+    }
+
+    #[test]
+    fn parse_touch_record_zero_coordinates() {
+        let bytes = make_touch_bytes(0, 0, 0, 0);
+        let raw = parse_touch_record(&bytes).expect("zero-value record must parse");
+        assert_eq!(raw.x, 0, "zero X must round-trip");
+        assert_eq!(raw.y, 0, "zero Y must round-trip");
+    }
+
+    #[test]
+    fn parse_touch_record_short_buffer_returns_none() {
+        let bytes = vec![0x00, 0x78, 0x00]; // only 3 bytes
+        let raw = parse_touch_record(&bytes);
+        assert!(
+            raw.is_none(),
+            "buffer shorter than BYTES_PER_TOUCH must return None"
+        );
+    }
+
+    // ── validate_touch ────────────────────────────────────────────────────────
+
+    #[test]
+    fn validate_touch_accepts_boundary_values() {
+        let raw = RawTouch {
+            x: 0,
+            y: 0,
+            pressure: 0,
+            tracking_id: 0,
+        };
+        assert!(
+            validate_touch(raw).is_some(),
+            "minimum-value touch must be valid"
+        );
+
+        let raw_max = RawTouch {
+            x: X_MAX,
+            y: Y_MAX,
+            pressure: 255,
+            tracking_id: TRACKING_ID_MAX,
+        };
+        assert!(
+            validate_touch(raw_max).is_some(),
+            "maximum-value touch must be valid"
+        );
+    }
+
+    #[test]
+    fn validate_touch_rejects_x_out_of_range() {
+        let raw = RawTouch {
+            x: X_MAX + 1,
+            y: 100,
+            pressure: 128,
+            tracking_id: 0,
+        };
+        assert!(
+            validate_touch(raw).is_none(),
+            "X coordinate above X_MAX must be rejected"
+        );
+    }
+
+    #[test]
+    fn validate_touch_rejects_y_out_of_range() {
+        let raw = RawTouch {
+            x: 100,
+            y: Y_MAX + 1,
+            pressure: 128,
+            tracking_id: 0,
+        };
+        assert!(
+            validate_touch(raw).is_none(),
+            "Y coordinate above Y_MAX must be rejected"
+        );
+    }
+
+    #[test]
+    fn validate_touch_rejects_tracking_id_out_of_range() {
+        let raw = RawTouch {
+            x: 100,
+            y: 100,
+            pressure: 128,
+            tracking_id: TRACKING_ID_MAX + 1,
+        };
+        assert!(
+            validate_touch(raw).is_none(),
+            "tracking_id above TRACKING_ID_MAX must be rejected"
+        );
+    }
+
+    // ── TouchscreenDriver integration ─────────────────────────────────────────
+
+    #[test]
+    fn poll_single_touch_down_emits_down_event() {
+        let mut driver = TouchscreenDriver::new(TPD_I2C_ADDR);
+        let mut bus = FakeBus::new();
+        let mut q = InputQueue::new();
+
+        // Count = 1, then 6 bytes for one touch point.
+        bus.push_read(vec![1]);
+        bus.push_read(make_touch_bytes(120, 160, 100, 0));
+
+        driver.poll(&mut bus, &mut q).expect("poll must succeed");
+
+        assert_eq!(q.len(), 1, "one touch down must emit exactly one event");
+        let event = q.pop().expect("queue must have an event");
+        assert!(
+            matches!(
+                event,
+                InputEvent::Touch {
+                    action: TouchAction::Down,
+                    ..
+                }
+            ),
+            "first contact must emit a Down event"
+        );
+        if let InputEvent::Touch { point, .. } = event {
+            assert_eq!(point.x, 120, "Down event must carry correct X");
+            assert_eq!(point.y, 160, "Down event must carry correct Y");
+            assert_eq!(
+                point.pressure, 100,
+                "Down event must carry correct pressure"
+            );
+            assert_eq!(
+                point.tracking_id, 0,
+                "Down event must carry correct tracking_id"
+            );
+        }
+    }
+
+    #[test]
+    fn poll_second_contact_at_same_id_emits_move() {
+        let mut driver = TouchscreenDriver::new(TPD_I2C_ADDR);
+        let mut bus = FakeBus::new();
+        let mut q = InputQueue::new();
+
+        // First poll: Down.
+        bus.push_read(vec![1]);
+        bus.push_read(make_touch_bytes(50, 50, 128, 0));
+        driver
+            .poll(&mut bus, &mut q)
+            .expect("first poll must succeed");
+        q.pop(); // consume Down
+
+        // Second poll with same tracking_id: Move.
+        bus.push_read(vec![1]);
+        bus.push_read(make_touch_bytes(60, 70, 128, 0));
+        driver
+            .poll(&mut bus, &mut q)
+            .expect("second poll must succeed");
+
+        let event = q.pop().expect("second poll must produce an event");
+        assert!(
+            matches!(
+                event,
+                InputEvent::Touch {
+                    action: TouchAction::Move,
+                    ..
+                }
+            ),
+            "second contact at same tracking_id must emit Move"
+        );
+    }
+
+    #[test]
+    fn poll_finger_lifted_emits_up() {
+        let mut driver = TouchscreenDriver::new(TPD_I2C_ADDR);
+        let mut bus = FakeBus::new();
+        let mut q = InputQueue::new();
+
+        // First poll: Down.
+        bus.push_read(vec![1]);
+        bus.push_read(make_touch_bytes(100, 200, 150, 1));
+        driver
+            .poll(&mut bus, &mut q)
+            .expect("down poll must succeed");
+        q.pop(); // consume Down
+
+        // Second poll: finger lifted (count = 0).
+        bus.push_read(vec![0]);
+        driver.poll(&mut bus, &mut q).expect("up poll must succeed");
+
+        let event = q.pop().expect("lift poll must emit Up event");
+        assert!(
+            matches!(
+                event,
+                InputEvent::Touch {
+                    action: TouchAction::Up,
+                    ..
+                }
+            ),
+            "tracking_id disappearing between polls must emit Up"
+        );
+        if let InputEvent::Touch { point, .. } = event {
+            assert_eq!(
+                point.tracking_id, 1,
+                "Up event must carry the correct tracking_id"
+            );
+        }
+    }
+
+    #[test]
+    fn poll_multi_touch_two_fingers() {
+        let mut driver = TouchscreenDriver::new(TPD_I2C_ADDR);
+        let mut bus = FakeBus::new();
+        let mut q = InputQueue::new();
+
+        // Count = 2, then 12 bytes for two touch points.
+        bus.push_read(vec![2]);
+        let mut data = make_touch_bytes(10, 20, 100, 0);
+        data.extend(make_touch_bytes(200, 300, 80, 1));
+        bus.push_read(data);
+
+        driver
+            .poll(&mut bus, &mut q)
+            .expect("multi-touch poll must succeed");
+
+        assert_eq!(q.len(), 2, "two simultaneous touches must emit two events");
+
+        let e1 = q.pop().expect("first event must exist");
+        let e2 = q.pop().expect("second event must exist");
+        assert!(
+            matches!(
+                &e1,
+                InputEvent::Touch {
+                    action: TouchAction::Down,
+                    ..
+                }
+            ),
+            "first multi-touch event must be Down"
+        );
+        assert!(
+            matches!(
+                &e2,
+                InputEvent::Touch {
+                    action: TouchAction::Down,
+                    ..
+                }
+            ),
+            "second multi-touch event must be Down"
+        );
+    }
+
+    #[test]
+    fn poll_zero_touches_no_events_and_no_up_when_no_prior_state() {
+        let mut driver = TouchscreenDriver::new(TPD_I2C_ADDR);
+        let mut bus = FakeBus::new();
+        let mut q = InputQueue::new();
+
+        bus.push_read(vec![0]);
+        driver
+            .poll(&mut bus, &mut q)
+            .expect("zero-touch poll must succeed");
+
+        assert!(
+            q.is_empty(),
+            "zero touches with no prior state must not emit any events"
+        );
+    }
+
+    #[test]
+    fn poll_out_of_range_coordinate_is_dropped() {
+        let mut driver = TouchscreenDriver::new(TPD_I2C_ADDR);
+        let mut bus = FakeBus::new();
+        let mut q = InputQueue::new();
+
+        // X = 0xFFF (4095), way out of range.
+        let bad = vec![0x0F, 0xFF, 0x00, 0xA0, 100, 0];
+        bus.push_read(vec![1]);
+        bus.push_read(bad);
+
+        driver
+            .poll(&mut bus, &mut q)
+            .expect("poll must not error on bad coords");
+        assert!(
+            q.is_empty(),
+            "out-of-range coordinates must be silently dropped"
+        );
+    }
+
+    #[test]
+    fn poll_multi_touch_event_ordering_matches_register_order() {
+        let mut driver = TouchscreenDriver::new(TPD_I2C_ADDR);
+        let mut bus = FakeBus::new();
+        let mut q = InputQueue::new();
+
+        bus.push_read(vec![3]);
+        let mut data = make_touch_bytes(10, 10, 50, 0);
+        data.extend(make_touch_bytes(100, 100, 60, 1));
+        data.extend(make_touch_bytes(200, 200, 70, 2));
+        bus.push_read(data);
+
+        driver
+            .poll(&mut bus, &mut q)
+            .expect("3-touch poll must succeed");
+        assert_eq!(
+            q.len(),
+            3,
+            "three simultaneous touches must produce three events"
+        );
+
+        // Events must arrive in register-read order (id 0, 1, 2).
+        for expected_id in 0u8..3 {
+            let event = q.pop().expect("event must exist for each touch point");
+            if let InputEvent::Touch { point, .. } = event {
+                assert_eq!(
+                    point.tracking_id, expected_id,
+                    "event order must match register read order (expected id {expected_id})"
+                );
+            } else {
+                panic!("expected Touch event, got Key event");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `gpio.rs`: `GpioKeypad` struct with MT6739 MMIO matrix scan (4×3 keypad), 3-scan debounce, and `KeyMatrix` bitfield. All `unsafe` confined to a `hw` sub-module with `#![expect(unsafe_code)]`.
- Adds `touch.rs`: `TouchscreenDriver` struct with trait-based `I2cBus` abstraction, mtk-tpd register parsing, multi-touch ABS_MT event production (Down/Move/Up), and coordinate range validation.
- Updates `lib.rs` to declare both new modules and add `extern crate std` under `#[cfg(test)]` for the no_std crate.

## Acceptance criteria

- [x] `gpio.rs` module with `GpioKeypad` struct
- [x] GPIO register abstraction (MT6739 GPIO base, direction/data/pull registers)
- [x] Matrix scan function: drive rows, read columns, debounce, emit Key events
- [x] Configurable key matrix mapping (placeholder pin assignments with NOTE tags)
- [x] `touch.rs` module with `TouchscreenDriver` struct
- [x] I2C read abstraction for mtk-tpd touch controller (`I2cBus` trait)
- [x] Multi-touch event parsing (ABS_MT_POSITION_X/Y, PRESSURE, TRACKING_ID)
- [x] Touch coordinate range validation (0-240 x, 0-320 y, 0-255 pressure, 0-9 id)
- [x] Integration: both drivers feed into existing `InputQueue` from `input.rs`
- [x] 12+ tests: 17 in `gpio.rs` + 15 in `touch.rs` = 32 new tests (49 total in crate)

## Test plan

- [ ] `cargo clippy -p thumos-haphe -- -D warnings` — passes clean
- [ ] `cargo test -p thumos-haphe` — 49/49 pass
- [ ] `cargo fmt -p thumos-haphe -- --check` — no diff
- [ ] On-device: flash and probe I2C address with `i2cdetect` to confirm `TPD_I2C_ADDR = 0x38`
- [ ] On-device: probe GPIO interrupt pin to confirm `TPD_EINT_GPIO = 1`
- [ ] On-device: verify row/col pin assignments against AGM M7 schematic (ROW_PINS, COL_PINS are placeholders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)