### PR TITLE
fix: resolve 43 lint violations via kanon lint --fix (tier-0)

### DIFF
--- a/docs/ATTRIBUTION.md
+++ b/docs/ATTRIBUTION.md
@@ -39,7 +39,7 @@ Hardcoded domains include: `app-measurement.com`, `googleads.g.doubleclick.net`,
 
 This means: a Chinese OTA framework embeds Google's full advertising and analytics stack. Your "OTA updater" is also an ad platform and telemetry beacon. Adups sends data to their servers in China. Google Analytics/Firebase sends data to Google in the US. Both run on every boot via `BOOT_COMPLETED` receiver.
 
-The `sysoper` companion package has `RecoveryService` and `SysService` — these can flash firmware and trigger recovery mode. Combined with Firebase Cloud Messaging push, this allows remote code execution: push a message to the device, download a payload, flash it via recovery. This is a remote exploitation chain built into the firmware.
+The `sysoper` companion package has `RecoveryService` and `SysService`  -  these can flash firmware and trigger recovery mode. Combined with Firebase Cloud Messaging push, this allows remote code execution: push a message to the device, download a payload, flash it via recovery. This is a remote exploitation chain built into the firmware.
 
 **TYD Technology Co., Ltd.** (天意德科技)
 Packages: `com.tyd.customkey`, `com.tydtech.clean`, `freeme` framework, `com.freeme.provider.badge`, `com.freeme.factory`
@@ -88,7 +88,7 @@ Push-to-talk app. Requires location permission. US-based, subject to US governme
 T9 keyboard input method. Has access to every keystroke. No public information about Marshaltec as a company. A compromised or malicious keyboard captures everything typed: passwords, messages, search queries.
 
 **com.example** (`/vendor/app/AutoDialer/AutoDialer.apk`)
-Package name is literally `com.example` — a placeholder. This is a vendor partition app called "AutoDialer" with a default/test package name. Unknown origin, unknown purpose. The fact that a production device ships with a `com.example` package on the vendor partition suggests minimal QA on the firmware build.
+Package name is literally `com.example`  -  a placeholder. This is a vendor partition app called "AutoDialer" with a default/test package name. Unknown origin, unknown purpose. The fact that a production device ships with a `com.example` package on the vendor partition suggests minimal QA on the firmware build.
 
 ## The dual-exfiltration architecture
 

--- a/docs/DRIVER-INTERFACES.md
+++ b/docs/DRIVER-INTERFACES.md
@@ -1,4 +1,4 @@
-# Driver Interface Specification — MT6739 Hardware Subsystems
+# Driver Interface Specification  -  MT6739 Hardware Subsystems
 
 This document is the hardware interface specification for the eight core driver
 subsystems on the AGM M7 (MediaTek MT6739). It is derived entirely from BSP
@@ -13,8 +13,8 @@ protocol descriptions.
 
 ## Table of Contents
 
