### PR TITLE
docs(thumos): reflect Phase 03 completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,42 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.3.0] -- 2026-04-01
+
+### Added
+
+- **Kernel integration (pyknosis-boot)**: full boot sequence wires all Phase 03 drivers, kernel hands off to userspace after hardware init (PR #15)
+- **USB ACM serial gadget (pyknosis-boot)**: MUSB controller driver with CDC-ACM serial gadget for debug console (PR #13)
+- **GPIO keypad and touchscreen (haphe)**: GPIO keypad matrix scan and mtk-tpd touchscreen driver with interrupt-driven event delivery (PR #12)
+- **BT HCI transport (pteron)**: STP framing layer and LE Privacy address rotation at 15-minute intervals, NRPA by default (PR #11)
+- **WiFi MAC driver (aither)**: WiFi gen2 HIF interface with per-connection MAC randomization (locally-administered bit set) and passive scanning by default (PR #10)
+- **Display driver (pyknosis-boot)**: DDP pipeline (OVL→RDMA→DSI→LCM) with pluggable `LcmDriver` trait and GC9306 stub (PR #9)
+- **WMT connectivity manager (kelyphos)**: CONSYS power-on sequence, STP transport, and subsystem management for WiFi/BT combo chip (PR #8)
+- **CCCI modem driver (pyknosis-boot)**: CLDMA ring buffers and CCIF mailbox for AP-modem communication; IMEI/IMSI filtered at kernel boundary, capability-gated, audit-logged (PR #6)
+- **Process isolation (pyknosis-boot)**: two-process isolation with separate address spaces and `waitpid` synchronization (PR #5)
+- **eMMC block device (pyknosis-boot)**: MSDC controller driver with PIO and DMA modes, GPD/BD descriptor support (PR #4)
+- **Syscall expansion (pyknosis-boot)**: syscall interface expanded to 46 calls covering process, memory, IPC, file, time, and signal domains (PR #3)
+- **GC9306 init sequence (docs)**: LCM initialization sequence extracted from four public sources (PR #14)
+- **Device identity protection threat model**: CLAUDE.md documents per-identifier mitigations at the register level
+
+### Changed
+
+- Architecture pivot documented in CLAUDE.md: full Rust from kernel to UI, Linux removed from final system description
+
+## [0.2.0] -- 2026-03-18
+
+### Added
+
+- Linux bootstrap: BSP kernel (Linux 4.4) cross-compiled for MT6739, all hardware interfaces documented
+- Userspace crate stubs: all 13 original crates with initial code, 364 tests
+- Kernel modules: 19 modules (~2,500 LOC), MMU, page allocator, slab heap, GIC, timer, basic scheduler
+
+## [0.1.0] -- 2026-03-18
+
+### Added
+
+- Hardware probe complete: BROM access, firmware dump, bootloader unlock, root access
+- Surveillance audit: 7 threats identified across 3 nation-state risk profiles
+- Kernel module map and modem interface map extracted from stock firmware
+- Initial workspace structure: 13 crates scaffolded

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Thumos is a custom Linux-based mobile OS targeting the AGM M7 (MT6739).
+Thumos is a custom Rust mobile OS targeting the AGM M7 (MT6739).
 
 ## Repository
 
@@ -10,17 +10,27 @@ Thumos is a custom Linux-based mobile OS targeting the AGM M7 (MT6739).
 
 ## Architecture
 
-Path B: Linux kernel + vendor HAL + custom userspace. No Android framework above HAL.
+Full Rust from kernel to UI. No C we author, no Linux in the final system. Monolithic kernel (pyknosis).
 
 | Layer | Status | Notes |
 |-------|--------|-------|
-| Kernel | Not started | Linux 4.4 from MT6739 BSP sources |
-| Vendor blobs | Not extracted | Modem, WiFi, BT, GPS from stock firmware |
-| RIL/telephony | Not started | Direct modem interface for calls/SMS |
-| WiFi/BT | Not started | wpa_supplicant + bluez or custom |
-| UI | Not started | Framebuffer-based, 240x320, keypad input |
-| Privacy | Not started | Firewall, DNS filtering, anti-tracking |
-| Radio tools | Not started | WiFi scan, BT scan, cell analysis |
+| Kernel (pyknosis-boot) | Phase 03 | MMU, page allocator, heap, GIC, timer, scheduler, syscalls (~46), IPC, ELF loader, ramfs |
+| eMMC driver | Phase 03 | MSDC controller, PIO + DMA, GPD/BD descriptors |
+| Display driver | Phase 03 | DDP pipeline (OVL→RDMA→DSI→LCM), pluggable LcmDriver trait |
+| CCCI modem driver | Phase 03 | CLDMA ring buffers, CCIF mailbox, identity containment |
+| USB driver | Phase 03 | MUSB ACM serial gadget |
+| WiFi MAC (aither) | Phase 03 | WiFi gen2 HIF, MAC randomization, passive scanning |
+| BT HCI (pteron) | Phase 03 | STP transport, LE Privacy address rotation |
+| WMT (kelyphos) | Phase 03 | CONSYS power-on, STP transport, subsystem management |
+| Input (haphe) | Phase 03 | GPIO keypad, mtk-tpd touchscreen, T9 |
+| Telephony (phone) | Substantial | AT parser, CCCI/CLDMA framing, SMS PDU |
+| UI (eidolon) | Substantial | Framebuffer 240x320, widgets, dialer |
+| Firewall (asphaleia) | Substantial | Packet filter, DNS blocklist |
+| Encrypted storage (stegnos) | Substantial | AES-256-XTS, LUKS key derivation |
+| Signal protocol (krypta) | Substantial | X3DH, double ratchet |
+| Panic mode (leipsanon) | Substantial | Priority-ordered wipe, triggers |
+| Radio tools (sema) | Substantial | WiFi scanner, IMSI catcher detection |
+| GPS (topos) | Substantial | NMEA parser, geofencing |
 
 ## Key constraints
 
@@ -36,9 +46,23 @@ Path B: Linux kernel + vendor HAL + custom userspace. No Android framework above
 - **SP Flash Tool**: MediaTek firmware flashing via scatter file
 - **adb**: Android Debug Bridge for device probing
 
+## Device identity protection
+
+Thumos treats all hardware identifiers as sensitive. Every radio driver implements identity protection at the register level:
+
+| Identifier | Mitigation |
+|---|---|
+| WiFi MAC | Random locally-administered MAC per connection via ring CSPRNG |
+| BT MAC | LE Privacy with rotating random addresses (15-min interval) |
+| IMEI | Filtered at CCCI kernel boundary, audit-logged, capability-gated |
+| IMSI | SIM-resident, logged on modem access, removable battery = easy SIM swap |
+| Probe requests | Passive WiFi scanning by default, no SSID broadcast |
+| BLE advertisements | Non-resolvable private address (NRPA) by default |
+| RF fingerprint | Accepted risk on M7 hardware. Custom PCB future addresses this. |
+
 ## Build
 
-Not yet buildable. Research phase.
+Workspace compiles on host. Cross-compilation for `armv7-unknown-none-eabihf` (kernel) and `armv7-unknown-linux-musleabihf` (userspace) via Nix on Verda.
 
 ## Standards
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ MT6739 hardware (modem on separate core, firewalled at CCCI driver level)
 
 ## Status
 
-Phase 03: Kernel and Drivers. Hardware probe complete (bootloader unlocked, firmware dumped, surveillance audit done). Linux bootstrap complete (BSP kernel cross-compiled, hardware interfaces documented). All 13 crates have code, 375+ tests. Kernel has MMU, page allocator, slab heap, interrupts, process model, IPC, ELF loader, syscall dispatch.
+Phase 03 complete (2026-04-01). All 14 crates have code, 486 tests, ~31K LOC. Kernel boots with 46 syscalls, MMU, page allocator, slab heap, GIC interrupts, preemptive scheduler, IPC, ELF loader, and ramfs. Hardware drivers operational: eMMC (MSDC), display (DDP pipeline), WiFi MAC (randomization, passive scan), BT HCI (STP, LE Privacy), WMT power sequencing, CCCI modem containment, USB ACM, GPIO keypad, and touchscreen. Two isolated userspace processes proven with separate page tables.
 
 ## Related
 


### PR DESCRIPTION
## What changed

- `CLAUDE.md`: architecture table replaced with current full-Rust layer table (17 rows, all Phase 03 drivers with status); device identity protection section added; Build section updated with cross-compilation targets; "research phase" note removed
- `README.md`: status line updated to Phase 03 complete (2026-04-01), 14 crates, 486 tests, ~31K LOC
- `CHANGELOG.md`: Phase 03 entries for all 11 PRs (#3--#15), prior phases documented at 0.2.0 and 0.1.0

## Why

Phase 03 dispatch (prompts 1797--1809) completed 2026-04-01. All 11 driver PRs merged. Docs still described the project as "research phase" with a Linux-based architecture table from before the full-Rust pivot.

## Verify

- Architecture table entries match merged PR list: syscalls (#3), eMMC (#4), process isolation (#5), CCCI (#6), display (#9), WiFi (#10), BT (#11), haphe (#12), USB (#13), GC9306 research (#14), kernel integration (#15)
- Test count (486) matches `cargo test --workspace` output
- Crate count (14) matches `ls crates/` output: aither, asphaleia, eidolon, haphe, kelyphos, krypta, leipsanon, phone, pteron, pyknosis, pyknosis-boot, sema, stegnos, topos

## Observations

- `pyknosis` and `pyknosis-boot` are two separate crates; STATE.md previously listed 13 crates (counting them as one). Updated to 14.
- PR #7 is absent from the merged PR list -- gap in PR numbering between CCCI (#6) and display (#9) suggests it may have been closed without merging or is a draft. No action taken.