-1. [CCCI — Modem Interface](#1-ccci--modem-interface)
-2. [WMT — Connectivity Manager](#2-wmt--connectivity-manager)
+1. [CCCI  -  Modem Interface](#1-ccci--modem-interface)
+2. [WMT  -  Connectivity Manager](#2-wmt--connectivity-manager)
 3. [WiFi gen2](#3-wifi-gen2)
 4. [Bluetooth](#4-bluetooth)
 5. [GPS](#5-gps)
@@ -24,7 +24,7 @@ protocol descriptions.
 
 ---
 
-## 1. CCCI — Modem Interface
+## 1. CCCI  -  Modem Interface
 
 **Source tree:** `eccci/`
 
@@ -32,9 +32,9 @@ CCCI (Cross-Core Communication Interface) manages the AP↔modem link. On
 MT6739 the modem is MD 6293, a separate ARM core. The interface has two
 physical transports:
 
-- **CLDMA** (Communication Link DMA) — high-throughput ring-buffer DMA for
+- **CLDMA** (Communication Link DMA)  -  high-throughput ring-buffer DMA for
   data channels (network, audio, logging).
-- **CCIF** (Cross-Core Interrupt/FIFO) — low-latency mailbox for control
+- **CCIF** (Cross-Core Interrupt/FIFO)  -  low-latency mailbox for control
   messages and exceptions (24 channels, 512-byte SRAM on MT6739).
 
 ### 1.1 Physical Register Map
@@ -54,7 +54,7 @@ physical transports:
 
 Source: `eccci/mt6739/modem_reg_base.h:21–128`
 
-#### CLDMA AO (Always-On) Register Offsets — Power-down backup
+#### CLDMA AO (Always-On) Register Offsets  -  Power-down backup
 
 These live at base `CLDMA_AP_BASE + AO block` and survive power-down.
 
@@ -175,7 +175,7 @@ Source: `eccci/mt6739/ccif_hif_platform.h:27–85`
 
 CCCI shared memory (bank4) is split into two regions.
 
-**Non-cacheable region** — control structures visible to both AP and modem:
+**Non-cacheable region**  -  control structures visible to both AP and modem:
 
 | ID | Name | Purpose |
 |---|---|---|
@@ -187,7 +187,7 @@ CCCI shared memory (bank4) is split into two regions.
 | `DHL_RAW_SHARE_MEMORY` | DHLogger raw | |
 | `MD_CONSYS_SHARE_MEMORY` | Modem-consys shared | |
 
-**Cacheable region** — bulk data:
+**Cacheable region**  -  bulk data:
 
 | ID | Name | Purpose |
 |---|---|---|
@@ -280,7 +280,7 @@ Full list is in `eccci/inc/ccci_core.h:46+`. Key channels:
 needed, read `CLDMA_AP_L3TISAR0/1` or `L3RISAR0/1` for per-queue detail.
 Mask future interrupts by writing to `L2TIMCR0` / `L2RIMCR0`.
 
-**CCIF IRQ** (two IRQs — one per direction): Read `APCCIF_RCHNUM` to get the
+**CCIF IRQ** (two IRQs  -  one per direction): Read `APCCIF_RCHNUM` to get the
 set of triggered MD→AP channels. Write the bitmask to `APCCIF_ACK` to clear.
 Dispatch by channel number.
 
@@ -289,7 +289,7 @@ Force dump via CCIF exception channels, then full chip reset.
 
 ---
 
-## 2. WMT — Connectivity Manager
+## 2. WMT  -  Connectivity Manager
 
 **Source tree:** `connectivity/common/common_main/`
 
@@ -310,7 +310,7 @@ firmware loading, and the STP (Serial Transport Protocol) multiplexer.
 
 Source: `connectivity/common/common_main/platform/include/mt6739.h:72–75`
 
-### 2.2 SPM Power Control Register — `CONSYS_TOP1_PWR_CTRL_REG` (`0xF000632C`)
+### 2.2 SPM Power Control Register  -  `CONSYS_TOP1_PWR_CTRL_REG` (`0xF000632C`)
 
 | Bit | Name | Function |
 |---|---|---|
@@ -337,7 +337,7 @@ Source: `connectivity/common/common_main/platform/include/mt6739.h:122–128`
 | `CONSYS_TOPAXI_PROT_EN` | `TOPCKGEN + 0x1220` | bits 13,14 | AXI bus protect |
 | `CONSYS_TOPAXI_PROT_STA1` | `TOPCKGEN + 0x1228` | bits 13,14 | AXI protect status |
 | `CONSYS_MCU_CFG_ACR_REG` | `CONN_MCU + 0x110` | bit 18 = MBIST | ACR register |
-| `CONSYS_EMI_MAPPING` | `TOPCKGEN + 0x1380` | — | EMI remapping |
+| `CONSYS_EMI_MAPPING` | `TOPCKGEN + 0x1380` |  -  | EMI remapping |
 | `CONSYS_AP2CONN_OSC_EN_REG` | `TOPCKGEN + 0x1800` | bit 10 = OSC_EN, bit 9 = WAKEUP | OSC enable |
 
 Source: `connectivity/common/common_main/platform/include/mt6739.h:83–158`
@@ -362,8 +362,8 @@ The CONSYS firmware region in external RAM:
 
 | Region | Physical Base | Size | Purpose |
 |---|---|---|---|
-| Firmware base | `0xF0080000` | — | CONSYS MCU firmware load target |
-| Paged trace | `FW_BASE + 0x400` | — | Live trace ring |
+| Firmware base | `0xF0080000` |  -  | CONSYS MCU firmware load target |
+| Paged trace | `FW_BASE + 0x400` |  -  | Live trace ring |
 | Paged dump | `FW_BASE + 0x8400` | 32 KB | Crash paged dump |
 | Full dump (DLM) | `FW_BASE + 0x10400` | 0x1F000 | Full core dump |
 | Full dump SYSB2 | DLM end | 0x6800 | |
@@ -496,8 +496,8 @@ Source: `connectivity/wlan/gen2/os/linux/hif/ahb/include/hif_pdma.h`
 | Packet length | [15:0] | Total TX packet byte length |
 | Packet type | [1:0] of word1 | 0=data, 1=command |
 | User priority | [4:2] | WMM UP 0–7 |
-| Resource mask | — | TX resource allocation hint |
-| Port index | — | Target TX queue |
+| Resource mask |  -  | TX resource allocation hint |
+| Port index |  -  | Target TX queue |
 
 `static_assert(sizeof(HIF_TX_HEADER_T) == 16)`
 
@@ -508,13 +508,13 @@ Source: `connectivity/wlan/gen2/include/nic/hif_tx.h`
 | Field | Bits | Description |
 |---|---|---|
 | Packet length | [15:0] | RX packet byte length |
-| Packet type | — | 0=data, others=event |
-| Network index | — | BSS index (0..3) |
+| Packet type |  -  | 0=data, others=event |
+| Network index |  -  | BSS index (0..3) |
 | TID | [3:0] | Traffic ID (AC) |
-| Security mode | — | WEP/TKIP/CCMP etc. |
+| Security mode |  -  | WEP/TKIP/CCMP etc. |
 | 802.11 header present | bit | Whether 802.11 header is in payload |
 | Reorder flag | bit | Needs BA reorder |
-| Channel number | — | Raw HW channel (2.4G: 1–14, 5G: 36–165) |
+| Channel number |  -  | Raw HW channel (2.4G: 1–14, 5G: 36–165) |
 
 `static_assert(sizeof(HIF_RX_HEADER_T) == 12)`
 
@@ -620,7 +620,7 @@ BT is STP function type 0. All HCI packets are encapsulated in STP frames
 
 1. STP delivers a complete frame from the receive ring.
 2. `mtk_wcn_stp_receive_data()` copies into `i_buf[2048]`.
-3. Userspace reads via `read()` — blocks on `BT_wq` wait queue.
+3. Userspace reads via `read()`  -  blocks on `BT_wq` wait queue.
 4. Write path: `mtk_wcn_stp_send_data()` wraps the HCI payload in an STP frame
    and queues it to the BTIF UART.
 
@@ -667,7 +667,7 @@ Power control modes: `GPS_PWRCTL_OFF`, `GPS_PWRCTL_ON`, `GPS_PWRCTL_RST`,
 
 Source: `connectivity/gps/gps.h`
 
-### 5.2 Frequency Hopping — MT6739
+### 5.2 Frequency Hopping  -  MT6739
 
 MT6739 requires frequency hopping mitigation for GPS. The GPS driver registers
 with the FH (Frequency Hopping) subsystem using `FH_MEM_PLLID` to configure
@@ -694,7 +694,7 @@ STP command channel.
 
 ### 5.5 MT3337 Standalone GPS (`gps_mt3337.c`)
 
-Alternate driver for the standalone MT3337 GPS chip over UART — not used when
+Alternate driver for the standalone MT3337 GPS chip over UART  -  not used when
 CONSYS STP GPS is active.
 
 ---

--- a/docs/KERNEL-BUILD.md
+++ b/docs/KERNEL-BUILD.md
@@ -4,7 +4,7 @@ MT6739 Linux 4.4 BSP kernel for AGM M7, compiled from `kernel-wiite/` (cateajans
 
 ---
 
-## W1-02 — Stock config + USB serial initramfs
+## W1-02  -  Stock config + USB serial initramfs
 
 **Status:** Built. `boot-v2.img` at `~/thumos/boot-v2.img`. Not yet flashed.
 
@@ -13,7 +13,7 @@ MT6739 Linux 4.4 BSP kernel for AGM M7, compiled from `kernel-wiite/` (cateajans
 | Item | W1-01 | W1-02 |
 |------|-------|-------|
 | Base config | `hct6739_36_n1_defconfig` | `kernel-config-stock` (extracted from `/proc/config.gz` on running device) |
-| LCM driver | `hct_ili9881p_dsi_vdo_hdp_panda_55_hz` (wrong DSI placeholder) | `gc9306_dbi_c_qvgal` (correct DBI panel, stub — source absent from BSP) |
+| LCM driver | `hct_ili9881p_dsi_vdo_hdp_panda_55_hz` (wrong DSI placeholder) | `gc9306_dbi_c_qvgal` (correct DBI panel, stub  -  source absent from BSP) |
 | Initramfs | Shell only | Shell + USB serial gadget (ACM) |
 | CMDLINE | `console=ttyMT0` only | `console=ttyMT0,921600n1 vmalloc=496M` |
 | FPSGO | Disabled | Disabled (same root cause: undefined FBT game symbols) |
@@ -45,18 +45,18 @@ the stock system partition (`/system/lib/hw/` or display HAL) in a future sprint
 |--------|-------|-------|--------|
 | `CONFIG_CROSS_COMPILE` | `"arm-eabi-"` | `"arm-linux-gnueabihf-"` | Installed toolchain |
 | `CONFIG_HARDENED_USERCOPY` | `y` | disabled | `mm/slub.c` references `kmem_cache.red_left_pad` which is absent from this BSP's `slub_def.h` (kernel version skew) |
-| `CONFIG_MTK_FPSGO` | `y` | disabled | FBT game symbols (`min_boost_freq`, `cpufreq_notifier_fp`) undefined — same issue as W1-01 |
+| `CONFIG_MTK_FPSGO` | `y` | disabled | FBT game symbols (`min_boost_freq`, `cpufreq_notifier_fp`) undefined  -  same issue as W1-01 |
 | `CONFIG_USB_C_SWITCH` | `y` | disabled | `register_typec_switch_callback` defined only in Type-C chip drivers (MT6336/ANX7418), none of which are built; AGM M7 uses micro-USB |
 | `CONFIG_BUILD_ARM_APPENDED_DTB_IMAGE_NAMES` | `"mt6739"` | `"hct6739_36_n1"` | No `mt6739.dts` in BSP; `hct6739_36_n1.dts` is the only MT6739 DTS |
 
 #### New code patches (kernel-wiite in-tree edits)
 
-**drivers/usb/gadget/function/u_ether.c — missing rndis.h include**
+**drivers/usb/gadget/function/u_ether.c  -  missing rndis.h include**
 
 `u_ether.c` uses `sizeof(struct rndis_packet_msg_type)` but did not include `rndis.h`,
 causing an "incomplete type" compile error. Fixed by adding `#include "rndis.h"`.
 
-**drivers/misc/mediatek/lcm/mt65xx_lcm_list.h — gc9306 registration**
+**drivers/misc/mediatek/lcm/mt65xx_lcm_list.h  -  gc9306 registration**
 
 Added `extern LCM_DRIVER gc9306_dbi_c_qvgal_lcm_drv` and the corresponding
 `#if defined(GC9306_DBI_C_QVGAL)` entry in `lcm_driver_list[]`.
@@ -180,7 +180,7 @@ Cmdline:       bootopt=64S3,32S1,32S1 console=ttyMT0,921600n1 root=/dev/ram vmal
 
 ---
 
-# W1-01 — First boot attempt (wrong LCM driver)
+# W1-01  -  First boot attempt (wrong LCM driver)
 
 ## Environment
 
@@ -244,7 +244,7 @@ cat arch/arm/boot/zImage arch/arm/boot/dts/hct6739_36_n1.dtb \
 
 All patches are in-tree edits; none are separate patch files.
 
-### scripts/dtc/Makefile — dtc yylloc multiple definition
+### scripts/dtc/Makefile  -  dtc yylloc multiple definition
 
 GCC 13 / GNU AS 2.44 rejects the `yylloc` symbol appearing in both `.lex.o` and `.tab.o`. Fix:
 
@@ -253,11 +253,11 @@ HOSTCFLAGS_dtc-lexer.lex.o  := $(HOSTCFLAGS_DTC) -fcommon
 HOSTCFLAGS_dtc-parser.tab.o := $(HOSTCFLAGS_DTC) -fcommon
 ```
 
-### arch/arm/ — ARM assembly `#alloc`/`#execinstr` section flags
+### arch/arm/  -  ARM assembly `#alloc`/`#execinstr` section flags
 
 GNU AS 2.44 rejects the historic `#alloc`, `#execinstr` section flag syntax in `.section` directives. Changed all 33 occurrences across `arch/arm/` to string form (`"a"` / `"ax"`).
 
-### arch/arm/Makefile — global MTK include paths + armv7-a march
+### arch/arm/Makefile  -  global MTK include paths + armv7-a march
 
 GCC 13 evaluates `cc-option(-march=armv7-a)` against `arm-linux-gnueabihf-gcc` whose default `-mfloat-abi=hard` causes the test to fail with a hard-float/soft-float ABI mismatch, making the Makefile fall back to `-march=armv5t`. GCC 13 then emits `.arch armv5t` in assembly output, overriding the `-Wa,-march=armv7-a` assembler flag and breaking DSB/ISB instructions.
 
@@ -282,7 +282,7 @@ KBUILD_CFLAGS += -I$(srctree)/drivers/misc/mediatek/mmp
 
 **Note:** `videox/` and `dispsys/` are intentionally NOT added globally. Adding them caused `videox/debug.h` to shadow `gen2/include/debug.h` for the WiFi driver, breaking the `DBGLOG`/`ASSERT` macros. These paths are added per-driver instead (see below).
 
-### drivers/misc/mediatek/connectivity/wlan/gen2/Makefile — absolute include paths
+### drivers/misc/mediatek/connectivity/wlan/gen2/Makefile  -  absolute include paths
 
 The gen2 WiFi driver Makefile used `$(src)` for include paths, which resolves incorrectly when objects in subdirectories (hif/ahb/) are compiled from the parent Makefile. Replaced with absolute `$(srctree)` paths:
 
@@ -294,7 +294,7 @@ ccflags-y += -I$(GEN2_DIR)/os -I$(GEN2_DIR)/os/linux/include \
              -I$(GEN2_DIR)/include/mgmt
 ```
 
-### drivers/misc/mediatek/video/mt6739/videox/Makefile — self-include path
+### drivers/misc/mediatek/video/mt6739/videox/Makefile  -  self-include path
 
 `videox/` was missing itself from its own include path. When dispsys headers (included by videox source files) in turn include other videox headers (e.g., `disp_drv_log.h` → `display_recorder.h`), the videox directory was not in the search path. Added:
 
@@ -302,7 +302,7 @@ ccflags-y += -I$(GEN2_DIR)/os -I$(GEN2_DIR)/os/linux/include \
 -I$(srctree)/drivers/misc/mediatek/video/$(MTK_PLATFORM)/videox/
 ```
 
-### drivers/misc/mediatek/video/mt6739/dispsys/Makefile — self-include path
+### drivers/misc/mediatek/video/mt6739/dispsys/Makefile  -  self-include path
 
 Same issue: dispsys files include each other via videox-mediated chains. Added:
 
@@ -310,19 +310,19 @@ Same issue: dispsys files include each other via videox-mediated chains. Added:
 -I$(srctree)/drivers/misc/mediatek/video/$(MTK_PLATFORM)/dispsys/
 ```
 
-### arch/arm/boot/dts/cust.dtsi — stub (replaces DrvGen output)
+### arch/arm/boot/dts/cust.dtsi  -  stub (replaces DrvGen output)
 
 `DrvGen.py` requires Python 2 to generate `cust.dtsi` from `hct6739_36_n1.dws`. Python 2 is unavailable. Created a minimal stub:
 
 ```c
-/* stub — GPIO/EINT bindings absent; hardware drivers won't probe */
+/* stub  -  GPIO/EINT bindings absent; hardware drivers won't probe */
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/interrupt-controller/arm-gic.h>
 ```
 
 Hardware drivers that rely on DTS GPIO bindings will not probe on boot, but the kernel boots.
 
-### vendor/haocheng/drivers/hct_include/hct_project_all_config.h — stub
+### vendor/haocheng/drivers/hct_include/hct_project_all_config.h  -  stub
 
 `include/linux/hct_include` is a broken symlink to `../../../vendor/haocheng/drivers/hct_include`. Created the target directory and a stub header to satisfy `lcm_i2c.h`.
 
@@ -391,7 +391,7 @@ adb shell dd if=/sdcard/boot.img of=/dev/block/platform/*/by-name/boot
 fastboot boot ~/thumos/boot.img   # test without flashing
 ```
 
-## Known Limitations (W1-01 — superseded by W1-02)
+## Known Limitations (W1-01  -  superseded by W1-02)
 
 - **LCM**: `hct_ili9881p_dsi_vdo_hdp_panda_55_hz` is a placeholder. The AGM M7's actual panel (nt35521) driver is absent from this BSP. Display will not initialize; boot console only.
 - **GPIO/EINT**: `cust.dtsi` is a stub (no DrvGen output). Drivers that depend on GPIO bindings will not probe.

--- a/docs/PROBE.md
+++ b/docs/PROBE.md
@@ -219,7 +219,7 @@ Unlocked via mtkclient BROM exploit. The fastboot  button confirmation is non-fu
 | Module | Size | Purpose |
 |--------|------|---------|
 | wlan_drv_gen2 | 1.0 MB | WiFi driver (MT6739 integrated) |
-| wmt_drv | 919 KB | Wireless Management Task — connectivity core |
+| wmt_drv | 919 KB | Wireless Management Task  -  connectivity core |
 | fmradio_drv | 135 KB | FM radio receiver driver |
 | bt_drv | 12 KB | Bluetooth driver |
 | gps_drv | 11 KB | GPS driver |

--- a/docs/SURVEILLANCE-AUDIT.md
+++ b/docs/SURVEILLANCE-AUDIT.md
@@ -112,7 +112,7 @@ Freeme OS is a Chinese Android customization framework (similar to MIUI, ColorOS
 | 21.28.129.209:42318 | 10.166.154.5:5060 | TCP | Carrier IMS/SIP (VoLTE) |
 | 21.28.129.209:50001 | 10.166.154.5:65529 | TCP | Carrier IMS control |
 
-Only carrier IMS traffic observed. WiFi was connected but no outbound connections to surveillance infrastructure during the probe window. This does not mean no exfiltration occurs — Adups typically exfiltrates on a 72-hour cycle, and the device may have been recently powered on.
+Only carrier IMS traffic observed. WiFi was connected but no outbound connections to surveillance infrastructure during the probe window. This does not mean no exfiltration occurs  -  Adups typically exfiltrates on a 72-hour cycle, and the device may have been recently powered on.
 
 ## Conclusion
 


### PR DESCRIPTION
Deterministic fixes by `kanon lint --fix`. No LLM, no GPU.
**Fixed:** 43 | **Before:** 1412 | **After:** 1369
Gate-Passed: kanon 0.1.0