### PR TITLE
sync(standards): update GNOMON.md from kanon canonical

### DIFF
--- a/standards/AGENT-DOCS.md
+++ b/standards/AGENT-DOCS.md
@@ -1,0 +1,194 @@
+# Agent docs
+
+> Standards for repository context files: CLAUDE.md, AGENTS.md, llms.txt, and similar static instruction files read by agent harnesses. Provider-agnostic principles that apply to any AI coding agent.
+
+**Scope:** Static context files checked into repositories or placed in user config directories. Does not cover API prompt construction (system messages, user messages, tool calls); see [PROMPTING.md](PROMPTING.md) for those.
+
+---
+
+## Principle
+
+Agent context files are instructions, not documentation. Every line costs tokens and competes for attention with the agent's built-in behavior. The goal is to change agent behavior on things it would otherwise get wrong -- not to describe the codebase.
+
+---
+
+## Inclusion filter
+
+Before adding any content, it must pass all four criteria:
+
+1. **Not discoverable** -- the agent cannot find this from README, configs, help commands, or reading code
+2. **Actionable** -- the agent can execute a specific action based on this instruction
+3. **Prevents silent failure** -- without this, the agent would produce a plausible but wrong result
+4. **Broadly applicable** -- this applies to most tasks, not just edge cases
+
+Content that fails any criterion does not belong in the context file.
+
+---
+
+## File types and placement
+
+### CLAUDE.md (Claude Code)
+
+Tool-specific context for Claude Code sessions. Loaded automatically from:
+- `~/.claude/CLAUDE.md` -- global (all sessions)
+- `./CLAUDE.md` -- project root (checked into git)
+- Parent directories -- monorepo support
+- Child directories -- loaded when agent works in that directory
+
+### AGENTS.md (cross-tool standard)
+
+Open standard (agents.md, Linux Foundation). Read by Claude Code, Cursor, Windsurf, Copilot, Codex, Jules, and others. Place at project root or any subdirectory -- closest file to edited code takes precedence.
+
+Use AGENTS.md for cross-tool content. Use CLAUDE.md for Claude Code-specific features (hooks, skills, Claude-specific behavioral directives).
+
+### llms.txt (website/documentation)
+
+Navigation index for LLMs consuming documentation sites. Not for code repos -- for websites. Format:
+- H1: project name
+- Blockquote: summary
+- H2 sections: lists of `[name](url): description` links
+- `/llms.txt` for navigation, `/llms-full.txt` for full content
+
+---
+
+## Structure
+
+### Required sections (in this order)
+
+**1. Non-standard tooling** -- commands the agent cannot guess
+
+```markdown
+## Commands
+- Build: `cargo build --release`
+- Test: `cargo nextest run --workspace`
+- Lint: `kanon lint . --summary`
+- Gate: `kanon gate` (must pass before pushing)
+```
+
+This is the single highest-value section. ETH Zurich research shows agents use mentioned tools 2.5x more often. Repository-specific tools (`kanon`, `uv`, custom scripts) see 1.6x usage increase.
+
+**2. Non-obvious rules** -- things the agent would get wrong
+
+```markdown
+## Rules
+- Use `#[expect(lint, reason = "...")]` not `#[allow]` -- because #[expect] warns when the suppression becomes stale
+- All PRs need `Gate-Passed: kanon 0.1.0` in the commit body -- the CI verify-gate check requires this
+- Desktop crate is excluded from workspace -- build standalone with `cargo check -p theatron-desktop`
+```
+
+Every rule explains WHY. Without the explanation, the agent follows the rule rigidly but cannot generalize to novel situations.
+
+**3. Architecture decisions** -- non-obvious structural choices
+
+Only include decisions the agent would violate without knowing:
+
+```markdown
+## Architecture
+- Errors: snafu with .context() and Location tracking (not thiserror, not anyhow)
+- IDs: newtypes for all domain IDs (not raw String/u64)
+- Async: Tokio actor model, not shared mutable state
+```
+
+Do NOT include: crate-by-crate descriptions, file trees, module maps. Agents explore codebases well without guidance.
+
+**4. Boundaries** -- three-tier permission framework
+
+```markdown
+## Boundaries
+Always: run cargo fmt before committing, stay within blast radius
+Ask first: changes to public API surface, database migrations
+Never: push to upstream, delete branches without checking, use --admin to bypass CI
+```
+
+### Optional sections
+
+**Code examples** -- one concrete example outperforms lengthy descriptions. Show the desired pattern, not a paragraph explaining it.
+
+**Environment quirks** -- required env vars, PATH additions, platform-specific setup that would cause silent failure.
+
+**Testing specifics** -- non-standard test runners, required flags, fixtures that must exist.
+
+---
+
+## Size limits
+
+| Scope | Target | Maximum |
+|-------|--------|---------|
+| Always-loaded root file | Under 100 lines | 300 lines |
+| Per-crate/per-directory file | Under 50 lines | 100 lines |
+| Combined across all loaded files | Under 200 lines | 500 lines |
+
+Research shows agent performance degrades when context files exceed ~500 words in always-loaded mode. The agent's system prompt already contains ~50 instructions -- every additional instruction competes for adherence.
+
+---
+
+## Voice
+
+General prompt voice rules (positive over negative, WHY on every rule, dial back aggressive emphasis) apply here too -- see [PROMPTING.md § Voice](PROMPTING.md#voice). The following are specific to context files:
+
+- **Direct and terse** -- every word costs tokens in always-loaded files; context files compete for attention more than one-shot prompts
+- **Concrete over abstract** -- "run `kanon gate`" not "ensure CI passes" because agents cannot act on vague instructions without additional lookup
+- **Imperative mood** -- "add tests for new public functions" not "tests should be added" because imperative framing maps directly to agent actions
+
+---
+
+## Anti-patterns
+
+- **Codebase overviews** -- agents navigate codebases well without guidance. Over 90% of files with overviews showed no measurable navigation improvement.
+- **LLM-generated content** -- ETH Zurich research shows LLM-generated context files reduce success rates by 3% while increasing cost 20%+. Manually craft every line.
+- **Linter-enforceable rules** -- use actual linters and hooks. Asking an agent to check formatting wastes context on something a tool does better.
+- **README duplication** -- if it's in the README, package.json, or config files, agents already find it.
+- **Generic boilerplate** -- "write clean code", "follow best practices", "be thorough" are noise. Agents already try to do these things.
+- **Task-specific workarounds** -- context files are loaded for every session. Content that applies to one task wastes tokens on all others.
+- **Frequent updates** -- if content changes weekly, it doesn't belong in a context file. Use dynamic injection (MCP, tools) instead.
+
+---
+
+## Per-crate CLAUDE.md template
+
+For subdirectory context files in monorepos:
+
+```markdown
+# {crate-name}
+
+{One-sentence purpose.}
+
+## Commands
+- Check: `cargo check -p {crate-name}`
+- Test: `cargo test -p {crate-name}`
+
+## Gotchas
+- {Thing that would cause silent failure if not known}
+```
+
+Under 30 lines. Only include what passes the 4-question filter.
+
+---
+
+## llms.txt template
+
+```markdown
+# Project Name
+
+> One-sentence project description with key technical details.
+
+## Documentation
+- [Architecture](docs/ARCHITECTURE.md): crate dependencies and data flow
+- [API Reference](docs/API.md): HTTP endpoints and CLI commands
+- [Deployment](docs/DEPLOYMENT.md): setup and configuration
+
+## Optional
+- [Changelog](CHANGELOG.md): version history
+- [Contributing](CONTRIBUTING.md): development workflow
+```
+
+---
+
+## Verification
+
+After writing or updating an agent context file:
+
+1. Read it as if you know nothing about the project -- is every instruction actionable without additional context?
+2. For each line: does it pass all 4 inclusion criteria? Remove if not.
+3. Check line count against limits. If over, prioritize by failure severity -- which instructions prevent the worst mistakes?
+4. Test with a fresh agent session -- does the agent follow the instructions? If not, the file is too long or the instructions are too vague.

--- a/standards/ARCHITECTURE.md
+++ b/standards/ARCHITECTURE.md
@@ -66,21 +66,17 @@ Explicit re-exports over wildcards. `pub use types::Fact;` not `pub use types::*
 
 ## Error boundaries
 
+See STANDARDS.md § Error Handling for universal principles (exhaustive types, boundary conversion, context propagation).
+
 ### One error type per crate
 
 Each library crate defines one `Error` enum (or struct). The binary crate uses `anyhow` for top-level aggregation. Library crates never use `anyhow`.
 
 ### Context at every boundary
 
-When an error crosses a crate boundary, wrap it with context. The caller should see what the callee was trying to do, not just what went wrong.
-
 ```rust
 store.open(&path).context(OpenStoreSnafu { path })?;
 ```
-
-### No error enum explosion
-
-If a crate has 30+ error variants, consider whether a structured diagnostic (single struct with severity + message + trace) would scale better than an enum. Enums are good for 5-15 variants. Beyond that, they become maintenance burden.
 
 ---
 
@@ -93,6 +89,149 @@ Configuration flows through function parameters or trait implementations, not gl
 ### Feature flags for optional capabilities
 
 Heavy dependencies (ML models, GUI frameworks, optional integrations) go behind feature flags. A minimal `cargo build` compiles only the core. Default features include what most users need. Optional features require explicit opt-in.
+
+---
+
+## Feature flag propagation policy
+
+Feature flags are architectural decisions. A poorly propagated flag silently compiles out functionality, creates untested code paths, and blocks refactors. This section covers compile-time Cargo features. For runtime feature flags (config/env var toggling), see ENVIRONMENT.md § Feature flags.
+
+### Compile-time vs runtime feature flags
+
+Use compile-time flags (`#[cfg(feature = "...")]`) when the flag controls which code is compiled. Use runtime flags (config values) when the flag controls which code path executes.
+
+**Compile-time flags are correct when:**
+
+- The feature pulls in heavy dependencies that most users don't need. WHY: dependencies that aren't compiled don't affect build time or binary size. A runtime check still links the dependency.
+- The feature is platform-specific or requires system libraries not universally available. WHY: the code won't compile on platforms without the library. A runtime check would fail at link time.
+- The feature gates test infrastructure (`test-support`). WHY: production binaries must not ship mock providers or test fixtures.
+
+**Runtime flags are correct when:**
+
+- The feature is experimental behavior that needs gradual rollout or quick rollback. WHY: recompiling and redeploying to toggle a flag is too slow for operational response.
+- The feature gates a code path where both sides compile against the same dependencies. WHY: compile-time gating adds conditional compilation complexity for no binary size or build time benefit.
+- The flag must change per-environment without rebuilding. WHY: the same binary must run in dev, staging, and production with different behavior.
+
+Do not mix the two. A feature that requires a compile-time dependency but is toggled at runtime needs both: a compile-time flag for the dependency and a runtime flag for activation. The compile-time flag gates availability; the runtime flag gates use.
+
+### Propagation across crate boundaries
+
+Cargo features are additive and workspace-wide. A feature enabled by any crate in the dependency tree is enabled for all crates that depend on that package. This means feature flags propagate upward — and mistakes propagate silently.
+
+**Rule: features propagate through explicit forwarding, never through default features of dependencies. Transitive propagation is the default — if crate C depends on B which depends on A, and B forwards A's feature `foo` as `b/foo`, then C must forward it as `c/foo = ["b/foo"]` to make it available to its own consumers.**
+
+The crate that owns the functionality defines the feature. Every crate above it in the dependency graph that needs to expose the feature re-exports it by forwarding:
+
+```toml
+# crates/phronesis/Cargo.toml (owns the feature)
+[features]
+cron_scheduler = ["dep:uuid", "dep:fd-lock"]
+
+# crates/kanon-cli/Cargo.toml (forwards the feature)
+[features]
+cron_scheduler = ["phronesis/cron_scheduler"]
+```
+
+WHY: forwarding makes the propagation chain visible in `Cargo.toml`. If `kanon-cli` doesn't forward `cron_scheduler`, the feature is invisible from the binary crate and cannot be enabled by the end user. If it's hidden inside a `default` feature of a mid-layer crate, the end user can't disable it.
+
+**Rules for propagation:**
+
+1. **Define features in the lowest crate that implements the gated code.** Higher crates forward; they don't redefine. WHY: feature definitions in high-level crates that conditionally import low-level code invert the dependency direction.
+
+2. **Never add features to `default` that pull in optional dependencies.** Default features are for the common case. Heavy or experimental dependencies require explicit opt-in at the top of the chain. WHY: `default-features = false` in one dependency doesn't cascade — any other dependency that enables the same crate with default features will re-enable them.
+
+3. **Name features after the capability, not the dependency.** `cron_scheduler`, not `uuid`. WHY: the dependency is an implementation detail. If you swap `uuid` for `ulid`, every `Cargo.toml` in the chain must change its feature name if the feature was named after the dependency.
+
+4. **Document the forwarding chain.** Each crate's `CLAUDE.md` lists its features and which downstream features they activate. WHY: `cargo tree -e features` shows the resolved graph but not the intent.
+
+**Exception: internal-only features.** Features that exist solely for the crate's own test or build infrastructure — `test-support`, `test-utils`, `_internal` — do not need forwarding. These features are never meaningful to downstream consumers and exposing them pollutes the public feature surface. If a feature is internal-only, name it with a `test-` prefix or `_internal` suffix to signal intent. WHY: forwarding a test fixture feature to a binary crate serves no purpose and creates a maintenance burden with no consumer benefit.
+
+### Auditing feature propagation
+
+Run `cargo tree -f '{p} {f}'` to display each package with its resolved features. This shows what is actually enabled, not what is declared. Compare against `Cargo.toml` forwarding entries to find:
+
+- **Missing propagation:** a dependency's feature is enabled via `features = ["foo"]` in `[dependencies]` but the consuming crate has no corresponding `foo = ["dep/foo"]` in its own `[features]` section.
+- **Dead features:** a feature is declared in `[features]` but never activated by any path in the workspace.
+- **Implicit activation:** a feature is enabled via a transitive dependency's `default` features rather than explicit forwarding.
+
+```bash
+# Show all packages and their resolved features
+cargo tree -f '{p} {f}'
+
+# Show the feature graph specifically
+cargo tree -e features
+
+# Check a specific feature's activation path
+cargo tree -f '{p} {f}' -i crate_name
+```
+
+### Feature flag testing
+
+Untested feature combinations are untested code. Compile-time flags create a combinatorial matrix of possible builds — each combination is a distinct program.
+
+**Minimum test matrix:**
+
+- **All features off** (minimal build). Confirms the core compiles and runs without optional functionality.
+- **All features on** (maximal build). Confirms no feature combinations conflict.
+- **Each feature individually on** (isolation). Confirms each feature is self-contained and doesn't implicitly depend on another feature being enabled.
+
+```yaml
+# CI matrix example
+strategy:
+  matrix:
+    features: ["", "--all-features", "--features cron_scheduler"]
+```
+
+WHY: the most common feature flag bug is code inside `#[cfg(feature = "A")]` that calls a function only available under `#[cfg(feature = "B")]`. This compiles when both are enabled (the "all features" case every developer uses) and fails only when A is enabled without B — a configuration no one tests until a user hits it.
+
+**Guard every `#[cfg(feature)]` block with a corresponding test under the same gate:**
+
+```rust
+#[cfg(feature = "cron_scheduler")]
+mod cron;
+
+#[cfg(test)]
+#[cfg(feature = "cron_scheduler")]
+mod cron_tests {
+    // Tests that exercise the cron module
+}
+```
+
+WHY: tests that are not behind the same feature gate run (and pass vacuously) even when the feature is off, giving false confidence.
+
+**CI must run the minimal feature set as its first check.** If the minimal build fails, the feature boundary is broken. Catching this early prevents the common failure mode where every developer builds with `--all-features` and breakage only surfaces when a user uses the default feature set.
+
+### Feature flag deprecation lifecycle
+
+Feature flags are not permanent. Every flag has a lifecycle: experimental, stable, deprecated, removed. Flags that linger become load-bearing and impossible to remove.
+
+**Lifecycle stages:**
+
+1. **Experimental.** Feature is behind a non-default flag. Documentation marks it as unstable. API may change without a major version bump. WHY: the flag boundary isolates instability from the stable surface.
+
+2. **Stable.** Feature has shipped for at least one release cycle without breaking changes. Move it to default features if it serves the common case. If it's niche, leave it as opt-in but remove the "experimental" marker. WHY: features that stay non-default forever accumulate. Each non-default feature is a CI matrix entry and a documentation burden.
+
+3. **Deprecated.** The feature is scheduled for removal. Add a `#[deprecated]` attribute to the feature's public API surface. Emit a compile-time warning using `#[cfg_attr]`:
+
+    ```rust
+    #[cfg(feature = "old_provider")]
+    #[deprecated(since = "0.8.0", note = "use `new_provider` feature instead")]
+    pub mod old_provider;
+    ```
+
+    Document the removal timeline in CHANGELOG. Keep the feature functional for one release cycle minimum. WHY: downstream users need time to migrate.
+
+4. **Removed.** Delete the feature from `Cargo.toml`, remove all `#[cfg(feature)]` blocks, and remove the forwarding entries from every crate in the chain. Do not leave dead `cfg` blocks. WHY: a feature entry in `Cargo.toml` with no gated code is misleading. A `cfg` block with no corresponding feature silently compiles out.
+
+**Every feature flag added must have an owner and a target lifecycle stage.** Add a comment in the defining crate's `Cargo.toml`:
+
+```toml
+[features]
+# Experimental — owner: @ck — target: default or remove by 0.9.0
+cron_scheduler = ["dep:uuid", "dep:fd-lock"]
+```
+
+WHY: features without owners become permanent. Features without timelines never graduate or get removed.
 
 ---
 
@@ -185,6 +324,189 @@ Define traits in the lowest common crate. Implement concretely in the binary. Mo
 Register cleanup callbacks at setup time, not drop time. Drop order depends on field declaration order (fragile). Async cleanup in Drop is impossible.
 
 Pattern: explicit callback list registered during initialization, executed in declared order during graceful shutdown.
+
+---
+
+## Trait boundaries
+
+Traits are the primary mechanism for enforcing module boundaries, enabling extension, and controlling coupling. Use them deliberately. A trait with one implementation is overhead; a trait at the wrong layer is a dependency magnet.
+
+### When to use a trait
+
+Define a trait when there are (or will be) multiple implementations behind a single call site. Concrete patterns that justify traits:
+
+- **Plugin registries.** A registry stores `Box<dyn T>` and iterates over heterogeneous implementations. Gate checks, reaction handlers, behavioral rules, and agent providers all follow this pattern. WHY: the registry must accept types it doesn't know about at compile time.
+- **Dependency inversion across layers.** A lower crate defines the trait; a higher crate implements it. The lower crate never imports the higher crate. WHY: this is the only way to depend on behavior from a higher layer without creating a circular dependency.
+- **System abstractions.** Filesystem, time, network, and process operations go through traits so tests can substitute deterministic implementations. WHY: real I/O in unit tests is slow, flaky, and non-reproducible.
+- **Replaceability boundaries.** External SDKs and APIs get wrapped in traits so the codebase is not structurally coupled to a vendor. WHY: vendors change APIs, get deprecated, or need swapping under deadline pressure.
+
+### When NOT to use a trait
+
+- **Single implementation with no planned second.** Use a concrete struct. If a second implementation materializes later, extract the trait then. Premature abstraction costs more than the refactor.
+- **Internal module boundaries.** Modules within a crate communicate through concrete types, not traits. WHY: intra-crate coupling is expected. Traits add indirection without isolation benefit when both sides compile together.
+- **Configuration differences.** Two behaviors that differ only in config values are one struct with different field values, not two trait implementations.
+
+### Trait object (`dyn Trait`) vs generics (`T: Trait`)
+
+Choose based on whether the concrete type is known at the call site.
+
+**Use trait objects (`dyn Trait`) when:**
+
+- A collection holds heterogeneous implementations. `Vec<Box<dyn GateCheck>>`, `HashMap<String, Arc<dyn AgentProvider>>`. WHY: generics require homogeneous collections; trait objects allow mixed types.
+- The caller does not and should not know the concrete type. Plugin registries, handler dispatch loops, and provider resolution all operate on trait objects. WHY: the whole point is runtime polymorphism.
+- The trait crosses an async boundary and the future is not `Send`. Return `Pin<Box<dyn Future<Output = T> + 'a>>` explicitly. WHY: native `async fn` in traits is dyn-incompatible when the returned future must be stored or dispatched.
+
+**Use generics (`T: Trait`) when:**
+
+- The concrete type is known at the call site and there's one type per instantiation. `fn print_progress<W: Write>(w: &mut W, ...)`. WHY: monomorphization eliminates vtable overhead and enables inlining.
+- The function is called in a hot path. WHY: dynamic dispatch has a per-call cost (vtable load + indirect branch) that matters at scale.
+- The caller benefits from knowing the concrete type (e.g., for method chaining or associated types). WHY: trait objects erase associated types and const generics.
+
+**Use `impl Trait` in argument position for single-use generics.** `fn new(name: impl Into<String>)` instead of `fn new<S: Into<String>>(name: S)` when the generic parameter appears only once and is not needed in the return type. WHY: less visual noise, same monomorphization.
+
+### Dyn-compatible trait design
+
+Traits intended for use as trait objects must be dyn-compatible (formerly "object safe"). Rules:
+
+- No `Self` in return position. Use associated types or boxed returns instead.
+- No generic methods. Each method must have a fixed signature. WHY: vtables cannot represent an unbounded set of monomorphized methods.
+- Async methods need manual boxing. Return `Pin<Box<dyn Future<Output = T> + 'a>>` instead of `async fn`. Define a type alias: `type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;`. WHY: the compiler cannot determine the future's size for dyn dispatch.
+- Require `Send + Sync` supertrait bounds when trait objects will be stored in `Arc` or passed across thread boundaries. Declare on the trait itself: `pub trait AgentProvider: Send + Sync`. WHY: adding bounds later is a breaking change for all implementations.
+
+### Blanket implementations
+
+Blanket impls (`impl<T: X> Y for T`) provide automatic capability based on existing trait bounds. Use them sparingly.
+
+**Appropriate uses:**
+
+- Bridge traits. `impl<T: Display> Log for T` where `Log` is a project trait that wraps formatting for the logging system. WHY: any displayable type automatically gains logging capability without per-type boilerplate.
+- Newtype delegation. `impl<T: AsRef<str>> PartialEq<T> for SessionId` to allow comparison with any string-like type. WHY: ergonomic API without manual impls for every string type.
+- Marker-based capability. `impl<T: Send + Sync + 'static> Registerable for T` for plugin registration systems. WHY: any thread-safe type can be registered; the constraint is structural, not behavioral.
+
+**Avoid blanket impls when:**
+
+- The impl adds behavior beyond what the source trait guarantees. A blanket `impl<T: Read> Parse for T` that assumes specific data formats is a semantic mismatch.
+- The impl would conflict with future specialization needs. Blanket impls block downstream code from providing more specific implementations. WHY: Rust's coherence rules prevent overlapping impls, so a blanket impl permanently occupies the design space.
+- The impl would surprise users. If `T: Display` automatically gets a blanket impl for `Serialize`, code that derives `Display` unexpectedly becomes serializable. WHY: implicit capability is invisible in the type signature.
+
+Use `#[diagnostic::do_not_recommend]` on blanket impls that produce confusing compiler suggestions. Use `#[diagnostic::on_unimplemented]` on the trait itself to guide users when no impl exists.
+
+### Sealed traits
+
+Seal a trait when external code should not implement it but should use it. Pattern:
+
+```rust
+mod sealed { pub trait Sealed {} }
+
+pub trait InternalPhase: sealed::Sealed {
+    fn advance(&self);
+}
+```
+
+Implement `Sealed` only for types within the crate. External code can call methods on `dyn InternalPhase` but cannot add new implementations. WHY: this preserves the crate's freedom to add required methods, change signatures, or add supertraits without breaking downstream.
+
+### Trait placement: consumer defines, provider implements
+
+The crate that **calls through** a trait defines it. The crate that **provides** the concrete behavior implements it. This is the Dependency Inversion Principle applied to crate boundaries: high-level modules define abstractions, low-level modules conform to them.
+
+**Core rule:** define the trait in the lowest crate that needs to call through it. Implement it in the highest crate that has the concrete type.
+
+```
+phronesis (defines GateCheck trait — the gate orchestrator calls through it)
+  ↑ implements
+kanon-cli (implements ScanCheck, LintCheck, AuditCheck — domain-specific checks)
+  ↑ wires
+main.rs (composition root — registers impls with the orchestrator)
+```
+
+The provider crate (`kanon-cli`) depends on the consumer crate (`phronesis`) to import the trait definition. The consumer never imports the provider. This inverts the naive dependency direction where the implementation would define the interface.
+
+**Correct — consumer defines the contract:**
+
+```rust
+// phronesis/src/gate/mod.rs — the orchestrator defines what a gate check must do
+pub trait GateCheck: Send + Sync {
+    fn name(&self) -> &str;
+    fn run(&self, ctx: &GateContext) -> Result<CheckResult>;
+}
+
+// kanon-cli/src/commands/gate/checks.rs — the application provides implementations
+use phronesis::gate::GateCheck;
+
+pub struct LintCheck { /* ... */ }
+impl GateCheck for LintCheck {
+    fn name(&self) -> &str { "lint" }
+    fn run(&self, ctx: &GateContext) -> Result<CheckResult> { /* ... */ }
+}
+```
+
+**Incorrect — provider defines the contract:**
+
+```rust
+// storage/src/lib.rs — the storage layer defines its own interface
+pub trait StorageBackend {
+    fn read(&self, key: &str) -> Result<Vec<u8>>;
+    fn write(&self, key: &str, data: &[u8]) -> Result<()>;
+}
+
+pub struct SqliteBackend { /* ... */ }
+impl StorageBackend for SqliteBackend { /* ... */ }
+
+// domain/src/lib.rs — business logic must now depend on the storage crate
+use storage::StorageBackend;  // wrong direction: domain depends on infrastructure
+```
+
+The fix: move `StorageBackend` into the domain crate (or a shared leaf crate). The storage crate depends on domain for the trait definition and provides the `SqliteBackend` implementation.
+
+**Never define a trait in the same crate as its only implementation** unless the trait is part of the public API contract (for downstream consumers or test mocking). WHY: a trait with one impl in the same crate adds indirection with no isolation benefit.
+
+### Exception: widely-shared traits
+
+Traits consumed by many crates across the dependency graph belong in a shared leaf crate rather than in any single consumer. This avoids forcing unrelated crates to depend on each other just to share a trait definition.
+
+Examples:
+- Standard library traits (`std::fmt::Display`, `std::error::Error`) — universally shared
+- Project-wide identity traits (e.g., `koina::Id`) — used across all domain crates
+- Cross-cutting behavioral traits (e.g., `kanon::BehavioralRule`) — consumed by multiple crates that each provide rules
+
+The shared crate sits at the leaf layer. It contains trait definitions, associated types, and error types. It contains no implementations beyond trivial defaults. WHY: implementations pull in dependencies; trait crates must remain lightweight.
+
+```
+koina (shared leaf — trait definitions, identity types)
+  ↑ depends on
+phronesis (uses traits from koina, defines its own consumer traits)
+  ↑ depends on
+kanon-cli (implements traits from both koina and phronesis)
+```
+
+### Composition root
+
+The composition root is where trait definitions meet their implementations. It lives in the binary crate — the top of the dependency graph — because only the binary has visibility into all crates.
+
+**Responsibilities of the composition root:**
+- Construct concrete types that implement traits
+- Register implementations with registries, routers, or orchestrators
+- Wire configuration into concrete types
+- Own the lifetime of shared resources (`Arc`, connection pools)
+
+**Pattern:**
+
+```rust
+// main.rs or a dedicated wiring module in the binary crate
+fn build_gate(config: &Config) -> Gate {
+    let mut gate = Gate::new();
+    gate.register(Box::new(FmtCheck::new()));
+    gate.register(Box::new(ClippyCheck::new()));
+    gate.register(Box::new(LintCheck::new(config.lint_config())));
+    gate.register(Box::new(TestCheck::new(config.test_config())));
+    gate
+}
+```
+
+**Rules:**
+- Library crates never construct their own trait implementations for dependency injection. They accept `Box<dyn Trait>` or `impl Trait` from the caller.
+- The composition root is the only place where concrete types and trait definitions are both in scope. This is by design — it forces the binary to be the integration point.
+- If a library crate needs a default implementation for convenience, provide a `::default()` constructor that the composition root can call. Do not auto-wire inside the library.
 
 ---
 

--- a/standards/CI.md
+++ b/standards/CI.md
@@ -1,24 +1,27 @@
 # CI/CD
 
-> Standards for continuous integration, continuous delivery, and release processes.
+> Standards for CI tooling: which checks run, how they're configured, target matrices, test sharding, and workflow generation.
+>
+> See also: DEPLOYMENT.md (merge gates, merge policy, branch protection), RELEASES.md (versioning, release-please, binary distribution).
 
 ---
 
 ## Required checks
 
-Every PR must pass ALL of these before merge. No exceptions, no manual overrides.
+These checks run on every PR. Merge gate policy (which checks block merge) is defined in DEPLOYMENT.md.
 
-| Check | Purpose | Blocks merge |
-|-------|---------|-------------|
-| Format | Consistent style | Yes |
-| Lint (clippy/ruff/eslint) | Catch bugs and anti-patterns | Yes |
-| Type check | Catch type errors | Yes |
-| Unit tests | Catch regressions | Yes |
-| Integration tests | Catch cross-module regressions | Yes |
-| Security scan | Catch leaked credentials | Yes |
-| Dependency audit | Catch known CVEs | Advisory (non-blocking for transitive) |
-| Commit lint | Enforce conventional commits | Yes |
-| Size check | Catch accidental large files | Yes |
+| Check | Tool | Purpose |
+|-------|------|---------|
+| Format | rustfmt / ruff format / prettier | Consistent style |
+| Lint | clippy / ruff / eslint | Catch bugs and anti-patterns |
+| Type check | cargo check / mypy / tsc | Catch type errors |
+| Unit tests | nextest / pytest / vitest | Catch regressions |
+| Integration tests | nextest / pytest | Catch cross-module regressions |
+| Security scan | cargo deny / trivy | Catch leaked credentials |
+| Dependency audit | cargo deny / pip-audit | Catch known CVEs |
+| Vulnerability audit | cargo audit / osv-scanner | Catch known vulnerabilities (RustSec) |
+| Commit lint | commitlint | Enforce conventional commits |
+| Size check | git diff --stat | Catch accidental large files |
 
 ### Check order
 
@@ -28,6 +31,27 @@ Fast checks first. Fail fast, don't waste compute:
 3. Unit tests (minutes)
 4. Integration tests (minutes)
 5. Security + dependency (parallel with tests)
+
+### Vulnerability scanning
+
+`cargo audit` checks the RustSec Advisory Database for known vulnerabilities in dependencies. It runs on every PR and on a daily schedule against the default branch.
+
+WHY: Running only on PRs catches new introductions but misses newly-published CVEs against existing dependencies. The daily schedule closes that gap. `cargo-deny` overlaps on advisories but uses a different database and checks additional concerns (licenses, bans, sources). Run both.
+
+#### Severity-based CI behavior
+
+| CVSS severity | CI behavior | Rationale |
+|---------------|-------------|-----------|
+| Critical (>= 9.0) | Fail CI | Active exploitation likely; must block merge |
+| High (>= 7.0) | Fail CI | Significant risk; must block merge |
+| Medium (4.0 – 6.9) | Warn (non-blocking) | Track and remediate per SLA (see SECURITY.md § CVE response SLAs) |
+| Low (< 4.0) | Warn (non-blocking) | Track in issue, fix when convenient |
+
+To suppress a known advisory while a fix is pending, add it to the `cargo-deny` allow list in `deny.toml` with a justification and review-by date. `cargo audit` respects the same ignore list when invoked with `--ignore` flags derived from `deny.toml`.
+
+#### SBOM generation
+
+Every release pipeline must generate a CycloneDX SBOM and attach it as a release artifact. See SECURITY.md § Software Bill of Materials for format requirements and tooling.
 
 ---
 
@@ -57,37 +81,6 @@ Fast checks first. Fail fast, don't waste compute:
 - Miri (undefined behavior detection)
 - Fuzz targets (parser/serializer correctness)
 - Documentation build (`cargo doc` / `rustdoc`)
-
----
-
-## Release process
-
-### Versioning
-
-Single workspace version. Semantic versioning. Pre-1.0: anything can break. Post-1.0: breaking changes bump major.
-
-### Release checklist
-
-1. All CI checks pass on main
-2. CHANGELOG.md updated (unreleased -> version)
-3. Version bumped in workspace
-4. Tag pushed (triggers release workflow)
-5. Release workflow builds all targets
-6. Binaries uploaded to GitHub releases
-7. Checksums published alongside binaries
-
-### Rollback
-
-Every release preserves the previous binary. Rollback is: stop, swap binary, start, health check. Database rollback documented separately per migration.
-
----
-
-## Branch protection
-
-- Main branch: require PR, require CI pass, require 1 approval (or bot approval for automated PRs)
-- No force push to main
-- No merge commits (rebase or squash only)
-- Branch auto-delete after merge
 
 ---
 

--- a/standards/CPP.md
+++ b/standards/CPP.md
@@ -322,7 +322,7 @@ Never wait on a condition variable on the real-time audio thread. Audio thread p
 
 ### The real-Time contract
 
-The audio callback runs on a deadline-driven thread (typically 1–10ms budget). Violations cause audible glitches. Every function reachable from the audio callback must be bounded-time and non-blocking.
+The audio callback runs on a deadline-driven thread (typically 1-10ms budget). Violations cause audible glitches. Every function reachable from the audio callback must be bounded-time and non-blocking.
 
 **Forbidden in the audio callback:**
 - Heap allocation/deallocation (`new`, `delete`, `malloc`, `free`, `vector::push_back` that reallocates)
@@ -432,7 +432,7 @@ inline int16_t float_to_int16(float f) noexcept {
 
 Use deinterleaved (planar) buffers for processing: each channel contiguous for SIMD. Interleave/deinterleave at I/O boundaries.
 
-### SIMD
+### SIMD (audio-specific)
 
 Use `__restrict__` on all buffer pointer parameters to enable auto-vectorization:
 
@@ -446,7 +446,7 @@ void mix(float* __restrict__ dst, const float* __restrict__ src,
 
 Compiler flags: `-O2` minimum, `-march=native` for build machine, `-ffast-math` acceptable for audio (exact IEEE compliance less important than throughput). Use `-Rpass=loop-vectorize` (Clang) to verify vectorization.
 
-For explicit SIMD, use intrinsics with compile-time dispatch (`__SSE2__`, `__AVX__`, `__AVX512F__`). `std::experimental::simd` (Parallelism TS) is not yet standardized: track but don't adopt.
+See § SIMD intrinsics below for the full intrinsics guide (dispatch, alignment, portable wrappers).
 
 ### Thread priority
 
@@ -564,6 +564,511 @@ extern "C" FfiStatus ffi_do_work(int32_t input,
 
 ---
 
+## SIMD intrinsics
+
+### Strategy: auto-vectorization first, intrinsics when proven necessary
+
+Write scalar loops with `__restrict__` and let the compiler vectorize. Drop to explicit intrinsics only when the compiler's output is measured as insufficient. This ordering exists because intrinsics are architecture-specific, fragile across compiler versions, and opaque to the optimizer.
+
+```cpp
+// WHY: __restrict__ promises no aliasing, enabling the compiler to emit
+// SIMD without manual intrinsics. Verify with -Rpass=loop-vectorize.
+void apply_gain(float* __restrict__ out, const float* __restrict__ in,
+                float gain, int n) noexcept {
+    for (int i = 0; i < n; ++i)
+        out[i] = in[i] * gain;
+}
+```
+
+### Compile-time ISA dispatch
+
+Use preprocessor guards to select the widest available instruction set at compile time. Each ISA tier gets its own translation unit compiled with the appropriate `-m` flag. The dispatch header selects the right implementation.
+
+```cpp
+// simd_dispatch.hpp
+#if defined(__AVX512F__)
+    #include "dsp_avx512.hpp"
+#elif defined(__AVX2__)
+    #include "dsp_avx2.hpp"
+#elif defined(__SSE2__)
+    #include "dsp_sse2.hpp"
+#elif defined(__ARM_NEON)
+    #include "dsp_neon.hpp"
+#else
+    #include "dsp_scalar.hpp"
+#endif
+```
+
+```cmake
+# WHY: Each TU compiled with its own ISA flags so intrinsics resolve.
+# The dispatch header selects the right symbol at compile time.
+add_library(dsp_sse2 OBJECT src/dsp_sse2.cpp)
+target_compile_options(dsp_sse2 PRIVATE -msse2)
+
+add_library(dsp_avx2 OBJECT src/dsp_avx2.cpp)
+target_compile_options(dsp_avx2 PRIVATE -mavx2 -mfma)
+
+add_library(dsp_avx512 OBJECT src/dsp_avx512.cpp)
+target_compile_options(dsp_avx512 PRIVATE -mavx512f)
+```
+
+### Runtime CPU dispatch (CPUID)
+
+When a single binary must run on heterogeneous hardware (distributed builds, plugin hosts), use runtime dispatch via CPUID. Resolve once at startup, cache the function pointer.
+
+```cpp
+#include <cpuid.h>
+
+namespace simd {
+
+// WHY: Resolved once at init, then called via pointer for zero per-call overhead.
+using GainFn = void(*)(float* __restrict__, const float* __restrict__, float, int);
+
+GainFn resolve_apply_gain() noexcept {
+    unsigned int eax, ebx, ecx, edx;
+    __get_cpuid(1, &eax, &ebx, &ecx, &edx);
+
+    // WHY: Check AVX bit (ECX bit 28) + OSXSAVE (ECX bit 27) together.
+    // AVX present without OS support means SIGILL on first use.
+    if ((ecx & (1 << 28)) && (ecx & (1 << 27))) {
+        __get_cpuid_count(7, 0, &eax, &ebx, &ecx, &edx);
+        if (ebx & (1 << 5))  // AVX2
+            return apply_gain_avx2;
+    }
+    return apply_gain_sse2;
+}
+
+// WHY: Static init resolves dispatch once; every subsequent call is a direct pointer.
+static const GainFn apply_gain = resolve_apply_gain();
+
+} // namespace simd
+```
+
+GCC and Clang also support `__attribute__((target_clones("avx2", "sse2", "default")))` for automatic multi-versioning, but it adds a hidden indirect call per invocation and interacts poorly with LTO. Prefer explicit dispatch for hot paths.
+
+### Alignment
+
+SIMD loads and stores require aligned memory. Misaligned access is silently slow on x86 (up to 2x penalty) and a fault on some ARM cores.
+
+```cpp
+// WHY: alignas(32) guarantees AVX-aligned loads without runtime checks.
+// 64-byte alignment covers AVX-512 and cache-line alignment simultaneously.
+alignas(64) float buffer[1024];
+
+// Heap allocation: std::aligned_alloc (C++17)
+// WHY: operator new does not guarantee SIMD alignment beyond alignof(max_align_t),
+// which is typically 16 bytes — insufficient for AVX (32) or AVX-512 (64).
+auto* buf = static_cast<float*>(std::aligned_alloc(64, 1024 * sizeof(float)));
+// SAFETY: aligned_alloc requires size to be a multiple of alignment.
+// 1024 * 4 = 4096, which is a multiple of 64.
+```
+
+For containers, use `std::pmr` with a properly aligned buffer resource (see § Custom memory allocators) or wrap `std::aligned_alloc` in an allocator adaptor.
+
+### Portable intrinsic wrappers
+
+Wrap raw intrinsics behind a thin abstraction that normalizes across SSE/AVX/NEON. Keep the wrapper in a single header per operation (e.g., `simd_gain.hpp`). The wrapper is not an abstraction layer — it is a portability shim. It must compile to the same instructions as raw intrinsics.
+
+```cpp
+// WHY: Thin wrapper gives one call site per DSP operation, with the ISA
+// detail isolated to a single header. Changing ISA targets does not touch callers.
+namespace simd {
+
+#if defined(__AVX2__)
+inline void gain_block(float* __restrict__ out, const float* __restrict__ in,
+                       float g, int n) noexcept {
+    __m256 vgain = _mm256_set1_ps(g);
+    // WHY: Process 8 floats per iteration (256 bits / 32 bits).
+    int i = 0;
+    for (; i + 7 < n; i += 8) {
+        __m256 v = _mm256_load_ps(in + i);   // requires 32-byte alignment
+        _mm256_store_ps(out + i, _mm256_mul_ps(v, vgain));
+    }
+    // PERF: Scalar tail for non-multiple-of-8 lengths.
+    for (; i < n; ++i)
+        out[i] = in[i] * g;
+}
+#elif defined(__SSE2__)
+inline void gain_block(float* __restrict__ out, const float* __restrict__ in,
+                       float g, int n) noexcept {
+    __m128 vgain = _mm_set1_ps(g);
+    int i = 0;
+    for (; i + 3 < n; i += 4) {
+        __m128 v = _mm_load_ps(in + i);
+        _mm_store_ps(out + i, _mm_mul_ps(v, vgain));
+    }
+    for (; i < n; ++i)
+        out[i] = in[i] * g;
+}
+#elif defined(__ARM_NEON)
+inline void gain_block(float* __restrict__ out, const float* __restrict__ in,
+                       float g, int n) noexcept {
+    float32x4_t vgain = vdupq_n_f32(g);
+    int i = 0;
+    for (; i + 3 < n; i += 4) {
+        float32x4_t v = vld1q_f32(in + i);
+        vst1q_f32(out + i, vmulq_f32(v, vgain));
+    }
+    for (; i < n; ++i)
+        out[i] = in[i] * g;
+}
+#else
+inline void gain_block(float* __restrict__ out, const float* __restrict__ in,
+                       float g, int n) noexcept {
+    for (int i = 0; i < n; ++i)
+        out[i] = in[i] * g;
+}
+#endif
+
+} // namespace simd
+```
+
+### Verification
+
+Every SIMD path must be verified two ways:
+
+1. **Compiler output.** Use `-Rpass=loop-vectorize -Rpass-missed=loop-vectorize` (Clang) or `-fopt-info-vec-all` (GCC) to confirm the compiler vectorized auto-vectorizable loops and to catch regressions.
+2. **Benchmarks.** Measure the SIMD path against the scalar fallback on the target hardware. If the SIMD path is not measurably faster, delete it: it adds maintenance cost with no benefit.
+
+### SIMD rules
+
+1. **Alignment.** `alignas(32)` minimum for AVX, `alignas(64)` for AVX-512. All audio buffers aligned at allocation time.
+2. **Tail handling.** Every SIMD loop must handle input lengths that are not a multiple of the vector width. Scalar tail loop is correct and sufficient.
+3. **No `_mm_loadu_ps` in hot paths.** Unaligned loads are slower. Guarantee alignment at allocation time, then use aligned loads.
+4. **`-ffast-math` scope.** Apply only to DSP translation units, not globally. It breaks `NaN` propagation, `inf` comparisons, and IEEE compliance.
+5. **`std::experimental::simd`** (Parallelism TS v2) is not yet standardized. Track P1928, do not adopt until it lands in a shipping standard.
+
+---
+
+## Custom memory allocators
+
+### When to use a custom allocator
+
+The default allocator (`operator new` / `malloc`) is general-purpose: thread-safe, fragmentation-resistant, and predictable. It is the right choice for most code. Use a custom allocator only when profiling shows one of these problems:
+
+1. **Allocation frequency in hot paths.** Thousands of small allocations per frame (audio callback, render loop, network packet processing). The general allocator's per-call overhead dominates.
+2. **Fragmentation in long-running processes.** Variable-size allocations over hours/days fragment the heap, increasing RSS and cache misses.
+3. **Deterministic latency.** Real-time threads cannot tolerate the general allocator's worst-case lock contention or mmap syscalls.
+
+If none of these apply, do not introduce a custom allocator.
+
+### `std::pmr` (polymorphic memory resources)
+
+`std::pmr` is the standard allocator customization point since C++17. All custom allocation strategies should use `std::pmr::memory_resource` as the base.
+
+```cpp
+#include <memory_resource>
+#include <vector>
+
+// WHY: monotonic_buffer_resource never deallocates individual objects.
+// It resets the entire buffer at once, giving O(1) "deallocation" cost.
+// Ideal for per-frame scratch memory that is discarded as a batch.
+alignas(64) static char scratch_buf[64 * 1024];
+std::pmr::monotonic_buffer_resource scratch{scratch_buf, sizeof(scratch_buf)};
+
+void process_frame() {
+    scratch.release();  // reset to start of buffer: O(1), no destructors
+    std::pmr::vector<float> temp{&scratch};
+    temp.resize(512);   // no malloc: carved from scratch_buf
+    // ... use temp ...
+}   // temp destructor is a no-op: monotonic resource ignores deallocate()
+```
+
+### Arena allocator (monotonic)
+
+The primary pattern for real-time and high-throughput code. Allocates by bumping a pointer. Individual deallocations are no-ops. The entire arena resets at a defined boundary (frame, request, callback).
+
+```cpp
+// WHY: Arena reset per audio callback means zero per-object deallocation cost.
+// All scratch memory is reclaimed in one operation between callbacks.
+class FrameArena {
+public:
+    explicit FrameArena(std::span<char> backing)
+        : resource_(backing.data(), backing.size()) {}
+
+    std::pmr::memory_resource* resource() noexcept { return &resource_; }
+
+    // WHY: Called once between frames. Not thread-safe by design:
+    // the arena belongs to a single thread (the audio thread).
+    void reset() noexcept { resource_.release(); }
+
+private:
+    std::pmr::monotonic_buffer_resource resource_;
+};
+
+// Usage in audio callback:
+alignas(64) static char arena_storage[256 * 1024];
+static FrameArena frame_arena{arena_storage};
+
+void audio_callback(float** out, const float** in,
+                    int channels, int frames) noexcept {
+    frame_arena.reset();
+    std::pmr::vector<float> work_buf{frame_arena.resource()};
+    work_buf.resize(frames);  // no syscall, no lock
+    // ...
+}
+```
+
+### Pool allocator (fixed-size blocks)
+
+For allocating many objects of the same size (nodes, events, messages). Pre-allocates a slab of N blocks, returns them via a free list. O(1) alloc and free, zero fragmentation.
+
+```cpp
+// WHY: Pool avoids fragmentation for fixed-size objects and gives O(1)
+// alloc/free without locks when used from a single thread.
+template <typename T, size_t Capacity>
+class FixedPool {
+    static_assert(sizeof(T) >= sizeof(void*),
+        "Pool element must be at least pointer-sized for free-list linkage");
+
+public:
+    FixedPool() noexcept {
+        // WHY: Build the free list at construction. Each free slot stores
+        // a pointer to the next free slot, overlaid on the object storage.
+        for (size_t i = 0; i + 1 < Capacity; ++i)
+            *reinterpret_cast<void**>(&storage_[i * sizeof(T)]) =
+                &storage_[(i + 1) * sizeof(T)];
+        *reinterpret_cast<void**>(&storage_[(Capacity - 1) * sizeof(T)]) = nullptr;
+        free_head_ = &storage_[0];
+    }
+
+    void* allocate() noexcept {
+        if (!free_head_) return nullptr;
+        void* block = free_head_;
+        free_head_ = *static_cast<void**>(free_head_);
+        return block;
+    }
+
+    void deallocate(void* ptr) noexcept {
+        *static_cast<void**>(ptr) = free_head_;
+        free_head_ = ptr;
+    }
+
+private:
+    alignas(T) char storage_[sizeof(T) * Capacity];
+    void* free_head_ = nullptr;
+};
+```
+
+### Wrapping a custom allocator as `std::pmr::memory_resource`
+
+Any custom allocation strategy must integrate with `std::pmr` so that standard containers (`pmr::vector`, `pmr::string`, `pmr::unordered_map`) work transparently.
+
+```cpp
+// WHY: Inheriting from memory_resource lets standard pmr containers use
+// the pool without any container-side changes.
+template <typename T, size_t Capacity>
+class PoolResource : public std::pmr::memory_resource {
+    FixedPool<T, Capacity> pool_;
+
+protected:
+    void* do_allocate(size_t bytes, size_t alignment) override {
+        if (bytes > sizeof(T) || alignment > alignof(T))
+            throw std::bad_alloc{};
+        void* p = pool_.allocate();
+        if (!p) throw std::bad_alloc{};
+        return p;
+    }
+
+    void do_deallocate(void* p, size_t, size_t) noexcept override {
+        pool_.deallocate(p);
+    }
+
+    bool do_is_equal(const memory_resource& other) const noexcept override {
+        return this == &other;
+    }
+};
+```
+
+### Allocator selection guide
+
+| Allocator | Pattern | Fragmentation | Thread safety | Use case |
+|-----------|---------|---------------|---------------|----------|
+| Default (`new`) | General | Managed | Thread-safe | Everything unless profiling says otherwise |
+| `monotonic_buffer_resource` | Bump pointer, batch reset | None (resets entire arena) | Single-thread | Per-frame scratch, request-scoped temp data |
+| `unsynchronized_pool_resource` | Free-list pools by size class | Low | Single-thread | Many variable-size allocs on one thread |
+| `synchronized_pool_resource` | Same with mutex | Low | Thread-safe | Multi-threaded pool (not real-time) |
+| Custom `FixedPool<T, N>` | Fixed-size free list | None | Single-thread | MIDI events, graph nodes, message queues |
+
+### Rules
+
+1. **Profile first.** Never introduce a custom allocator without measurements showing the default is the bottleneck.
+2. **`std::pmr` as the interface.** Custom allocators implement `std::pmr::memory_resource` so containers are not coupled to the allocator strategy.
+3. **Single-owner arenas.** Arenas belong to one thread. No shared arenas between threads: that reintroduces the synchronization cost you were trying to avoid.
+4. **Pre-allocate backing memory.** Arena and pool backing buffers are allocated (and `mlock`ed for audio) at init time, not in hot paths.
+5. **Reset, don't deallocate.** For batch-lifetime memory (per-frame, per-request), use `monotonic_buffer_resource::release()` instead of per-object deallocation.
+6. **Overflow policy is explicit.** Document what happens when the arena or pool is exhausted: throw, return null, fall back to upstream resource, or output silence (audio thread).
+
+---
+
+## Thread-local storage
+
+### When to use `thread_local`
+
+Thread-local storage (TLS) gives each thread its own instance of a variable, eliminating synchronization overhead. Use it when:
+
+1. **Per-thread caches or scratch buffers.** Avoids contention on a shared cache while keeping the data warm in the thread's L1/L2 cache.
+2. **Per-thread statistics and accumulators.** Aggregate at reporting time, not on every increment.
+3. **Last-error patterns for FFI.** Thread-local error state avoids passing error context through every call in a C API.
+
+Do not use TLS as a substitute for proper parameter passing. If a function needs data, take it as a parameter. TLS is for cross-cutting concerns where threading the value through every call site would be disproportionate.
+
+### Initialization and lifetime
+
+`thread_local` variables are initialized on first access in each thread (lazy init). Destruction occurs when the thread exits, in reverse order of construction.
+
+```cpp
+// WHY: Per-thread buffer avoids contention on a shared scratch buffer.
+// Each audio worker thread gets its own 64KB scratch space.
+thread_local alignas(64) char tls_scratch[64 * 1024];
+
+// WHY: Wrapping in a function avoids the static-initialization-order fiasco
+// across translation units. The thread_local is initialized on first call.
+std::pmr::monotonic_buffer_resource& thread_scratch_resource() {
+    thread_local std::pmr::monotonic_buffer_resource resource{
+        tls_scratch, sizeof(tls_scratch)
+    };
+    return resource;
+}
+```
+
+### Destructor ordering
+
+`thread_local` destructors run when the thread exits, but the order across translation units is unspecified. If one TLS object depends on another, place them in the same TU or use a function-local `thread_local` to control initialization order.
+
+```cpp
+// WHY: Logger depends on scratch buffer. Function-local thread_local
+// guarantees scratch is constructed before logger within each thread.
+struct ThreadContext {
+    std::pmr::monotonic_buffer_resource scratch{buf_, sizeof(buf_)};
+    ThreadLocalLogger logger{&scratch};
+
+private:
+    alignas(64) char buf_[32 * 1024];
+};
+
+ThreadContext& thread_ctx() {
+    // WHY: Single thread_local object controls destruction order.
+    // scratch outlives logger because members destruct in reverse declaration order.
+    thread_local ThreadContext ctx;
+    return ctx;
+}
+```
+
+### Last-error pattern for FFI
+
+Thread-local error state is the standard pattern for rich error messages across `extern "C"` boundaries where only an integer status code can be returned.
+
+```cpp
+// WHY: C APIs return int status codes but callers often need a human-readable
+// message. Thread-local storage avoids the need for caller-provided buffers
+// or global error state that races across threads.
+namespace {
+thread_local std::string tls_last_error;
+}
+
+extern "C" int32_t engine_process(Engine* e, const float* in,
+                                   float* out, size_t frames) noexcept {
+    try {
+        e->process(in, out, frames);
+        return 0;
+    } catch (const std::exception& ex) {
+        tls_last_error = ex.what();
+        return -1;
+    }
+}
+
+extern "C" const char* engine_last_error() noexcept {
+    // WHY: Returns pointer to thread_local string. Valid until the next
+    // call to any engine_* function on the same thread.
+    return tls_last_error.c_str();
+}
+```
+
+### Per-thread accumulators
+
+Accumulate statistics per-thread, then aggregate when needed. Eliminates atomic contention on every increment.
+
+```cpp
+struct ThreadStats {
+    uint64_t samples_processed = 0;
+    uint64_t xruns = 0;
+    uint64_t alloc_bytes = 0;
+};
+
+// WHY: No atomics needed — each thread writes only its own instance.
+thread_local ThreadStats tls_stats;
+
+// Called from worker thread hot path: zero synchronization cost
+void record_samples(uint64_t n) noexcept {
+    tls_stats.samples_processed += n;
+}
+
+// WHY: Aggregation reads all threads' stats, but only at reporting boundaries
+// (typically once per second). The brief lock contention here is acceptable
+// because it is outside the hot path.
+class StatsAggregator {
+public:
+    void register_thread() {
+        std::scoped_lock lock{mu_};
+        thread_stats_.push_back(&tls_stats);
+    }
+
+    ThreadStats aggregate() const {
+        std::scoped_lock lock{mu_};
+        ThreadStats total{};
+        for (const auto* ts : thread_stats_) {
+            total.samples_processed += ts->samples_processed;
+            total.xruns += ts->xruns;
+            total.alloc_bytes += ts->alloc_bytes;
+        }
+        return total;
+    }
+
+private:
+    mutable std::mutex mu_;
+    std::vector<ThreadStats*> thread_stats_;
+};
+```
+
+### TLS and thread pools
+
+`thread_local` destructors run when the thread exits, not when a task finishes. In thread pools (where threads are long-lived and recycled), this means:
+
+1. **State leaks between tasks.** A `thread_local` accumulator from task A is still present when task B runs on the same thread. Reset TLS state explicitly at task boundaries if isolation is required.
+2. **Destructors run late.** TLS resources are freed only when the pool thread is destroyed (typically at shutdown). For resources that should be freed earlier, use task-scoped RAII, not TLS.
+3. **Registration lifetime.** If you register TLS pointers in an aggregator (as above), deregister them when the thread exits or the aggregator will hold dangling pointers.
+
+```cpp
+// WHY: RAII guard ensures the thread deregisters from the aggregator
+// when the pool thread exits, preventing dangling pointer reads.
+struct ThreadRegistration {
+    explicit ThreadRegistration(StatsAggregator& agg) : agg_(agg) {
+        agg_.register_thread();
+    }
+    ~ThreadRegistration() { agg_.deregister_thread(); }
+
+    ThreadRegistration(const ThreadRegistration&) = delete;
+    ThreadRegistration& operator=(const ThreadRegistration&) = delete;
+
+private:
+    StatsAggregator& agg_;
+};
+
+// In thread pool worker init:
+thread_local ThreadRegistration reg{global_aggregator};
+```
+
+### Rules
+
+1. **No TLS on the real-time audio thread.** First access triggers lazy initialization, which may allocate. Pre-allocate all audio-thread state at init time and pass it explicitly.
+2. **Function-local `thread_local` over namespace-scope.** Avoids static-initialization-order issues and makes the initialization point explicit.
+3. **Reset at task boundaries in thread pools.** TLS state persists across tasks on the same thread. If tasks require isolation, reset explicitly.
+4. **Deregister on thread exit.** If TLS addresses are stored externally (aggregators, registries), use an RAII guard to deregister on destruction.
+5. **Do not use TLS to avoid parameter passing.** If a function needs data, take it as a parameter. TLS is for cross-cutting concerns (error state, statistics, scratch buffers) where threading the parameter would be disproportionate.
+
+---
+
 ## Memory safety
 
 ### `std::span` and bounds checking
@@ -599,11 +1104,12 @@ From `microsoft/GSL` (use selectively):
 
 ## Testing
 
-### Framework and structure
+See TESTING.md for all testing principles (naming, isolation, coverage, test data, property testing).
+
+C++-specific framework choices and tooling:
 
 - **Framework:** GoogleTest or Catch2
-- **Names:** `TEST(AudioProcessor, ReturnsEmptyWhenNoInput)`, not `Test1`
-- **Property tests:** `rapidcheck` for round-trip, algebraic, and invariant properties
+- **Property tests:** `rapidcheck`
 - **Fuzz targets:** libFuzzer for codec, parser, and deserialization code
 
 ### Sanitizer builds

--- a/standards/CSHARP.md
+++ b/standards/CSHARP.md
@@ -144,6 +144,8 @@ Visibility restricted to the declaring file. Primary use: source generators, fil
 
 ## Error handling
 
+See STANDARDS.md § Error Handling for universal principles.
+
 ### Custom exception hierarchies
 
 ```csharp
@@ -158,7 +160,6 @@ public class SessionException : AppException { /* ... */ }
 
 ### Rules
 
-- Never `catch (Exception)` without re-throw or structured logging
 - `IResult` / `Results.Problem()` for API error responses
 - Include correlation ID in error responses
 - Custom exception types per domain area
@@ -286,11 +287,314 @@ Set `JsonSerializerIsReflectionEnabledByDefault` to `false` in `.csproj` to prev
 
 ## Caching
 
-- `IMemoryCache` for metadata responses (15-min default TTL)
-- `FrozenDictionary<K,V>` / `FrozenSet<T>` for static lookup data built once at startup: ~50% faster reads than `Dictionary`, thread-safe by nature (immutable)
-- Cache keys: deterministic, include all varying parameters
-- Never cache user-specific data in shared cache
-- Explicit eviction on data mutation
+### IMemoryCache for hot-path data
+
+Use `IMemoryCache` for metadata and reference data that is read far more often than written. 15-minute default TTL.
+
+```csharp
+public class GenreCache(IMemoryCache cache, IMediaRepository repository, ILogger<GenreCache> logger)
+{
+    private static readonly TimeSpan DefaultTtl = TimeSpan.FromMinutes(15);
+
+    public async Task<IReadOnlyList<Genre>> GetGenresAsync(CancellationToken ct)
+    {
+        // WHY: GetOrCreateAsync is atomic — only one factory runs even under concurrent requests.
+        // Prevents cache stampede where N requests all miss and all hit the database.
+        return await cache.GetOrCreateAsync("genres:all", async entry =>
+        {
+            entry.AbsoluteExpirationRelativeToNow = DefaultTtl;
+            logger.LogDebug("Cache miss for genres, loading from database");
+            return await repository.ListGenresAsync(ct);
+        }) ?? [];
+    }
+
+    public void InvalidateGenres()
+    {
+        cache.Remove("genres:all");
+    }
+}
+```
+
+Rules:
+- **Always use `GetOrCreateAsync`**, not separate get-then-set. WHY: separate get/set has a race window where multiple threads miss and all execute the factory.
+- **Absolute expiration, not sliding.** WHY: sliding expiration keeps stale data alive indefinitely under steady traffic. Absolute forces periodic refresh.
+- **Invalidate on mutation.** Every write operation that changes cached data must call `Remove` on the relevant keys. Stale reads after a write are bugs, not acceptable latency.
+- **Cache keys: deterministic, include all varying parameters.** Format: `{entity}:{qualifier}:{id}`. Example: `albums:artist:42`.
+
+### IDistributedCache for shared state
+
+Use `IDistributedCache` when cache must be shared across multiple app instances or survive process restarts. Backed by Redis or similar.
+
+```csharp
+public class SessionCache(IDistributedCache cache, ILogger<SessionCache> logger)
+{
+    private static readonly DistributedCacheEntryOptions Options = new()
+    {
+        AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(30),
+    };
+
+    public async Task<UserSession?> GetSessionAsync(string sessionId, CancellationToken ct)
+    {
+        byte[]? data = await cache.GetAsync($"session:{sessionId}", ct);
+        if (data is null) return null;
+
+        // WHY: Source-generated deserialization for AOT safety and performance.
+        return JsonSerializer.Deserialize(data, AppJsonContext.Default.UserSession);
+    }
+
+    public async Task SetSessionAsync(string sessionId, UserSession session, CancellationToken ct)
+    {
+        byte[] data = JsonSerializer.SerializeToUtf8Bytes(session, AppJsonContext.Default.UserSession);
+        await cache.SetAsync($"session:{sessionId}", data, Options, ct);
+    }
+}
+```
+
+Rules:
+- **Serialize with `System.Text.Json` source generation.** WHY: `IDistributedCache` stores `byte[]`, not objects. Reflection-based serialization breaks AOT and is slower.
+- **Never store large objects (>64KB).** WHY: distributed cache is a network hop. Large values saturate bandwidth and increase latency for all consumers.
+- **Set explicit TTL on every entry.** No indefinite entries in distributed cache. Orphaned keys consume memory on the backing store with no eviction pressure.
+
+### FrozenDictionary / FrozenSet for static data
+
+`FrozenDictionary<K,V>` / `FrozenSet<T>` for lookup data built once at startup. ~50% faster reads than `Dictionary`, thread-safe by nature (immutable).
+
+```csharp
+public class CodecRegistry
+{
+    // WHY: Built once at startup, never mutated. FrozenDictionary optimizes
+    // its internal layout for the actual keys, yielding faster lookups.
+    private readonly FrozenDictionary<string, CodecInfo> _codecs;
+
+    public CodecRegistry(IEnumerable<CodecInfo> codecs)
+    {
+        _codecs = codecs.ToFrozenDictionary(c => c.Name, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public CodecInfo? Find(string name) =>
+        _codecs.GetValueOrDefault(name);
+}
+```
+
+- Never cache user-specific data in shared memory cache. WHY: memory cache is process-wide. User A sees User B's data on the next request routed to the same instance.
+
+---
+
+## Activity and context propagation
+
+### Distributed tracing with Activity
+
+`System.Diagnostics.Activity` is the .NET standard for distributed tracing. It integrates with OpenTelemetry, ASP.NET Core, and HttpClient without third-party libraries.
+
+```csharp
+public static class Telemetry
+{
+    // WHY: ActivitySource is the .NET equivalent of a tracer. One per logical component.
+    // The name must match the OpenTelemetry SDK's AddSource() registration.
+    public static readonly ActivitySource Source = new("Mouseion.Media");
+}
+
+public class AlbumService(IMediaRepository repository, ILogger<AlbumService> logger)
+{
+    public async Task<Album?> FindAsync(int id, CancellationToken ct)
+    {
+        // WHY: StartActivity returns null if no listener is registered,
+        // so this is zero-cost when tracing is not configured.
+        using var activity = Telemetry.Source.StartActivity("AlbumService.Find");
+        activity?.SetTag("album.id", id);
+
+        var album = await repository.FindByIdAsync(id, ct);
+
+        activity?.SetTag("album.found", album is not null);
+        return album;
+    }
+}
+```
+
+### Propagation rules
+
+- **One `ActivitySource` per logical component.** Register in a static field. WHY: `ActivitySource` is the unit of subscription in OpenTelemetry. Granular sources let operators enable tracing per-component without noise.
+- **`using` on every `StartActivity` call.** WHY: `Activity` implements `IDisposable`. Missing `using` means the span never closes, corrupting trace timelines.
+- **Set tags for query parameters, entity IDs, and outcomes.** These are the fields you search in Jaeger/Tempo. A span without tags is a span you cannot filter.
+- **Propagate `Activity.Current` across async boundaries automatically.** ASP.NET Core and `HttpClient` do this by default. Do not manually set `Activity.Current` unless you are spawning a detached background task.
+
+### Correlation IDs for non-traced paths
+
+When full tracing is not active, propagate a correlation ID via `HttpContext.TraceIdentifier`:
+
+```csharp
+// WHY: TraceIdentifier is set automatically by ASP.NET Core from
+// the W3C traceparent header or a generated value. Use it as the
+// correlation ID in logs and error responses — no custom header needed.
+logger.LogError("Failed to load album {AlbumId}, trace {TraceId}",
+    id, httpContext.TraceIdentifier);
+```
+
+---
+
+## Bulk operations
+
+### Dapper bulk patterns
+
+Individual queries in a loop are the primary performance trap with Dapper. Batch operations reduce round-trips.
+
+#### Multi-row insert with Dapper
+
+```csharp
+public async Task InsertTracksAsync(IReadOnlyList<Track> tracks, CancellationToken ct)
+{
+    // WHY: Single statement with multiple value tuples. One round-trip
+    // regardless of collection size. Dapper maps the list to parameters.
+    const string sql = """
+        insert into tracks (album_id, title, duration_ms, track_number)
+        values (@AlbumId, @Title, @DurationMs, @TrackNumber)
+        """;
+
+    // WHY: Wrap in transaction so a partial failure doesn't leave orphaned rows.
+    using var transaction = _connection.BeginTransaction();
+    await _connection.ExecuteAsync(
+        new CommandDefinition(sql, tracks, transaction: transaction, cancellationToken: ct));
+    transaction.Commit();
+}
+```
+
+#### Bulk read with `WHERE IN`
+
+```csharp
+public async Task<IReadOnlyList<Album>> GetByIdsAsync(IReadOnlyList<int> ids, CancellationToken ct)
+{
+    if (ids.Count == 0) return [];
+
+    // WHY: Dapper expands @Ids into a parameterized IN clause automatically.
+    // No string interpolation, no SQL injection risk.
+    const string sql = """
+        select * from albums where id in @Ids
+        """;
+
+    var results = await _connection.QueryAsync<Album>(
+        new CommandDefinition(sql, new { Ids = ids }, cancellationToken: ct));
+    return results.AsList();
+}
+```
+
+### Rules
+
+- **Never query in a loop.** WHY: N+1 queries dominate latency. A loop of 100 individual SELECTs is 100 round-trips; a single `WHERE IN` is one.
+- **Batch size limit: 1000 parameters per statement.** WHY: SQLite and some PostgreSQL configurations have parameter count limits. For larger sets, chunk into batches of 1000 and wrap in a single transaction.
+- **Always wrap multi-statement bulk writes in a transaction.** WHY: without a transaction, a failure mid-batch leaves the database in an inconsistent state with partial writes.
+- **Return affected row count from bulk mutations** so callers can verify expectations:
+
+```csharp
+public async Task<int> DeactivateAlbumsAsync(IReadOnlyList<int> albumIds, CancellationToken ct)
+{
+    const string sql = """
+        update albums set is_active = false where id in @Ids
+        """;
+    return await _connection.ExecuteAsync(
+        new CommandDefinition(sql, new { Ids = albumIds }, cancellationToken: ct));
+}
+```
+
+---
+
+## Middleware pipeline
+
+### Ordering
+
+Middleware order determines behavior. The ASP.NET Core pipeline is a Russian doll: each middleware wraps the next. Order is not arbitrary.
+
+```csharp
+var app = builder.Build();
+
+// WHY: Exception handler must be outermost so it catches errors from all inner middleware.
+app.UseExceptionHandler();
+
+// WHY: Request logging wraps the full pipeline to capture timing and status for every request.
+app.UseRequestLogging();
+
+// WHY: CORS must run before auth so preflight OPTIONS requests are handled
+// without requiring credentials.
+app.UseCors();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+// WHY: Rate limiting after auth so authenticated users get their own limits
+// and anonymous abuse is caught by a separate, stricter policy.
+app.UseRateLimiter();
+
+app.MapControllers();
+app.MapHealthChecks("/health");
+```
+
+### Custom middleware pattern
+
+Write middleware as a class, not an inline lambda. WHY: class-based middleware is testable, injectable, and visible in stack traces.
+
+```csharp
+public class CorrelationIdMiddleware(RequestDelegate next)
+{
+    // WHY: Ensures every request has a correlation ID for log correlation,
+    // whether the client sent one or not. Downstream services receive it
+    // via HttpClient's default headers.
+    public async Task InvokeAsync(HttpContext context)
+    {
+        const string headerName = "X-Correlation-Id";
+
+        if (!context.Request.Headers.TryGetValue(headerName, out var correlationId)
+            || StringValues.IsNullOrEmpty(correlationId))
+        {
+            correlationId = context.TraceIdentifier;
+        }
+
+        context.Response.Headers[headerName] = correlationId.ToString();
+
+        using (logger.BeginScope(new Dictionary<string, object>
+        {
+            ["CorrelationId"] = correlationId.ToString()!,
+        }))
+        {
+            await next(context);
+        }
+    }
+}
+```
+
+### Request logging middleware
+
+Log every request with structured fields. This is the observability contract for the API boundary.
+
+```csharp
+public class RequestLoggingMiddleware(RequestDelegate next, ILogger<RequestLoggingMiddleware> logger)
+{
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            await next(context);
+        }
+        finally
+        {
+            stopwatch.Stop();
+            logger.LogInformation(
+                "HTTP {Method} {Path} responded {StatusCode} in {ElapsedMs}ms",
+                context.Request.Method,
+                context.Request.Path,
+                context.Response.StatusCode,
+                stopwatch.ElapsedMilliseconds);
+        }
+    }
+}
+```
+
+### Rules
+
+- **Exception handling middleware is always first (outermost).** WHY: any middleware before it can throw unhandled exceptions that bypass your error response format.
+- **Never use inline `app.Use(async (ctx, next) => ...)` for anything beyond trivial one-liners.** WHY: lambdas are untestable, invisible in stack traces, and accumulate into an unreadable `Program.cs`.
+- **Health check endpoints bypass auth and rate limiting.** Map them after `UseAuthorization` but configure the endpoint to allow anonymous. WHY: monitoring probes must not fail because of expired tokens or rate limits.
+- **Each middleware does one thing.** Correlation ID injection is not also request logging. WHY: composability. Operators must be able to add, remove, or reorder individual concerns without side effects.
 
 ---
 
@@ -306,11 +610,13 @@ Set `JsonSerializerIsReflectionEnabledByDefault` to `false` in `.csproj` to prev
 
 ## Testing
 
+See TESTING.md for all testing principles (naming, isolation, coverage, test data, property testing).
+
+C#-specific framework choices:
+
 - **Framework:** xUnit (or NUnit)
-- **Names:** `GetAlbum_ReturnsNull_WhenNotFound`, not `Test1`
-- **Mocking:** Moq or NSubstitute at interface boundaries
-- **Arrange-Act-Assert** pattern in every test
-- Integration tests use `WebApplicationFactory<T>` for API tests
+- **Mocking:** NSubstitute (or Moq) at interface boundaries
+- **Integration tests:** `WebApplicationFactory<T>` for API tests
 
 ---
 
@@ -340,8 +646,14 @@ tests/               : unit and integration tests
 5. **`dynamic` or untyped `var`**: explicit types when non-obvious
 6. **Hardcoded connection strings**: configuration injection
 7. **`string.Format` over interpolation**: use `$"..."` syntax
-8. **Bare `catch (Exception)`**: catch specific, log, re-throw
+8. **Bare `catch (Exception)`**: see STANDARDS.md § No Silent Catch
 9. **`null!` without explanation**: fix the nullability, don't suppress it
 10. **`ConfigureAwait(false)` in ASP.NET Core app code**: unnecessary noise, no `SynchronizationContext` exists
 11. **Reflection-based JSON serialization in AOT/trimmed builds**: use `System.Text.Json` source generation
 12. **`new[] { }` / `new List<T> { }`**: use collection expressions: `[1, 2, 3]`
+13. **Querying in a loop**: batch with `WHERE IN` or bulk insert. N+1 kills latency.
+14. **Separate get-then-set on `IMemoryCache`**: use `GetOrCreateAsync` to avoid cache stampede.
+15. **Sliding cache expiration under steady traffic**: stale data never expires. Use absolute expiration.
+16. **Missing `using` on `StartActivity`**: unclosed spans corrupt trace timelines.
+17. **Inline `app.Use()` lambdas for non-trivial middleware**: untestable, invisible in stack traces. Use a middleware class.
+18. **Middleware before `UseExceptionHandler`**: unhandled exceptions bypass your error response format.

--- a/standards/DATALOG.md
+++ b/standards/DATALOG.md
@@ -2,6 +2,8 @@
 
 > Additive to STANDARDS.md. Read that first. Everything here is specific to the CozoDB-derived Datalog dialect used in the krites engine.
 
+> **Status: pre-production.** No code in any repo uses Datalog today. Krites (Phase 05b) has not started implementation. This document defines the target standard so that design decisions and dispatched work converge on one dialect from the start. Treat every section as a constraint on future implementation, not a description of current behavior.
+
 ---
 
 ## Overview
@@ -20,7 +22,7 @@ Relations are stored (persistent) or derived (computed from rules).
 
 ```datalog
 # Stored relation: insert data
-?[entity, relation, target] <- [["chiron", "knows", "cody"], ["chiron", "uses", "aletheia"]]
+?[entity, relation, target] <- [["agent-01", "knows", "user"], ["agent-01", "uses", "aletheia"]]
 
 # Query a stored relation
 ?[entity, target] := *facts[entity, _, target]
@@ -57,7 +59,7 @@ Rules define derived relations. The head (left of `:=`) is what you produce. The
 ?[name, score] := *facts[_, name, _, score], score > 0.5
 
 # String matching
-?[name] := *entities[_, name, _], starts_with(name, "chiron")
+?[name] := *entities[_, name, _], starts_with(name, "agent")
 
 # Arithmetic
 ?[entity, total] := *scores[entity, s1], *bonuses[entity, s2], total = s1 + s2
@@ -74,7 +76,7 @@ Rules define derived relations. The head (left of `:=`) is what you produce. The
 | Stored relations | `snake_case` | `facts`, `entities`, `relationships` |
 | Rule names | `snake_case` | `active_facts`, `related_entities` |
 | Variables | `snake_case` | `entity_id`, `fact_content` |
-| Constants | As stored (case-sensitive) | `"Verified"`, `"chiron"` |
+| Constants | As stored (case-sensitive) | `"Verified"`, `"agent-01"` |
 
 ### Query structure
 
@@ -133,10 +135,96 @@ Facts have a tier indicating confidence level:
 | `Identity` | "Cody is a data scientist" |
 | `Preference` | "User prefers tables over prose" |
 | `Skill` | "Agent can query Redshift" |
-| `Relationship` | "Chiron reports to Cody" |
+| `Relationship` | "Agent-01 reports to User" |
 | `Event` | "Deployed v0.11.0 on 2026-03-14" |
 | `Task` | "Investigate Landlock exec failure" |
 | `Observation` | "Haiku pricing not configured" |
+
+---
+
+## Mneme integration
+
+Mneme is the memory subsystem. Krites is the query engine inside mneme. All Datalog access flows through the `KnowledgeStore` API — never through raw engine handles.
+
+### Query composition
+
+Use `KnowledgeStore::query()` for read-only Datalog. Pass the query string and receive typed results. WHY: a single entry point lets mneme enforce access control, audit logging, and timeout budgets uniformly.
+
+```rust
+// Correct: query through the KnowledgeStore API
+let results = store.query(r#"
+    ?[entity_name, confidence] :=
+        *facts[_, entity_id, _, confidence, "Verified", _, _, _],
+        *entities[entity_id, entity_name, _],
+        confidence > 0.7
+"#).await?;
+
+// Wrong: obtaining a raw engine handle bypasses validation and audit
+let results = engine.run_query(...); // never do this
+```
+
+### Mutations
+
+Mutate facts exclusively through `KnowledgeStore` methods (`store_fact`, `forget_fact`, `update_confidence`, `supersede`). WHY: these methods enforce schema validation, conflict detection, succession chains, and emit events for downstream consumers. Raw Datalog inserts bypass all of these.
+
+### Vector search into Datalog
+
+Semantic similarity searches return candidate fact IDs. Feed those IDs into a Datalog rule for logical filtering. WHY: HNSW produces approximate neighbors — Datalog applies exact constraints the vector index cannot express.
+
+```datalog
+# Step 1 (Rust): similarity search returns candidate IDs
+# let candidates = store.semantic_search(query_embedding, top_k=50).await?;
+
+# Step 2 (Datalog): filter candidates with logical constraints
+?[fact_id, content, confidence] :=
+    *facts[fact_id, entity_id, content, confidence, tier, _, _, _],
+    *entities[entity_id, _, "person"],
+    fact_id in $candidates,
+    confidence > 0.3,
+    tier != "Assumed"
+```
+
+### TTL and decay
+
+Facts decay based on epistemic tier and access frequency. The `KnowledgeStore` runs decay as a background sweep, not as inline query logic. WHY: inline decay in every query adds latency and creates inconsistent snapshots when concurrent queries observe different decay states.
+
+| Tier | Half-life | Boosted by access |
+|------|-----------|-------------------|
+| `Verified` | 180 days | Yes — each access resets the clock |
+| `Inferred` | 60 days | Yes — diminishing returns after 5 accesses |
+| `Assumed` | 14 days | No — assumed facts decay on schedule regardless |
+
+Facts below a confidence floor (default 0.05) are candidates for garbage collection. `forget_fact` marks a fact as forgotten immediately; decay lets facts fade naturally.
+
+### Conflict resolution
+
+When two sources assert contradictory facts about the same entity and relation, mneme applies source-priority merge:
+
+1. **Higher-tier wins.** A `Verified` fact supersedes an `Inferred` fact on the same claim. WHY: epistemic tier encodes how much evidence backs the claim.
+2. **Same tier: later timestamp wins.** WHY: more recent observation is more likely current.
+3. **Explicit supersession.** `KnowledgeStore::supersede(old_id, new_id, reason)` records the chain. WHY: the succession relation preserves provenance so downstream consumers can trace why a fact changed.
+
+Never silently overwrite. Every conflict resolution produces a succession record.
+
+### Recursive rule complexity
+
+Recursive rules must terminate. Krites stratifies negation automatically, but recursion depth is unbounded by default.
+
+- Set `:limit N` on recursive queries during development. WHY: unbounded recursion over a growing knowledge graph produces unpredictable latency.
+- Recursive rules that traverse `relationships` must include a depth counter or cycle guard. WHY: entity graphs contain cycles (A knows B, B knows A). Without a guard, the engine explores the cycle until the stratification checker intervenes with a cryptic error.
+
+```datalog
+# Correct: bounded transitive closure
+?[src, dst, depth] :=
+    *relationships[src, dst, _, _],
+    depth = 1
+
+?[src, dst, depth] :=
+    *relationships[src, mid, _, _],
+    ?[mid, dst, prev_depth],
+    depth = prev_depth + 1,
+    depth <= 10
+```
 
 ---
 
@@ -146,7 +234,7 @@ Krites includes fixed rules (built-in algorithms) accessible from Datalog:
 
 ```datalog
 # Shortest path
-?[path] <~ ShortestPathBFS(*relationships[], src: "chiron", dst: "cody")
+?[path] <~ ShortestPathBFS(*relationships[], src: "agent-01", dst: "user")
 
 # Community detection
 ?[node, community] <~ CommunityDetectionLouvain(*relationships[])

--- a/standards/DEPLOYMENT.md
+++ b/standards/DEPLOYMENT.md
@@ -1,0 +1,234 @@
+# Deployment
+
+> Single authority for deployment gates, merge policy, release timing, rollback procedures, and health check requirements. All deployment decisions reference this document.
+>
+> See also: CI.md (tooling configuration), OPERATIONS.md (service-specific runbooks), WORKFLOW.md (dispatch orchestration), RELEASES.md (versioning and binary distribution).
+
+---
+
+## Deployment gates
+
+A deployment gate is a condition that must be satisfied before code moves from one stage to the next. Gates are automated and enforced by the pipeline, not by convention.
+
+### PR merge gate
+
+Every PR must pass ALL checks before merge. No exceptions, no manual overrides.
+
+| Gate | Source | Blocks merge |
+|------|--------|:------------:|
+| Format | CI.md (tooling) | Yes |
+| Lint | CI.md (tooling) | Yes |
+| Type check | CI.md (tooling) | Yes |
+| Unit tests | CI.md (tooling) | Yes |
+| Integration tests | CI.md (tooling) | Yes |
+| Security scan | CI.md (tooling) | Yes |
+| Commit lint | CI.md (tooling) | Yes |
+| Size check | CI.md (tooling) | Yes |
+| Dependency audit | CI.md (tooling) | Advisory (non-blocking for transitive) |
+
+Check execution order: fast checks first. Fail fast, don't waste compute.
+
+1. Format + lint (seconds)
+2. Type check (seconds to minutes)
+3. Unit tests (minutes)
+4. Integration tests (minutes)
+5. Security + dependency (parallel with tests)
+
+### Dispatch QA gate
+
+The dispatch pipeline applies an additional QA layer before merge eligibility. QA verdicts are control signals that drive the dispatch loop, not reports for humans to read.
+
+| Verdict | Merge eligible | Next action |
+|---------|:--------------:|-------------|
+| PASS | Yes | Proceeds to merge policy evaluation |
+| PARTIAL | No (held) | Corrective prompts auto-generated, dependents continue |
+| FAIL | No (held) | Dependents blocked, diagnostic generated |
+
+QA evaluation: per-criterion assessment against the prompt's acceptance criteria, evaluated from the PR diff. Details in WORKFLOW.md (verification stage).
+
+---
+
+## Merge policy
+
+### Automated merge (dispatch pipeline)
+
+The CI manager auto-merges PRs that satisfy both the PR merge gate and the dispatch QA gate. Merge decisions are tiered by blast radius and content:
+
+| Condition | Action |
+|-----------|--------|
+| QA PASS + CI green + single-module blast radius | Auto-merge |
+| QA PASS + CI green + multi-module blast radius | Merge, notify architect for observation triage |
+| QA PARTIAL or hold flag | Hold for architect review |
+| Touches public API surface | Hold for architect review |
+| R-type prompt (research, no PR) | Move prompt to done/ |
+
+### Manual merge
+
+PRs not created by the dispatch pipeline follow standard review:
+
+- Require CI pass (all gates above)
+- Require 1 approval (human or bot for automated PRs)
+
+### Branch protection
+
+| Rule | Applies to |
+|------|-----------|
+| Require PR for all changes | main |
+| Require CI pass | main |
+| No force push | main |
+| No merge commits (rebase or squash only) | main |
+| Branch auto-delete after merge | all feature branches |
+
+---
+
+## Release timing
+
+### Wave-based releases
+
+Version bumps happen per-wave, not per-PR. A wave is a coherent batch of work with a unifying theme. See RELEASES.md for versioning policy and changelog format.
+
+Exceptions that get immediate PATCH bumps:
+- Security fixes
+- Critical runtime bugs (data loss, crash on startup)
+
+### release-please cadence
+
+release-please runs on an hourly schedule, not on every push to main. During active dispatch batches, 10-30 PRs/hour land; per-push runs waste CI minutes and create noise. The hourly run picks up all accumulated commits and updates a single release PR.
+
+The release-please PR is the version gate. It is never auto-merged. Operator sign-off required.
+
+### Deployment windows
+
+Container auto-updates via `podman-auto-update.timer`: Sundays 4 AM. Pin auto-update schedules to low-traffic windows to contain blast radius of bad updates.
+
+---
+
+## Upgrade procedure
+
+### Binary services
+
+1. Back up (verify backup integrity before proceeding)
+2. Stop service
+3. Replace binary (verify checksum against published SHA256)
+4. Start service
+5. Health check (automated, with timeout)
+6. Smoke test (one real request through the system)
+
+### Container services
+
+1. Pull new image (`podman pull`)
+2. Stop container (`systemctl stop <name>-container`)
+3. Remove old container (`podman rm <name>`)
+4. Recreate with same volume mounts and network config
+5. Start (`systemctl start <name>-container`)
+6. Health check
+7. Verify logs for startup errors
+
+For auto-updated containers, steps 1-5 happen via `podman auto-update`. Verify health after the timer fires.
+
+### Zero-downtime (when applicable)
+
+For services requiring uptime:
+- Blue-green deployment OR rolling restart
+- Health check gates before traffic shift
+- Automatic rollback on health check failure
+
+---
+
+## Rollback
+
+Every deployment is rollback-safe. The rollback procedure is tested and documented.
+
+### Binary rollback
+
+1. Stop service
+2. Swap binary (previous version preserved at known path or in prior GitHub release)
+3. Start service
+4. Health check
+
+### Container rollback
+
+1. Stop container
+2. Remove container
+3. Recreate with previous image tag
+4. Start container
+5. Health check
+
+### Database rollback
+
+Database migrations are forward-only. Rollback SQL is documented per migration but treated as emergency-only. Design migrations to be backward-compatible where possible.
+
+### Requirements
+
+- Previous binary/image preserved (not overwritten)
+- Database migrations have documented rollback SQL
+- Rollback procedure tested against actual deployment
+
+---
+
+## Health checks
+
+Health checks serve two purposes: deployment readiness validation and ongoing service monitoring. This section covers what health checks a deployable service must expose. OPERATIONS.md covers monitoring dashboards, alerting thresholds, and runbook-level health verification.
+
+### Required endpoints
+
+Every long-running service exposes:
+
+| Endpoint | Purpose | Failure meaning |
+|----------|---------|----------------|
+| Liveness | Is the process running? | Restart the service |
+| Readiness | Can it handle requests? | Remove from load balancer, do not route traffic |
+| Dependency | Are database, cache, external APIs reachable? | Investigate upstream, do not deploy dependents |
+
+### Pre-deployment validation
+
+Before starting or upgrading a service, validate resource availability:
+
+| Check | What | Why |
+|-------|------|-----|
+| Disk space | Data directories have sufficient free space | Prevents write failures mid-operation |
+| Port availability | Listen ports are free | Prevents bind errors at startup |
+| Credential validity | Auth tokens work (single probe request) | Prevents cryptic 401s after minutes of operation |
+| Network reachability | External dependencies respond | Surfaces network issues before user traffic |
+
+### Container health checks
+
+Every long-running container defines a health check. Services behind a reverse proxy additionally have the proxy verify backend health.
+
+```bash
+# Container-level health
+podman healthcheck run <container-name>
+
+# Service-level health
+curl -sf http://localhost:<port>/health || exit 1
+```
+
+---
+
+## Fleet management
+
+The dispatch fleet runs multi-provider AI agents. Deployment concerns specific to fleet operations:
+
+### Provider routing
+
+Provider selection is derived from per-provider success rate data, not manually maintained routing tables. See WORKFLOW.md for dispatch orchestration details.
+
+### Fleet health
+
+Fleet health is aggregated to `/tmp/dispatch-fleet-health.json`. The steward daemon monitors PR status and takes corrective action (fix agents on failure, auto-merge on green).
+
+### Worktree isolation
+
+Every worker operates in a dedicated git worktree. No shared mutable state between workers. Worktrees are created per-prompt and cleaned up post-merge. This is a deployment invariant: parallel execution depends on isolation.
+
+---
+
+## Principles
+
+**Gates are automated.** If a human must remember to check something before merge, it is not a gate. Gates are pipeline stages that block progression programmatically.
+
+**Derive deployment config.** Blast radius derives from cargo metadata. Routing derives from success rates. Gate requirements derive from CI tooling configuration. Manually maintained deployment checklists drift from the actual pipeline. See STANDARDS.md (derive, don't maintain).
+
+**Rollback is not optional.** Every deployment must have a tested rollback path. "We'll fix forward" is not a rollback plan. The cost of preserving the previous artifact is negligible; the cost of not having it during an incident is unbounded.
+
+**Health checks gate traffic, not just uptime.** A service that is running but cannot handle requests must not receive traffic. Liveness and readiness are distinct signals with distinct responses.

--- a/standards/ENVIRONMENT.md
+++ b/standards/ENVIRONMENT.md
@@ -1,0 +1,307 @@
+# Environment Configuration
+
+> Standards for environment variables, configuration files, and runtime settings. Defines how values vary across deploy contexts and how configuration is discovered, loaded, and validated.
+
+---
+
+## Guiding principles
+
+**Configuration is data, not code.** Values that change between environments (credentials, hostnames, feature flags) live in configuration, not source. The same binary runs in dev, staging, and production with different configuration.
+
+**Hierarchical configuration.** Configuration layers from most general (compiled defaults) to most specific (CLI flags). Each layer overrides the previous. This enables shared defaults with environment-specific overrides without duplication.
+
+**Explicit over implicit.** Configuration paths, variable names, and default values are explicit and documented. No hidden defaults, no surprise environment variable mappings.
+
+**Fail fast on invalid config.** Configuration is validated at startup. Missing required values, invalid paths, or type mismatches produce clear errors immediately, not at first use.
+
+**Secrets are configuration, but special.** Secrets follow the same hierarchy but are handled with additional care: never logged, never committed, rotated automatically when possible.
+
+---
+
+## Configuration hierarchy
+
+Configuration loads in five layers, from lowest to highest precedence:
+
+```
+Layer 1: Compiled defaults
+    ↓
+Layer 2: Global config (~/.config/kanon/config.toml)
+    ↓
+Layer 3: Repo-local config (workflow/kanon.toml)
+    ↓
+Layer 4: Environment variables (KANON_*)
+    ↓
+Layer 5: CLI flags
+```
+
+Higher layers override lower layers. Environment variables override file config. CLI flags override everything.
+
+### Layer 1: Compiled defaults
+
+Default values embedded in the binary. Every configuration field has a default. These defaults are intentionally conservative and safe for development.
+
+```rust
+fn default_model() -> String { "claude-opus-4-6".to_string() }
+fn default_state_dir() -> PathBuf { dirs::home_dir().unwrap().join(".dispatch") }
+```
+
+### Layer 2: Global config
+
+User-specific settings that persist across repository clones. Lives at:
+
+- Linux: `~/.config/kanon/config.toml`
+- macOS: `~/Library/Application Support/kanon/config.toml`
+
+Override path via `KANON_GLOBAL_CONFIG` environment variable.
+
+Use for: personal preferences, API keys, default models, local paths that don't vary by project.
+
+### Layer 3: Repo-local config
+
+Project-specific settings. Lives at `workflow/kanon.toml` relative to the kanon repository root.
+
+Use for: project definitions, per-project paths, gate command overrides, feature flags specific to this deployment.
+
+### Layer 4: Environment variables
+
+Runtime overrides. Variables use `KANON_` prefix with double-underscore separator for nested keys:
+
+| Environment variable | Maps to config field |
+|---------------------|---------------------|
+| `KANON_MODEL` | `model` |
+| `KANON_MODEL_QA` | `model_qa` |
+| `KANON_STATE_DIR` | `state_dir` |
+| `KANON_DISPATCH__MAX_PARALLEL` | `dispatch.max_parallel` |
+| `KANON_PROJECTS__ALEtheia__REPO_DIR` | `projects.aletheia.repo_dir` |
+
+The `__` (double underscore) separates struct fields. Single `_` is part of the field name.
+
+### Layer 5: CLI flags
+
+Highest precedence. CLI arguments override all other sources. Used for one-off overrides and scripting.
+
+---
+
+## Required environment variables
+
+No environment variables are strictly required for basic operation. The system uses compiled defaults and discovers paths when possible. However, production deployments typically set:
+
+| Variable | Purpose | When required |
+|----------|---------|---------------|
+| `KANON_ROOT` | Path to kanon repository | When running outside the repo |
+| `KANON_GLOBAL_CONFIG` | Override global config path | Testing, isolated environments |
+
+## Optional environment variables
+
+### Core configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `KANON_MODEL` | `claude-opus-4-6` | Default model for agent sessions |
+| `KANON_MODEL_QA` | `claude-sonnet-4-6` | Model for QA evaluation |
+| `KANON_EFFORT` | `high` | Agent effort level (low/medium/high) |
+| `KANON_STATE_DIR` | `~/.dispatch` | Runtime state directory (SQLite, logs) |
+
+### Dispatch configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `KANON_DISPATCH__MAX_PARALLEL` | `10` | Maximum concurrent sessions per group |
+| `KANON_DISPATCH__WORKTREE_BASE` | `/data/worktrees` | Base directory for git worktrees |
+| `KANON_DISPATCH__TARGET_DIR` | `/data/target` | Shared cargo target directory |
+| `KANON_DISPATCH__SKIP_QA` | `false` | Skip QA gate evaluation |
+| `KANON_DISPATCH__DETACH` | `true` | Run sessions in detached process group |
+
+### Provider configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `KANON_PROVIDER__DEFAULT` | `claude-code` | Default agent provider |
+| `KANON_PROVIDER__PROXY_URL` | (none) | LLM proxy URL for multi-backend routing |
+| `KANON_PROVIDER__PROXY_API_KEY` | (none) | API key for LLM proxy authentication |
+
+### Steward configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `KANON_STEWARD__CI_MODE` | `github` | CI validation mode (`github` or `local`) |
+| `KANON_STEWARD__REACTIONS__AUTO_MERGE` | `true` | Enable auto-merge handler |
+| `KANON_STEWARD__REACTIONS__FIX_CI` | `true` | Enable CI-fix handler |
+
+---
+
+## Path resolution
+
+### Variable expansion
+
+Configuration supports limited variable expansion in path values:
+
+| Pattern | Expansion |
+|---------|-----------|
+| `~/path` | `$HOME/path` |
+| `$HOME/path` | Home directory |
+| `$KANON_ROOT/path` | Kanon repository root |
+
+Expansion happens after configuration loading. The raw value is stored; expansion occurs when the path is used.
+
+### Discovery order
+
+Kanon root discovery (for finding `workflow/kanon.toml`):
+
+1. Walk up from current directory looking for `projects/` and `workflow/kanon.toml`
+2. `KANON_ROOT` environment variable
+3. Error if neither succeeds
+
+Project repo directories (per-project `repo_dir`):
+
+1. Use configured path from `kanon.toml`
+2. Expand variables (`~`, `$HOME`, `$KANON_ROOT`)
+3. Validate directory exists on use
+
+---
+
+## Feature flags
+
+Runtime feature flags enable experimental functionality without code changes. Flags live in the `[features]` section of config or via `KANON_FEATURES__*` variables.
+
+| Flag | Variable | Default | Description |
+|------|----------|---------|-------------|
+| `cron_scheduler` | `KANON_FEATURES__CRON_SCHEDULER` | `false` | Cron-based scheduler for recurring jobs |
+| `progress_streaming` | `KANON_FEATURES__PROGRESS_STREAMING` | `false` | Stream progress events from sessions |
+| `tool_whitelisting` | `KANON_FEATURES__TOOL_WHITELISTING` | `false` | Restrict MCP tool visibility |
+| `coordinator_fanout` | `KANON_FEATURES__COORDINATOR_FANOUT` | `false` | Fan out coordinator work |
+| `microcompaction` | `KANON_FEATURES__MICROCOMPACTION` | `false` | Compact SQLite during idle periods |
+| `dispatch_local` | `KANON_FEATURES__DISPATCH_LOCAL` | `false` | Enable local LLM provider support |
+
+All flags default to `false` (conservative). Enable explicitly in production when feature is stable.
+
+---
+
+## Secrets handling
+
+Secrets are environment variables or configuration values that grant access to external systems.
+
+### Rules
+
+1. **Never commit secrets.** API keys, tokens, and passwords live in environment variables or secret stores, never in git.
+
+2. **Use secret types.** In code, use dedicated secret types that prevent accidental exposure:
+   - Rust: `secrecy::SecretString`
+   - Never implement `Display` for types containing secrets
+   - Redact in `Debug` output: `[REDACTED]`
+
+3. **No secret defaults.** Secret configuration fields have no defaults. Missing secrets produce clear errors at startup.
+
+4. **Log carefully.** Never log secret values, even at trace level. Log the presence/absence of secrets, not their content.
+
+### Required secrets
+
+| Secret | Environment variable | Used for |
+|--------|---------------------|----------|
+| LLM API key | `ANTHROPIC_AUTH_TOKEN` | Claude Code sessions |
+| LLM proxy key | `KANON_PROVIDER__PROXY_API_KEY` | Proxy authentication |
+| GitHub token | `GITHUB_TOKEN` | PR operations, steward |
+
+---
+
+## Configuration validation
+
+Configuration validation occurs at load time. Invalid configuration produces errors with specific messages.
+
+### Validation rules
+
+- **Required directories exist:** `state_dir`, project `repo_dir` paths are validated
+- **Project prefixes unique:** No two projects share the same 2-3 character prefix
+- **Prefixes well-formed:** 2-3 lowercase ASCII letters only
+- **References valid:** Standards files referenced in config exist on disk
+
+### Error messages
+
+Error messages explain what is wrong and how to fix it:
+
+```
+project "foo": prefix "f" must be 2-3 lowercase ASCII letters
+state directory is not accessible: /data/dispatch
+project repo directory does not exist: /home/user/missing-project
+```
+
+---
+
+## Environment-specific patterns
+
+### Development
+
+Use global config for personal preferences. Local config for project paths. Minimal environment variables.
+
+```toml
+# ~/.config/kanon/config.toml
+model = "claude-sonnet-4-6"
+effort = "medium"
+
+[dispatch]
+max_parallel = 4
+```
+
+### CI/CD
+
+Use environment variables for all configuration. No persisted config files. Explicit and reproducible.
+
+```bash
+export KANON_MODEL="claude-sonnet-4-6"
+export KANON_DISPATCH__MAX_PARALLEL="2"
+export KANON_STEWARD__CI_MODE="local"
+```
+
+### Production
+
+Use repo-local config for stable settings. Environment variables for secrets and host-specific overrides.
+
+```toml
+# workflow/kanon.toml (committed)
+[dispatch]
+max_parallel = 20
+worktree_base = "/data/worktrees"
+
+[features]
+cron_scheduler = true
+```
+
+```bash
+# /etc/kanon/environment (not committed)
+KANON_PROVIDER__PROXY_API_KEY="sk-..."
+ANTHROPIC_AUTH_TOKEN="sk-ant-..."
+```
+
+---
+
+## Anti-patterns
+
+1. **Hardcoded paths.** Never hardcode paths to user directories or system locations. Use configuration.
+
+2. **Environment variables for logic.** Use feature flags for behavioral changes, not environment variable presence checks.
+
+3. **Silent defaults for secrets.** Secrets should error if missing, not silently use a default.
+
+4. **Complex environment variable parsing.** Don't implement custom parsing for environment variables. Use the configuration system's type coercion.
+
+5. **Configuration in code.** If it varies by environment, it belongs in configuration, not `#[cfg(...)]` or conditional compilation.
+
+---
+
+## Debugging configuration
+
+To see effective configuration, run with debug logging:
+
+```bash
+RUST_LOG=debug kanon config show
+```
+
+This outputs the merged configuration from all layers (with secrets redacted).
+
+To test configuration without side effects:
+
+```bash
+kanon config validate
+```
+
+Returns exit code 0 if configuration is valid, non-zero with error messages otherwise.

--- a/standards/GNOMON.md
+++ b/standards/GNOMON.md
@@ -168,6 +168,82 @@ A name fails as a gnomon when the name draws attention to itself rather than to 
 
 ---
 
+## Naming review gate
+
+Every new component name passes this checklist before architecture is finalized. Not post-hoc renaming — the name shapes the design. A name that ships without review becomes load-bearing before anyone evaluates whether it was right.
+
+**WHY a gate:** Names are the hardest thing to change. Once a name enters code, docs, conversation, and mental models, renaming costs more than the original design. Catching a bad name before merge costs minutes. Catching it after costs weeks of migration and confusion.
+
+### L1: Practical
+
+The name must function as a working identifier in code and conversation.
+
+| Check | Pass criteria |
+|-------|--------------|
+| **Pronounceable** | A native English speaker can say it aloud without hesitation. If reviewers stumble, the name fails. |
+| **Typeable** | Lowercase ASCII transliteration fits standard identifiers. No diacritics in code paths. Greek is for documentation and conceptual reference. |
+| **Grep-friendly** | The name returns relevant results and only relevant results. No collisions with common English words, standard library types, or existing crate/module names in the ecosystem. |
+| **No internal collisions** | `grep -r <name>` across all repos returns zero false positives from unrelated components. |
+| **Length** | 3-12 characters in code form. Shorter names must be more common roots (e.g., `nous`). Longer names must justify the syllables. |
+
+**WHY L1 first:** A name that fails L1 will be worked around. Developers will invent abbreviations, aliases, or avoid saying it. The workaround becomes the real name, and the official name becomes decoration.
+
+### L2: Structural
+
+The name must reflect the component's role and compose with its neighbors.
+
+| Check | Pass criteria |
+|-------|--------------|
+| **Role alignment** | The Greek source meaning maps to what the component *does* in the system, not what it *contains*. |
+| **Domain convention** | Follows the suffix system: -ia/-eia for platforms/qualities, -sis for processes, -on for tools/instruments, -ων/-μων for agents. Mismatched suffixes mislead. |
+| **Sibling coherence** | Names at the same architectural level share a register. A module named alongside `dianoia` and `noesis` should not suddenly be `DataProcessor`. |
+| **Parent-child fit** | If nested under a named parent, the child name makes sense as a part of that whole. Aletheia's children should relate to unconcealment. |
+
+**WHY L2:** Structural misalignment compounds silently. A name that contradicts its role trains every reader to distrust the naming system. Once distrust sets in, names stop carrying information and become arbitrary labels.
+
+### L3: Philosophical
+
+The Greek source meaning must align with the component's purpose. The metaphor must be coherent, not forced.
+
+| Check | Pass criteria |
+|-------|--------------|
+| **Source verification** | The Greek etymology is confirmed against LSJ (Liddell-Scott-Jones) or equivalent primary source. No folk etymologies, no second-hand glosses. |
+| **Meaning alignment** | The primary LSJ sense (not an obscure tertiary sense) maps to the component's essential nature. If you need the fifth definition to make it work, the name is wrong. |
+| **Metaphor integrity** | The conceptual mapping holds under examination. If someone who knows the Greek would object, the name fails. |
+| **Not forced** | The name was discovered, not justified. If the review discussion is mostly explaining why the Greek fits, it does not fit. |
+
+**WHY L3:** A name with a broken philosophical mapping is worse than an English name. It signals precision it does not deliver, which erodes trust in every other Greek name in the system.
+
+### L4: Topological
+
+The name must compose with the broader naming topology. No name exists in isolation.
+
+| Check | Pass criteria |
+|-------|--------------|
+| **Neighbor composition** | The name forms a coherent semantic field with its siblings. List the neighbors and read them together — do they tell a consistent story? |
+| **No semantic collision** | The name does not overlap in meaning with an existing name at any level. Two names that mean approximately the same thing force readers to guess at a distinction that may not exist. |
+| **Relationship encoding** | If the component has a meaningful relationship with another (dependency, opposition, containment), the names encode or at least permit that reading. |
+| **Future composition** | The name does not block obvious future additions. A name that claims too much semantic space forces awkward naming for later components. |
+
+**WHY L4:** The topology is the system's conceptual architecture made legible. A name that disrupts the topology doesn't just misname one thing — it degrades the information density of every other name.
+
+### Gate process
+
+1. **Proposer** writes the name, its Greek source, LSJ reference, and a one-line reading at each layer (L1-L4).
+2. **Reviewer** runs the checklist above. Any L1 failure is a hard block. L2-L4 failures require discussion and explicit resolution.
+3. **Topology audit.** Reviewer lists the five nearest neighbors (same parent, same level, direct dependencies) and evaluates composition. If the name creates dissonance, it does not merge.
+4. **Record the decision.** The PR description includes the name proposal, the checklist results, and any alternatives considered. This is the naming decision record. Future readers should not have to reconstruct *why* this name was chosen.
+
+**WHY record:** Names outlive the people who chose them. Without a decision record, the next person to question the name has no way to distinguish a carefully chosen name from an arbitrary one. They will either accept it uncritically or rename it without understanding the original reasoning. Both outcomes are bad.
+
+### Exceptions
+
+- **Internal-only identifiers** (private functions, local variables, test helpers) do not require the full gate. Standard code naming rules from STANDARDS.md apply.
+- **Established names** already in production are not retroactively gated. If a name is wrong but load-bearing, file an issue for planned migration rather than blocking current work.
+- **Prototype/spike work** may use placeholder names. The gate applies when the component is promoted to a permanent name. Placeholder names must be obviously temporary (e.g., `spike_foo`, `proto_bar`).
+
+---
+
 ## Sources
 
 - **Plato.** *Republic* (the divided line: dianoia and noesis), *Meno* (anamnesis), *Theaetetus* (knowledge and perception)

--- a/standards/KOTLIN.md
+++ b/standards/KOTLIN.md
@@ -2,9 +2,9 @@
 
 > Additive to STANDARDS.md. Read that first. Everything here is Kotlin-specific.
 >
-> Target: Kotlin 2.x (K2 compiler), Android (Jetpack Compose, Hilt, Room). Akroasis media player.
+> Target: Kotlin 2.x (K2 compiler), Android (Jetpack Compose, Hilt, Room), Kotlin Multiplatform (KMP), Compose Multiplatform. Akroasis media player.
 >
-> **Key decisions:** K2 compiler, Compose + Material 3, Hilt DI, Room DB, KSP (not kapt), kotlinx.serialization, StateFlow (not LiveData), coroutines.
+> **Key decisions:** K2 compiler, Compose Multiplatform + Material 3, Hilt DI (Android), Koin (KMP), Room DB, KSP (not kapt), kotlinx.serialization, StateFlow (not LiveData), coroutines, Navigation (type-safe), expect/actual for platform abstraction.
 
 ---
 
@@ -86,6 +86,8 @@ Kotlin's type system distinguishes nullable (`String?`) from non-null (`String`)
 
 ## Error handling
 
+See STANDARDS.md § Error Handling for universal principles.
+
 ### `Result<T>` for operations that can fail
 
 ```kotlin
@@ -108,7 +110,6 @@ sealed class AppError {
 
 ### Rules
 
-- Never bare `catch (Exception)`: catch specific types
 - `runCatching { }` for concise error handling where appropriate
 - Propagate errors to the ViewModel: let the UI layer decide presentation
 
@@ -176,9 +177,7 @@ fun TrackItem(
 - Material 3 design system
 - Extract reusable composables into separate files
 
-### Compose multiplatform
-
-iOS: stable (since CMP 1.8). Desktop: stable. Web (Wasm): beta. Use for shared UI across Android/iOS when applicable.
+See § Compose Multiplatform for cross-platform UI patterns.
 
 ---
 
@@ -224,8 +223,12 @@ data class TrackResponse(
 
 ## Testing
 
+See TESTING.md for all testing principles (naming, isolation, coverage, test data, property testing).
+
+Kotlin-specific framework choices:
+
 - **Framework:** JUnit 5 + Turbine (for Flow testing)
-- **Names:** `loadAlbum_emitsLoaded_whenSuccess`, not `test1`
+- **Property testing:** Kotest property testing
 - **Coroutine testing:** `runTest { }` with `TestDispatcher`
 - **Compose testing:** `createComposeRule()` for UI tests
 - **Mocking:** MockK at interface boundaries
@@ -252,6 +255,385 @@ app/src/main/java/app/akroasis/
 
 ---
 
+## Kotlin Flow
+
+StateFlow basics are in § Async & concurrency. This section covers advanced Flow patterns.
+
+### Operators
+
+Use `map`, `filter`, `combine`, `flatMapLatest` for declarative stream transformation. Avoid `collect` inside `collect` — compose flows with operators instead.
+
+WHY: Nested collection creates nested coroutines that are hard to cancel correctly and easy to leak. Operators keep the flow pipeline flat and cancellation-safe.
+
+```kotlin
+// Wrong: nested collection
+viewModelScope.launch {
+    searchQuery.collect { query ->
+        repository.search(query).collect { results ->
+            _uiState.value = results
+        }
+    }
+}
+
+// Right: flatMapLatest cancels the previous inner flow on new emission
+searchQuery
+    .debounce(300)
+    .flatMapLatest { query -> repository.search(query) }
+    .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+```
+
+### `stateIn` and `shareIn`
+
+Convert cold flows to hot shared flows at the ViewModel layer. Never expose cold flows from a ViewModel — every collector would restart the upstream.
+
+WHY: Cold flows re-execute their producer on each collection. A Room query flow collected by two composables would run two separate database queries. `stateIn` shares one upstream and replays the latest value.
+
+```kotlin
+val albums: StateFlow<List<Album>> = albumRepository.observeAll()
+    .stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = emptyList(),
+    )
+```
+
+`WhileSubscribed(5000)`: keeps the upstream alive for 5 seconds after the last subscriber disappears. Survives configuration changes without restarting the query. `Eagerly` and `Lazily` exist but rarely fit UI use cases.
+
+### `callbackFlow` for bridging imperative APIs
+
+Wrap callback-based APIs (media players, sensors, platform listeners) in `callbackFlow`:
+
+```kotlin
+fun observePlaybackState(player: MediaPlayer): Flow<PlaybackState> = callbackFlow {
+    val listener = object : Player.Listener {
+        override fun onPlaybackStateChanged(state: Int) {
+            trySend(state.toPlaybackState())
+        }
+    }
+    player.addListener(listener)
+    awaitClose { player.removeListener(listener) }
+}
+```
+
+WHY: `callbackFlow` provides a `SendChannel` with proper lifecycle — `awaitClose` guarantees cleanup runs when the flow collector cancels. Raw channels miss this guarantee.
+
+### Flow testing
+
+Use Turbine for deterministic flow assertions:
+
+```kotlin
+@Test
+fun `search emits results after debounce`() = runTest {
+    val viewModel = SearchViewModel(FakeRepository())
+    viewModel.results.test {
+        viewModel.onQueryChanged("beethoven")
+        awaitItem() // initial empty
+        awaitItem() // search results
+        cancelAndIgnoreRemainingEvents()
+    }
+}
+```
+
+Never use `first()` or `take(1)` in tests — they silently swallow timing issues. Turbine makes assertion order explicit and fails on unexpected emissions.
+
+---
+
+## Navigation
+
+### Type-safe navigation (Navigation 2.8+)
+
+Use Kotlin serializable classes as route definitions. String-based routes are banned in new code.
+
+WHY: String routes are stringly-typed — typos compile, missing arguments are runtime crashes, and refactoring is grep-and-pray. Serializable route objects give compile-time safety for arguments and destinations.
+
+```kotlin
+@Serializable
+data class AlbumRoute(val albumId: Long)
+
+@Serializable
+data object PlayerRoute
+
+@Serializable
+data object LibraryRoute
+```
+
+### NavHost setup
+
+```kotlin
+@Composable
+fun AppNavHost(
+    navController: NavHostController,
+    modifier: Modifier = Modifier,
+) {
+    NavHost(
+        navController = navController,
+        startDestination = LibraryRoute,
+        modifier = modifier,
+    ) {
+        composable<LibraryRoute> {
+            LibraryScreen(onAlbumClick = { navController.navigate(AlbumRoute(it.id)) })
+        }
+        composable<AlbumRoute> { backStackEntry ->
+            val route = backStackEntry.toRoute<AlbumRoute>()
+            AlbumScreen(albumId = route.albumId)
+        }
+        composable<PlayerRoute> {
+            PlayerScreen()
+        }
+    }
+}
+```
+
+### Rules
+
+- One `NavHost` per app. Nested navigation uses `navigation()` builder for sub-graphs, not nested `NavHost`.
+- `NavController` lives in the top-level composable or Activity. Never pass it into ViewModels. ViewModels emit navigation events; the UI layer acts on them.
+- Deep links: define on the route class with `@Serializable` + `deepLinks` parameter in `composable()`.
+- Back stack: use `popUpTo` with `inclusive` to prevent stack accumulation on bottom navigation tabs.
+
+WHY (NavController out of ViewModel): Navigation is a UI concern. ViewModels survive configuration changes — if they hold a NavController reference, it points to a destroyed Activity's controller after rotation. Emit a one-shot event (`Channel<NavigationEvent>`) instead.
+
+```kotlin
+// In ViewModel
+private val _navigation = Channel<NavigationEvent>(Channel.BUFFERED)
+val navigation = _navigation.receiveAsFlow()
+
+fun onAlbumSelected(albumId: Long) {
+    viewModelScope.launch {
+        _navigation.send(NavigationEvent.GoToAlbum(albumId))
+    }
+}
+
+// In composable
+LaunchedEffect(Unit) {
+    viewModel.navigation.collect { event ->
+        when (event) {
+            is NavigationEvent.GoToAlbum -> navController.navigate(AlbumRoute(event.albumId))
+        }
+    }
+}
+```
+
+---
+
+## Compose Multiplatform
+
+### Platform targets
+
+| Target | Status | Notes |
+|--------|--------|-------|
+| Android | Stable | Primary target, full Jetpack integration |
+| iOS | Stable (CMP 1.8+) | UIKit interop via `UIKitView` |
+| Desktop (JVM) | Stable | Swing/AWT interop via `SwingPanel` |
+| Web (Wasm) | Beta | `@ExperimentalWasmDsl`, limited interop |
+
+### Project structure
+
+```
+shared/
+├── commonMain/       : shared UI composables, ViewModels, expect declarations
+├── androidMain/      : Android-specific actual implementations
+├── iosMain/          : iOS-specific actual implementations
+├── desktopMain/      : Desktop-specific actual implementations
+└── commonTest/       : shared tests
+```
+
+All UI composables go in `commonMain` unless they depend on platform APIs. Platform-specific composables use `expect`/`actual` (see § Kotlin Multiplatform).
+
+### Shared composables
+
+Write composables against the Compose Multiplatform API, not Jetpack Compose directly. The API surface is nearly identical but the import paths differ.
+
+WHY: `androidx.compose.*` imports are Android-only. `org.jetbrains.compose.*` works across all targets. Mixing them causes compilation failures on non-Android targets.
+
+```kotlin
+// commonMain — works everywhere
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun Greeting(name: String, modifier: Modifier = Modifier) {
+    Text(text = "Hello, $name", modifier = modifier)
+}
+```
+
+Material 3 is available cross-platform via the `compose.material3` dependency in Compose Multiplatform.
+
+### Platform-specific UI
+
+Use `expect`/`actual` for composables that wrap platform-native views:
+
+```kotlin
+// commonMain
+@Composable
+expect fun VideoPlayer(uri: String, modifier: Modifier = Modifier)
+
+// androidMain
+@Composable
+actual fun VideoPlayer(uri: String, modifier: Modifier) {
+    AndroidView(factory = { context -> ExoPlayerView(context).apply { load(uri) } })
+}
+
+// iosMain
+@Composable
+actual fun VideoPlayer(uri: String, modifier: Modifier) {
+    UIKitView(factory = { AVPlayerView().apply { load(uri) } })
+}
+```
+
+### Resources
+
+Use `Res` from Compose Multiplatform resources API (`org.jetbrains.compose.resources`). Place resources in `commonMain/composeResources/`.
+
+WHY: Android's `R` class does not exist on other platforms. The Compose Multiplatform resources API generates type-safe accessors that work everywhere.
+
+```kotlin
+// commonMain
+Image(
+    painter = painterResource(Res.drawable.album_art),
+    contentDescription = "Album art",
+)
+Text(text = stringResource(Res.string.app_name))
+```
+
+### Rules
+
+- Test shared composables in `commonTest` with `@OptIn(ExperimentalTestApi::class) runComposeUiTest { }`.
+- Image loading: use Coil 3 (multiplatform) or Kamel. Glide and Picasso are Android-only.
+- Lifecycle: use `androidx.lifecycle` ViewModel and `Lifecycle` from the multiplatform artifact (`lifecycle-viewmodel-compose`, `lifecycle-runtime-compose`).
+- Window management: `application { Window() }` on desktop, standard Activity on Android, no window concept on iOS (UIKit manages it).
+
+---
+
+## Kotlin Multiplatform (KMP)
+
+### Architecture
+
+Shared business logic in `commonMain`. Platform code only for platform APIs. The boundary is `expect`/`actual`.
+
+```
+:shared              (KMP library)
+├── commonMain/      : domain models, use cases, repositories (interfaces), ViewModels
+├── androidMain/     : Android Room DAO implementations, Android-specific APIs
+├── iosMain/         : iOS CoreData/platform implementations
+└── commonTest/      : shared unit tests
+
+:androidApp          (Android application, depends on :shared)
+:iosApp              (Xcode project, depends on :shared via framework export)
+:desktopApp          (JVM application, depends on :shared)
+```
+
+WHY: Business logic changes once, ships everywhere. Platform modules implement the platform contract — they do not contain business logic. If a use case is duplicated across platform modules, it belongs in `commonMain`.
+
+### `expect` / `actual`
+
+Declare platform abstractions in `commonMain`, implement in each target:
+
+```kotlin
+// commonMain
+expect class PlatformContext
+
+expect fun createDatabaseDriver(context: PlatformContext): SqlDriver
+
+// androidMain
+actual typealias PlatformContext = Context
+
+actual fun createDatabaseDriver(context: PlatformContext): SqlDriver {
+    return AndroidSqliteDriver(AppDatabase.Schema, context, "app.db")
+}
+
+// iosMain
+actual class PlatformContext  // no-arg on iOS
+
+actual fun createDatabaseDriver(context: PlatformContext): SqlDriver {
+    return NativeSqliteDriver(AppDatabase.Schema, "app.db")
+}
+```
+
+### Rules
+
+- `expect`/`actual` for platform APIs only. If the implementation is identical across all targets, it belongs in `commonMain` without `expect`/`actual`.
+- Prefer interfaces over `expect`/`actual` when the abstraction is DI-injected. `expect`/`actual` is for types and functions that must resolve at compile time. Interfaces are for dependencies that can be swapped at runtime (testing, configuration).
+- Never put `expect`/`actual` on domain models. Domain models are platform-agnostic by definition.
+
+WHY (interfaces over expect/actual for DI): `expect`/`actual` resolves at compile time per target — you cannot swap implementations in tests without a separate test source set. An interface injected via Koin or a manual DI graph can be faked trivially.
+
+### Dependency injection in KMP
+
+Hilt is Android-only (Dagger is JVM-only). For KMP projects, use Koin:
+
+```kotlin
+// commonMain
+val sharedModule = module {
+    singleOf(::AlbumRepository)
+    factoryOf(::GetAlbumsUseCase)
+    viewModelOf(::AlbumViewModel)
+}
+
+// androidMain
+val androidModule = module {
+    single<SqlDriver> { AndroidSqliteDriver(AppDatabase.Schema, get(), "app.db") }
+}
+
+// iosMain
+val iosModule = module {
+    single<SqlDriver> { NativeSqliteDriver(AppDatabase.Schema, "app.db") }
+}
+```
+
+WHY: Koin is pure Kotlin with no annotation processing — it works identically on all KMP targets. Hilt generates Android-specific components via KSP that cannot run on iOS or desktop.
+
+### Networking
+
+Ktor client for all HTTP in KMP. Platform engines:
+
+```kotlin
+// commonMain
+val httpClient = HttpClient {
+    install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+    install(Logging) { level = LogLevel.INFO }
+}
+
+// androidMain — OkHttp engine
+actual fun createEngine(): HttpClientEngine = OkHttp.create()
+
+// iosMain — Darwin engine
+actual fun createEngine(): HttpClientEngine = Darwin.create()
+```
+
+WHY: Ktor's multiplatform client uses the platform's native HTTP stack. OkHttp on Android, NSURLSession on iOS. No bridging overhead, platform-appropriate TLS and caching.
+
+### Database
+
+SQLDelight for KMP projects (Room is Android-only). Generates type-safe Kotlin from SQL:
+
+```sql
+-- Album.sq
+selectAll:
+SELECT id, title, artist FROM album ORDER BY title;
+
+insertAlbum:
+INSERT INTO album (title, artist) VALUES (?, ?);
+```
+
+```kotlin
+// commonMain — generated API
+val albums: Flow<List<Album>> = queries.selectAll().asFlow().mapToList(Dispatchers.IO)
+```
+
+WHY: Room generates Android-specific code (SupportSQLiteDatabase). SQLDelight generates pure Kotlin from SQL and supports Android, iOS, JVM, and JS/Wasm targets with platform-native drivers.
+
+### Testing in KMP
+
+- `commonTest` for platform-agnostic tests (business logic, use cases, ViewModels with faked repositories)
+- Platform test source sets (`androidTest`, `iosTest`) only for code that uses `actual` implementations
+- Use `kotlinx-coroutines-test` with `runTest` in `commonTest` — it works on all targets
+- Fakes over mocks in `commonTest`: MockK is JVM-only
+
+WHY: Tests in `commonTest` run on every target in CI, catching platform-specific issues (number formatting, string normalization, date handling) that single-platform tests miss.
+
+---
+
 ## Anti-Patterns
 
 1. **`LiveData` in new code**: use `StateFlow`
@@ -261,8 +643,17 @@ app/src/main/java/app/akroasis/
 5. **Stateful composables**: hoist state to ViewModel
 6. **Manual DI**: use Hilt, not manual factory patterns
 7. **Blocking on `Dispatchers.Main`**: switch to `IO` for I/O work
-8. **Bare `catch (Exception)`**: catch specific types
+8. **Bare `catch (Exception)`**: see STANDARDS.md § No Silent Catch
 9. **Mutable state exposed directly**: private `MutableStateFlow`, public `StateFlow`
 10. **Missing `@Preview`**: every reusable composable gets a preview
 11. **kapt for annotation processing**: use KSP (kapt is maintenance-only)
 12. **Gson in new code**: use kotlinx.serialization (or Moshi for existing JVM-only projects)
+13. **String-based navigation routes**: use `@Serializable` route classes (Navigation 2.8+)
+14. **NavController in ViewModel**: emit navigation events via `Channel`, let the UI navigate
+15. **Cold flows from ViewModel**: use `stateIn`/`shareIn` to share upstream; cold flows restart per collector
+16. **Nested `collect` calls**: compose flows with `flatMapLatest`, `combine`, or `zip`
+17. **`expect`/`actual` on domain models**: domain models are platform-agnostic, keep them in `commonMain`
+18. **Hilt in KMP**: Hilt is Android-only; use Koin for multiplatform DI
+19. **Room in KMP**: Room is Android-only; use SQLDelight for multiplatform persistence
+20. **`androidx.compose.*` imports in `commonMain`**: use Compose Multiplatform imports for cross-platform builds (Material 3 is available via CMP)
+21. **MockK in `commonTest`**: MockK is JVM-only; use fakes in shared test source sets

--- a/standards/NGINX.md
+++ b/standards/NGINX.md
@@ -1,0 +1,488 @@
+# NGINX
+
+> Additive to STANDARDS.md. Read that first. Everything here is NGINX-specific.
+>
+> Covers: NGINX configuration, reverse proxy patterns, SSL/TLS, security headers, rate limiting, and load balancing.
+>
+> **Key decisions:** explicit `server` blocks, no default server, security headers mandatory, rate limiting by default, SSL labs A+ target.
+
+---
+
+## Configuration structure
+
+### File organization
+
+| File | Purpose |
+|------|---------|
+| `nginx.conf` | Main configuration, global settings, includes |
+| `conf.d/*.conf` | Site-specific configurations (one per service) |
+| `sites-available/` | Complete server block definitions |
+| `sites-enabled/` | Symlinks to activated sites |
+
+```nginx
+# nginx.conf - minimal, delegates to conf.d/
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log warn;
+pid /run/nginx.pid;
+
+events {
+    worker_connections 4096;
+    use epoll;
+    multi_accept on;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    # Logging format
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" $request_time';
+
+    access_log /var/log/nginx/access.log main;
+
+    # Performance
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+
+    # Security defaults
+    include /etc/nginx/conf.d/security.conf;
+
+    # Site configurations
+    include /etc/nginx/sites-enabled/*;
+}
+```
+
+### Security baseline (conf.d/security.conf)
+
+```nginx
+# Hide NGINX version
+server_tokens off;
+
+# Security headers
+add_header X-Frame-Options "SAMEORIGIN" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-XSS-Protection "1; mode=block" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+# Permissions Policy (formerly Feature-Policy)
+add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+
+# Size limits
+client_max_body_size 10m;
+client_body_buffer_size 16k;
+client_header_buffer_size 1k;
+large_client_header_buffers 4 8k;
+
+# Timeouts
+client_body_timeout 12;
+client_header_timeout 12;
+keepalive_timeout 15;
+
+# Rate limiting zone (defined here, applied per-server)
+limit_req_zone $binary_remote_addr zone=general:10m rate=10r/s;
+limit_conn_zone $binary_remote_addr zone=addr:10m;
+```
+
+---
+
+## Server blocks
+
+### Reverse proxy template
+
+```nginx
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name api.example.com;
+
+    # SSL configuration
+    ssl_certificate /etc/ssl/certs/api.example.com.crt;
+    ssl_certificate_key /etc/ssl/private/api.example.com.key;
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SSL:50m;
+    ssl_session_tickets off;
+
+    # Modern TLS only
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+
+    # HSTS (uncomment only when HTTPS is fully working)
+    # add_header Strict-Transport-Security "max-age=63072000" always;
+
+    # Rate limiting
+    limit_req zone=general burst=20 nodelay;
+    limit_conn addr 10;
+
+    # Proxy to upstream
+    location / {
+        proxy_pass http://localhost:8080;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "";
+
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
+    # Health check endpoint (bypass rate limiting if needed)
+    location /health {
+        proxy_pass http://localhost:8080/health;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+
+        # Optional: exempt from rate limiting
+        limit_req off;
+    }
+}
+```
+
+### Static file serving
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name static.example.com;
+
+    root /var/www/static;
+    index index.html;
+
+    # Cache static assets
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2)$ {
+        expires 6m;
+        access_log off;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Security: deny access to hidden files
+    location ~ /\. {
+        deny all;
+        access_log off;
+        log_not_found off;
+    }
+
+    # Security: deny access to backup/config files
+    location ~* \.(bak|config|sql|fla|psd|ini|log|sh|inc|swp|dist)$ {
+        deny all;
+        access_log off;
+        log_not_found off;
+    }
+}
+```
+
+---
+
+## SSL/TLS
+
+### Certificate handling
+
+- Store certificates in `/etc/ssl/certs/` (public) and `/etc/ssl/private/` (private)
+- Private key files must be `chmod 600`, owned by root
+- Use Let's Encrypt for public-facing services (automated renewal)
+- Test configuration with: `nginx -t && systemctl reload nginx`
+
+### SSL Labs A+ configuration
+
+```nginx
+server {
+    listen 443 ssl http2;
+
+    ssl_certificate /path/to/fullchain.pem;
+    ssl_certificate_key /path/to/privkey.pem;
+
+    # Session settings
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SSL:50m;
+    ssl_session_tickets off;
+
+    # Protocols and ciphers (Mozilla Intermediate, 2024)
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+
+    # OCSP Stapling
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    ssl_trusted_certificate /path/to/chain.pem;
+    resolver 1.1.1.1 8.8.8.8 valid=300s;
+    resolver_timeout 5s;
+
+    # HSTS
+    add_header Strict-Transport-Security "max-age=63072000" always;
+}
+```
+
+### HTTP to HTTPS redirect
+
+```nginx
+# Redirect all HTTP to HTTPS
+server {
+    listen 80;
+    listen [::]:80;
+    server_name _;
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+
+    # Let's Encrypt challenge (certbot)
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+}
+```
+
+---
+
+## Rate limiting
+
+### Zone definitions
+
+```nginx
+# Per-IP rate limiting
+limit_req_zone $binary_remote_addr zone=ip:10m rate=10r/s;
+
+# Per-user rate limiting (requires auth)
+limit_req_zone $http_authorization zone=user:10m rate=30r/s;
+
+# Per-API-key rate limiting
+map $http_x_api_key $api_key_limit {
+    "" $binary_remote_addr;
+    default $http_x_api_key;
+}
+limit_req_zone $api_key_limit zone=api_key:10m rate=100r/s;
+```
+
+### Application
+
+```nginx
+server {
+    location /api/ {
+        # Burst allows short spikes, nodelay processes immediately if bucket has tokens
+        limit_req zone=api_key burst=50 nodelay;
+
+        # Return 429 instead of 503 when rate limited
+        limit_req_status 429;
+
+        proxy_pass http://backend;
+    }
+}
+```
+
+---
+
+## Load balancing
+
+### Upstream definitions
+
+```nginx
+upstream backend {
+    least_conn;  # or ip_hash, least_time (NGINX Plus)
+
+    server 10.0.0.1:8080 weight=5;
+    server 10.0.0.2:8080 weight=5;
+    server 10.0.0.3:8080 backup;
+
+    keepalive 32;
+    keepalive_timeout 60s;
+    keepalive_requests 1000;
+}
+```
+
+### Health checks (active)
+
+```nginx
+upstream backend {
+    zone upstream_backend 64k;
+
+    server 10.0.0.1:8080;
+    server 10.0.0.2:8080;
+
+    # NGINX Plus only
+    # health_check interval=5s fails=3 passes=2 uri=/health;
+}
+
+server {
+    location / {
+        proxy_pass http://backend;
+        health_check;  # NGINX Plus
+    }
+}
+```
+
+### Passive health checks (open source)
+
+```nginx
+upstream backend {
+    server 10.0.0.1:8080 max_fails=3 fail_timeout=30s;
+    server 10.0.0.2:8080 max_fails=3 fail_timeout=30s;
+}
+```
+
+---
+
+## Security
+
+### Access control
+
+```nginx
+# IP-based restriction
+location /admin {
+    allow 10.0.0.0/8;
+    allow 192.168.0.0/16;
+    deny all;
+
+    proxy_pass http://backend;
+}
+
+# Basic auth (fallback only, not for primary auth)
+location /status {
+    auth_basic "Restricted";
+    auth_basic_user_file /etc/nginx/.htpasswd;
+
+    proxy_pass http://backend;
+}
+```
+
+### Request filtering
+
+```nginx
+# Block common attack patterns
+location / {
+    # Block common exploits
+    if ($request_uri ~* "(eval\(|base64_decode|\.\.\/|union.*select.*\()") {
+        return 403;
+    }
+
+    # Block specific user agents
+    if ($http_user_agent ~* (wget|curl|nikto|sqlmap|nmap|masscan)) {
+        return 403;
+    }
+
+    proxy_pass http://backend;
+}
+```
+
+### WebSocket support
+
+```nginx
+location /ws {
+    proxy_pass http://backend;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_read_timeout 86400;
+}
+```
+
+---
+
+## Logging
+
+### Structured logging (JSON)
+
+```nginx
+log_format json_analytics escape=json '{"time":"$time_iso8601",'
+    '"remote_addr":"$remote_addr",'
+    '"request":"$request",'
+    '"status":$status,'
+    '"bytes_sent":$bytes_sent,'
+    '"request_time":$request_time,'
+    '"upstream_time":"$upstream_response_time",'
+    '"user_agent":"$http_user_agent"}';
+
+access_log /var/log/nginx/access.log json_analytics;
+```
+
+### Conditional logging
+
+```nginx
+# Don't log health checks
+map $request_uri $loggable {
+    /health 0;
+    default 1;
+}
+
+access_log /var/log/nginx/access.log main if=$loggable;
+```
+
+---
+
+## Validation
+
+### Pre-deployment checks
+
+```bash
+# Syntax validation
+nginx -t
+
+# Test specific configuration file
+nginx -t -c /path/to/nginx.conf
+
+# Check for common misconfigurations
+grep -E "(listen.*80[^0-9]|ssl_certificate.*selfsigned)" /etc/nginx/sites-enabled/*
+```
+
+### Reload vs restart
+
+```bash
+# Reload configuration without dropping connections
+systemctl reload nginx
+
+# Or directly
+nginx -s reload
+```
+
+---
+
+## Anti-patterns
+
+| Anti-pattern | Problem | Fix |
+|-------------|---------|-----|
+| `if` in location blocks | Unpredictable behavior, often breaks | Use `map` or separate locations |
+| `server_name _;` as default | Vague, may expose unintended content | Explicit default server with 444 or 404 |
+| `ssl_protocols TLSv1 TLSv1.1;` | Deprecated, insecure protocols | TLSv1.2+ only |
+| No rate limiting | Vulnerable to abuse | Add `limit_req` to all public endpoints |
+| `proxy_pass` without headers | Backend sees wrong client IP | Always set `X-Forwarded-*` headers |
+| Root inside location block | Confusing inheritance | Set `root` at server level |
+| `access_log off` globally | No visibility | Keep access logs, use conditional logging |
+| Missing `server_tokens off;` | Version disclosure in errors | Always disable |
+| HSTS before HTTPS works | Site becomes unreachable | Enable only after HTTPS is verified |
+| `client_max_body_size` default | 1MB too small for APIs | Increase explicitly per use case |
+
+---
+
+## Tooling
+
+| Tool | Purpose |
+|------|---------|
+| `nginx -t` | Configuration syntax test |
+| `nginx -s reload` | Graceful configuration reload |
+| `nginx -V` | Show compiled modules and flags |
+| `curl -I` | Test headers and response codes |
+| `openssl s_client -connect` | Test SSL/TLS configuration |
+| [SSL Labs Test](https://www.ssllabs.com/ssltest/) | External SSL assessment |
+| `certbot` | Let's Encrypt certificate automation |
+| `goaccess` | Log analyzer with real-time dashboard |
+
+---
+
+## Cross-references
+
+| Topic | Standard |
+|-------|----------|
+| Security headers | SECURITY.md#headers |
+| SSL/TLS configuration | SECURITY.md#transport |
+| Rate limiting strategy | SECURITY.md#rate-limiting |
+| Log aggregation | OPERATIONS.md#observability |
+| Health checks | OPERATIONS.md#monitoring |

--- a/standards/NIX.md
+++ b/standards/NIX.md
@@ -2,9 +2,9 @@
 
 > Additive to STANDARDS.md. Read that first. Everything here is Nix-specific.
 >
-> Covers: Nix language, flake conventions, NixOS module patterns, derivation packaging.
+> Covers: Nix language, flake conventions, NixOS module patterns, derivation packaging, environment selection, overlays, cross-compilation, musl static builds, lazy evaluation debugging, dependency auditing.
 >
-> **Key decisions:** nixfmt formatter, let-in over rec, explicit pkgs over with, Crane for Rust, .follows on transitive nixpkgs, no lookup paths.
+> **Key decisions:** nixfmt formatter, let-in over rec, explicit pkgs over with, Crane for Rust, .follows on transitive nixpkgs, no lookup paths, final/prev overlay convention, nativeBuildInputs/buildInputs split for cross, pkgsStatic for musl, --show-trace always, vulnix in CI.
 
 ---
 
@@ -219,6 +219,333 @@ devShells.default = pkgs.mkShell {
 };
 ```
 
+### Environment decision tree
+
+Choose the right environment builder for the task.
+
+| Builder | Use when | Trade-offs |
+|---------|----------|------------|
+| `mkShell` | Development shells, CI environments | Lightweight. Does not produce a derivation output. Cannot be installed or deployed. |
+| `stdenv.mkDerivation` | Building packages for installation or deployment | Full derivation lifecycle (unpack, patch, configure, build, install). Heavier to iterate on. |
+| `buildFHSEnv` | Wrapping binaries that assume FHS paths (`/usr/lib`, `/usr/bin`) | Creates a lightweight FHS-compatible sandbox. Necessary for proprietary tools, pre-built binaries, and some language toolchains that hardcode paths. Adds runtime overhead from the namespace mount. |
+
+**`mkShell` is not a subset of `mkDerivation`.** `mkShell` skips build phases entirely and only sets up environment variables. It is purpose-built for `nix develop` / `nix-shell`. Do not try to build a `mkShell` derivation — it will produce an empty output.
+
+**Use `buildFHSEnv` only when the binary cannot be patched.** For open-source software, prefer patching with `autoPatchelfHook` or `patchelf` directly. WHY: `buildFHSEnv` hides the FHS assumption rather than fixing it, and the namespace mount adds startup latency and complicates debugging.
+
+```nix
+# FHS environment for a proprietary tool
+pkgs.buildFHSEnv {
+  name = "vendor-tool";
+  targetPkgs = pkgs: with pkgs; [ zlib openssl ];
+  runScript = "./vendor-tool";
+}
+```
+
+---
+
+## Overlays
+
+Overlays customize nixpkgs without forking it. An overlay is a function that takes two arguments (`final`, `prev`) and returns an attrset of additions or modifications merged into the package set.
+
+### Overlay structure
+
+```nix
+# final: the fully resolved package set (use for dependencies)
+# prev: the package set before this overlay (use for the base package being modified)
+final: prev: {
+  myapp = final.callPackage ./pkgs/myapp { };
+
+  ffmpeg = prev.ffmpeg.override {
+    withFdk = true;
+  };
+}
+```
+
+**Use `final` for dependencies, `prev` for the package being modified.** WHY: Using `prev` for dependencies can reference stale versions. Using `final` for the base package causes infinite recursion since the package depends on itself.
+
+### Applying overlays
+
+```nix
+# In a flake — explicit import with overlays list
+pkgs = import nixpkgs {
+  inherit system;
+  config = {};
+  overlays = [ self.overlays.default ];
+};
+
+# In a NixOS configuration — via nixpkgs.overlays option
+nixpkgs.overlays = [ self.overlays.default ];
+```
+
+**Always apply overlays via the `overlays` parameter or `nixpkgs.overlays` option.** WHY: Ad-hoc `pkgs.extend` calls create package sets that diverge from the one NixOS modules see, causing subtle version mismatches.
+
+### Overlay patterns
+
+**One overlay per concern.** Split custom packages, version pins, and patches into separate overlays. WHY: Monolithic overlays are hard to toggle, hard to debug, and create unnecessary rebuilds when one part changes.
+
+**Export overlays from the flake.**
+
+```nix
+# flake.nix outputs
+overlays.default = final: prev: {
+  myapp = final.callPackage ./pkgs/myapp { };
+};
+```
+
+WHY: Consumers of your flake can compose your overlay with their own package set instead of depending on your specific nixpkgs pin.
+
+**Never use `rec` inside an overlay body.** Use `final` to reference sibling packages. WHY: `rec` binds at definition time and ignores later overlays, defeating the entire overlay composition model.
+
+**Pin `config = {}; overlays = [];` on any `import nixpkgs` call that itself receives overlays.** WHY: Without this, system-level nixpkgs config and overlays leak in, making the result non-reproducible and potentially applying overlays twice.
+
+### Overlay ordering
+
+Overlays apply left to right. Later overlays see modifications from earlier ones via `final`. If overlay B depends on packages added by overlay A, list A first.
+
+---
+
+## Cross-compilation
+
+Nix separates the concept of *where code runs* from *where code is built*. This makes cross-compilation a first-class operation rather than an afterthought.
+
+### Platform terminology
+
+| Term | Meaning | Example |
+|------|---------|---------|
+| `buildPlatform` | Machine running the compiler | `x86_64-linux` |
+| `hostPlatform` | Machine running the compiled binary | `aarch64-linux` |
+| `targetPlatform` | Machine the compiled binary generates code for (compilers only) | `riscv64-linux` |
+
+Most packages only care about `buildPlatform` and `hostPlatform`. `targetPlatform` matters only for toolchains (GCC, LLVM, binutils).
+
+### Cross-compiling with nixpkgs
+
+```nix
+# Import nixpkgs with crossSystem set
+pkgsCross = import nixpkgs {
+  localSystem = "x86_64-linux";
+  crossSystem = "aarch64-linux";
+  config = {};
+  overlays = [];
+};
+
+# Or use the pre-configured cross package sets
+pkgs.pkgsCross.aarch64-multiplatform.hello
+pkgs.pkgsCross.raspberryPi.hello
+pkgs.pkgsCross.riscv64.hello
+```
+
+**Use `pkgsCross` attribute sets for standard targets.** WHY: They are pre-configured with the correct toolchain, sysroot, and platform flags. Manual `crossSystem` is needed only for non-standard targets.
+
+### Spliced package sets
+
+In a cross-compilation context, nixpkgs provides spliced package sets that automatically select the right variant:
+
+| Reference | Resolves to | Use for |
+|-----------|-------------|---------|
+| `pkgs.pkg` | Host package | Runtime dependencies |
+| `pkgs.buildPackages.pkg` | Build package | Build-time tools (code generators, compilers) |
+| `pkgs.__targetPackages.pkg` | Target package | Rare — only for building toolchains |
+
+**Use `nativeBuildInputs` for build-time tools, `buildInputs` for runtime dependencies.** WHY: Nix uses this distinction to select the correct spliced package. Putting a build tool in `buildInputs` during cross-compilation pulls in the wrong architecture binary, and the build fails or silently produces a broken result.
+
+### Cross-compilation in a flake
+
+```nix
+# Expose a cross-compiled package alongside the native one
+packages.x86_64-linux = let
+  pkgs = import nixpkgs { system = "x86_64-linux"; config = {}; overlays = []; };
+  pkgsAarch64 = import nixpkgs {
+    localSystem = "x86_64-linux";
+    crossSystem = "aarch64-linux";
+    config = {};
+    overlays = [];
+  };
+in {
+  default = pkgs.callPackage ./. { };
+  aarch64 = pkgsAarch64.callPackage ./. { };
+};
+```
+
+### Musl static builds
+
+Static linking with musl produces fully self-contained binaries with no glibc dependency. This is the standard approach for container images and single-binary deployment.
+
+```nix
+# Static musl build for x86_64
+pkgs.pkgsStatic.callPackage ./. { }
+
+# Cross-compile a static aarch64 binary on x86_64
+let
+  pkgsCross = import nixpkgs {
+    localSystem = "x86_64-linux";
+    crossSystem = {
+      config = "aarch64-unknown-linux-musl";
+      isStatic = true;
+    };
+    config = {};
+    overlays = [];
+  };
+in pkgsCross.callPackage ./. { }
+```
+
+**Use `pkgsStatic` for same-architecture static builds.** WHY: `pkgsStatic` is a pre-configured package set where `stdenv` targets musl and sets static linking flags. Manual `RUSTFLAGS` or `LDFLAGS` overrides are fragile and miss transitive dependencies.
+
+**Static builds break packages that dlopen.** Libraries loaded at runtime via `dlopen` (NSS, locale data, some database drivers) do not work with static musl. If the binary needs dynamic loading, use glibc with `--static` selectively or accept dynamic linking for those dependencies.
+
+### Making a derivation cross-compatible
+
+**Split `buildInputs` and `nativeBuildInputs` correctly.** This is the single most common cross-compilation failure.
+
+```nix
+{
+  nativeBuildInputs = [ pkg-config cmake ];  # Runs on build machine
+  buildInputs = [ openssl zlib ];            # Links into the final binary
+}
+```
+
+**Do not hardcode architecture paths or compiler names.** Use variables from the stdenv toolchain (`$CC`, `$AR`, `$STRIP`). WHY: Hardcoded `gcc` or `/usr/lib` bypasses the cross toolchain and produces native binaries instead of cross-compiled ones.
+
+**Test cross-compilation in CI.** Add a `nix build .#aarch64` check even if your deploy target is the same architecture today. WHY: Cross-compilation correctness degrades silently. A build that works natively can fail when cross-compiled due to impure build scripts, and you will not find out until you need it.
+
+---
+
+## Lazy evaluation debugging
+
+Nix is lazily evaluated: no value is computed until it is needed. This is powerful (unused code costs nothing) but creates debugging challenges that are unlike any strict language.
+
+### Core mental model
+
+**Nix values are thunks until forced.** A thunk is an unevaluated expression. Errors inside a thunk do not surface until something demands the value. This means:
+
+- An attrset can contain a key whose value is an error, and accessing other keys works fine
+- A list can contain a `throw` element, and `builtins.length` still returns the correct count
+- An `assert` inside an unused `let` binding never fires
+
+### Debugging tools
+
+**`builtins.trace`**: Print a value during evaluation and return the second argument.
+
+```nix
+builtins.trace "evaluating foo" foo
+# Prints "evaluating foo" to stderr, returns value of foo
+
+# Trace an attrset (forces it for printing)
+builtins.trace (builtins.toJSON { inherit x y; }) result
+```
+
+WHY `builtins.trace` over `lib.debug.traceVal`: `builtins.trace` takes two arguments (message, return value), giving explicit control over what is printed vs. returned. `lib.debug.traceVal` is a convenience wrapper. Use `builtins.trace` when you need to trace one value and return a different one.
+
+**`builtins.deepSeq`**: Force full evaluation of a value (recursively).
+
+```nix
+# Force evaluation of the entire attrset, surface any hidden errors
+builtins.deepSeq myAttrset myAttrset
+```
+
+WHY: Normal evaluation only forces the values actually demanded by the build. `deepSeq` forces everything, which reveals errors hiding in unused branches. Use it as a diagnostic tool, not in production derivations.
+
+**`builtins.tryEval`**: Catch evaluation errors without crashing.
+
+```nix
+builtins.tryEval (throw "broken")
+# => { success = false; value = false; }
+
+builtins.tryEval 42
+# => { success = true; value = 42; }
+```
+
+WHY: Useful for probing which values in a set are evaluable. Does NOT catch errors inside `builtins.deepSeq` or derivation builds.
+
+### Common lazy evaluation traps
+
+**Infinite recursion from self-reference.** Nix detects direct cycles (`x = x`) but not all indirect ones. The error message `infinite recursion encountered` gives no stack trace by default.
+
+```bash
+# Get a stack trace on infinite recursion
+nix eval --show-trace .#problematicValue
+```
+
+**Always pass `--show-trace` when debugging evaluation errors.** WHY: Without it, Nix shows only the final error. With it, you get the full chain of file locations and function calls that led to the failure.
+
+**Errors inside `builtins.map` or `builtins.filter` are deferred.** The list is constructed lazily. Errors surface only when the specific element is forced.
+
+```nix
+# This succeeds — the broken element is never accessed
+let
+  xs = builtins.map (x: if x == 2 then throw "boom" else x) [ 1 2 3 ];
+in builtins.head xs  # => 1
+
+# This fails — element at index 1 is forced
+let
+  xs = builtins.map (x: if x == 2 then throw "boom" else x) [ 1 2 3 ];
+in builtins.elemAt xs 1  # => error: boom
+```
+
+**`//` (merge) does not force values.** Merging two attrsets does not evaluate the values on either side. An error in a value from the left side persists silently if nothing accesses it, even after the merge.
+
+**Attribute selection is the primary forcing mechanism.** Accessing `x.foo` forces the thunk for `foo` (but not `x.bar`). Build systems force attributes by demanding derivation outputs. Understanding what forces what is the key to understanding when errors appear.
+
+### Debugging workflow
+
+1. **Reproduce with `--show-trace`.** `nix eval --show-trace .#attr` or `nix build --show-trace .#pkg`.
+2. **Isolate the thunk.** Use the REPL (`nix repl .`) to interactively access attributes and find which key triggers the error.
+3. **Insert `builtins.trace` at the boundary.** Trace function arguments at the point where the value enters the failing expression.
+4. **Force with `builtins.deepSeq` to smoke-test.** If you suspect hidden errors in an attrset, force it fully to surface them all at once.
+5. **Check for `//` masking.** If a value "should" be set but is not, verify it was not silently replaced by a shallow merge.
+
+---
+
+## Dependency auditing
+
+Nix closures can be large. Auditing what a derivation actually pulls in prevents bloated images, unexpected runtime dependencies, and known-vulnerable packages shipping in production.
+
+### Closure analysis
+
+```bash
+# Show the full closure (all runtime dependencies) of a package
+nix path-info -rsSh .#mypackage
+
+# Compare closures between two versions or configurations
+nix-diff /nix/store/<hash-a>-mypackage /nix/store/<hash-b>-mypackage
+
+# List closure as a dependency tree
+nix-store --query --tree $(nix build .#mypackage --print-out-paths)
+```
+
+**Use `nix path-info -rsSh` to check closure size before deploying.** WHY: A single misplaced runtime dependency (GCC toolchain, Python interpreter, X11 libraries) can inflate a container image from 50MB to 2GB. Closure size is invisible until you measure it.
+
+**Use `nix-diff` when a closure size changes unexpectedly.** `nix-diff` shows exactly which derivations changed and why — new dependencies, version bumps, or build flag differences. It operates on store paths, not source, so it catches transitive changes that diff-on-source misses.
+
+### Reducing closure size
+
+**Move build-only dependencies to `nativeBuildInputs`.** Packages in `buildInputs` propagate into the runtime closure. Build tools (compilers, code generators, `pkg-config`) in `buildInputs` bloat the closure for no benefit.
+
+**Use `removeReferencesTo` for stubborn references.** Some build systems embed store paths in binaries (rpath, embedded config). If a reference is not needed at runtime:
+
+```nix
+postInstall = ''
+  remove-references-to -t ${pkgs.stdenv.cc} $out/bin/myapp
+'';
+```
+
+WHY: The Nix garbage collector and closure computation follow store path references. A single stray reference to `gcc` pulls in the entire toolchain as a runtime dependency.
+
+### Vulnerability scanning
+
+```bash
+# Scan a closure for known CVEs using vulnix
+vulnix $(nix build .#mypackage --print-out-paths)
+
+# Check a specific store path
+vulnix /nix/store/<hash>-openssl-3.1.4
+```
+
+**Run `vulnix` in CI against production closures.** WHY: Nix pins exact package versions. Unlike rolling distributions, a pinned `flake.lock` does not receive security patches automatically. Scanning detects when a pinned version has known vulnerabilities, prompting a `nix flake update` for the affected input.
+
+**`vulnix` matches store paths against the NVD (National Vulnerability Database).** False positives are common when nixpkgs backports patches without bumping the version number. Check the nixpkgs commit log for the package before acting on a CVE report.
+
 ---
 
 ## Anti-patterns
@@ -288,6 +615,14 @@ flake-utils.lib.eachDefaultSystem (system: {
 9. **`specialArgs`** to pass flake inputs to modules. Not `_module.args`.
 10. **Checks gate CI.** `nix flake check` must pass.
 11. **No lookup paths.** No `<nixpkgs>`. No `$NIX_PATH` dependencies.
+12. **`final` for deps, `prev` for the package being modified** in overlays. No `rec` in overlay bodies.
+13. **One overlay per concern.** Export from the flake for composability.
+14. **`nativeBuildInputs` for build tools, `buildInputs` for runtime deps.** Non-negotiable for cross-compilation correctness.
+15. **`pkgsStatic` for musl static builds.** Do not set linker flags manually.
+16. **`buildFHSEnv` only for unpatchable binaries.** Prefer `autoPatchelfHook` for open-source software.
+17. **`--show-trace` on all debugging.** Never debug evaluation errors without it.
+18. **Audit closure size before deploying.** `nix path-info -rsSh` catches accidental bloat.
+19. **`vulnix` in CI on production closures.** Pinned versions do not auto-update for security.
 
 ---
 
@@ -304,3 +639,6 @@ flake-utils.lib.eachDefaultSystem (system: {
 | `statix` | Nix linter (catches anti-patterns) |
 | `deadnix` | Find unused code in Nix files |
 | `nix-tree` | Visualize dependency tree |
+| `nix-diff` | Compare closures to find what changed between builds |
+| `vulnix` | Scan Nix closures for known CVEs |
+| `nix path-info` | Inspect closure size and dependencies |

--- a/standards/OPERATIONS.md
+++ b/standards/OPERATIONS.md
@@ -1,6 +1,8 @@
 # Operations
 
-> Standards for deployment, monitoring, backup, incident response, and operational readiness. If it runs in production, these rules apply.
+> Standards for service-specific concerns: runbooks, monitoring, backup, incident response, and operational readiness. If it runs in production, these rules apply.
+>
+> See also: DEPLOYMENT.md (gates, merge policy, rollback, health check requirements), SYSTEMD.md (unit files), PODMAN.md (containers), SECURITY.md (firewall, browser policy), NGINX.md (reverse proxy).
 
 ---
 
@@ -28,10 +30,7 @@ A runbook is complete when an on-call engineer who has never seen the service ca
 
 ### Required health checks
 
-Every service exposes:
-- Liveness endpoint (is the process running?)
-- Readiness endpoint (can it handle requests?)
-- Dependency checks (are database, cache, external APIs reachable?)
+See DEPLOYMENT.md for health check endpoint requirements (liveness, readiness, dependency). This section covers monitoring-specific metrics and alerting thresholds.
 
 ### Required metrics
 
@@ -77,35 +76,6 @@ A backup you've never restored from is not a backup. Test restores on a schedule
 - Agent state (workspace files, memory)
 
 What NOT to back up: logs (ephemeral), build artifacts (reproducible), cache (rebuildable).
-
----
-
-## Deployment
-
-### Upgrade procedure
-
-1. Back up (verify backup integrity before proceeding)
-2. Stop service
-3. Replace binary (verify checksum)
-4. Start service
-5. Health check (automated, with timeout)
-6. Smoke test (one real request through the system)
-
-### Rollback
-
-Every deployment is rollback-safe. The rollback procedure is tested and documented.
-
-Requirements:
-- Previous binary preserved (not overwritten)
-- Database migrations are forward-only with documented rollback SQL
-- Rollback script tested against actual deployment
-
-### Zero-downtime (when applicable)
-
-For services requiring uptime:
-- Blue-green deployment OR rolling restart
-- Health check gates before traffic shift
-- Automatic rollback on health check failure
 
 ---
 
@@ -193,3 +163,109 @@ Every buffered channel has explicit capacity. When full:
 - **Drop**: excess events dropped, counter incremented
 
 No unbounded channels in production.
+
+---
+
+## DNS
+
+> Implementation details (AdGuard config, validation commands, bootstrap setup): `docs/deployment/DNS-SETUP.md`
+
+### Principles
+
+DNS is a single point of failure for the entire network. Treat it as critical infrastructure.
+
+| Principle | Requirement | WHY |
+|-----------|-------------|-----|
+| Redundancy | Minimum two upstream resolvers | Single upstream failure takes down all resolution |
+| Encryption | All upstream queries use DoH or DoT | Plaintext DNS leaks browsing data to ISP and intermediaries |
+| DNSSEC | Enabled on all resolvers that support it | Prevents cache poisoning and spoofed responses |
+| Internal resolution | All service hostnames resolve via DNS, not `/etc/hosts` | Hosts files don't propagate; DNS is the single source of truth |
+| VPN accessibility | Internal rewrites point to Tailscale IPs, not LAN IPs | Services must be reachable from any Tailscale-connected device |
+| Blocking mode | NXDOMAIN, not `0.0.0.0` or `127.0.0.1` | Prevents connection attempts and false positives from loopback services |
+
+### Architecture
+
+| Component | Role |
+|-----------|------|
+| DNS resolver (e.g., AdGuard Home) | Primary resolver for LAN and VPN clients |
+| Upstream resolvers | DoH to two independent providers for redundancy and privacy |
+| DHCP server | Points all LAN clients to the resolver |
+| VPN DNS | Global nameserver override for VPN clients |
+
+### Failure modes
+
+| Symptom | Likely cause | Resolution |
+|---------|-------------|------------|
+| All resolution fails | Resolver process down or port 53 conflict | Check service status and `ss -tlnp \| grep ':53'` |
+| Internal names fail, external works | DNS rewrites misconfigured or missing | Check resolver rewrite rules |
+| External fails, internal works | Upstream resolvers unreachable or DoH cert issue | Test upstream DoH endpoints directly |
+| Intermittent failures | systemd-resolved stub listener conflict | Disable `DNSStubListener` in `/etc/systemd/resolved.conf` |
+| Blocked domains still resolve | Stale or failed filter lists | Verify filter list fetch status; lists fail silently |
+| VPN clients can't resolve internal names | VPN DNS override not pointing to resolver | Check VPN nameserver configuration |
+
+### systemd-resolved conflict
+
+WHY: On Fedora (systemd 256+), `systemd-resolved` binds `127.0.0.54:53`, conflicting with the DNS resolver's wildcard bind. Set `DNSStubListener=no` in `/etc/systemd/resolved.conf`. This is a host-level concern -- containerized resolvers bind to the host network namespace via pod port mapping.
+
+### Validation
+
+After any DNS change, verify:
+1. Internal resolution: `dig @<resolver-ip> <internal-hostname>`
+2. External resolution: `dig @<resolver-ip> example.com`
+3. NXDOMAIN blocking: blocked domain returns NXDOMAIN
+4. No port conflict: single process on port 53
+
+---
+
+## Service management
+
+### Container lifecycle
+
+Containerized services managed by systemd follow this lifecycle:
+
+```
+create pod → create containers → start pod → health check → serve traffic
+```
+
+#### Pod architecture
+
+Group containers into pods when they need to share network namespace (e.g., reverse proxy + DNS in same pod share `127.0.0.1`). Standalone containers for services with no inter-container localhost dependencies.
+
+| Grouping | When |
+|----------|------|
+| Pod | Containers communicate over localhost (same network namespace) |
+| Standalone | No localhost dependency on other containers |
+
+#### Systemd unit naming
+
+Container services use the pattern `<name>-container.service`. Pod services create the pod first, then add containers.
+
+```bash
+# Check all container services
+sudo podman ps --format "table {{.Names}} {{.Status}}"
+
+# Restart a service
+sudo systemctl restart <name>-container
+
+# View logs
+sudo podman logs --tail 50 <container-name>
+```
+
+#### Auto-updates
+
+Use `podman-auto-update.timer` for image-based auto-updates on a schedule. Pin the schedule to low-traffic windows (e.g., Sunday 4 AM). All containers using `io.containers.autoupdate=registry` label receive updates automatically.
+
+#### Environment files
+
+Service credentials live in environment files, not in systemd units or container command lines.
+
+| Location | Permissions | Purpose |
+|----------|------------|---------|
+| `/etc/menos-*.env` | 0600 root:root | Service credentials read by systemd at start |
+| `~/menos-ops/secrets/` | 0600 user | Backup passwords, API keys for scripts |
+
+systemd reads `EnvironmentFile=` at service start. Credentials never appear in `podman inspect` or process listings.
+
+### Health checks and upgrades
+
+See DEPLOYMENT.md for container health check requirements and upgrade procedures (binary and container).

--- a/standards/PERFORMANCE.md
+++ b/standards/PERFORMANCE.md
@@ -82,3 +82,237 @@ Expensive resources (embedding models, database connections, large indices) init
 ### Feature-gate heavy dependencies
 
 ML models, GUI frameworks, and optional integrations behind feature flags. A minimal build should be fast to compile and small to deploy.
+
+---
+
+## Algorithmic complexity
+
+### Documentation requirements
+
+Every public function that operates on a collection, processes input of variable size, or performs search/sort/traversal must document its time and space complexity. Document complexity on the function, not on the module — readers need it at the call site, not in a separate file they won't open.
+
+WHY: Undocumented complexity hides quadratic behavior behind innocent-looking APIs. A function that works fine on 10 items and destroys latency at 10,000 is a production incident waiting for enough data. Making complexity visible at the declaration forces the author to reason about scaling behavior at design time, not after the alert fires.
+
+| Requirement | Rule |
+|-------------|------|
+| Public collection operations | Document time and space complexity in the doc comment. No exceptions. |
+| Trait implementations | Document complexity if it differs from the trait's expected contract (e.g., an `Index` impl that is O(n) instead of O(1)). |
+| Internal hot-path functions | Document complexity. These are not public, but they appear in profiles and need the annotation for optimization work. |
+| Trivial O(1) accessors | No annotation required. Getters, field access, and constant-time lookups are assumed O(1). |
+
+### Big-O annotation conventions
+
+Use the following format in doc comments:
+
+```rust
+/// Finds the nearest neighbor in the spatial index.
+///
+/// Time: O(log n) average, O(n) worst case
+/// Space: O(1)
+///
+/// Where `n` is the number of indexed points.
+pub fn nearest(&self, point: &Point) -> Option<&Point> { /* ... */ }
+```
+
+Rules:
+
+1. **State average and worst case separately** when they differ. An `O(1) amortized` without noting `O(n) worst case` hides resize spikes that cause latency outliers.
+2. **Define variables.** `O(n)` means nothing without specifying what `n` is. State it: "where `n` is the number of items in the queue."
+3. **Include space complexity** when the function allocates. Omit only for truly zero-allocation functions.
+4. **Use standard notation.** `O(n)`, `O(n log n)`, `O(n * m)`. Do not use informal descriptions like "linear" or "quadratic" as substitutes — use them alongside, not instead of, the notation.
+5. **Document amortized bounds explicitly.** Write `O(1) amortized` not just `O(1)` when the bound depends on amortization. Callers in latency-sensitive loops need to know about occasional expensive operations.
+
+WHY: Consistent notation enables mechanical grep. `rg "Time: O\(n\^2\)"` finds every quadratic function in the codebase. Informal descriptions defeat this. Defining variables prevents the ambiguity of `O(n)` in a function that takes two collections of different sizes.
+
+### Complexity budgets
+
+Assign complexity budgets to hot paths the same way resource budgets are assigned to services:
+
+| Path type | Maximum time complexity | Escalation |
+|-----------|------------------------|------------|
+| Per-request handler | O(n log n) | O(n^2) requires written justification in the doc comment and a benchmark proving acceptable wall time at projected max n |
+| Inner loop / tight path | O(n) | Anything super-linear requires profiling evidence that it is not the bottleneck |
+| Startup / initialization | No budget | Document complexity, but startup paths are not latency-sensitive |
+| Batch / offline processing | No budget | Document complexity for capacity planning |
+
+WHY: Budgets turn complexity from an observation into a constraint. Without a budget, O(n^2) drifts in through convenience (nested loops, repeated lookups) and is only caught when production data grows. A budget forces the conversation at review time, not incident time.
+
+### Complexity testing
+
+For performance-critical paths, assert that complexity holds at scale. A doc comment claiming O(n log n) is a promise — tests verify the promise holds as data grows.
+
+#### Growth ratio pattern
+
+Run the operation at multiple input sizes and assert that the runtime growth ratio matches the expected complexity class:
+
+```rust
+use std::time::Instant;
+
+/// Assert that `f` scales as O(n log n) by measuring at three input sizes.
+///
+/// Time: O(n log n) where n is the largest test size (10,000)
+/// Space: O(n)
+fn assert_nlogn_scaling<F: Fn(usize)>(f: F) {
+    let sizes = [100, 1_000, 10_000];
+    let mut timings = Vec::with_capacity(sizes.len());
+
+    for &n in &sizes {
+        let start = Instant::now();
+        f(n);
+        timings.push((n, start.elapsed().as_nanos() as f64));
+    }
+
+    // Compare growth ratio between consecutive sizes.
+    // For O(n log n): ratio ≈ (n2 * log(n2)) / (n1 * log(n1))
+    for window in timings.windows(2) {
+        let (n1, t1) = window[0];
+        let (n2, t2) = window[1];
+        let expected_ratio =
+            (n2 as f64 * (n2 as f64).ln()) / (n1 as f64 * (n1 as f64).ln());
+        let actual_ratio = t2 / t1;
+
+        // Allow 3x tolerance for measurement noise.
+        assert!(
+            actual_ratio < expected_ratio * 3.0,
+            "scaling exceeded O(n log n): n1={n1}, n2={n2}, \
+             expected_ratio={expected_ratio:.1}, actual_ratio={actual_ratio:.1}"
+        );
+    }
+}
+```
+
+#### Rules
+
+| Requirement | Rule |
+|-------------|------|
+| Test sizes | N=100, N=1,000, N=10,000 minimum. Choose sizes large enough to dominate constant factors. |
+| Growth ratio | Compare `t(N2) / t(N1)` against the expected ratio for the complexity class. Allow 2-3x tolerance for measurement noise. |
+| Criterion benchmarks | Performance-critical paths use `criterion` benchmarks at multiple sizes. Complexity tests use `#[test]` with `Instant` for simplicity. |
+| Complexity classes | O(n): ratio ≈ 10x per 10x input. O(n log n): ratio ≈ 13x per 10x input. O(n²): ratio ≈ 100x per 10x input. |
+| Flaky test prevention | Use large enough N that constant overhead is negligible. Warm up before measuring. Assert ratio bounds, not absolute times. |
+
+WHY: A doc comment claiming O(n) is unfalsifiable without a test. Growth ratio tests turn complexity claims into regression-catchable assertions. They also catch accidental quadratic behavior — O(n²) disguised as "a bit slow" at N=100 becomes obviously wrong at N=10,000.
+
+### Documentation examples
+
+#### Collection operation
+
+```rust
+/// Resolves all pending tasks in the queue, executing them in priority order.
+///
+/// Time: O(n log n) — priority sort dominates
+/// Space: O(n) — allocates a sorted copy of the task list
+///
+/// Where `n` is the number of pending tasks in `self.queue`.
+pub fn resolve_pending(&mut self) -> Vec<TaskResult> { /* ... */ }
+```
+
+#### Recursive traversal
+
+```rust
+/// Walks the directory tree rooted at `path`, collecting all file metadata.
+///
+/// Time: O(n) where `n` is the total number of filesystem entries
+/// Space: O(d) where `d` is the maximum directory depth (recursion stack)
+pub fn walk_tree(&self, path: &Path) -> Result<Vec<FileInfo>> { /* ... */ }
+```
+
+#### Amortized operation
+
+```rust
+/// Inserts a key-value pair into the map.
+///
+/// Time: O(1) amortized, O(n) worst case (resize)
+/// Space: O(1) amortized
+///
+/// Where `n` is the current number of entries. Resize occurs when
+/// load factor exceeds 0.75.
+pub fn insert(&mut self, key: K, value: V) -> Option<V> { /* ... */ }
+```
+
+#### Multi-variable complexity
+
+```rust
+/// Joins two sorted iterators, yielding matched pairs.
+///
+/// Time: O(n + m) where `n = left.len()`, `m = right.len()`
+/// Space: O(1) — streaming, no intermediate allocation
+pub fn merge_join<'a, L, R>(left: L, right: R) -> MergeJoin<L, R>
+where
+    L: Iterator<Item = &'a Entry>,
+    R: Iterator<Item = &'a Entry>,
+{ /* ... */ }
+```
+
+---
+
+## Benchmark-driven optimization
+
+### Workflow
+
+Never optimize based on reading the code. Optimize based on profiling data. The workflow is:
+
+1. **Reproduce the slow case.** Write a benchmark that exercises the hot path with realistic data sizes. Artificial micro-benchmarks that don't reflect production load mislead.
+2. **Profile.** Use `cargo flamegraph`, `perf`, `samply`, or equivalent. Identify the actual bottleneck — it is rarely where intuition says.
+3. **Hypothesize and measure.** Change one thing. Run the benchmark. Record before/after numbers with statistical significance (criterion provides this automatically).
+4. **Commit the benchmark.** The benchmark is part of the deliverable. An optimization without a benchmark is an unverifiable claim.
+
+WHY: Code review cannot evaluate performance claims. "This is faster" is an assertion. A benchmark with before/after numbers and statistical confidence is evidence. Without the benchmark committed alongside the change, the next developer cannot verify the claim, reproduce the measurement, or detect when a later change regresses it.
+
+### Benchmark requirements
+
+| Requirement | Rule |
+|-------------|------|
+| Location | `benches/` directory, separate from tests |
+| Framework | `criterion` (Rust), `pytest-benchmark` (Python), or equivalent statistical benchmarking tool |
+| Data size | Benchmark at minimum two data sizes (small and projected-max). Single-size benchmarks hide complexity class. |
+| Baseline | Record baseline numbers in the PR description. CI stores historical data for trend detection. |
+| Naming | `bench_{operation}_{data_size}` — e.g., `bench_parse_10k_events`, `bench_index_lookup_1m_entries` |
+
+### When to benchmark
+
+Benchmark when:
+
+- Optimizing an existing path (before and after — mandatory)
+- Adding a new hot path (establish baseline — mandatory)
+- Changing data structures in a hot path (verify no regression — mandatory)
+- Reviewing a PR that claims performance improvement (reproducing the claim — mandatory)
+
+Do not benchmark when:
+
+- The operation is I/O-bound and the benchmark would measure I/O, not computation
+- The path runs once at startup and is not user-facing
+- The function is trivial and the benchmark overhead exceeds the function time
+
+---
+
+## Performance regression detection
+
+### CI integration
+
+Performance-sensitive paths must have benchmarks that run in CI. Regressions are caught by comparing against a stored baseline, not by eyeballing numbers.
+
+| Component | Tool | Threshold |
+|-----------|------|-----------|
+| Rust benchmarks | criterion + `critcmp` or `cargo-bench-cmp` | >5% regression flags warning, >15% blocks merge |
+| Python benchmarks | pytest-benchmark `--benchmark-compare` | Same thresholds |
+| Binary size | CI size check (see resource budgets) | >10% increase blocks merge |
+| Startup time | CI benchmark | Exceeding budget blocks merge |
+
+WHY: Human review cannot detect a 7% regression in a function that runs 50,000 times per second. Automated comparison against a baseline catches it. The 5% warning threshold accounts for measurement noise; the 15% merge-blocking threshold catches real regressions. Without automation, performance degrades monotonically — each small regression is individually tolerable and collectively fatal.
+
+### Baseline management
+
+1. **Store baselines in CI artifacts**, not in the repository. Baselines are environment-specific and pollute version history.
+2. **Update baselines explicitly.** A baseline update is a deliberate act with a justification in the commit message, not an automatic side effect of a green build.
+3. **Pin CI runner hardware** (or use consistent instance types) for benchmark jobs. Cross-machine comparison is meaningless.
+4. **Track trends over time.** A sequence of 3% regressions across five PRs is a 15% regression that no individual PR flagged. Store historical data (GreptimeDB or equivalent) and alert on sustained trends.
+
+WHY: Baseline drift is the silent killer of performance regression detection. If baselines auto-update on every merge, every regression becomes the new normal within one commit. Explicit updates with justification create an audit trail: someone decided this slower number is acceptable, and they wrote down why.
+
+### Responding to regressions
+
+1. **If CI flags a regression:** investigate before merging. Do not bump the baseline to make CI green.
+2. **If the regression is real and intentional** (e.g., added validation that costs CPU): document the tradeoff in the PR description, update the baseline with justification.
+3. **If the regression is real and unintentional:** fix it. If the fix is non-trivial, file an issue and revert the regressing change.
+4. **If the regression is noise:** re-run the benchmark. If it persists across three runs, it is not noise.

--- a/standards/PLANNING.md
+++ b/standards/PLANNING.md
@@ -16,7 +16,7 @@ Plans are living documents. They change as work reveals reality. Stale plans are
 
 ## Directory structure
 
-Every project in `kanon/projects/{name}/` follows this structure:
+Every project in `projects/{name}/` follows this structure:
 
 ```
 projects/{name}/
@@ -24,15 +24,17 @@ projects/{name}/
 ├── vision.md           # Why the project exists, design principles, strategic moat
 ├── STATE.md            # Current position, locked decisions, active blockers
 ├── ROADMAP.md          # Phase index -- lean table of phases with goals and success criteria
-└── phases/
-    ├── 01-{name}/
-    │   ├── PLAN.md     # Full phase detail: scope, requirements, decisions, open questions
-    │   └── SUMMARY.md  # Post-completion: what shipped, what was learned, what changed
-    ├── 02-{name}/
-    │   ├── PLAN.md
-    │   └── SUMMARY.md
-    └── NN-{name}/      # Active phase -- has PLAN.md but no SUMMARY.md yet
-        └── PLAN.md
+├── phases/
+│   ├── 01-{name}/
+│   │   ├── PLAN.md     # Full phase detail: scope, requirements, decisions, open questions
+│   │   └── SUMMARY.md  # Post-completion: what shipped, what was learned, what changed
+│   ├── 02-{name}/
+│   │   ├── PLAN.md
+│   │   └── SUMMARY.md
+│   └── NN-{name}/      # Active phase -- has PLAN.md but no SUMMARY.md yet
+│       └── PLAN.md
+└── planning/
+    └── archive/        # Legacy docs (old roadmap.md, backlog.md, etc.)
 ```
 
 ### Required files

--- a/standards/PODMAN.md
+++ b/standards/PODMAN.md
@@ -1,0 +1,534 @@
+# Podman
+
+> Additive to STANDARDS.md, SYSTEMD.md, and OPERATIONS.md. Read those first. Everything here is container-specific.
+>
+> Covers: pod architecture, container naming, volume mounts (SELinux), health checks, auto-update timer, systemd integration, rootless vs rootful, image pinning, Containerfile patterns, networking, security.
+>
+> **Key decisions:** rootful with pods for service grouping, systemd `.service` units wrapping `podman run`, `:Z` on all volume mounts, health checks mandatory, `podman-auto-update.timer` for image updates, `io.containers.autoupdate=registry` label on every container, env files at `/etc/menos-*.env` with 0600 root:root.
+
+---
+
+## Pod architecture
+
+Pods group related containers that share a network namespace. Containers within a pod communicate over `127.0.0.1`. Ports are published on the pod, not individual containers.
+
+### When to use pods
+
+| Pattern | Example | Reason |
+|---------|---------|--------|
+| Shared network namespace | AdGuard + NPM (gateway pod) | NPM proxies to AdGuard on `127.0.0.1:8080` within the pod |
+| Co-scheduled services | Plex + Tautulli (media pod) | Tautulli monitors Plex; they scale together |
+| Dashboard grouping | Homepage + Uptime Kuma (dashboard pod) | Related UI services, single port surface |
+| Independent service | CrowdSec, ntopng, GreptimeDB | No shared-namespace benefit; standalone |
+
+### Pod creation
+
+```bash
+# Create pod with all published ports
+# WHY: ports belong to the pod, not individual containers
+podman pod create --name gateway -p 53:53/tcp -p 53:53/udp -p 80:80 -p 81:81 -p 443:443 -p 3000:8080
+
+# Add containers to the pod
+podman run -d --pod gateway --name adguard ...
+podman run -d --pod gateway --name npm ...
+```
+
+### Pod networking rules
+
+- **Cross-pod communication:** Use the host LAN IP (`192.168.0.18`), never `localhost`
+- **Same-pod communication:** Use `127.0.0.1` with the container's internal port
+- **Port mapping:** Defined at pod creation; individual containers do not publish ports
+
+| Scenario | Address | Example |
+|----------|---------|---------|
+| NPM proxying to AdGuard (same pod) | `127.0.0.1:8080` | `proxy.lan` -> `dns.lan` backend |
+| Homepage calling Uptime Kuma (same pod) | `127.0.0.1:3001` | Widget data source |
+| Uptime Kuma monitoring Plex (cross-pod) | `192.168.0.18:32400` | Health check target |
+
+---
+
+## Container naming
+
+| Element | Convention | Example |
+|---------|-----------|---------|
+| Pod names | `kebab-case`, functional group | `gateway`, `media`, `dashboard` |
+| Container names | `kebab-case`, service name | `adguard`, `npm`, `plex`, `tautulli` |
+| Systemd units | `{name}-container.service` | `adguard-container.service` |
+| Image references | Full registry path with tag or digest | `docker.io/adguard/adguardhome:v0.107.52` |
+| Volume paths | `/data/{service}` on dedicated disk | `/data/adguard`, `/data/npm` |
+| Env files | `/etc/menos-{service}.env` | `/etc/menos-npm.env` |
+
+---
+
+## Systemd integration
+
+Every container runs as a systemd service. No manual `podman run` in production.
+
+### Unit file template
+
+```ini
+# /etc/systemd/system/{name}-container.service
+[Unit]
+Description={Name} container
+After=network-online.target
+Wants=network-online.target
+# WHY: pod must exist before container starts
+Requires={pod-name}-pod.service
+After={pod-name}-pod.service
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=10s
+TimeoutStartSec=300
+
+# WHY: env files contain credentials, 0600 root:root
+EnvironmentFile=-/etc/menos-%i.env
+
+ExecStartPre=-/usr/bin/podman rm -f %N
+ExecStart=/usr/bin/podman run \
+    --name %N \
+    --pod {pod-name} \
+    --label io.containers.autoupdate=registry \
+    --health-cmd="..." \
+    --health-interval=30s \
+    --health-retries=3 \
+    --health-start-period=10s \
+    -v /data/{service}/config:/opt/{service}/conf:Z \
+    {image}:{tag}
+ExecStop=/usr/bin/podman stop -t 30 %N
+ExecStopPost=-/usr/bin/podman rm -f %N
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### Pod unit file template
+
+```ini
+# /etc/systemd/system/{pod-name}-pod.service
+[Unit]
+Description={Pod-Name} pod
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStartPre=-/usr/bin/podman pod rm -f {pod-name}
+ExecStart=/usr/bin/podman pod create --name {pod-name} \
+    -p {port-mappings}
+ExecStop=/usr/bin/podman pod stop {pod-name}
+ExecStopPost=/usr/bin/podman pod rm -f {pod-name}
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### Lifecycle commands
+
+```bash
+# Start/stop a service (restarts container, not pod)
+sudo systemctl restart adguard-container
+
+# View status across all containers
+sudo podman ps --format "table {{.Names}} {{.Status}}"
+
+# View logs
+sudo journalctl -u adguard-container.service -f
+
+# Rebuild after config change
+sudo systemctl restart adguard-container
+```
+
+---
+
+## Volume mounts
+
+### SELinux labeling
+
+All volume mounts require SELinux context flags. Omitting these causes silent permission denials on SELinux-enforcing systems (Fedora, RHEL).
+
+| Flag | Meaning | Use |
+|------|---------|-----|
+| `:Z` | Private unshared label | Default for all mounts. Each container gets its own label. |
+| `:z` | Shared label | Only when multiple containers must access the same path. |
+| `:ro` | Read-only | Combine with `:Z` as `:ro,Z` for config files. |
+
+```bash
+# Standard data mount
+-v /data/adguard/work:/opt/adguardhome/work:Z
+-v /data/adguard/conf:/opt/adguardhome/conf:Z
+
+# Read-only config mount
+-v /etc/myapp.conf:/etc/myapp.conf:ro,Z
+
+# NAS mount (already has NFS context, no :Z needed)
+# WARNING: :Z on NFS mounts will fail or corrupt SELinux labels on the NFS server
+-v /nas/media:/media:ro
+```
+
+### Volume layout
+
+Service data lives on the dedicated data disk (`/data`), not the OS disk (`/`):
+
+```
+/data/
+├── adguard/        # AdGuard Home config + work
+│   ├── conf/
+│   └── work/
+├── npm/            # Nginx Proxy Manager
+├── plex/
+│   └── config/
+├── tautulli/
+├── homepage/
+│   └── config/
+├── uptime-kuma/
+├── crowdsec/
+├── ntopng/
+│   └── redis/      # NOTE: uid 101:102 required or credentials lost on restart
+├── ntfy/
+├── greptimedb/
+└── vector/
+```
+
+### Ownership and permissions
+
+```bash
+# Most containers run as non-root internally; match UIDs
+# NOTE: check the image docs for expected UID/GID
+
+# ntopng Redis needs specific ownership
+sudo chown -R 101:102 /data/ntopng/redis
+
+# Secrets and env files are root-only
+sudo chmod 0600 /etc/menos-*.env
+sudo chown root:root /etc/menos-*.env
+```
+
+---
+
+## Health checks
+
+Every long-running container defines a health check. Containers without health checks fail silently.
+
+### Health check patterns
+
+| Service type | Health check | Example |
+|-------------|-------------|---------|
+| HTTP service | HTTP GET to health/status endpoint | `curl -f http://localhost:8080/health` |
+| DNS service | DNS query | `nslookup localhost 127.0.0.1` |
+| Database | Client connection test | `greptimedb-cli health` |
+| Queue/stream | Process check | `pgrep -f vector` |
+
+### Containerfile HEALTHCHECK
+
+```dockerfile
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/health || exit 1
+```
+
+### Runtime health check flags
+
+```bash
+podman run \
+    --health-cmd="curl -f http://localhost:8080/health || exit 1" \
+    --health-interval=30s \
+    --health-retries=3 \
+    --health-start-period=10s \
+    --health-timeout=3s \
+    myimage:tag
+```
+
+### Monitoring health
+
+```bash
+# Check individual container health
+podman healthcheck run adguard
+
+# View health status in ps output
+podman ps --format "table {{.Names}} {{.Status}}"
+
+# Uptime Kuma monitors use LAN IPs, not Tailscale
+# WHY: Uptime Kuma runs on the same LAN as the services
+```
+
+---
+
+## Auto-update
+
+The `podman-auto-update.timer` pulls new images and restarts containers with the `io.containers.autoupdate=registry` label.
+
+### Setup
+
+```bash
+# Enable the timer (runs weekly, Sundays 4am by default)
+sudo systemctl enable --now podman-auto-update.timer
+
+# Verify timer schedule
+systemctl list-timers podman-auto-update.timer
+```
+
+### Requirements
+
+Every container that should auto-update must have:
+
+1. **The autoupdate label:**
+   ```bash
+   --label io.containers.autoupdate=registry
+   ```
+
+2. **A fully qualified image reference (not `latest`):**
+   ```bash
+   # Valid: tag or digest
+   docker.io/adguard/adguardhome:v0.107.52
+   docker.io/library/nginx:1.27@sha256:abc123...
+
+   # Invalid: bare name or latest
+   adguardhome
+   nginx:latest
+   ```
+
+### Manual trigger
+
+```bash
+# Dry run (check for updates without applying)
+sudo podman auto-update --dry-run
+
+# Apply updates
+sudo podman auto-update
+```
+
+---
+
+## Image pinning
+
+### Tag strategy
+
+| Environment | Strategy | Example |
+|-------------|----------|---------|
+| Production services | Minor version pin | `adguardhome:v0.107` |
+| Critical infrastructure | Patch version pin | `adguardhome:v0.107.52` |
+| Maximum reproducibility | Digest pin | `adguardhome@sha256:abc123...` |
+| Build stages only | Major version pin | `rust:1.78-bookworm` |
+
+Never use `latest` in systemd unit files. The tag must be explicit and auditable.
+
+### Containerfile pinning
+
+```dockerfile
+# Build stage: major version pin is acceptable
+FROM rust:1.78-bookworm AS builder
+
+# Runtime stage: pin to digest for reproducibility
+FROM gcr.io/distroless/cc-debian12@sha256:abc123...
+```
+
+---
+
+## Rootless vs rootful
+
+### Decision matrix
+
+| Requirement | Rootless | Rootful |
+|-------------|----------|---------|
+| Bind ports < 1024 (53, 80, 443) | No | **Yes** |
+| Device access (GPU, USB) | No | **Yes** |
+| NFS mount access | Depends | **Yes** |
+| User namespace isolation | **Yes** | No |
+| No root on host | **Yes** | No |
+| Development/testing | **Yes** | Either |
+
+### Homelab pattern
+
+Homelab services run rootful because they bind low ports (53, 80, 443) and access NFS mounts. Systemd units use system scope (`/etc/systemd/system/`), not user scope.
+
+```bash
+# Rootful: system-level service
+sudo systemctl start adguard-container.service
+
+# Rootless: user-level service (development)
+systemctl --user start dev-api.service
+```
+
+### Rootless prerequisites
+
+When running rootless containers:
+
+```bash
+# Enable lingering (containers survive logout)
+loginctl enable-linger $USER
+
+# Enable user podman socket
+systemctl --user enable --now podman.socket
+
+# Storage locations
+# Images: ~/.local/share/containers/storage
+# Runtime: /run/user/$(id -u)/containers
+# Config: ~/.config/containers
+```
+
+---
+
+## Containerfile guidelines
+
+### Multi-stage builds
+
+Separate build and runtime concerns:
+
+```dockerfile
+FROM rust:1.78-bookworm AS builder
+WORKDIR /app
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+RUN cargo build --release
+
+FROM gcr.io/distroless/cc-debian12
+COPY --from=builder /app/target/release/myapp /bin/
+ENTRYPOINT ["/bin/myapp"]
+```
+
+### Base image priority
+
+| Priority | Source | Example |
+|----------|--------|---------|
+| 1 | Distroless | `gcr.io/distroless/static-debian12` |
+| 2 | Minimal official | `alpine:3.19` |
+| 3 | Slim variants | `debian:12-slim` |
+| 4 | Full official | `rust:1.78-bookworm` (build only) |
+
+### Required metadata
+
+```dockerfile
+LABEL org.opencontainers.image.source="https://github.com/org/repo"
+LABEL org.opencontainers.image.revision="${GIT_REVISION}"
+LABEL org.opencontainers.image.version="${VERSION}"
+```
+
+### Layer ordering
+
+Order by change frequency (least-changing first): base image, system deps, user creation, workdir, dependency manifests, dependency install, source copy, build, runtime config (`USER`, `EXPOSE`, `HEALTHCHECK`, `ENTRYPOINT`).
+
+---
+
+## Networking
+
+### Network types
+
+| Type | Use |
+|------|-----|
+| Pod networking | Default for grouped services (shared `localhost`) |
+| `bridge` | Container-to-container on same host (standalone containers) |
+| `pasta` | Rootless default on Podman 5+ |
+| `slirp4netns` | Rootless fallback |
+| `host` | Avoid unless required (breaks isolation) |
+
+### Custom networks for standalone containers
+
+```bash
+podman network create --driver bridge internal-net
+podman run --network internal-net --name crowdsec ...
+```
+
+### Port publishing
+
+```bash
+# Bind to all interfaces (default for services)
+podman run -p 8080:8080 myapp
+
+# Bind to specific interface
+podman run -p 127.0.0.1:8080:8080 myapp
+
+# UDP (required for DNS)
+podman run -p 53:53/udp dns-server
+```
+
+---
+
+## Security
+
+### Capability management
+
+```bash
+# Drop all, add only what's needed
+podman run --cap-drop=ALL --cap-add=NET_BIND_SERVICE myapp
+```
+
+### Runtime hardening
+
+```bash
+podman run \
+    --security-opt=no-new-privileges \
+    --read-only \
+    --tmpfs /tmp \
+    --tmpfs /var/cache \
+    myapp
+```
+
+### Secrets
+
+```bash
+# Podman secrets (preferred over env vars for credentials)
+printf 'mysecret' | podman secret create db_password -
+podman run --secret db_password,target=/run/secrets/db_password myapp
+
+# Env file approach (used in homelab)
+# WHY: systemd EnvironmentFile is simpler for service-level config
+# Env files at /etc/menos-*.env, 0600 root:root
+```
+
+### Container user
+
+```dockerfile
+# Create non-root user in Containerfile
+RUN addgroup --gid 1000 appgroup && \
+    adduser --uid 1000 --ingroup appgroup --disabled-password appuser
+USER appuser:appgroup
+```
+
+---
+
+## Anti-patterns
+
+| Anti-pattern | Problem | Fix |
+|-------------|---------|-----|
+| `--privileged` | Bypasses all security | Use specific `--cap-add` |
+| Running as root in container | Unnecessary privilege | `USER` directive in Containerfile |
+| `latest` tag in unit files | Non-deterministic, breaks auto-update | Pin to version tag |
+| Missing `:Z` on Fedora/RHEL | Silent permission denial | Always use `:Z` for bind mounts |
+| `:Z` on NFS mounts | Corrupts SELinux labels on NFS server | Omit SELinux flags for NFS |
+| Ports on containers in pods | Ignored; ports belong to the pod | Publish ports at pod creation |
+| `localhost` for cross-pod calls | Pods have isolated network namespaces | Use host LAN IP |
+| Missing health checks | Silent failures | `--health-cmd` on every container |
+| Manual `podman run` in production | Not reproducible, no restart | Wrap in systemd unit |
+| Docker socket mounting | Massive security risk | Use Podman API socket if needed |
+| No resource limits | Unbounded containers exhaust host | Set `--memory` and `--cpus` |
+| Env vars for secrets | Visible in `podman inspect` | Use Podman secrets or mounted files |
+
+---
+
+## Tooling
+
+| Tool | Purpose |
+|------|---------|
+| `podman` | Container runtime (daemonless, OCI-compliant) |
+| `buildah` | Low-level image building |
+| `skopeo` | Image inspection and registry operations |
+| `podman-compose` | Docker Compose compatibility layer |
+| `systemctl` | Service lifecycle for container units |
+| `journalctl -u {name}-container` | Container service logs |
+| `podman healthcheck run {name}` | Manual health check trigger |
+| `podman auto-update --dry-run` | Check for available image updates |
+
+---
+
+## Cross-references
+
+| Topic | Standard |
+|-------|----------|
+| Systemd unit patterns | SYSTEMD.md |
+| Reverse proxy configuration | NGINX.md |
+| Backup of service data | RESTIC.md |
+| Monitoring and health checks | OPERATIONS.md#monitoring |
+| Credential handling | SECURITY.md |
+| DNS and firewall | SECURITY.md#dns, OPERATIONS.md |

--- a/standards/PROMPTING.md
+++ b/standards/PROMPTING.md
@@ -1,0 +1,282 @@
+# Prompting
+
+> Standards for constructing API prompts: system messages, user messages, tool-use instructions, and evaluation prompts sent to LLM providers. Based on Anthropic's documented best practices for Claude 4.x models.
+
+**Scope:** API-level prompt construction -- the text sent as system prompts, user messages, and tool calls to LLM APIs. Does not cover repository context files (CLAUDE.md, AGENTS.md, llms.txt); see [AGENT-DOCS.md](AGENT-DOCS.md) for those.
+
+---
+
+## Structure
+
+### System prompt ordering
+
+Static content first, variable content last. This maximizes prompt cache hits (cache prefix matching requires identical leading tokens).
+
+```
+1. Behavioral directives (1-2 sentences — what to do, not who to be)
+2. Rules and constraints (XML-wrapped)
+3. Standards and rules
+4. Validation gate
+5. Project context (variable per project)
+6. Contextual injections (lessons, observations, warm context)
+```
+
+### User prompt ordering
+
+Task description goes at the bottom of the prompt body, not the top. Anthropic testing shows up to 30% quality improvement when the query appears after all context.
+
+```
+1. Setup instructions
+2. Context (prior work, related observations, handoff docs)
+3. Acceptance criteria
+4. Blast radius
+5. Task / directive (LAST)
+```
+
+---
+
+## XML tags
+
+Use XML tags to separate instructions from data. Claude processes XML boundaries as structural markers -- content inside tags is less likely to be misinterpreted as instructions, and instructions inside tags are less likely to be treated as data.
+
+### When to use XML tags
+
+- Wrapping behavioral directive blocks in system prompts
+- Separating few-shot examples from instructions
+- Structuring output format specifications
+- Isolating code/diff content from evaluation instructions
+
+### Tag naming
+
+Tag names should describe their content. No canonical "best" names -- use what makes sense.
+
+```xml
+<behavioral_directives>
+Evaluate code changes against the acceptance criteria.
+Ground every judgment in specific code from the diff.
+Evaluate each criterion independently.
+</behavioral_directives>
+
+<examples>
+<example>
+Input: ...
+Output: ...
+</example>
+</examples>
+
+<output_format>
+Respond with this JSON structure: ...
+</output_format>
+```
+
+### When NOT to use XML tags
+
+- Simple single-purpose prompts (overhead > value)
+- Inside few-shot examples (examples should mirror actual expected I/O)
+- For formatting that markdown handles well (tables, lists, headers)
+
+---
+
+## Voice
+
+### Positive instructions over negative
+
+Tell Claude what to DO, not what NOT to do. Claude 4.x models overtrigger on negative framing -- "Do NOT" causes excessive avoidance.
+
+Wrong:
+```
+Do NOT modify files outside the blast radius.
+NEVER use unwrap() in library code.
+```
+
+Right:
+```
+Stay within the blast radius because files outside scope create merge conflicts that block other agents.
+Use the ? operator with snafu context in library code because unwrap panics crash the server without diagnostic information.
+```
+
+### WHY on every rule
+
+Every rule must explain why it exists. Claude generalizes from the explanation and applies the principle to novel situations. Rules without WHY are followed rigidly but not understood.
+
+Wrong:
+```
+Use #[expect] over #[allow].
+```
+
+Right:
+```
+Use #[expect(lint, reason = "...")] over #[allow] because #[expect] fires a compiler warning when the suppressed lint is resolved, preventing stale suppressions from accumulating.
+```
+
+### Dial back aggressive language
+
+Claude 4.x overtriggers on MUST, CRITICAL, ALWAYS, NEVER. Use direct statements without escalation.
+
+Wrong:
+```
+CRITICAL: You MUST use this tool when searching for files.
+ALWAYS check the blast radius before modifying code.
+```
+
+Right:
+```
+Use this tool when searching for files.
+Check the blast radius before modifying code.
+```
+
+Reserve emphasis for genuinely critical safety constraints (credential handling, destructive operations).
+
+---
+
+## Few-shot examples
+
+### Placement
+
+Examples go in an `<examples>` block after instructions and before the task. 3-5 examples is optimal. Each example wraps in `<example>` tags.
+
+### Quality over quantity
+
+Examples must be relevant (mirror actual use cases), diverse (cover edge cases), and include both input and expected output. Diverse canonical examples beat exhaustive edge-case lists.
+
+### Reasoning in examples
+
+Include `<thinking>` tags inside examples to demonstrate reasoning patterns. Claude generalizes the reasoning style to its own extended thinking.
+
+```xml
+<examples>
+<example>
+Input: PR diff adds a new HTTP endpoint without input validation
+<thinking>
+The endpoint accepts user input via query parameters but does not validate length or content.
+SECURITY.md requires boundary validation on all HTTP endpoints.
+The diff shows no size limit check.
+</thinking>
+Output:
+- CRITERION: Input validation at boundary
+- VERDICT: FAIL
+- EVIDENCE: handler at line 45 reads query param without length check
+</example>
+</examples>
+```
+
+---
+
+## Structured output
+
+### JSON for machine parsing
+
+When output must be parsed programmatically, specify a JSON schema in the prompt. Include the exact structure with field types.
+
+```xml
+<output_format>
+Respond with this JSON:
+{
+  "evaluations": [
+    {
+      "criterion_id": 1,
+      "verdict": "PASS" | "FAIL",
+      "confidence": "high" | "medium" | "low",
+      "evidence": "specific code reference",
+      "reasoning": "brief chain of thought"
+    }
+  ]
+}
+</output_format>
+```
+
+### Escape hatches
+
+Include escape hatches for ambiguous cases. "Return Unknown when insufficient information" prevents forced judgments.
+
+### ID-based matching
+
+When evaluating a list (criteria, requirements, items), assign numeric IDs and reference by ID in the output. Avoids fuzzy string matching failures.
+
+---
+
+## Chain of thought
+
+### Adaptive over prescriptive
+
+General instructions ("think thoroughly about edge cases") produce better reasoning than prescriptive step-by-step plans. Claude finds valid approaches that prompt designers don't anticipate.
+
+### Self-verification
+
+Add a self-check instruction at the end: "verify your answer against the acceptance criteria before responding." This catches errors reliably for coding and evaluation tasks.
+
+### Think tool
+
+For multi-step tool use sequences, the think tool (mid-response reasoning) outperforms front-loaded chain-of-thought. Use when the agent needs to reason between tool calls.
+
+---
+
+## Prompt caching
+
+### Cache prefix ordering
+
+Claude's prompt cache matches on leading token prefixes. The order matters:
+
+```
+1. Tools (most static)
+2. System prompt (static per role)
+3. Messages (variable per session)
+```
+
+Changes at any level invalidate that level and all subsequent levels.
+
+### Breakpoint placement
+
+Place cache breakpoints on the last identical block across requests. Common mistake: placing breakpoints on changing content (timestamps, session IDs) -- the hash never matches.
+
+### Minimum tokens
+
+Minimum cacheable prefix: 1,024 tokens for Sonnet 4.5/4, 2,048 for Sonnet 4.6, 4,096 for Opus/Haiku 4.5. Cache reads cost 0.1x base input (90% savings).
+
+---
+
+## Evaluation prompts
+
+### Isolated judgment
+
+Grade each dimension with a separate evaluation, not one judge for all dimensions. Multi-dimensional evaluation in a single prompt produces less consistent results.
+
+### Grade outcomes, not paths
+
+Agents regularly find valid approaches that evaluators didn't anticipate. Grade whether acceptance criteria are met, not whether the approach matches expectations.
+
+### Calibration
+
+Test evaluation prompts against known-good and known-bad examples before deployment. Ensure pass rate on known-good is >95% and fail rate on known-bad is >90%.
+
+---
+
+## Role framing
+
+### Directive hierarchy
+
+Three independent studies (2024-2026) show measurable differences between role-framing strategies. Ranked by coding and factual-recall accuracy:
+
+| Tier | Strategy | Example | Finding |
+|------|----------|---------|---------|
+| 1 (best) | Directive-only | "Analyze this code for security issues" | Highest accuracy on coding and factual tasks |
+| 2 | Behavioral + capability | "You are an expert security analyst. Analyze this code for security issues" | Middle tier -- helps alignment tasks, slight cost on factual recall |
+| 3 (weakest) | Identity claim | "You are a senior engineer at Google. Analyze this code for security issues" | Degrades coding accuracy and factual recall; only helps alignment-heavy tasks |
+
+Use Tier 1 by default. Use Tier 2 when the task requires domain-specific judgment framing. Avoid Tier 3 -- the identity claim adds no information the model can act on and measurably hurts performance.
+
+---
+
+## Anti-patterns
+
+- Prose-dump system prompts without structural markers (use XML tags)
+- Negative-voice rule lists ("Do NOT" x20) without WHY explanations
+- Aggressive emphasis (MUST, CRITICAL, ALWAYS) on non-safety rules
+- Task at the top of the prompt body (put it last)
+- Fuzzy string matching on structured output (use ID-based matching)
+- Prescriptive step-by-step plans where general guidance suffices
+- Placing variable content before static content (kills cache hits)
+- Evaluating multiple dimensions in a single prompt
+- Examples that don't match actual use cases
+- Rules without WHY (followed rigidly, not understood)
+- Identity claims in role definitions (see [Role framing](#role-framing) -- use directive-only instead)

--- a/standards/PROTOBUF.md
+++ b/standards/PROTOBUF.md
@@ -1,6 +1,6 @@
 # Protocol Buffers
 
-> Standards for proto3 schema design, wire compatibility, and Rust codegen. Applies to all `.proto` files and generated code.
+> Standards for proto3 schema design, wire compatibility, gRPC service patterns, JSON mapping, and Rust codegen. Applies to all `.proto` files and generated code.
 
 ---
 
@@ -58,8 +58,8 @@
 
 ## Field numbering
 
-- Numbers 1–15 encode as one byte on the wire. Reserve these for frequently-set fields.
-- Numbers 16–2047 encode as two bytes. Use for less common fields.
+- Numbers 1-15 encode as one byte on the wire. Reserve these for frequently-set fields.
+- Numbers 16-2047 encode as two bytes. Use for less common fields.
 - Never reuse a field number, even after deleting the field. Serialized data in logs, caches, and storage may still reference old numbers.
 - Reserve deleted field numbers AND names to prevent accidental reuse:
 
@@ -69,7 +69,7 @@ reserved "old_field", "deprecated_field";
 ```
 
 - Number gaps are acceptable when fields have been removed and reserved. Document with a comment above the `reserved` block.
-- Field numbers above 19000–19999 are reserved by the protobuf implementation. Never use them.
+- Field numbers above 19000-19999 are reserved by the protobuf implementation. Never use them.
 
 ## Backwards compatibility
 
@@ -97,6 +97,44 @@ Protobuf's value is schema evolution. Breaking the wire format negates the reaso
 - Add a comment explaining what replaces it.
 - Reserve the field number and name when the field is finally removed.
 
+### Oneof migration
+
+`oneof` membership is a wire-level commitment. Moving a field into or out of a `oneof` is a breaking change -- it alters the wire encoding and breaks generated stubs (particularly in Go, where `oneof` fields become interface types).
+
+**Adding a variant to an existing oneof** is safe:
+
+```protobuf
+// v1: two variants
+oneof payload_variant {
+  TextPayload text = 3;
+  BinaryPayload binary = 4;
+}
+
+// v1 (evolved): third variant added -- safe, old clients ignore it
+oneof payload_variant {
+  TextPayload text = 3;
+  BinaryPayload binary = 4;
+  JsonPayload json = 5;
+}
+```
+
+**Removing a variant**: never delete the field. Mark it `[deprecated = true]`, stop setting it in new code, and `reserved` the number when no clients remain:
+
+```protobuf
+oneof payload_variant {
+  TextPayload text = 3;
+  BinaryPayload binary = 4 [deprecated = true];
+  JsonPayload json = 5;
+}
+// After all clients migrate away from binary:
+// reserved 4;
+// reserved "binary";
+```
+
+**Replacing a oneof entirely**: introduce a new `oneof` with a different name and new field numbers. Deprecate the old `oneof`'s fields. Never reuse the old field numbers. Handlers must check both oneofs during the transition window.
+
+**Rust handling**: `prost` generates an `enum` for each `oneof`. New variants added by schema evolution will deserialize as `None` in old code (the field is simply unset from the old binary's perspective). Design match arms to handle the `None` / unknown case explicitly.
+
 ## Enum conventions
 
 - First value is always zero and signals "unset": `FOO_UNSPECIFIED = 0` or `FOO_UNKNOWN = 0`.
@@ -114,6 +152,181 @@ Protobuf's value is schema evolution. Breaking the wire format negates the reaso
 - Standard CRUD methods: `Get`, `List`, `Create`, `Update`, `Delete`.
 - Long-running operations return an `Operation` message with status polling.
 
+## Pagination
+
+Use cursor-based pagination by default. Offset-based pagination is fragile under concurrent writes (inserts shift offsets, causing skipped or duplicated items).
+
+### Message pattern
+
+```protobuf
+message ListDevicesRequest {
+  // Maximum number of items to return. Server may return fewer.
+  // Must be positive. Server enforces an upper bound (e.g., 1000).
+  int32 page_size = 1;
+
+  // Opaque token from a previous ListDevicesResponse.
+  // Empty string for the first page.
+  string page_token = 2;
+
+  // Optional filter or sort criteria.
+  string filter = 3;
+}
+
+message ListDevicesResponse {
+  repeated Device devices = 1;
+
+  // Token for the next page. Empty string means no more pages.
+  // Clients must not interpret or construct tokens -- they are opaque.
+  string next_page_token = 2;
+
+  // Optional: total count if the client needs it for UI pagination.
+  // Omit if computing the total is expensive (requires a full scan).
+  int32 total_size = 3;
+}
+```
+
+### Rules
+
+- `page_token` is an opaque string. The server encodes cursor state (e.g., last-seen ID, sort key) into it. Clients must never parse, construct, or modify tokens.
+- `page_size` is a request, not a guarantee. The server may return fewer items (final page, server-side cap). The client checks `next_page_token` emptiness to detect the last page, not the response count.
+- Servers must enforce a maximum `page_size`. Unbounded page sizes defeat the purpose of pagination.
+- Tokens must be stable across schema changes. Encode by value (last-seen sort key + ID), not by position. A token that embeds an offset breaks when rows are inserted or deleted.
+- Tokens should expire after a reasonable TTL (e.g., 24 hours). Document the expiry. Expired tokens return `INVALID_ARGUMENT`, not stale data.
+- `List` RPCs that support pagination must also work without it: if `page_token` is empty and `page_size` is zero, return the first page with the server's default size.
+
+### Offset-based pagination
+
+Use only when the client genuinely needs random page access (e.g., "jump to page 7") and the dataset is append-only or rarely mutated. The pattern uses `offset` and `limit` fields instead of `page_token`:
+
+```protobuf
+message ListAuditLogsRequest {
+  int32 limit = 1;
+  int32 offset = 2;
+}
+```
+
+Offset pagination must never be the default. Document the consistency caveats when it is used.
+
+## gRPC patterns
+
+### Streaming
+
+Choose the streaming mode that matches the data flow. Mismatched modes leak complexity into both client and server.
+
+| Mode | When | Example |
+|------|------|---------|
+| Unary | Single request, single response | `GetChannel`, `CreateSession` |
+| Server streaming | Single request, multiple responses over time | `ListNodes` with large result sets, event subscriptions |
+| Client streaming | Multiple requests, single response | Batch upload, aggregated metrics |
+| Bidirectional streaming | Both sides send independently | Real-time chat, collaborative editing |
+
+- Server-streaming RPCs must define a clear end condition. The server closes the stream; the client must not assume it stays open forever.
+- Client-streaming RPCs must define a maximum message count or total size. Unbounded client streams invite resource exhaustion on the server.
+- Bidirectional streams must handle half-close: either side can finish sending while the other continues. Design the protocol so both sides know when the conversation is over.
+
+```protobuf
+service TelemetryService {
+  // Unary: single device lookup.
+  rpc GetDevice(GetDeviceRequest) returns (GetDeviceResponse);
+
+  // Server streaming: subscribe to metrics as they arrive.
+  // Stream closes when the device goes offline or the client cancels.
+  rpc WatchMetrics(WatchMetricsRequest) returns (stream DeviceMetrics);
+
+  // Client streaming: batch-upload recorded positions.
+  // Server responds with a summary after the client closes the stream.
+  rpc UploadPositions(stream Position) returns (UploadPositionsResponse);
+}
+```
+
+### Backpressure and flow control
+
+gRPC uses HTTP/2 flow control at the transport layer, but application-level backpressure is the developer's responsibility.
+
+- **Server streaming**: The server must respect client consumption rate. If the client is slow, buffered messages consume server memory. Bound the send buffer and apply backpressure by blocking the send when the buffer is full rather than dropping messages silently.
+- **Client streaming**: The server should enforce a maximum message count or total payload size. Reject streams that exceed the limit with `RESOURCE_EXHAUSTED`.
+- **Bidirectional streaming**: Both sides must handle slow consumers. Design protocols with explicit acknowledgment or windowing so neither side races ahead unboundedly.
+- Set `max_concurrent_streams` on the server to limit how many RPCs a single HTTP/2 connection can multiplex simultaneously. The default is often unlimited, which invites resource exhaustion under load.
+
+### Keepalive configuration
+
+Keepalives detect dead connections that the OS TCP stack has not yet noticed (NAT timeouts, silent intermediary failures).
+
+- **Server-side**: Enable keepalive pings to detect clients that have silently disconnected. Set `keepalive_interval` (how often to ping idle connections) and `keepalive_timeout` (how long to wait for a pong before closing).
+- **Client-side**: Enable keepalive pings to detect unresponsive servers before the OS TCP timeout (which can exceed 10 minutes).
+- Set `permit_keepalive_without_calls` to `true` on the server if clients maintain long-lived idle connections (e.g., watch streams).
+- Coordinate keepalive intervals: the client's interval must not be shorter than the server's `min_recv_ping_interval_without_data`, or the server will terminate the connection with `ENHANCE_YOUR_CALM`.
+
+```rust
+// Server keepalive configuration
+Server::builder()
+    .http2_keepalive_interval(Some(std::time::Duration::from_secs(60)))
+    .http2_keepalive_timeout(Some(std::time::Duration::from_secs(20)))
+    .add_service(service)
+    .serve(addr)
+    .await?;
+
+// Client keepalive configuration
+let channel = Channel::from_shared(endpoint)?
+    .keep_alive_while_idle(true)
+    .http2_keep_alive_interval(std::time::Duration::from_secs(60))
+    .keep_alive_timeout(std::time::Duration::from_secs(20))
+    .connect()
+    .await?;
+```
+
+### Deadlines and timeouts
+
+- Every RPC call must set a deadline. Calls without deadlines can hang indefinitely, consuming server resources and blocking client threads.
+- Propagate deadlines across service boundaries. If service A calls service B within a request, B's deadline must not exceed A's remaining time.
+- Servers must check deadline expiry before starting expensive work. Return `DEADLINE_EXCEEDED` early rather than completing work the client has already abandoned.
+
+### Health checking
+
+- Every gRPC service exposes the standard `grpc.health.v1.Health` service. Load balancers and orchestrators depend on it for routing decisions.
+- `Check` returns `SERVING`, `NOT_SERVING`, or `UNKNOWN`. Never return `SERVING` if the service cannot fulfil requests (e.g., database connection lost).
+- `Watch` enables streaming health updates for clients that need push-based notifications.
+
+### Reflection
+
+- Enable gRPC server reflection in development and staging environments. It enables `grpcurl` and other diagnostic tools without maintaining separate proto files on the client side.
+- Disable reflection in production unless the service is internal-only. Reflection exposes the full schema, which is an information disclosure risk for public APIs.
+
+### Interceptors (middleware)
+
+- Use interceptors for cross-cutting concerns: logging, metrics, authentication, deadline enforcement, request-id propagation.
+- Order interceptors deliberately. Authentication must run before authorization. Logging must run before anything that might reject the request, so failures are visible.
+- Never put business logic in interceptors. Interceptors handle infrastructure; handlers handle domain.
+
+### Error model
+
+Map domain errors to gRPC status codes consistently. The mapping must be documented and enforced, not ad hoc per handler.
+
+| gRPC code | Domain meaning | When |
+|-----------|---------------|------|
+| `OK` | Success | Request completed |
+| `INVALID_ARGUMENT` | Malformed request | Validation failure, bad field value |
+| `NOT_FOUND` | Resource does not exist | Get/Update/Delete on missing entity |
+| `ALREADY_EXISTS` | Duplicate creation | Create with conflicting unique key |
+| `PERMISSION_DENIED` | Caller lacks access | Authenticated but unauthorized |
+| `UNAUTHENTICATED` | Missing or invalid credentials | No token, expired token |
+| `RESOURCE_EXHAUSTED` | Quota or rate limit hit | Too many requests, storage full |
+| `FAILED_PRECONDITION` | State conflict | Optimistic concurrency violation, invalid state transition |
+| `UNAVAILABLE` | Transient failure | Downstream timeout, circuit breaker open. Client should retry |
+| `INTERNAL` | Server bug | Unhandled error. Log full details server-side, return generic message |
+| `DEADLINE_EXCEEDED` | Timeout | Propagated from deadline infrastructure |
+| `UNIMPLEMENTED` | RPC not implemented | Stub for future work or deprecated method |
+
+- Never return `UNKNOWN` for errors you can classify. `UNKNOWN` means the error escaped classification, which is a bug in error handling.
+- Include structured error details via `google.rpc.Status` and `google.rpc.ErrorInfo` for machine-readable context. Free-text messages are for humans; structured details are for retry logic and error aggregation.
+
+### Retry and idempotency
+
+- Idempotent RPCs (`Get`, `List`, `Delete` of an already-deleted resource) are safe to retry on `UNAVAILABLE` and `DEADLINE_EXCEEDED`.
+- Non-idempotent RPCs (`Create`, `Update`) must use an idempotency key (client-generated UUID in the request) so the server can deduplicate retries. Without this, retries cause double-writes.
+- Retry with exponential backoff and jitter. Fixed-interval retries cause thundering herds when a downstream recovers.
+- Set a retry budget: no more than 3 attempts or 10% of total requests, whichever is lower. Unbounded retries amplify outages.
+
 ## Import conventions
 
 - Use package-relative paths: `import "meshtastic/mesh.proto";`.
@@ -129,7 +342,7 @@ Protobuf's value is schema evolution. Breaking the wire format negates the reaso
 - Leading `//` comment on every field that isn't self-explanatory from its name and type.
 - Comments describe purpose and constraints, not the type (the schema already says that).
 - Document units for numeric fields: `// Altitude in metres above sea level.`
-- Document valid ranges or special sentinel values: `// 0 means unset; valid range 1–255.`
+- Document valid ranges or special sentinel values: `// 0 means unset; valid range 1-255.`
 
 ## Wire format considerations
 
@@ -154,6 +367,133 @@ Protobuf's value is schema evolution. Breaking the wire format negates the reaso
 - Keep individual messages under 1 MB. Protobuf is not designed for bulk data transfer.
 - Avoid messages with more than 100 fields -- they bloat memory and hit codegen limits in some languages.
 - Use streaming RPCs for large result sets instead of single giant response messages.
+
+### Custom type wrappers
+
+Bare scalar fields carry no semantic meaning beyond their type. A `string` field for a device ID and a `string` field for a user name are interchangeable at the proto level. Wrapper messages add type safety at the schema boundary.
+
+**When to wrap:**
+
+- **Identifiers**: entity IDs that must not be confused with each other. A `DeviceId` and a `UserId` are both strings, but swapping them is a bug.
+- **Monetary values**: currency and amount must travel together. A bare `double` for money invites rounding errors and currency mismatches.
+- **Constrained strings**: email addresses, URLs, semver versions -- values with format invariants the proto schema cannot express.
+
+**When not to wrap**: generic labels, descriptions, free-text fields, and values where the field name alone is unambiguous. Wrapping everything inflates message nesting for no safety gain.
+
+```protobuf
+// Semantic wrapper for device identifiers.
+message DeviceId {
+  string value = 1;
+}
+
+// Monetary amount with explicit currency.
+message Money {
+  // ISO 4217 currency code (e.g., "USD", "EUR").
+  string currency_code = 1;
+
+  // Integer units of the currency.
+  int64 units = 2;
+
+  // Nano-units (10^-9) of the currency. Must be -999999999 to 999999999.
+  // Sign must match units (both positive or both negative).
+  int32 nanos = 3;
+}
+
+// Use wrappers in service messages.
+message GetDeviceRequest {
+  DeviceId device_id = 1;
+}
+```
+
+**Rust-side enforcement**: the generated wrapper is a struct with a single field. Implement `TryFrom` on the Rust side to validate the inner value at the conversion boundary (see Domain conversion below). The proto wrapper provides type distinction; the Rust newtype provides invariant enforcement.
+
+## JSON / protobuf mapping
+
+Protobuf has a canonical JSON encoding defined in the spec. Deviating from it produces payloads that other protobuf-aware tools cannot parse.
+
+### Canonical JSON rules
+
+| Proto type | JSON representation | Notes |
+|-----------|-------------------|-------|
+| `int32`, `uint32`, `sint32` | Number | |
+| `int64`, `uint64`, `sint64`, `fixed64`, `sfixed64` | String | 64-bit integers exceed JavaScript's `Number.MAX_SAFE_INTEGER`. String encoding prevents silent precision loss. |
+| `float`, `double` | Number | `NaN`, `Infinity`, `-Infinity` encoded as strings `"NaN"`, `"Infinity"`, `"-Infinity"` |
+| `bool` | `true` / `false` | |
+| `string` | String | |
+| `bytes` | Base64 string | Standard base64 with padding |
+| `enum` | String (enum value name) | `"HARDWARE_MODEL_UNSET"`, not `0` |
+| `repeated` | Array | Empty repeated field omitted or `[]` |
+| `map<K,V>` | Object | Keys are always strings in JSON |
+| `google.protobuf.Timestamp` | RFC 3339 string | `"2026-04-04T12:00:00Z"` |
+| `google.protobuf.Duration` | String with `s` suffix | `"1.5s"`, `"300s"` |
+| `google.protobuf.FieldMask` | Comma-delimited string | `"foo,bar.baz"` (lower_camel in JSON) |
+| `google.protobuf.Struct` | JSON object | Pass-through |
+| `google.protobuf.Any` | Object with `@type` field | `{"@type": "type.googleapis.com/...", ...}` |
+
+### Field name mapping
+
+- Proto field names are `snake_case`. Canonical JSON uses `lowerCamelCase`: `battery_level` becomes `"batteryLevel"`.
+- Parsers must accept both `snake_case` and `lowerCamelCase`. Emitters must produce `lowerCamelCase`.
+- Override with `json_name` only when interfacing with external APIs that use a fixed JSON schema. Document the override with a comment explaining the external constraint.
+
+```protobuf
+message DeviceMetrics {
+  // Maps to "batteryLevel" in JSON (automatic).
+  uint32 battery_level = 1;
+
+  // Override: external telemetry API expects "rxSNR" not "rxSnr".
+  float rx_snr = 2 [json_name = "rxSNR"];
+}
+```
+
+### Field presence in JSON
+
+- Proto3 scalar fields have implicit presence: unset fields take their default value (`0`, `""`, `false`) and are omitted from JSON output.
+- `optional` fields have explicit presence: the field is either set (including to the default value) or absent. Use `optional` when distinguishing "not set" from "set to zero" matters.
+- `message` fields always have explicit presence: `null` in JSON means absent.
+- `oneof` fields: exactly one field is set, or none. JSON includes only the set field's key.
+
+```protobuf
+message SensorReading {
+  // Implicit presence: 0.0 means "default" and is omitted from JSON.
+  double temperature_celsius = 1;
+
+  // Explicit presence: 0.0 means "measured zero", absent means "no reading".
+  optional double humidity_percent = 2;
+}
+```
+
+### JSON serialization in Rust
+
+- Use `prost` types with `serde` derives injected via `tonic_build::configure().type_attribute()`. Do not hand-write serde impls for generated types.
+- For canonical protobuf JSON (as defined above), use `pbjson` or `prost-reflect` rather than plain serde. Plain serde does not handle 64-bit integers as strings, enums as names, or well-known type formatting.
+
+```rust
+// build.rs -- canonical protobuf JSON support via pbjson
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let descriptor_path =
+        std::path::PathBuf::from(std::env::var("OUT_DIR")?)
+            .join("proto_descriptor.bin");
+
+    tonic_build::configure()
+        .file_descriptor_set_path(&descriptor_path)
+        .compile_protos(&["proto/service.proto"], &["proto/"])?;
+
+    let descriptor_set = std::fs::read(&descriptor_path)?;
+    pbjson_build::Builder::new()
+        .register_descriptors(&descriptor_set)?
+        .build(&[".mypackage"])?;
+
+    Ok(())
+}
+```
+
+### When to use JSON vs binary encoding
+
+- **Binary** (default): Service-to-service gRPC, persistent storage, message queues. Smaller, faster, schema-enforced.
+- **JSON**: External-facing REST APIs, browser clients, debugging, log payloads that humans read. Larger but human-readable.
+- Never use protobuf text format for interchange. It is unstable across implementations and breaks on field renames.
+- When a service exposes both gRPC and REST, use `grpc-gateway` or a similar transcoder rather than maintaining parallel handler implementations. Dual implementations drift.
 
 ## Rust codegen patterns
 
@@ -180,11 +520,269 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 - Implement `From<ProtoType>` / `TryFrom<ProtoType>` between proto types and domain types.
 - Validate at the conversion boundary. Proto types are permissive (all fields optional in proto3). Domain types enforce invariants.
 - Keep proto types out of business logic. Convert at the edge (handler entry, client call site).
+- Use `TryFrom` (not `From`) when the proto type can represent invalid states. `From` is for infallible conversions (domain → proto).
+
+```rust
+use std::num::NonZeroU32;
+
+/// Domain type with enforced invariants.
+pub struct Device {
+    pub id: DeviceId,
+    pub name: String,
+    pub battery_level: NonZeroU32,
+}
+
+/// Validated device identifier. Non-empty, ASCII-only.
+pub struct DeviceId(String);
+
+impl TryFrom<String> for DeviceId {
+    type Error = ValidationError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        if value.is_empty() {
+            return Err(ValidationError::EmptyField("device_id"));
+        }
+        if !value.is_ascii() {
+            return Err(ValidationError::InvalidFormat("device_id", "ASCII only"));
+        }
+        Ok(Self(value))
+    }
+}
+
+/// Proto → domain: fallible, because proto fields are permissive.
+impl TryFrom<proto::GetDeviceResponse> for Device {
+    type Error = ValidationError;
+
+    fn try_from(proto: proto::GetDeviceResponse) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: DeviceId::try_from(proto.device_id)?,
+            name: proto.name,
+            battery_level: NonZeroU32::new(proto.battery_level)
+                .ok_or(ValidationError::EmptyField("battery_level"))?,
+        })
+    }
+}
+
+/// Domain → proto: infallible, domain types are always valid proto.
+impl From<Device> for proto::GetDeviceResponse {
+    fn from(device: Device) -> Self {
+        Self {
+            device_id: device.id.0,
+            name: device.name,
+            battery_level: device.battery_level.get(),
+        }
+    }
+}
+```
 
 ### Error mapping
 
 - Map gRPC status codes to domain errors via `impl From<ServiceError> for tonic::Status`.
 - Include structured details in `tonic::Status::with_details()` for machine-readable error context.
+
+```rust
+use tonic::{Code, Status};
+
+/// Domain error for the telemetry service.
+#[derive(Debug, snafu::Snafu)]
+pub enum TelemetryError {
+    #[snafu(display("device {device_id} not found"))]
+    DeviceNotFound { device_id: String },
+
+    #[snafu(display("invalid time range: start must precede end"))]
+    InvalidTimeRange,
+
+    #[snafu(display("storage unavailable: {source}"))]
+    Storage { source: sqlx::Error },
+}
+
+impl From<TelemetryError> for Status {
+    fn from(err: TelemetryError) -> Self {
+        match &err {
+            TelemetryError::DeviceNotFound { .. } => {
+                Status::not_found(err.to_string())
+            }
+            TelemetryError::InvalidTimeRange => {
+                Status::new(Code::InvalidArgument, err.to_string())
+            }
+            TelemetryError::Storage { .. } => {
+                // Log full details server-side; return generic message to client.
+                tracing::error!(%err, "storage failure");
+                Status::unavailable("storage temporarily unavailable")
+            }
+        }
+    }
+}
+```
+
+### Server implementation
+
+Implement the generated trait, convert proto types to domain types at the handler boundary, and convert back for the response. Keep handlers thin: validate, convert, delegate to domain logic, convert result.
+
+```rust
+use tonic::{Request, Response, Status};
+use crate::proto::telemetry_service_server::TelemetryService;
+use crate::proto::{GetDeviceRequest, GetDeviceResponse};
+use crate::domain::DeviceId;
+
+pub struct TelemetryHandler {
+    store: Arc<dyn DeviceStore>,
+}
+
+#[tonic::async_trait]
+impl TelemetryService for TelemetryHandler {
+    async fn get_device(
+        &self,
+        request: Request<GetDeviceRequest>,
+    ) -> Result<Response<GetDeviceResponse>, Status> {
+        let req = request.into_inner();
+
+        // Validate and convert at the boundary.
+        let device_id = DeviceId::try_from(req.device_id)
+            .map_err(|e| Status::invalid_argument(e.to_string()))?;
+
+        // Delegate to domain logic.
+        let device = self.store
+            .get(device_id)
+            .await
+            .map_err(TelemetryError::from)?;
+
+        // Convert domain type to proto for the response.
+        Ok(Response::new(GetDeviceResponse::from(device)))
+    }
+}
+```
+
+### Client usage
+
+Wrap generated clients in a domain-specific client that handles connection management, deadline setting, and response conversion. Raw generated clients leak proto types and connection details into business logic.
+
+```rust
+use crate::proto::telemetry_service_client::TelemetryServiceClient;
+use tonic::transport::Channel;
+
+pub struct TelemetryClient {
+    inner: TelemetryServiceClient<Channel>,
+    default_timeout: std::time::Duration,
+}
+
+impl TelemetryClient {
+    pub async fn connect(endpoint: &str) -> Result<Self, tonic::transport::Error> {
+        let channel = Channel::from_shared(endpoint.to_owned())?
+            .connect_timeout(std::time::Duration::from_secs(5))
+            .connect()
+            .await?;
+
+        Ok(Self {
+            inner: TelemetryServiceClient::new(channel),
+            default_timeout: std::time::Duration::from_secs(10),
+        })
+    }
+
+    pub async fn get_device(&self, id: DeviceId) -> Result<Device, TelemetryError> {
+        let mut client = self.inner.clone();
+        let mut request = tonic::Request::new(GetDeviceRequest {
+            device_id: id.to_string(),
+        });
+
+        // Every call gets a deadline. No exceptions.
+        request.set_timeout(self.default_timeout);
+
+        let response = client
+            .get_device(request)
+            .await
+            .map_err(TelemetryError::from)?;
+
+        Device::try_from(response.into_inner())
+    }
+}
+```
+
+### Interceptors
+
+Use tonic interceptors for cross-cutting concerns. Each interceptor does one thing.
+
+```rust
+use tonic::{Request, Status};
+
+/// Injects a request-id into every outbound request for tracing correlation.
+pub fn request_id_interceptor(mut req: Request<()>) -> Result<Request<()>, Status> {
+    let request_id = ulid::Ulid::new().to_string();
+    req.metadata_mut().insert(
+        "x-request-id",
+        request_id.parse().unwrap(),
+    );
+    Ok(req)
+}
+
+// Attach to client:
+// TelemetryServiceClient::with_interceptor(channel, request_id_interceptor);
+```
+
+For server-side interceptors that need async or access to service state, use `tonic::service::interceptor` with a tower layer:
+
+```rust
+use tower::ServiceBuilder;
+
+let layer = ServiceBuilder::new()
+    .layer(tonic::service::interceptor(auth_interceptor))
+    .into_inner();
+
+Server::builder()
+    .layer(layer)
+    .add_service(telemetry_service)
+    .serve(addr)
+    .await?;
+```
+
+### Testing gRPC services
+
+Test gRPC services by instantiating the handler struct directly and calling trait methods. This avoids network overhead, port allocation, and flaky connection timing. Reserve integration tests with a real server for verifying wire-level concerns (serialization, TLS, interceptor ordering).
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tonic::Request;
+
+    #[tokio::test]
+    async fn get_device_returns_not_found_for_missing_device() {
+        let store = Arc::new(InMemoryDeviceStore::empty());
+        let handler = TelemetryHandler { store };
+
+        let request = Request::new(GetDeviceRequest {
+            device_id: "nonexistent".into(),
+        });
+
+        let status = handler
+            .get_device(request)
+            .await
+            .unwrap_err();
+
+        assert_eq!(status.code(), tonic::Code::NotFound);
+    }
+
+    #[tokio::test]
+    async fn get_device_returns_device_when_present() {
+        let store = Arc::new(InMemoryDeviceStore::with_device(test_device()));
+        let handler = TelemetryHandler { store };
+
+        let request = Request::new(GetDeviceRequest {
+            device_id: test_device().id.to_string(),
+        });
+
+        let response = handler
+            .get_device(request)
+            .await
+            .expect("should succeed");
+
+        assert_eq!(
+            response.into_inner().device_id,
+            test_device().id.to_string(),
+        );
+    }
+}
+```
 
 ## Anti-patterns
 
@@ -202,3 +800,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 | Text format for interchange | Breaks on any field rename | Binary or JSON encoding |
 | `oneof` field migration | Moving fields in/out breaks Go stubs and loses data | Treat `oneof` membership as permanent |
 | Stringly-typed fields for structured data | No validation, no evolution | Nested message or enum |
+| RPCs without deadlines | Hung calls consume resources indefinitely | Always set a deadline on every call |
+| Returning `UNKNOWN` for classified errors | Hides error semantics from clients and monitoring | Map every domain error to a specific gRPC code |
+| Business logic in interceptors | Interceptors apply to all RPCs; domain logic is per-RPC | Interceptors for infra, handlers for domain |
+| Plain serde for protobuf JSON | Mishandles int64, enums, well-known types | `pbjson` or `prost-reflect` for canonical encoding |
+| Unbounded retries without backoff | Thundering herds amplify outages | Exponential backoff with jitter and retry budget |
+| Dual REST/gRPC handler implementations | Implementations drift over time | `grpc-gateway` or transcoder from a single definition |
+| Offset-based pagination on mutable data | Inserts/deletes shift offsets, skipping or duplicating items | Cursor-based pagination with opaque `page_token` |
+| Client-parseable page tokens | Clients depend on token internals, blocking server changes | Opaque tokens; encode cursor state server-side |
+| Bare scalars for entity identifiers | `string` device ID and `string` user name are interchangeable | Wrapper messages (`DeviceId`, `UserId`) |
+| No keepalive on long-lived connections | Dead connections consume resources until OS TCP timeout | Configure keepalive interval and timeout on both sides |
+| Unbounded streaming without backpressure | Slow consumers cause server memory exhaustion | Bound send buffers, enforce message/size limits |

--- a/standards/PYTHON.md
+++ b/standards/PYTHON.md
@@ -2,7 +2,7 @@
 
 > Additive to STANDARDS.md. Read that first. Everything here is Python-specific.
 >
-> **Key decisions:** 3.13+, uv packages, ruff lint/format, mypy strict, anyio async, polars data, msgspec serialization, pydantic at boundaries, loguru logging.
+> **Key decisions:** 3.13+, uv packages, ruff lint/format, mypy strict, anyio async, polars data, msgspec serialization, pydantic at boundaries, loguru logging, contextvars propagation, py-spy profiling, src/ layout.
 
 ---
 
@@ -229,7 +229,6 @@ Don't retrofit `except*` into sequential code where a single `except` suffices.
 
 - `sys.exit(1)` for fatal errors
 - Error messages to stderr: `print("error: ...", file=sys.stderr)`
-- Never bare `except Exception` without logging or re-raising
 - No `exec()` or `eval()`
 
 ### Context managers
@@ -279,6 +278,182 @@ result = (
 
 ---
 
+## Profiling
+
+See PERFORMANCE.md for universal measurement principles. Profile before optimizing. These are the Python-specific tools.
+
+### CPU profiling
+
+Use `cProfile` for quick hot-path identification. Use `py-spy` for production profiling without code changes.
+
+```bash
+# cProfile: built-in, zero dependencies
+python -m cProfile -s cumulative my_script.py
+
+# py-spy: sampling profiler, attaches to running process
+py-spy top --pid 12345
+py-spy record -o profile.svg -- python my_script.py
+```
+
+- `py-spy` is preferred for services: no instrumentation overhead, produces flame graphs directly
+- `cProfile` is fine for scripts and one-off investigation
+- Never leave profiling hooks in production code paths
+
+### Memory profiling
+
+Use `memray` for allocation tracking. It traces every allocation with negligible overhead compared to `tracemalloc`.
+
+```bash
+# memray: trace allocations, generate flame graph
+memray run my_script.py
+memray flamegraph memray-my_script.py.bin
+
+# memray: attach to running process
+memray attach 12345
+```
+
+- `memray` over `tracemalloc`: richer output (flame graphs, leak detection), lower overhead
+- For quick checks, `tracemalloc` is acceptable (stdlib, no install)
+- Track peak memory in benchmarks for data-heavy code (polars pipelines, large msgspec payloads)
+
+### Line-level profiling
+
+Use `scalene` when you need CPU, memory, and GPU profiling at line granularity.
+
+```bash
+scalene my_script.py
+```
+
+- WHY: `cProfile` shows function-level time. `scalene` shows which *line* is slow and whether the bottleneck is CPU, memory allocation, or copying.
+- Use for investigating specific functions after `py-spy` identifies the hot path
+
+### Async profiling
+
+For `anyio`/`asyncio` workloads, use `py-spy` (captures native and Python frames across coroutines) or `yappi` with async clock mode.
+
+```python
+import yappi
+
+yappi.set_clock_type('wall')  # wall clock, not CPU: async I/O shows up
+yappi.start()
+# ... run async code ...
+yappi.stop()
+yappi.get_func_stats().print_all()
+```
+
+- WHY: `cProfile` measures CPU time per call. Async code spends time waiting, not computing. Wall-clock profiling shows where coroutines actually block.
+
+### Benchmarking
+
+Use `pytest-benchmark` for repeatable microbenchmarks. Benchmarks live in `benches/` or `tests/bench_*.py`.
+
+```python
+def test_parse_config(benchmark: BenchmarkFixture) -> None:
+    data = load_fixture('config.toml')
+    result = benchmark(parse_config, data)
+    assert result.host == 'localhost'
+```
+
+- Commit benchmarks alongside the optimization
+- Track results over time: a 20%+ regression without a feature justification is a bug
+
+---
+
+## Context propagation
+
+### `contextvars` for request-scoped state
+
+Use `contextvars.ContextVar` for propagating request IDs, correlation IDs, and trace context through async call stacks. Never use thread-locals in async code. Never pass context through function parameters when the context is cross-cutting.
+
+```python
+import contextvars
+
+request_id: contextvars.ContextVar[str] = contextvars.ContextVar('request_id')
+```
+
+- WHY: `threading.local()` breaks in async code because multiple coroutines share a thread. `contextvars` is the stdlib solution: each task gets its own context automatically.
+
+### Setting context at boundaries
+
+Set context vars at the entry point (HTTP handler, CLI command, message consumer). All downstream code reads from the context var without explicit parameter passing.
+
+```python
+import contextvars
+from uuid import uuid4
+
+correlation_id: contextvars.ContextVar[str] = contextvars.ContextVar('correlation_id')
+
+async def handle_request(request: Request) -> Response:
+    token = correlation_id.set(request.headers.get('x-correlation-id', str(uuid4())))
+    try:
+        return await process(request)
+    finally:
+        correlation_id.reset(token)
+```
+
+- Always `reset()` in a `finally` block. WHY: prevents context leaking between requests when tasks are reused.
+
+### Structured logging with context
+
+Integrate `contextvars` with `loguru` so every log line automatically includes the correlation ID.
+
+```python
+from loguru import logger
+
+def correlation_filter(record: dict) -> bool:
+    record['extra']['correlation_id'] = correlation_id.get('')
+    return True
+
+logger.configure(
+    patcher=lambda record: record['extra'].update(
+        correlation_id=correlation_id.get('none')
+    ),
+)
+
+# Every log line now includes correlation_id without explicit passing
+logger.info('processing started')
+```
+
+- WHY: manual `logger.bind(correlation_id=...)` at every call site is error-prone and noisy. Centralize once, emit everywhere.
+
+### Task group context propagation
+
+`anyio` and `asyncio.TaskGroup` automatically copy the current context to child tasks. Verify this in your framework; some third-party task spawners do not.
+
+```python
+import anyio
+
+async def parent() -> None:
+    correlation_id.set('abc-123')
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(child)  # child sees correlation_id='abc-123'
+
+async def child() -> None:
+    cid = correlation_id.get()  # 'abc-123'
+    logger.info(f'child running with {cid}')
+```
+
+- If using raw `loop.create_task()`, context is copied automatically (Python 3.12+)
+- If using `loop.run_in_executor()`, context is NOT propagated. Use `contextvars.copy_context().run()` explicitly.
+
+### Cross-process context
+
+For distributed traces (HTTP calls, message queues), serialize context into headers. Use W3C Trace Context (`traceparent`/`tracestate`) or a custom `x-correlation-id` header.
+
+```python
+import httpx
+
+async def call_downstream(url: str) -> httpx.Response:
+    headers = {'x-correlation-id': correlation_id.get('none')}
+    async with httpx.AsyncClient() as client:
+        return await client.get(url, headers=headers)
+```
+
+- WHY: context vars are process-local. Distributed tracing requires explicit serialization at process boundaries.
+- If using OpenTelemetry, its propagators handle this automatically. Otherwise, propagate manually.
+
+---
+
 ## Serialization
 
 ### msgspec for high-Throughput paths
@@ -308,34 +483,118 @@ event = decoder.decode(data)
 
 ---
 
-## Testing
+## Package organization
 
-See STANDARDS.md § Testing and TESTING.md for universal test principles.
+### `src/` layout
 
-- **Framework:** `pytest`
-- **Fixtures:** `@pytest.fixture` for setup, not `setUp()` methods
-- **Parametrize:** `@pytest.mark.parametrize` for testing multiple inputs
-- **Mocking:** `unittest.mock.patch` at module boundaries, not on internals
-- **No `print` debugging in tests.** Use `pytest -s` and `logging` if needed.
-
-### Project layout
-
-Use `src/` layout for all packages:
+Use `src/` layout for all packages. WHY: prevents accidental import of the development directory over the installed package. `import my_package` always resolves to the installed version, not the local source tree.
 
 ```
 project/
 ├── src/
 │   └── my_package/
 │       ├── __init__.py
-│       └── core.py
+│       ├── _internal/
+│       │   ├── __init__.py
+│       │   └── parser.py
+│       ├── cli.py
+│       ├── config.py
+│       ├── core.py
+│       └── py.typed
 ├── tests/
+│   ├── conftest.py
+│   ├── test_core.py
+│   └── test_config.py
+├── benches/
+│   └── bench_parser.py
 ├── pyproject.toml
 └── uv.lock
 ```
 
-- `__init__.py` in every package directory (explicit packages, not namespace packages)
-- Define `__all__` in `__init__.py` to declare the public API
-- `src/` layout prevents accidental import of the development directory over the installed package
+### Explicit packages with `__init__.py`
+
+Every package directory gets an `__init__.py`. No namespace packages in application code. WHY: namespace packages have implicit resolution rules that cause confusing import failures and make tooling (mypy, pytest discovery) less reliable.
+
+### `__all__` defines the public API
+
+Every `__init__.py` must define `__all__`. This is the module's public contract.
+
+```python
+# src/my_package/__init__.py
+__all__ = ['Config', 'Session', 'load_config']
+
+from .config import Config, load_config
+from .core import Session
+```
+
+- WHY: without `__all__`, `from my_package import *` exports everything, including internal helpers. `__all__` makes the public API explicit and reviewable.
+- Anything not in `__all__` is internal. Downstream code importing it takes on breakage risk.
+
+### Internal modules
+
+Prefix internal modules and packages with `_underscore`. Group private implementation details in a `_internal/` subpackage when the private surface is large.
+
+```python
+# Public API: importable by users
+from my_package import Config, load_config
+
+# Internal: not part of the contract, may change without notice
+from my_package._internal.parser import RawConfigParser  # at caller's risk
+```
+
+- WHY: Python has no access modifiers. The `_prefix` convention is the only signal to downstream code that a name is not part of the public API.
+
+### `py.typed` marker
+
+Include an empty `py.typed` file in the package root. WHY: tells mypy and pyright that this package ships inline type hints. Without it, type checkers treat the package as untyped and skip checking call sites.
+
+### Module size
+
+Split modules when they exceed ~300 lines. A module with 800 lines of mixed concerns is hard to navigate and harder to test in isolation. Group by domain concept, not by implementation pattern (don't create `utils.py`, `helpers.py`, or `misc.py`).
+
+- WHY: a `utils.py` file is a gravity well. Every unrelated function lands there. It grows unbounded, has no cohesion, and becomes a dependency bottleneck that everything imports.
+
+### Circular imports
+
+Circular imports are a design signal: the dependency graph is tangled. Fix by extracting the shared dependency into a lower-level module.
+
+```python
+# Wrong: a.py imports b.py, b.py imports a.py
+# Symptom: ImportError at runtime, or type-checking failures
+
+# Fix: extract the shared type/function into a third module
+# shared.py defines the type, both a.py and b.py import from shared.py
+```
+
+- Use `TYPE_CHECKING` blocks only as a last resort for circular type references, not as a general fix for circular runtime imports.
+- WHY: `TYPE_CHECKING` hides the cycle from runtime but doesn't fix the dependency tangle. The modules are still coupled.
+
+### Entry points
+
+CLI entry points use `pyproject.toml` `[project.scripts]`, not `if __name__ == '__main__'` in library modules.
+
+```toml
+[project.scripts]
+my-tool = "my_package.cli:main"
+```
+
+- WHY: `[project.scripts]` creates proper console scripts on install. `__main__.py` is acceptable for `python -m my_package` invocation but should delegate to the same entry point function.
+
+---
+
+## Testing
+
+See TESTING.md for all testing principles (naming, isolation, coverage, test data, property testing).
+
+Python-specific framework choices:
+
+- **Framework:** `pytest`
+- **Fixtures:** `@pytest.fixture` for setup, not `setUp()` methods
+- **Parametrize:** `@pytest.mark.parametrize` for testing multiple inputs
+- **Property testing:** `hypothesis`
+- **Mocking:** `unittest.mock.patch` at module boundaries, not on internals
+- **No `print` debugging in tests.** Use `pytest -s` and `logging` if needed.
+- **Project layout:** see Package organization above for `src/` layout, test directory structure
 
 ---
 
@@ -409,7 +668,7 @@ AI agents consistently produce these in Python:
 1. **Missing type hints**: every function signature, no exceptions
 2. **`Optional[str]` instead of `str | None`**: use modern union syntax
 3. **`List[str]` instead of `list[str]`**: use built-in generics (3.9+)
-4. **Bare `except Exception`**: catch specific types, always handle or re-raise
+4. **Bare `except Exception`**: see STANDARDS.md § No Silent Catch
 5. **String path concatenation**: use `pathlib.Path`
 6. **`os.path.join` over `/` operator**: `Path("a") / "b"` is cleaner
 7. **Print for debugging**: use `loguru` or structured logging
@@ -422,3 +681,9 @@ AI agents consistently produce these in Python:
 14. **`if`/`elif` chains for structured dispatch**: use `match` for 3+ branches on type or discriminant field (3.10+)
 15. **Flat layout without `src/`**: use `src/` layout to prevent import confusion
 16. **Missing `__init__.py`**: explicit packages, not namespace packages. Define `__all__` for public API.
+17. **`threading.local()` in async code**: use `contextvars.ContextVar`. Thread-locals break when multiple coroutines share a thread.
+18. **Passing context through every function signature**: use `contextvars` for cross-cutting concerns (request IDs, correlation IDs, trace context)
+19. **`utils.py` / `helpers.py` catch-all modules**: group by domain concept, not by "miscellaneous". These files grow unbounded and have no cohesion.
+20. **Circular imports patched with `TYPE_CHECKING`**: fix the dependency graph. Extract shared types into a lower-level module.
+21. **Optimizing without profiling**: use `py-spy` or `cProfile` first. Guessing at bottlenecks wastes time and often makes things worse.
+22. **Missing `py.typed` marker**: include in package root so type checkers recognize inline hints

--- a/standards/QA.md
+++ b/standards/QA.md
@@ -1,6 +1,6 @@
 # QA
 
-> The audit playbook. Defines what a periodic audit and a full audit contain, how findings are captured, and how the process improves itself. Per-PR checks are handled by the dispatch pipeline and CI, not this document.
+> The audit playbook. Defines when audits run, what they contain, what "passing" looks like, how findings are tracked over time, and how the process improves itself. Per-PR checks are handled by the dispatch pipeline and CI, not this document.
 
 ---
 
@@ -31,6 +31,106 @@ The goal is perfection. Every audit asks: is this the best it can be? If not, fi
 **Test from the user's seat.** Deploy the system. Use it as an operator would. File every friction point.
 
 **Question your own completeness.** After every pass: what haven't I checked? What angle haven't I considered? The audit is done when you can't think of another question.
+
+---
+
+## Audit scheduling
+
+WHY: An audit that runs "when someone remembers" doesn't run. Fixed cadences convert intent into habit. Frequency scales with risk: high-churn repos accumulate violations faster.
+
+| Tier | Repos | Periodic | Full |
+|------|-------|----------|------|
+| Core | kanon, aletheia | Weekly | Monthly |
+| Supporting | harmonia, akroasis, thumos | Biweekly | Quarterly |
+| Standards-only | basanos/standards | On change | On change |
+
+**Periodic audits** cover violation baseline, privacy/secrets, and standards enforcement gaps (see [Periodic audit](#periodic-audit)). Run them at the cadence above. Skip only if zero commits since the last run — and log the skip.
+
+**Full audits** cover every phase. Schedule them at the cadence above. A full audit also runs after any major release (semver minor or major bump) or architectural change (new crate, crate split, dependency direction change).
+
+**On-change audits** for standards-only repos trigger when any `.md` file in the standards directory is modified. The audit verifies internal consistency (no contradictions between standards), link validity, and claim accuracy.
+
+**Batch execution.** Use `kanon audit --all` to run periodic audits across every repo in the fleet. Use `kanon audit --all --full` for full audits. If batch tooling does not yet exist, file on kanon to track it — do not silently run audits manually at scale.
+
+WHY: Manual execution across five repos is error-prone and creates inconsistent audit timestamps. Batch tooling ensures every repo is audited with the same standards version in the same pass.
+
+---
+
+## Baseline scores
+
+WHY: Without a defined target, audits produce findings but no verdict. Baselines separate "improving" from "acceptable" and create a gate that blocks regressions.
+
+Each audit summary record includes category scores (see [Training data output](#training-data-output)). These are the minimum thresholds:
+
+| Category | Minimum | Target | Gate? |
+|----------|---------|--------|-------|
+| Writing | B | A- | Yes |
+| Safety | B+ | A | Yes |
+| Architecture | B | A- | Yes |
+| Testing | B | B+ | No |
+| Security | B+ | A | Yes |
+| Operations | B- | B+ | No |
+
+**Gate** means a repo scoring below the minimum on a gated category blocks the next release. Non-gated categories are tracked and trended but do not block.
+
+**How scores map to grades.** Scores derive from the violation density (violations per 1K lines) and severity distribution within each category. The grading function lives in basanos and is the single source of truth. Do not hardcode grade thresholds in this document — reference the implementation.
+
+WHY: Hardcoded thresholds in prose diverge from the code that actually computes them. The table above defines policy (what the minimums are); the code defines mechanics (how a score becomes a grade).
+
+**Ratchet rule.** Once a repo reaches a score, the minimum for that repo ratchets to that score. Baselines only move up. If a repo achieves A- in Security, A- becomes its new minimum. Store per-repo baselines in `workflow/baselines/{repo}.toml`.
+
+WHY: Without a ratchet, repos oscillate. A team fixes violations to reach A-, then regresses to B+ next quarter. The ratchet converts every improvement into a permanent floor.
+
+**New repos.** A repo's first full audit establishes its initial baseline. No gating applies until the second audit. The first audit is measurement, not judgment.
+
+---
+
+## Quality metric tracking
+
+WHY: Point-in-time audits tell you where you are. Trends tell you whether you're getting better or worse. Without historical tracking, the same violations get rediscovered every cycle.
+
+### What to track
+
+| Metric | Source | Granularity |
+|--------|--------|-------------|
+| Total violation count | `kanon lint --summary` | Per repo, per audit |
+| Violation count by severity | Audit summary record | Per repo, per audit |
+| Violation count by standard | Audit JSONL findings | Per repo, per audit |
+| Category scores | Audit summary record | Per repo, per audit |
+| Delta from previous audit | Computed from consecutive summaries | Per repo, per audit |
+| Time to resolve (filed → closed) | GitHub issue timestamps | Per repo, rolling |
+| Standards coverage | Enforcement gap analysis | Per repo, per full audit |
+
+### Storage
+
+Audit JSONL files in `workflow/training/audits/` are the raw data. Per-repo baselines in `workflow/baselines/{repo}.toml` are the derived policy state. Both are committed to the kanon repo.
+
+WHY: Committing audit data to the repo makes trends visible in git history, reviewable in PRs, and available to any tool without external service dependencies.
+
+### Trend analysis
+
+After each audit, compare against the previous three audits for the same repo and tier:
+
+- **Violation delta.** Is the total count decreasing? If not, investigate. A flat or rising count means new violations are being introduced as fast as old ones are fixed.
+- **Category score movement.** Any category that dropped since the last audit gets a tracking issue explaining why and what will reverse it.
+- **Stale findings.** Any finding that appears in three consecutive audits without a corresponding open issue is a process failure. File it and flag the gap.
+- **Resolution velocity.** Track the median time from issue filed to issue closed for audit findings. If median exceeds 30 days, the audit is producing findings faster than the team resolves them — adjust audit scope or increase fix bandwidth.
+
+WHY: Measuring resolution velocity prevents the failure mode where audits produce an ever-growing backlog that everyone ignores. The audit must produce actionable work at a sustainable rate.
+
+### Reporting
+
+Each audit run appends to the repo's trend. `kanon audit-report --repo <name>` renders the trend as a table showing the last 6 audits with deltas. If this tooling does not yet exist, file on kanon — do not build ad-hoc scripts that become invisible workarounds.
+
+---
+
+## Prerequisites
+
+```bash
+cargo install cargo-fuzz cargo-outdated cargo-deny cargo-audit
+rustup toolchain install nightly  # for fuzz
+# gitleaks: https://github.com/gitleaks/gitleaks/releases
+```
 
 ---
 
@@ -91,11 +191,11 @@ Per-crate if all-features OOMs. Document which commands produce full coverage.
 #### 1.2 fuzz targets
 
 ```bash
-cargo fuzz list
-cargo fuzz run <target> -- -max_total_time=60
+rustup run nightly cargo fuzz list
+rustup run nightly cargo fuzz run <target> -- -max_total_time=60
 ```
 
-Each target 60 seconds. Crashes are bugs.
+Requires nightly toolchain. Each target 60 seconds. Crashes are bugs.
 
 #### 1.3 binary smoke test
 
@@ -110,6 +210,23 @@ cargo outdated
 
 Flag duplicates. Flag stale deps.
 
+#### 1.5 supply chain audit
+
+```bash
+cargo deny check
+cargo audit
+```
+
+cargo-deny checks advisories, license compliance, banned crates, and source verification. cargo-audit checks the RUSTSEC advisory database. Both are zero-config with a deny.toml.
+
+#### 1.6 shell script lint
+
+```bash
+shellcheck scripts/*.sh
+```
+
+Catches portability issues (GNU-only flags, quoting bugs) and POSIX compliance.
+
 ### Phase 2: writing and docs (LLM-assisted)
 
 #### 2.1 writing quality
@@ -123,6 +240,17 @@ Changed docs since last audit: do code references point to real files? Do number
 #### 2.3 cLAUDE.md freshness
 
 Does CLAUDE.md match the codebase? Paths correct? CLI subcommands current?
+
+#### 2.4 doc claims verification
+
+Cross-check documented claims against ground truth:
+
+- Version numbers in docs match `Cargo.toml` `version` field
+- Config field names in CONFIGURATION.md (or equivalent) match the config struct definition
+- CLI subcommands listed in CLAUDE.md match `--help` output (compare `kanon --help` tree against prose)
+- Internal doc links (`[text](path)`) resolve to existing files
+
+Flag every mismatch as a separate finding. Documentation that lies is worse than no documentation.
 
 ### Phase 3: code quality (LLM-assisted)
 
@@ -179,6 +307,17 @@ New HTTP endpoints validate at boundary? New tool inputs check allowed_roots? Ne
 #### 5.3 sandbox
 
 New `tokio::spawn` without `.instrument()`? New process spawning without ProcessGuard? New file ops bypassing FileSystem trait?
+
+#### 5.4 CSRF and auth default audit
+
+Compare security-relevant code defaults against documented defaults. Mismatches here are critical: if DEPLOYMENT.md says CSRF is "enabled by default" but the code initializes it disabled, operators configure based on the docs and ship with a silent security hole.
+
+Check:
+- Auth mode default (e.g., `AuthMode::None` vs. `AuthMode::Required`) matches documented default
+- CSRF protection enabled or disabled by default
+- Sandbox enforcement on or off by default
+- Credential file permissions (must be 0600 if written)
+- Token preview length (must not expose full token in logs or UI)
 
 ### Phase 6: operational readiness
 

--- a/standards/RELEASES.md
+++ b/standards/RELEASES.md
@@ -209,6 +209,229 @@ Database migrations are forward-only. Rollback SQL is documented per migration b
 
 ---
 
+## Emergency and hotfix releases
+
+### When this applies
+
+An emergency release is warranted when one or more of the following conditions exist:
+
+| Condition | Examples |
+|-----------|---------|
+| Active security vulnerability | Exploitable CVE in a dependency, leaked credential requiring rotation, authentication bypass |
+| Data loss or corruption risk | Migration bug destroying records, write-path silent truncation, backup integrity failure |
+| Service-down with no workaround | Crash on startup, infinite loop on common input, dependency hard-failure |
+| Severity P0 or P1 per OPERATIONS.md | See OPERATIONS.md incident response severity levels |
+
+If the issue does not meet these criteria, it follows the normal wave-based release cadence. Do not use the emergency process for convenience.
+
+WHY: The emergency process trades thoroughness for speed. Every use of it skips the wave boundary review that catches regressions. Overuse erodes the safety the normal process provides. Underuse leaves users exposed. The criteria above are the bright line.
+
+Emergency releases ship immediately. They do not wait for in-progress waves to complete, for the hourly release-please schedule, or for unrelated PRs to merge. The hotfix is the priority.
+
+### Hotfix process
+
+Hotfixes branch from the latest release tag, not from main. This isolates the fix from unreleased work on main that has not been through the full release cycle.
+
+#### Steps
+
+1. **Create hotfix branch from the release tag.**
+   ```bash
+   git checkout -b hotfix/vX.Y.Z+1 vX.Y.Z
+   ```
+
+2. **Apply the minimal fix.** If the fix already exists as a commit on main, cherry-pick it onto the hotfix branch (`git cherry-pick <sha>`). If the fix does not exist yet, develop it directly on the hotfix branch. Either way, scope the change to the smallest diff that resolves the issue. No refactors, no drive-by improvements, no unrelated fixes. Every additional line is additional risk in an already high-risk situation.
+
+3. **Run the full CI gate.** All PR merge gates from DEPLOYMENT.md apply. The emergency process does not skip CI. If CI is broken, fix CI first.
+
+WHY: An untested hotfix has a meaningful probability of making the incident worse. The time spent on CI is insurance against a second incident while the first is still open. The only thing worse than a P0 is two P0s.
+
+4. **Bump version as an immediate PATCH.** Update `workspace.package.version` in root `Cargo.toml`. The version bump commit uses the conventional commit format: `fix: <description of the security/stability issue>`.
+
+5. **Tag and release from the hotfix branch.** Manually trigger the release-please workflow (`workflow_dispatch`) rather than waiting for the hourly schedule. Verify the release artifacts are published and checksums match.
+
+6. **Backport to main.** Cherry-pick the fix into main per the backport process below.
+
+7. **Cherry-pick to any active release branches.** If other release branches exist, apply the fix there too. Do not leave known vulnerabilities in any supported version.
+
+#### What the hotfix process does NOT change
+
+- CI gates are not relaxed.
+- Branch protection is not bypassed.
+- Auto-merge is not used. Operator sign-off is required.
+- The release-please PR still requires review.
+
+WHY: Every gate that exists in the normal process exists because its absence caused an incident in the past or would foreseeably cause one. An emergency is the worst time to disable safety mechanisms.
+
+### Backport to main
+
+After the emergency release ships, the fix must land on main. The hotfix branch diverged from a release tag, not from main, so main does not have the fix.
+
+#### When main is close to the release tag
+
+Cherry-pick the fix commit(s) from the hotfix branch into a PR against main:
+
+```bash
+git checkout -b backport/hotfix-vX.Y.Z+1 origin/main
+git cherry-pick <fix-commit-sha>
+```
+
+The backport PR follows normal merge gates. It does not use the emergency process.
+
+#### When main has diverged significantly
+
+If main has accumulated substantial changes since the release tag, a clean cherry-pick may not apply. In this case:
+
+1. Create a new branch from main.
+2. Re-implement the fix against the current main state.
+3. Open a PR with the original hotfix PR cross-referenced.
+
+The fix may look different on main -- different function signatures, different module structure. The intent is identical. The backport PR body must reference the original emergency release for traceability.
+
+#### CHANGELOG marker
+
+Document the emergency release in CHANGELOG.md with an explicit marker so it is distinguishable from normal wave releases:
+
+```markdown
+## [0.5.2] -- 2026-XX-XX [EMERGENCY]
+
+### Fixed
+- <description of the fix>
+
+_Emergency release: hotfix from v0.5.1 for [P0 description]._
+```
+
+The `[EMERGENCY]` tag in the version header aids post-incident review and release auditing.
+
+### Dispatch interaction
+
+Emergency releases operate on a separate branch from the dispatch pipeline. The two processes run independently with specific coordination rules.
+
+#### In-flight dispatches
+
+Dispatches in progress continue against main. They are not rebased onto, blocked by, or redirected to the hotfix branch. The hotfix branch is short-lived and merges back to main via the backport process. Workers that started before the emergency continue uninterrupted.
+
+WHY: Redirecting in-flight dispatches to a hotfix branch would require restarting sessions, invalidating worktrees, and re-evaluating QA verdicts. The cost exceeds the benefit. The backport merge into main resolves the divergence naturally.
+
+#### Steward priority
+
+The steward merges the hotfix backport PR with priority over queued dispatch PRs. If the steward is polling and both a hotfix backport PR and dispatch PRs are green, the hotfix backport PR merges first. Dispatch PRs re-validate against the new main HEAD after the hotfix lands.
+
+WHY: The hotfix fixes a P0/P1 issue. Dispatch PRs are feature work. Delaying the hotfix merge to preserve dispatch PR ordering defeats the purpose of the emergency process. Dispatch PRs that conflict with the hotfix get rebased by the fix agent, which is the normal conflict resolution path.
+
+### Rollback procedures
+
+Rollback is the first response to a bad release, not a last resort. If a release causes a P0/P1 incident and the fix is not immediately obvious, roll back first, then diagnose.
+
+#### Decision framework
+
+| Situation | Action |
+|-----------|--------|
+| Root cause identified, fix is < 20 lines, CI can run in < 15 min | Hotfix forward |
+| Root cause unclear or fix is complex | Roll back, then investigate |
+| Database migration has run | Assess: if migration is backward-compatible, roll back binary only. If not, execute documented rollback SQL under operator supervision. |
+| Multiple services affected | Roll back in reverse dependency order (leaf services first, shared dependencies last) |
+
+WHY: The instinct during an incident is to push forward -- "we're almost there, just one more fix." This instinct produces cascading failures. Rolling back restores known-good state immediately. Diagnosis under pressure with a broken system running produces worse fixes than diagnosis at leisure with the system stable.
+
+#### Binary rollback
+
+1. Stop service.
+2. Replace binary with previous version (preserved at known path or downloaded from prior GitHub release).
+3. Start service.
+4. Run health check. Verify liveness, readiness, and dependency endpoints per DEPLOYMENT.md.
+5. Run smoke test: one real request through the full path.
+
+#### Container rollback
+
+1. Stop container (`systemctl stop <name>-container`).
+2. Remove container (`podman rm <name>`).
+3. Recreate with previous image tag.
+4. Start container (`systemctl start <name>-container`).
+5. Run health check and verify logs for startup errors.
+
+#### Database rollback
+
+Database migrations are forward-only by default. Rollback SQL exists per migration for emergency use only.
+
+1. **Verify the rollback SQL exists** for the migration in question. If it does not, this is a P0 gap -- write it now under four-eyes review.
+2. **Back up the current database state** before executing rollback SQL. A failed rollback on top of a failed migration is unrecoverable without a backup.
+3. **Execute rollback SQL** under operator supervision. Never automate migration rollback -- the operator must verify each statement's effect.
+4. **Verify data integrity** after rollback. Run the service's integrity checks or manually verify critical tables.
+
+WHY: Forward-only migrations exist because backward migrations are inherently dangerous -- they can drop columns, delete data, and violate constraints that new data depends on. Executing them is a conscious, supervised decision, not an automated recovery step.
+
+### Communication
+
+Timely, accurate communication during an incident is as important as the technical fix. Silence erodes trust faster than bad news.
+
+#### Templates
+
+**Incident declaration** (post to team channel and any affected-user channels immediately upon P0/P1 classification):
+
+```
+INCIDENT: [P0/P1] [brief description]
+IMPACT: [what is broken, who is affected]
+STATUS: Investigating / Mitigating / Monitoring
+NEXT UPDATE: [time, no more than 30 minutes from now]
+```
+
+**Status update** (every 30 minutes for P0, every 60 minutes for P1, until resolved):
+
+```
+UPDATE: [P0/P1] [brief description]
+STATUS: [current status]
+ACTIONS TAKEN: [what has been done since last update]
+NEXT STEPS: [what happens next]
+NEXT UPDATE: [time]
+```
+
+**Resolution notice** (when service is restored):
+
+```
+RESOLVED: [P0/P1] [brief description]
+RESOLUTION: [what fixed it: rollback / hotfix vX.Y.Z / config change]
+DURATION: [time from detection to resolution]
+POST-MORTEM: Scheduled within 48 hours.
+```
+
+WHY: Templated communication removes decision fatigue during an incident. The operator should be thinking about the fix, not about how to phrase a status update. Fixed intervals prevent both radio silence and noisy over-communication.
+
+#### Notification channels
+
+| Audience | Channel | When |
+|----------|---------|------|
+| Team (operators) | Team chat / ntfy | Every update |
+| Affected users | Status page / email | Declaration, major updates, resolution |
+| Stakeholders | Summary email | Resolution and post-mortem |
+
+### Post-incident review
+
+Every emergency release triggers a post-incident review within 48 hours. This is not optional and is not waived based on severity resolution speed.
+
+#### Required sections
+
+| Section | Contents |
+|---------|----------|
+| Timeline | Timestamped sequence: detection, classification, actions taken, resolution. Source from logs and chat history, not memory. |
+| Root cause | The technical cause AND the systemic cause. "A bug in X" is the technical cause. "No test coverage for Y path" or "migration lacked rollback SQL" is the systemic cause. |
+| Impact | What broke, for how long, for how many users/systems. Quantify where possible. |
+| Detection | How the incident was detected. If a human noticed before monitoring did, that is a monitoring gap to address. |
+| Response evaluation | What went well, what went poorly, what was lucky. |
+| Action items | Concrete, assigned, deadlined. Each action item prevents recurrence of either the root cause or a response gap. |
+
+WHY: The post-incident review exists to make the system better, not to assign blame. "Human error" is never a root cause -- it is a symptom of a system that made the error possible. Every P0/P1 that does not produce systemic improvements is a wasted crisis.
+
+#### Action item standards
+
+- Every action item has an owner and a deadline.
+- Action items are filed as issues in the relevant repository, not left in a document.
+- Action items are tracked to completion. An action item that is filed and forgotten is worse than no action item -- it creates the illusion of improvement.
+- Common action item categories: add test coverage, add monitoring/alerting, add rollback SQL, improve documentation, fix CI gap, add pre-flight check.
+
+WHY: Unfiled action items decay into good intentions. Issues in the tracker are visible to the dispatch pipeline, get prioritized, and get assigned. The review document is an input to the tracker, not a substitute for it.
+
+---
+
 ## Pre-release checklist
 
 Before merging a release-please PR:

--- a/standards/RESTIC.md
+++ b/standards/RESTIC.md
@@ -1,0 +1,318 @@
+# Restic
+
+> Standards for backup operations using restic. Applies to all systems running automated or manual backups.
+
+---
+
+## Repository setup
+
+### Location
+
+Restic repositories are target-mounted, not local. Local repositories are prohibited -- they fail when the disk fails.
+
+| Environment | Repository Path | Rationale |
+|-------------|-----------------|-----------|
+| Homelab | `/nas/docker/backups/{hostname}` | NAS is the source of truth for backups |
+| Cloud | `s3:{bucket}/backups/{hostname}` | Object storage for ephemeral instances |
+
+### Initialization
+
+Initialize once per host. Document the repository location in the host's CLAUDE.md.
+
+```bash
+# Initialize with explicit repo path (never rely on defaults)
+restic -r /nas/docker/backups/menos init
+
+# Or with environment file
+RESTIC_REPOSITORY=/nas/docker/backups/menos
+RESTIC_PASSWORD_FILE=~/secrets/restic-password
+restic init
+```
+
+### Password management
+
+- **Never** pass passwords via command line (visible in `ps`)
+- **Never** store passwords in backup scripts
+- Use `RESTIC_PASSWORD_FILE` pointing to a file with `0600` permissions
+- Validate permissions at runtime: fail if readable by group/other
+
+```bash
+# Runtime permission check
+if [[ "$(stat -c '%a' "$RESTIC_PASSWORD_FILE")" != "600" ]]; then
+    echo "ERROR: Password file must have 0600 permissions"
+    exit 1
+fi
+```
+
+---
+
+## Backup operations
+
+### Scope
+
+Back up what matters, not everything:
+
+| Include | Rationale |
+|---------|-----------|
+| User configs (`~/.config/`, dotfiles) | Hard to recreate |
+| Systemd units and timers | Service definitions |
+| Service configs (`/etc/menos-*.env`) | Runtime configuration |
+| SSH keys and auth | Identity |
+| `/theke/` or equivalent knowledge store | Institutional memory |
+
+| Exclude | Rationale |
+|---------|-----------|
+| Container images | Re-pullable from registry |
+| Build artifacts (`target/`, `node_modules/`) | Reproducible from source |
+| Bulk media data | Already on NAS (source of truth) |
+| `~/.cache/` | Transient |
+
+### Command structure
+
+```bash
+# Standard backup invocation
+restic backup \
+    --tag "$(date +%Y%m%d-%H%M%S)" \
+    --exclude-file=/etc/restic/excludes \
+    --one-file-system \
+    /home/ck /etc/menos-ops /etc/systemd/system
+```
+
+Flags:
+- `--one-file-system`: Prevents crossing into NFS mounts accidentally
+- `--exclude-file`: Centralized exclusion list, version-controlled
+- `--tag`: Timestamp tags for easy selection
+
+### Snapshot verification
+
+Verify after every backup. A backup you can't restore is worthless.
+
+```bash
+# Quick integrity check (metadata only)
+restic check
+
+# Full data verification (slow, do weekly)
+restic check --read-data
+```
+
+---
+
+## Retention policy
+
+### Standard schedule
+
+| Snapshot type | Count | When to prune |
+|---------------|-------|---------------|
+| Daily | 7 | Every day |
+| Weekly | 4 | Every week |
+| Monthly | 3 | Every month |
+
+### Prune execution
+
+```bash
+# Apply retention policy
+restic forget \
+    --keep-daily 7 \
+    --keep-weekly 4 \
+    --keep-monthly 3 \
+    --prune
+```
+
+`--prune` reclaims space immediately. Without it, data is marked for deletion but retained.
+
+---
+
+## Automation
+
+### Systemd timer (preferred)
+
+```ini
+# ~/.config/systemd/user/restic-backup.service
+[Unit]
+Description=Daily restic backup
+After=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=%h/menos-ops/secrets/restic-env
+ExecStartPre=/bin/sh -c 'test "$(stat -c %%a %h/menos-ops/secrets/restic-env)" = "600"'
+ExecStart=/usr/local/bin/restic-backup.sh
+ExecStartPost=/usr/local/bin/restic-verify.sh
+```
+
+```ini
+# ~/.config/systemd/user/restic-backup.timer
+[Unit]
+Description=Run backup daily at 3 AM
+
+[Timer]
+OnCalendar=*-*-* 03:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+Enable: `systemctl --user enable restic-backup.timer`
+
+### Cron (acceptable)
+
+```bash
+# crontab entry
+0 3 * * * /usr/local/bin/restic-backup.sh 2>&1 | logger -t restic-backup
+```
+
+Cron requires manual log rotation handling. Prefer systemd for log management.
+
+---
+
+## Monitoring and alerting
+
+### Failure notification
+
+Backup failures must surface immediately. Silent failures accumulate until data loss.
+
+```bash
+#!/bin/bash
+# restic-backup.sh - wrapper with ntfy notification
+
+set -euo pipefail
+
+# WHY: trap ensures notification on any exit path
+cleanup() {
+    local exit_code=$?
+    if [[ $exit_code -ne 0 ]]; then
+        curl -H "Authorization: Bearer $NTFY_TOKEN" \
+             -d "Backup failed on $(hostname) with exit $exit_code" \
+             ntfy.sh/alerts
+    fi
+}
+trap cleanup EXIT
+
+# Actual backup
+restic backup --exclude-file=/etc/restic/excludes /home/ck /etc/menos-ops
+restic forget --keep-daily 7 --keep-weekly 4 --keep-monthly 3 --prune
+```
+
+### Metrics to track
+
+| Metric | Collection method | Alert threshold |
+|--------|-------------------|-----------------|
+| Backup duration | systemd timer logs | >30 min |
+| Snapshot count | `restic snapshots | wc -l` | <3 (indicates failure) |
+| Repository size | `restic stats` | >80% of target capacity |
+| Last backup age | `restic snapshots --json | jq` | >25 hours |
+
+---
+
+## Recovery procedures
+
+### Full restore
+
+```bash
+# List available snapshots
+restic snapshots
+
+# Restore entire snapshot to temporary location
+restic restore latest --target /tmp/restore-$(date +%s)
+
+# Restore specific file
+restic restore latest --target /tmp/restore --include /home/ck/.ssh/id_ed25519
+```
+
+Always restore to a temporary location first. Verify before replacing live files.
+
+### Lock recovery
+
+Stale locks block operations after unclean termination:
+
+```bash
+# Check for locks
+restic list locks
+
+# Remove stale lock (verify no other process is running first)
+restic unlock
+```
+
+Document this procedure in host CLAUDE.md. Agents encountering lock errors must check CLAUDE.md before proceeding.
+
+---
+
+## Security
+
+### Transport encryption
+
+- NAS mounts: Rely on NFS encryption (WireGuard tunnel) or local network trust
+- Cloud: Restic encrypts client-side; transport via HTTPS
+
+### At-rest encryption
+
+Restic encrypts by default. No additional configuration needed.
+
+### Key rotation
+
+Restic does not support key rotation. To rotate:
+1. Initialize new repository with new password
+2. Backup to new repository
+3. Verify restore from new repository
+4. Remove old repository
+
+### Permission model
+
+| File | Mode | Owner |
+|------|------|-------|
+| Backup script | 0755 | root or user |
+| Password file | 0600 | User running backup |
+| Exclude list | 0644 | root or user |
+| Restic binary | 0755 | root |
+
+---
+
+## Troubleshooting
+
+### Stale lock files
+
+**Symptom**: `unable to create lock in backend: repository is already locked`
+
+**Resolution**:
+```bash
+# Verify no backup is running
+ps aux | grep restic
+
+# Unlock
+restic unlock
+```
+
+**Prevention**: Use `trap EXIT` in scripts to ensure cleanup on interruption.
+
+### Permission denied on restore
+
+**Symptom**: Restored files have wrong ownership
+
+**Cause**: Restic preserves UIDs/GIDs, which may not map on new system
+
+**Fix**: Restore with `--numeric-ids` or `chown` after restore
+
+### Repository corruption
+
+**Symptom**: `checksum mismatch` or `cipher: message authentication failed`
+
+**Immediate action**: Do not prune. Check repository on different machine.
+
+**Recovery**:
+```bash
+# Attempt repair (may lose snapshots)
+restic repair index
+restic repair snapshots
+```
+
+---
+
+## Anti-patterns
+
+1. **Plaintext passwords in scripts**: Use `RESTIC_PASSWORD_FILE`
+2. **Local-only backups**: Always replicate to separate hardware
+3. **Unverified backups**: Test restores quarterly
+4. **Infinite retention**: Prune old snapshots to control size
+5. **Crossing filesystem boundaries**: Use `--one-file-system` to avoid backup loops
+6. **Ignoring exit codes**: Wrap in scripts with `set -e` and monitoring

--- a/standards/RUST.md
+++ b/standards/RUST.md
@@ -255,6 +255,387 @@ Use `#[diagnostic::on_unimplemented]` for domain-specific trait error messages. 
 
 ---
 
+## Validation constructors
+
+Implements STANDARDS.md § Parse, Don't Validate for Rust. Invalid data must not survive construction. Every domain type enforces its invariants at the boundary — deserialization, config loading, CLI parsing — so downstream code never checks validity again.
+
+### Newtype wrappers with `TryFrom`
+
+Newtypes that accept arbitrary input must validate through `TryFrom`, not `new`. A public `new` that accepts any `&str` defeats the point of the wrapper — callers can construct invalid instances.
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+pub struct ProjectSlug(compact_str::CompactString);
+// WHY: TryFrom is the validation boundary. Once constructed, the slug is
+// known-valid. No runtime checks needed downstream.
+
+impl TryFrom<&str> for ProjectSlug {
+    type Error = ValidationError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        ensure!(
+            !value.is_empty(),
+            EmptyFieldSnafu { field: "project_slug" }
+        );
+        ensure!(
+            value.len() <= 64,
+            FieldTooLongSnafu { field: "project_slug", max: 64, actual: value.len() }
+        );
+        ensure!(
+            value.chars().all(|c| c.is_ascii_lowercase() || c == '-'),
+            InvalidFormatSnafu {
+                field: "project_slug",
+                expected: "lowercase ASCII with hyphens",
+                actual: value.to_string(),
+            }
+        );
+        Ok(Self(value.into()))
+    }
+}
+
+impl ProjectSlug {
+    /// Access the validated slug as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+```
+
+Do not implement `From<&str>` on types that require validation. `From` is infallible — it tells callers the conversion cannot fail, which is a lie when invariants exist. Use `TryFrom` exclusively.
+
+### Serde validation
+
+All public types that derive `Deserialize` and have invariants must validate on deserialize, not after. Derive-based `Deserialize` bypasses constructors — serde writes directly to struct fields, skipping any `TryFrom` or `new` logic. Every type with invariants must route deserialization through the validation path. A `#[derive(Deserialize)]` on a type with a `new()` or `try_new()` constructor is a bug: those constructors exist because the type has invariants, and serde bypasses them.
+
+```rust
+// WHY: #[serde(try_from)] delegates deserialization to TryFrom, so the
+// validation constructor is the single entry point for both code and data.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(try_from = "&str")]
+pub struct EmailAddress(compact_str::CompactString);
+
+impl TryFrom<&str> for EmailAddress {
+    type Error = ValidationError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        ensure!(
+            value.contains('@') && value.len() <= 254,
+            InvalidFormatSnafu {
+                field: "email",
+                expected: "valid email address",
+                actual: value.to_string(),
+            }
+        );
+        Ok(Self(value.into()))
+    }
+}
+
+impl<'de> Deserialize<'de> for EmailAddress {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = <&str>::deserialize(deserializer)?;
+        Self::try_from(s).map_err(serde::de::Error::custom)
+    }
+}
+```
+
+For struct fields that need validation but aren't newtypes, use `deserialize_with`:
+
+```rust
+#[derive(Debug, Deserialize)]
+pub struct RateLimitConfig {
+    #[serde(deserialize_with = "deserialize_positive_nonzero")]
+    pub requests_per_second: u32,
+
+    #[serde(deserialize_with = "deserialize_duration_secs")]
+    pub window: Duration,
+}
+
+// WHY: Serde happily deserializes 0 into u32. A rate limit of 0 is
+// nonsensical and would cause division-by-zero downstream. Catch it here.
+fn deserialize_positive_nonzero<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = u32::deserialize(deserializer)?;
+    if value == 0 {
+        return Err(serde::de::Error::custom(
+            "value must be greater than zero",
+        ));
+    }
+    Ok(value)
+}
+```
+
+Three patterns, in order of preference:
+1. **`#[serde(try_from = "T")]`** on the type — best for newtypes where `TryFrom` is already the constructor
+2. **Manual `Deserialize` impl** — when the intermediate representation differs from what `try_from` accepts
+3. **`#[serde(deserialize_with = "fn")]`** on the field — for validating fields within a larger struct
+
+Never rely on bare `#[derive(Deserialize)]` for types with invariants. If a struct has a "must be positive" or "must match pattern" field, the derive is wrong by default.
+
+#### `deny_unknown_fields` for config types
+
+Config types loaded from files, environment, or user input must reject unrecognized fields. A typo in a config key (`timout` instead of `timeout`) silently becomes a default value. `deny_unknown_fields` turns that into a hard error at load time.
+
+```rust
+// WHY: Config files are the #1 source of "it worked on my machine" bugs.
+// A misspelled key silently uses the default, which may be zero, empty, or
+// wrong. deny_unknown_fields catches typos at parse time.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RetryConfig {
+    pub max_attempts: u32,
+    pub backoff_ms: u64,
+    pub jitter: bool,
+}
+```
+
+Apply `deny_unknown_fields` to all types that represent configuration, settings, or options loaded from external sources. Do not apply it to API request/response types or wire-format types where forward compatibility matters.
+
+#### Complex struct validation via `TryFrom`
+
+When a struct has cross-field invariants, deserialize into a raw intermediate type and validate during conversion. This keeps the validation logic in one place and prevents invalid state from ever existing.
+
+```rust
+// WHY: ScheduleConfig has a cross-field invariant: if retry is enabled,
+// retry_delay must be set. Bare derive would allow { retry: true, retry_delay: None }.
+#[derive(Debug, Clone, Serialize)]
+pub struct ScheduleConfig {
+    pub cron: String,
+    pub retry: bool,
+    pub retry_delay: Duration,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawScheduleConfig {
+    cron: String,
+    retry: Option<bool>,
+    retry_delay_secs: Option<u64>,
+}
+
+impl TryFrom<RawScheduleConfig> for ScheduleConfig {
+    type Error = ValidationError;
+
+    fn try_from(raw: RawScheduleConfig) -> Result<Self, Self::Error> {
+        let retry = raw.retry.unwrap_or(false);
+        let retry_delay = match (retry, raw.retry_delay_secs) {
+            (true, None) => return Err(CrossFieldSnafu {
+                rule: "retry = true requires retry_delay_secs",
+            }.build()),
+            (true, Some(secs)) => Duration::from_secs(secs),
+            (false, _) => Duration::ZERO,
+        };
+        Ok(Self { cron: raw.cron, retry, retry_delay })
+    }
+}
+
+impl<'de> Deserialize<'de> for ScheduleConfig {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = RawScheduleConfig::deserialize(deserializer)?;
+        Self::try_from(raw).map_err(serde::de::Error::custom)
+    }
+}
+```
+
+#### Exception: pure data transfer types
+
+Types that are pure data containers with no invariants — every combination of field values is valid — may use plain `#[derive(Deserialize)]`. These are typically:
+
+- Wire-format types mapping 1:1 to an external API response
+- Event payloads where all fields are informational
+- Intermediate representations used only as input to a validation step
+
+Mark these types explicitly so the intent is clear and the lint rule does not flag them:
+
+```rust
+// WHY: Pure data transfer type — no invariants. All field combinations are
+// valid. This struct maps directly to the GitHub API response shape.
+#[derive(Debug, Deserialize)]
+pub struct GitHubPullRequest {
+    pub number: u64,
+    pub title: String,
+    pub state: String,
+    pub draft: bool,
+}
+```
+
+The key test: if the type has a `new()`, `try_new()`, or `build()` constructor, it has invariants and must not use bare `#[derive(Deserialize)]`. If every field combination is valid and there is no constructor, plain derive is correct.
+
+### Builder pattern for complex configs
+
+Use builders when construction requires multiple validated fields with cross-field constraints. A flat constructor with 5+ parameters is unreadable, and field order becomes a bug vector.
+
+```rust
+/// WHY: DispatchConfig has cross-field invariants (max_retries requires
+/// retry_delay, budget_limit must exceed single-request cost). A builder
+/// validates these at build() time, not scattered across call sites.
+#[derive(Debug, Clone)]
+pub struct DispatchConfig {
+    provider: ProviderKind,
+    model: ModelId,
+    max_retries: u32,
+    retry_delay: Duration,
+    budget_limit: BudgetLimit,
+}
+
+#[derive(Debug, Default)]
+pub struct DispatchConfigBuilder {
+    provider: Option<ProviderKind>,
+    model: Option<ModelId>,
+    max_retries: Option<u32>,
+    retry_delay: Option<Duration>,
+    budget_limit: Option<BudgetLimit>,
+}
+
+impl DispatchConfigBuilder {
+    #[must_use]
+    pub fn provider(mut self, provider: ProviderKind) -> Self {
+        self.provider = Some(provider);
+        self
+    }
+
+    #[must_use]
+    pub fn model(mut self, model: ModelId) -> Self {
+        self.model = Some(model);
+        self
+    }
+
+    #[must_use]
+    pub fn max_retries(mut self, n: u32, delay: Duration) -> Self {
+        // WHY: retries without a delay is a tight loop that burns budget.
+        // Requiring both together makes the invalid state unrepresentable.
+        self.max_retries = Some(n);
+        self.retry_delay = Some(delay);
+        self
+    }
+
+    #[must_use]
+    pub fn budget_limit(mut self, limit: BudgetLimit) -> Self {
+        self.budget_limit = Some(limit);
+        self
+    }
+
+    /// Consume the builder and produce a validated config.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ValidationError` if required fields are missing or
+    /// cross-field invariants are violated.
+    pub fn build(self) -> Result<DispatchConfig, ValidationError> {
+        let provider = self.provider.context(MissingFieldSnafu { field: "provider" })?;
+        let model = self.model.context(MissingFieldSnafu { field: "model" })?;
+        let max_retries = self.max_retries.unwrap_or(0);
+        let retry_delay = self.retry_delay.unwrap_or(Duration::ZERO);
+        let budget_limit = self.budget_limit.context(MissingFieldSnafu { field: "budget_limit" })?;
+
+        // Cross-field validation
+        ensure!(
+            max_retries == 0 || retry_delay > Duration::ZERO,
+            CrossFieldSnafu {
+                rule: "max_retries > 0 requires retry_delay > 0",
+            }
+        );
+
+        Ok(DispatchConfig { provider, model, max_retries, retry_delay, budget_limit })
+    }
+}
+
+impl DispatchConfig {
+    #[must_use]
+    pub fn builder() -> DispatchConfigBuilder {
+        DispatchConfigBuilder::default()
+    }
+}
+```
+
+Rules for builders:
+- `#[must_use]` on every setter method and on `builder()`. A dropped builder is always a bug.
+- `build()` returns `Result`, never panics. Validation failures are expected, not exceptional.
+- Required fields are `Option` in the builder, validated at `build()` time. Not `Default::default()` with silent wrong values.
+- Cross-field invariants live in `build()`, not in individual setters. Setters validate single fields; `build()` validates relationships.
+- Implement `Deserialize` on the config type via the builder, so serde routes through the same validation.
+
+For simple configs (2-3 fields, no cross-field constraints), `TryFrom` on a raw deserialization struct is sufficient. Use builders when the construction logic justifies the ceremony.
+
+### Error types for validation failures
+
+Validation errors must be structured, not stringly-typed. Callers need to match on failure kinds programmatically — for user-facing messages, retry logic, or aggregating multiple failures.
+
+```rust
+// WHY: A single validation pass may produce multiple errors (e.g., a config
+// file with 3 bad fields). Collecting all of them lets the user fix
+// everything in one pass instead of playing whack-a-mole.
+#[derive(Debug, Snafu)]
+pub enum ValidationError {
+    #[snafu(display("field '{field}' is required"))]
+    MissingField {
+        field: &'static str,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("field '{field}' is empty"))]
+    EmptyField {
+        field: &'static str,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("field '{field}' exceeds maximum length {max} (got {actual})"))]
+    FieldTooLong {
+        field: &'static str,
+        max: usize,
+        actual: usize,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("field '{field}': expected {expected}, got '{actual}'"))]
+    InvalidFormat {
+        field: &'static str,
+        expected: &'static str,
+        actual: String,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("cross-field constraint violated: {rule}"))]
+    CrossField {
+        rule: &'static str,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    #[snafu(display("{count} validation errors"))]
+    Multiple {
+        count: usize,
+        errors: Vec<ValidationError>,
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+}
+```
+
+Rules for validation errors:
+- One `ValidationError` enum per crate (or per domain boundary). Not per-type — validation errors share structure.
+- Every variant carries the field name. "Validation failed" with no context is useless.
+- Include expected vs. actual values in format errors. The user shouldn't have to guess what's wrong.
+- Support a `Multiple` variant for batch validation. Fail-fast is the default; batch collection is opt-in for user-facing boundaries (config loading, HTTP request parsing).
+- Implement `Display` with full context. The error message alone, without a stack trace, must be sufficient to diagnose the problem.
+- Follow the crate's snafu conventions: `#[snafu(implicit)] location` on every variant, `source` field only when wrapping another error.
+
+### What not to do
+
+- `String` as error type from validation: callers cannot match, test, or recover programmatically
+- `new()` that silently clamps or truncates invalid input: the caller doesn't know their input was altered
+- `Default` values substituted for missing required fields: masks configuration errors until production
+- `#[derive(Deserialize)]` on a type with invariants without `try_from` or `deserialize_with`: serde bypasses your constructor
+- `unwrap()` on `TryFrom` in deserialization: converts a recoverable validation failure into a panic
+- `validate()` method called after construction: the invalid state exists between `new()` and `validate()` — any code path that forgets to call `validate()` has a bug
+
+---
+
 ## Safety and correctness
 
 ### No silent truncation
@@ -642,12 +1023,13 @@ Never fight the borrow checker with `RefCell` or `unsafe` for graph structures. 
 
 ## Testing
 
-See STANDARDS.md § Testing and TESTING.md for universal test principles.
+See TESTING.md for all testing principles (naming, isolation, coverage, test data, property testing).
+
+Rust-specific framework choices and conventions:
 
 - `#[cfg(test)] mod tests` in the same file, `use super::*` at the top
 - `#[should_panic(expected = "message")]` for panic-testing (not bare `#[should_panic]`)
 - `#[tokio::test]` for async tests, `tokio::time::pause()` for deterministic time
-- Every `Serialize + Deserialize` type gets a roundtrip property test
 - `proptest` / `bolero` for property-based testing
 - `insta` for snapshot testing of serialization formats, error messages, and CLI output
 - `tracing-test` for asserting that errors are actually logged
@@ -684,7 +1066,8 @@ See STANDARDS.md § Testing and TESTING.md for universal test principles.
 - Each new dependency must justify itself. If it's 10 lines, write it.
 - Prefer std over external. `std::sync::Mutex` over `parking_lot::Mutex` unless benchmarks prove otherwise. `std::collections::HashMap` over `hashbrown` unless the hasher matters.
 - Gate heavy dependencies behind features. ML (candle), GUI (dioxus), optional integrations (pcre2) should not compile unless requested. A minimal `cargo build` pulls only what the core needs.
-- Count transitive dependencies. A crate that adds 3 direct deps may pull 80 transitive. Check with `cargo tree -d` before adding.
+- Count transitive dependencies before adding. Run `cargo tree -d` and report the transitive depth. A crate that adds 3 direct deps may pull 80 transitive. Flag if a new dependency increases the workspace's total transitive count by more than 20%. WHY: a single "convenient" crate can silently double compile times and attack surface.
+- When alternatives exist, prefer the crate with fewer transitive dependencies. A crate that does the same thing with 5 transitive deps is better than one with 50, even if the API is slightly less ergonomic.
 - Audit new deps: maintenance status, download count, last publish date, unsafe usage. Pre-1.0 crates with <1000 downloads/month are a supply chain risk.
 
 ### Feature flags
@@ -725,6 +1108,124 @@ unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 ```
+
+### Dependency footprint audit
+
+Supply chain weight compounds silently. A workspace that compiles 400 crates today compiles 600 next quarter unless someone actively resists. Auditing is not a one-time gate; it is a recurring discipline.
+
+#### Pre-addition checklist
+
+Before adding any new crate dependency:
+
+1. **Measure baseline:** `cargo tree --workspace --depth 999 --prefix none | sort -u | wc -l`
+2. **Add the dependency** and re-measure. If the transitive count increased by more than 20%, stop and evaluate alternatives.
+3. **Run `cargo tree -d`** to check for new duplicate crate versions introduced by the addition.
+4. **Compare alternatives:** If multiple crates solve the problem, prefer the one with fewer transitive dependencies. Run `cargo tree -i <crate>` for each candidate to see what it pulls.
+5. **Document the choice:** If the selected crate has a high transitive count, add a comment above the dependency line explaining why it was chosen over lighter alternatives.
+
+```bash
+# Full pre-addition workflow
+BEFORE=$(cargo tree --workspace --depth 999 --prefix none | sort -u | wc -l)
+# ... add the dependency ...
+AFTER=$(cargo tree --workspace --depth 999 --prefix none | sort -u | wc -l)
+INCREASE=$(( (AFTER - BEFORE) * 100 / BEFORE ))
+echo "Transitive count: $BEFORE -> $AFTER (+${INCREASE}%)"
+cargo tree -d  # check for new duplicates
+```
+
+#### Tools
+
+Run both `cargo-deny` and `cargo-audit` on every PR. They overlap but are not redundant.
+
+| Tool | Primary role | WHY both |
+|------|-------------|----------|
+| `cargo-deny` | Licenses, bans, duplicate versions, source restrictions | Policy enforcement: catches banned crates, license violations, and registry drift |
+| `cargo-audit` | RustSec advisory database lookup | Vulnerability focus: faster advisory DB updates, `cargo audit fix` can auto-patch lockfiles |
+
+```bash
+cargo deny check                 # full policy check (deny.toml)
+cargo audit                      # RustSec advisories against Cargo.lock
+cargo audit --deny warnings      # CI: treat warnings (unmaintained, unsound) as failures
+```
+
+`cargo-deny` catches what `cargo-audit` misses (licenses, bans, sources). `cargo-audit` catches what `cargo-deny` sometimes lags on (RustSec DB freshness, auto-fix suggestions). Running only one leaves a gap.
+
+#### Dependency size budgets
+
+Track two numbers per release: **crate count** and **binary size**.
+
+```bash
+# Total unique crates compiled (including transitive)
+cargo tree --workspace --depth 999 --prefix none | sort -u | wc -l
+
+# Duplicate crates (same crate, different versions)
+cargo tree -d
+
+# Binary size (release profile)
+ls -lh target/release/<binary>
+```
+
+**Budget rules:**
+
+- Set a crate count ceiling in CI. Start with the current count + 5% margin. WHY: without a ceiling, dependency creep is invisible until compile times double.
+- A PR that increases crate count by more than 5 must include justification in the PR description. WHY: small additions feel harmless individually; the budget forces a conversation.
+- Binary size increases above 10% without a corresponding feature addition are regressions (already in CI tools table above). Track per release in the changelog.
+- Duplicate crate versions (`cargo tree -d`) should trend toward zero. Each duplicate means two copies compiled and linked. Resolve by aligning version ranges or patching upstream.
+
+**Transitive depth thresholds per workspace member:**
+
+Check per-crate transitive counts with `cargo tree -p <crate> --prefix none | sort -u | wc -l`.
+
+| Crate type | Threshold | Action |
+|------------|-----------|--------|
+| Leaf library (no downstream dependents in workspace) | <50 transitive | Warning above threshold; investigate and justify or trim |
+| Internal library (depended on by other workspace crates) | <100 transitive | Each transitive dep is inherited by all downstream consumers; weight multiplies |
+| Application / binary crate | <200 transitive | Hard ceiling; increases above this require architectural review |
+
+WHY: A leaf crate with 80 transitive deps is a smell — it likely pulls a framework when it needs a utility. An application crate above 200 is accumulating the entire ecosystem. These thresholds are enforced by the `MANIFEST/dep-count` basanos rule on `Cargo.lock` (workspace-level total) and by manual `cargo tree -p` review per member at release time.
+
+#### Feature flag minimization
+
+Every dependency should be added with `default-features = false` and only the features actually used enabled explicitly. WHY: default feature sets pull transitive dependencies you never call. A single `features = ["full"]` can double the dependency tree.
+
+```toml
+# Wrong: pulls every optional feature tokio offers
+tokio = "1"
+
+# Right: only what this crate actually uses
+tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "macros", "signal"] }
+```
+
+Audit feature flags during dependency review:
+
+```bash
+# Show features enabled for a specific crate and why
+cargo tree -e features -i tokio
+
+# Show all features enabled across the workspace
+cargo tree -e features --workspace
+```
+
+When a dependency's default features include something heavy (TLS backends, compression, serialization formats), disable defaults and opt in. Document the choice in a comment above the dependency line. WHY: the next developer adding a feature flag needs to know what was deliberately excluded.
+
+#### Audit frequency
+
+| Trigger | Action |
+|---------|--------|
+| Every PR | `cargo deny check` + `cargo audit --deny warnings` in CI |
+| Weekly (automated) | `cargo audit` with updated advisory DB. WHY: new advisories land between PRs; a crate safe on Monday may have a CVE by Friday. |
+| Each new dependency | Full review: maintenance status, download count, last publish date, unsafe usage, transitive tree impact (already in Dependencies policy above) |
+| Quarterly (manual) | Full footprint review: crate count trend, binary size trend, duplicate versions, stale `[patch]` entries, feature flag audit. WHY: drift is only visible at longer timescales. |
+
+For the weekly check, use a scheduled CI job or cron:
+
+```bash
+cargo install cargo-audit --locked
+cargo audit fetch                # update advisory DB
+cargo audit --deny warnings      # fail on any known issue
+```
+
+The quarterly review is a manual pass. Check the crate count and binary size against the previous quarter. If either grew more than 10% without a proportional feature addition, investigate and trim. Remove unused dependencies (`cargo-udeps`), consolidate duplicates, and tighten feature flags.
 
 ---
 

--- a/standards/SECURITY.md
+++ b/standards/SECURITY.md
@@ -1,6 +1,8 @@
 # Security
 
-> Standards for secure code, credential handling, input validation, and threat mitigation. Applies to all languages and all codebases.
+> Standards for secure code, credential handling, input validation, threat mitigation, firewall management, and browser policy. Applies to all languages and all codebases.
+>
+> See also: OPERATIONS.md (DNS configuration, service management), SYSTEMD.md (unit hardening), PODMAN.md (container security).
 
 ---
 
@@ -24,6 +26,154 @@
 - TLS for all credential transmission. No HTTP fallback.
 - Token prefix in logs (first 8 chars) for debugging. Never full token.
 - Credential source (oauth, api-key, file) logged at INFO on startup.
+
+---
+
+## Secret type discipline
+
+Secrets must be distinguishable from ordinary strings at the type level. A plain `String` holding an API key is a bug: it can be logged, serialized, compared in variable time, and will persist in memory after the value is no longer needed.
+
+WHY: Every secret leak in production traces back to a secret that was indistinguishable from regular data at some point in the call chain. Typed wrappers make misuse a compile error (or at minimum a visible violation), not a silent runtime behavior.
+
+### Requirements
+
+| Requirement | Rule |
+|-------------|------|
+| Typed wrapper | Every secret has a dedicated type. Rust: `secrecy::SecretString` or a newtype around it. Other languages: equivalent opaque wrapper. Never bare `String`, `str`, `[]byte`. |
+| Zeroize on drop | Secret memory is overwritten when the value is dropped. Rust: derive or implement `Zeroize` + `ZeroizeOnDrop`. This is not optional for keys, tokens, or passwords. |
+| No `Display` | Secret types must not implement `Display`. Accidental interpolation in format strings, log lines, or error messages is the most common leak vector. |
+| Redacted `Debug` | Implement `Debug` manually, emitting `[REDACTED]`. Derive-based `Debug` prints field contents. |
+| Explicit expose | Accessing the inner value requires an explicit call (`expose_secret()`, not `Deref`). This makes every use site auditable via grep. |
+| Constant-time comparison | Use `subtle::ConstantTimeEq` (Rust) or equivalent for secret comparison. Standard `==` leaks secret length and content via timing. |
+| No serialization | Secret types must not implement `Serialize`. Secrets should never appear in JSON responses, state dumps, or telemetry payloads. If serialization is needed for storage, use an explicit encryption step. |
+
+WHY: Each rule targets a specific leak vector. `Display` causes log leaks. `Serialize` causes API response leaks. `Deref` causes implicit coercion leaks. Variable-time `==` causes timing side-channels. Zeroize prevents memory forensics. The discipline is cumulative: omitting any single rule reopens the vector it guards.
+
+### Language-specific guidance
+
+**Rust**: Use `secrecy::SecretString` (or `koina::SecretString` if available in the workspace). `SecretString` and `Secret<T>` provide zeroize-on-drop, no Display, and `expose_secret()` gating out of the box. Combine with `subtle::ConstantTimeEq` for comparisons. See RUST.md for crate details.
+
+**Python**: Create a `SecretStr` class that overrides `__str__` and `__repr__` to return `[REDACTED]`. Use pydantic's `SecretStr` as a reference implementation. Python cannot guarantee zeroize (GC controls lifetime), but the wrapper prevents accidental logging. Use `hmac.compare_digest()` for constant-time comparison.
+
+**TypeScript**: Wrap secrets in an opaque class whose `toString()` and `toJSON()` return `[REDACTED]`. Use `timingSafeEqual` from `node:crypto` for comparison.
+
+**Go**: Use a struct with a private field and no `String()` method. Use `subtle.ConstantTimeCompare` for comparison. Zero the backing byte slice explicitly when done.
+
+### Lint enforcement
+
+The `RUST/plain-string-secret` basanos rule enforces secret type discipline at lint time. It flags any binding where the name contains `secret`, `password`, `token`, `key`, or `credential` and the type is bare `String`. This catches both struct fields and function parameters.
+
+The rule is auto-fixable: it replaces `String` with `SecretString` in flagged positions. Projects should run `kanon lint` (or the language-equivalent linter) in CI to prevent plain-string secrets from merging.
+
+### Examples
+
+**Rust** — correct secret handling:
+
+```rust
+use secrecy::{ExposeSecret, SecretString};
+use subtle::ConstantTimeEq;
+
+struct ServiceConfig {
+    api_token: SecretString,     // NOT String
+    password: SecretString,      // NOT String
+    endpoint: String,            // non-secret, String is fine
+}
+
+fn authenticate(credential: &SecretString) {
+    // Access requires explicit unwrap — every use site is auditable
+    let header_value = format!("Bearer {}", credential.expose_secret());
+
+    // Constant-time comparison
+    let expected: &[u8] = b"expected_value";
+    let matches = credential
+        .expose_secret()
+        .as_bytes()
+        .ct_eq(expected)
+        .into();
+}
+
+// Debug output prints [REDACTED], not the secret value
+// Display is not implemented — format!("{}", token) won't compile
+```
+
+**Python** — correct secret handling:
+
+```python
+import hmac
+
+
+class SecretStr:
+    """Opaque wrapper that prevents accidental secret logging."""
+
+    def __init__(self, value: str) -> None:
+        self._value = value
+
+    def get_secret_value(self) -> str:
+        return self._value
+
+    def __str__(self) -> str:
+        return "[REDACTED]"
+
+    def __repr__(self) -> str:
+        return "SecretStr('[REDACTED]')"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SecretStr):
+            return NotImplemented
+        return hmac.compare_digest(self._value, other._value)
+
+
+# Usage
+api_token = SecretStr(os.environ["API_TOKEN"])
+print(api_token)          # prints: [REDACTED]
+logging.info("token=%s", api_token)  # logs: token=[REDACTED]
+```
+
+**TypeScript** — correct secret handling:
+
+```typescript
+import { timingSafeEqual } from "node:crypto";
+
+class SecretString {
+  readonly #value: string;
+
+  constructor(value: string) {
+    this.#value = value;
+  }
+
+  exposeSecret(): string {
+    return this.#value;
+  }
+
+  toString(): string {
+    return "[REDACTED]";
+  }
+
+  toJSON(): string {
+    return "[REDACTED]";
+  }
+
+  equals(other: SecretString): boolean {
+    const a = Buffer.from(this.#value);
+    const b = Buffer.from(other.#value);
+    if (a.length !== b.length) return false;
+    return timingSafeEqual(a, b);
+  }
+}
+
+// Usage
+const apiToken = new SecretString(process.env.API_TOKEN!);
+console.log(apiToken);              // prints: [REDACTED]
+JSON.stringify({ token: apiToken }); // produces: {"token":"[REDACTED]"}
+```
+
+### Boundary rules
+
+- Secrets enter the system as typed wrappers at the earliest possible point: config loading, environment variable parsing, or HTTP header extraction.
+- Secrets leave the typed wrapper only at the point of use (e.g., setting an HTTP Authorization header). The unwrapped value must not be stored in an intermediate variable with a broader scope.
+- Functions that accept secrets must accept the wrapper type, not the inner string. This pushes type safety through the entire call chain.
+
+WHY: If a secret enters as `String` and is wrapped later, every line between entry and wrapping is an unguarded leak surface. Wrapping at the boundary means the leak surface is zero lines.
 
 ---
 
@@ -116,7 +266,7 @@ Full detail: stack trace, paths, parameters, timing. This is where debugging hap
 
 ## Dependency supply chain
 
-- `cargo-deny` (or language equivalent) runs on every PR
+- `cargo audit` and `cargo-deny` (or language equivalents) run on every PR — fail on critical/high, warn on medium/low
 - Known CVEs tracked in allow list with justification and review date
 - No pre-1.0 crates with <1000 monthly downloads in critical paths
 - Lockfiles committed for all binary crates
@@ -128,7 +278,7 @@ Full detail: stack trace, paths, parameters, timing. This is where debugging hap
 
 Every deployed system should have:
 - Automated secret scanning (gitleaks, trufflehog) in CI
-- Dependency vulnerability scanning in CI
+- Dependency vulnerability scanning (`cargo audit`, `cargo-deny`) in CI with severity-based gating
 - Manual security review for: auth flows, credential handling, sandbox boundaries, input validation
 - Documented threat model: what are we protecting, from whom, at what cost
 
@@ -159,3 +309,501 @@ Plugin API version is embedded in the WASM binary as a custom section, not just 
 ### Async isolation
 
 Plugins run on their own task, not the host thread. Communication is via message queue. A stalled plugin cannot freeze the host. Epoch-based yielding prevents infinite loops.
+
+---
+
+## Firewall
+
+### nftables
+
+nftables is the standard Linux firewall framework (successor to iptables). All firewall rules use nftables syntax.
+
+#### Rule structure
+
+```nft
+table inet filter {
+    chain input {
+        type filter hook input priority 0; policy drop;
+
+        # Allow established connections
+        ct state established,related accept
+
+        # Allow loopback
+        iif "lo" accept
+
+        # Allow SSH
+        tcp dport 22 accept
+
+        # Allow DNS (TCP + UDP)
+        tcp dport 53 accept
+        udp dport 53 accept
+
+        # Allow HTTP/HTTPS
+        tcp dport { 80, 443 } accept
+
+        # Drop everything else (implicit via policy)
+    }
+}
+```
+
+#### Principles
+
+| Principle | Rule |
+|-----------|------|
+| Default deny | `policy drop` on input chain. Allow only what is needed. |
+| Stateful | Allow `established,related` connections. Don't re-evaluate every packet. |
+| Specific | Match on port AND protocol. Don't allow TCP when only UDP is needed. |
+| Documented | Comment every allow rule with the service name it enables. |
+| Persistent | Save rules to `/etc/nftables.conf` or load via systemd. Unsaved rules vanish on reboot. |
+
+#### Verification
+
+```bash
+# List active rules
+nft list ruleset
+
+# Test connectivity after rule changes
+ss -tlnp                       # Verify listening ports
+curl -sf http://localhost:80    # Verify allowed traffic
+```
+
+### CrowdSec integration
+
+CrowdSec is a collaborative IDS that bans malicious IPs based on log analysis and community threat intelligence.
+
+#### Architecture
+
+```
+logs → CrowdSec engine → decisions → nftables bouncer → firewall rules
+```
+
+| Component | Role |
+|-----------|------|
+| CrowdSec engine | Parses logs, matches scenarios, issues ban decisions |
+| Community blocklists | Shared threat intelligence (~15K+ IPs) |
+| nftables bouncer | Translates CrowdSec decisions into nftables rules |
+| Local API | Connects bouncers to the engine |
+
+#### Bouncer configuration
+
+The nftables bouncer creates and manages its own nftables sets. Do not manually edit bouncer-managed sets.
+
+```yaml
+# /etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml
+mode: nftables
+nftables:
+  ipv4:
+    table: crowdsec
+    chain: crowdsec-chain
+  ipv6:
+    table: crowdsec6
+    chain: crowdsec6-chain
+```
+
+NOTE: On Fedora, the CrowdSec nftables bouncer RPM may ship with iptables-era configuration paths. Verify the config references nftables explicitly after installation.
+
+#### Operations
+
+```bash
+# Check CrowdSec decisions (active bans)
+cscli decisions list
+
+# Check bouncer status
+cscli bouncers list
+
+# Manually ban an IP
+cscli decisions add --ip 1.2.3.4 --reason "manual ban"
+
+# Remove a ban
+cscli decisions delete --ip 1.2.3.4
+
+# Update community blocklists
+cscli hub update && cscli hub upgrade
+```
+
+---
+
+## Browser policy
+
+### Firefox policies.json schema
+
+Firefox enterprise policies control browser behavior through a JSON configuration file. The schema follows Mozilla's enterprise policy specification.
+
+#### File format validation
+
+| Requirement | Rule | Validation |
+|-------------|------|------------|
+| Valid JSON | Must parse without errors | `python3 -m json.tool policies.json` |
+| Root object | Must contain `policies` key | `grep '"policies"' policies.json` |
+| Policy keys | Must be valid policy names | See Mozilla policy documentation |
+| Value types | Must match policy schema | Strings for URLs, booleans for flags |
+
+Schema example with all required fields:
+
+```json
+{
+  "policies": {
+    "DisableTelemetry": true,
+    "DisableFirefoxStudies": true,
+    "DisablePocket": true,
+    "DNSOverHTTPS": {
+      "Enabled": false,
+      "Locked": true
+    },
+    "ExtensionSettings": {
+      "*": {
+        "installation_mode": "blocked"
+      }
+    }
+  }
+}
+```
+
+#### Required security policies
+
+These policies must be set for controlled environments:
+
+| Policy | Value | Rationale |
+|--------|-------|-----------|
+| `DisableTelemetry` | `true` | Prevents data exfiltration to Mozilla |
+| `DisableFirefoxStudies` | `true` | Blocks automatic feature experiments |
+| `DisablePocket` | `true` | Disables third-party integration |
+| `DNSOverHTTPS.Enabled` | `false` | Forces system DNS resolver |
+| `DNSOverHTTPS.Locked` | `true` | Prevents user override |
+| `ExtensionSettings.*.installation_mode` | `"blocked"` | Default-deny for extensions |
+
+Additional recommended policies:
+
+| Policy | Value | Rationale |
+|--------|-------|-----------|
+| `PasswordManagerEnabled` | `false` | Enforce external password manager |
+| `FirefoxHome.Search` | `false` | Disable search on new tab |
+| `FirefoxHome.TopSites` | `false` | Disable top sites on new tab |
+| `FirefoxHome.Highlights` | `false` | Disable highlights on new tab |
+| `UserMessaging.UrlbarInterventions` | `false` | Disable interventions |
+| `UserMessaging.FeatureRecommendations` | `false` | Disable recommendations |
+
+#### Platform compatibility
+
+Policy file locations vary by platform. Using the wrong location silently fails.
+
+| Platform | Path | Notes |
+|----------|------|-------|
+| Linux (system-wide) | `/etc/firefox/policies/policies.json` | Applies to all users |
+| Linux (user) | `~/.mozilla/firefox/<profile>/` | Not recommended; use system-wide |
+| macOS (system) | `/Library/Preferences/org.mozilla.firefox.plist` | Convert JSON to plist |
+| macOS (app bundle) | `/Applications/Firefox.app/Contents/Resources/distribution/policies.json` | Per-installation |
+| Windows | `C:\Program Files\Mozilla Firefox\distribution\policies.json` | Or Group Policy ADMX |
+
+Platform-specific warnings:
+
+- **Linux**: Directory must be created: `sudo mkdir -p /etc/firefox/policies/`
+- **macOS**: JSON format not natively supported at system level; use `plutil` to convert: `plutil -convert xml1 policies.json -o org.mozilla.firefox.plist`
+- **Windows**: Group Policy overrides local file; check `gpresult /r` for conflicts
+
+#### Extension management
+
+Control which extensions can be installed. Extension IDs are UUIDs or email-style identifiers.
+
+```json
+{
+  "policies": {
+    "ExtensionSettings": {
+      "*": {
+        "installation_mode": "blocked"
+      },
+      "uBlock0@raymondhill.net": {
+        "installation_mode": "force_installed",
+        "install_url": "https://addons.mozilla.org/firefox/downloads/latest/ublock-origin/latest.xpi"
+      },
+      "{446900e4-71c2-419f-a6a7-df60251e0f8a}": {
+        "installation_mode": "allowed"
+      }
+    }
+  }
+}
+```
+
+Extension ID formats:
+
+| Format | Example | Source |
+|--------|---------|--------|
+| Email-style | `uBlock0@raymondhill.net` | `manifest.json` → `browser_specific_settings.gecko.id` |
+| UUID | `{446900e4-71c2-419f-a6a7-df60251e0f8a}` | AMO-assigned for unbranded extensions |
+
+Finding extension IDs:
+
+```bash
+# From installed extension (Linux)
+cat ~/.mozilla/firefox/*.default/extensions/*.xpi | unzip -p - manifest.json | grep '"id"'
+
+# From AMO page
+# View source, search for "guid" in JSON-LD metadata
+```
+
+Installation modes:
+
+| Mode | Behavior |
+|------|----------|
+| `blocked` | Cannot be installed |
+| `allowed` | User can install manually |
+| `force_installed` | Auto-install, user cannot remove |
+| `normal_installed` | Auto-install, user can remove |
+
+### Firefox DNS-over-HTTPS (DoH) bypass prevention
+
+Firefox enables DNS-over-HTTPS by default, which bypasses the network's DNS resolver (AdGuard). This undermines DNS-based ad blocking, security filtering, and internal DNS rewrites.
+
+#### Enterprise policy
+
+Disable Firefox DoH via enterprise policy so the browser uses the system resolver:
+
+```json
+{
+  "policies": {
+    "DNSOverHTTPS": {
+      "Enabled": false,
+      "Locked": true
+    }
+  }
+}
+```
+
+| Platform | Policy file location |
+|----------|---------------------|
+| Linux | `/etc/firefox/policies/policies.json` |
+| macOS | `/Library/Preferences/org.mozilla.firefox.plist` or `/Applications/Firefox.app/Contents/Resources/distribution/policies.json` |
+| Windows | Group Policy or `distribution/policies.json` in Firefox install dir |
+
+`Locked: true` prevents users from re-enabling DoH in `about:preferences`. Without this, individual users can override the policy.
+
+#### Verification
+
+```bash
+# Verify policy is loaded
+# In Firefox: about:policies → should show DNSOverHTTPS Enabled=false
+
+# Verify DNS queries go through system resolver
+dig @<resolver-ip> example.com  # Should show AdGuard as resolver
+```
+
+#### Other browsers
+
+Chromium-based browsers also support DoH. Disable via enterprise policy or managed preferences if running a controlled DNS environment. The key principle: no client should bypass the network resolver.
+
+### Certificate management
+
+For internal services using TLS with self-signed or internal CA certificates:
+
+| Task | Method |
+|------|--------|
+| System trust store | Add CA cert to `/etc/pki/ca-trust/source/anchors/` then `update-ca-trust` (Fedora/RHEL) |
+| Browser trust | Firefox uses its own trust store — import via `certutil` or enterprise policy `Certificates.Install` |
+| Container trust | Mount CA cert into container and set `SSL_CERT_FILE` or add to container's trust store |
+
+Never disable TLS verification (`--insecure`, `verify=False`) as a workaround for certificate issues. Fix the trust chain instead.
+
+---
+
+## DNS security
+
+### Threat model
+
+DNS is a high-value target. Compromise gives attackers the ability to redirect all traffic silently.
+
+| Threat | Mitigation |
+|--------|-----------|
+| DNS spoofing | Use DoH/DoT for upstream queries (encrypted + authenticated) |
+| Cache poisoning | DNSSEC validation on upstream resolvers |
+| DNS exfiltration | Monitor query logs for anomalous patterns (long subdomains, high entropy) |
+| Resolver hijacking | Firewall blocks outbound port 53 from all hosts except the resolver |
+| Internal rewrite tampering | Restrict AdGuard admin access (auth required, not exposed externally) |
+
+### Outbound DNS lockdown
+
+Only the designated resolver should make outbound DNS queries. All other hosts on the network must use the resolver.
+
+#### nftables rules
+
+```nft
+table inet filter {
+    chain output {
+        type filter hook output priority 0; policy accept;
+        
+        # Allow resolver host to reach external DNS
+        ip saddr <resolver-ip> tcp dport 53 accept
+        ip saddr <resolver-ip> udp dport 53 accept
+        
+        # Allow resolver host to reach DoH/DoT ports
+        ip saddr <resolver-ip> tcp dport 443 accept
+        ip saddr <resolver-ip> tcp dport 853 accept
+        
+        # Block all other hosts from outbound DNS
+        ip saddr != <resolver-ip> tcp dport 53 drop
+        ip saddr != <resolver-ip> udp dport 53 drop
+    }
+}
+```
+
+Replace `<resolver-ip>` with the actual IP address of your AdGuard/Pi-hole instance (e.g., `192.168.1.10`).
+
+#### Validation
+
+Verify the lockdown after applying rules:
+
+```bash
+# From resolver host: should work
+dig @8.8.8.8 example.com
+
+# From other host: should timeout/fail
+dig @8.8.8.8 example.com
+# Expected: connection timed out
+
+# Check nftables counters
+nft list chain inet filter output
+# Look for packet counts on DNS drop rules
+```
+
+This prevents clients from bypassing the resolver by hardcoding external DNS servers (e.g., `8.8.8.8`).
+
+### Query logging
+
+Log DNS queries for security analysis and debugging. Retain query logs for at minimum 7 days. Query logs feed into the observability pipeline (see OPERATIONS.md § Observability patterns) for anomaly detection.
+
+---
+
+## Software Bill of Materials (SBOM)
+
+Every released binary and container image must have a machine-readable SBOM attached. The SBOM lists every dependency (direct and transitive), its version, and its license. Without an SBOM, you cannot answer "are we affected?" when a CVE drops — you are reduced to grepping lockfiles across dozens of repos under time pressure.
+
+WHY: An SBOM turns CVE triage from an emergency investigation into a database query. Regulators (NIST EO 14028, EU CRA) increasingly mandate SBOMs for software sold or deployed in critical infrastructure. Even without regulatory pressure, the operational value is immediate: you know what you ship.
+
+### Format
+
+| Requirement | Rule |
+|-------------|------|
+| Primary format | CycloneDX 1.5+ (JSON). CycloneDX is the default because it models vulnerabilities, services, and build metadata natively — not just package lists. |
+| Secondary format | SPDX 2.3+ (JSON) when required by a downstream consumer or compliance framework. Generate both if needed; never skip CycloneDX to produce only SPDX. |
+| Scope | Every direct and transitive dependency. Runtime, build-time, and dev dependencies tracked separately via CycloneDX component scopes. |
+| Content | Component name, version, purl (package URL), license (SPDX expression), hash (SHA-256 minimum). Missing fields are a lint failure. |
+
+WHY: purl enables cross-ecosystem vulnerability matching (a CVE references a purl, your SBOM contains purls — join on purl). Without purl, matching is string heuristics that miss or false-positive.
+
+### Generation
+
+Generate SBOMs in CI, not locally. Manual generation drifts from what was actually built.
+
+| Language | Tool | Command |
+|----------|------|---------|
+| Rust | `cargo-cyclonedx` | `cargo cyclonedx --format json --all` |
+| Python | `cyclonedx-bom` | `cyclonedx-py environment --output-format json -o sbom.cdx.json` |
+| TypeScript | `@cyclonedx/cdxgen` | `cdxgen -o sbom.cdx.json` |
+| Go | `cyclonedx-gomod` | `cyclonedx-gomod mod -json -output sbom.cdx.json` |
+| Container images | `syft` | `syft <image> -o cyclonedx-json > sbom.cdx.json` |
+
+For multi-language monorepos, generate one SBOM per deliverable artifact (binary, container image, published package), not one per workspace.
+
+### Storage and distribution
+
+- SBOMs are CI artifacts: attach to the release (GitHub release asset, container registry annotation, or artifact store).
+- SBOMs are versioned with the artifact they describe. An SBOM without a matching artifact version is useless.
+- Do not commit SBOMs to the source repo. They are build outputs, not source.
+
+### Validation
+
+Validate SBOM completeness in CI before publishing:
+
+```bash
+# Validate CycloneDX schema conformance
+cyclonedx validate --input-format json --input-file sbom.cdx.json --fail-on-errors
+
+# Check that every component has a purl and license
+# (project-specific lint rule — add to kanon lint)
+```
+
+Treat validation failures as release blockers. An invalid SBOM is worse than no SBOM — it provides false confidence.
+
+---
+
+## CVE response SLAs
+
+When a CVE affects a dependency in any shipped artifact, the response timeline is determined by severity. These SLAs measure time from awareness (CVE published or privately disclosed) to remediation deployed.
+
+WHY: Without defined SLAs, CVE response is ad-hoc and severity-blind. A critical RCE and a low-severity information disclosure get the same treatment: "we'll get to it." SLAs force triage discipline and make response time auditable.
+
+### Severity tiers
+
+| Severity | CVSS range | Response SLA | Remediation SLA | Examples |
+|----------|------------|--------------|-----------------|----------|
+| Critical | 9.0 – 10.0 | 4 hours | 24 hours | RCE, auth bypass, sandbox escape |
+| High | 7.0 – 8.9 | 24 hours | 7 days | Privilege escalation, data exposure |
+| Medium | 4.0 – 6.9 | 7 days | 30 days | DoS, limited information disclosure |
+| Low | 0.1 – 3.9 | 30 days | 90 days | Theoretical attacks, unlikely conditions |
+
+- **Response** means: CVE triaged, affected artifacts identified (via SBOM query), impact assessed, and a tracking issue filed with owner assigned.
+- **Remediation** means: patched dependency merged, CI green, and deployed to all affected environments. If a patch is not available upstream, remediation means applying a mitigation (disabling the affected feature, adding a workaround, or pinning to a non-vulnerable version) and documenting the residual risk.
+
+WHY: "Response" and "remediation" are separate because they require different resources. Response is a triage function (one person, one hour). Remediation may require upstream patches, testing, and coordinated deployment. Conflating them makes the SLA either unachievable or meaningless.
+
+### Process
+
+1. **Detection**: `cargo audit` / `cargo-deny` / `osv-scanner` / GitHub Dependabot alerts / manual disclosure. At least one automated scanner must run on every PR and on a daily schedule against the default branch. CI must fail on critical/high advisories and warn on medium/low (see CI.md § Vulnerability scanning for severity thresholds).
+2. **Triage**: Query SBOM to identify all affected artifacts. Determine actual exploitability (not all CVEs in a dependency are reachable). Record the determination.
+3. **Track**: File a tracking issue with severity, affected artifacts, SLA deadline, and assigned owner. Link to the CVE and the SBOM query result.
+4. **Remediate**: Update dependency, apply workaround, or accept risk (with documented justification and a review date no later than 90 days). If accepting risk, the acceptance must be reviewed by a second person.
+5. **Verify**: Confirm the fix by regenerating the SBOM and re-running the vulnerability scanner. The CVE must not appear in the new scan.
+6. **Communicate**: Notify affected downstream consumers if the vulnerability is in a published library or API.
+
+### Exceptions
+
+- If an upstream patch does not exist and no workaround is viable, document the gap, set a review cadence (minimum weekly for Critical/High), and escalate if the upstream patch SLA exceeds your remediation SLA by more than 2x.
+- SLA clock pauses only for externally-blocked dependencies (waiting on upstream). Internal delays (backlog, prioritization) do not pause the clock.
+- `cargo-deny` allow-list entries for known CVEs must include the justification, the date added, and a review-by date. Stale allow-list entries (past review-by date) are CI failures.
+
+---
+
+## Vulnerability disclosure
+
+This section defines how to handle vulnerability reports received from external researchers and how to disclose vulnerabilities found internally.
+
+WHY: A defined disclosure process protects researchers who report in good faith, gives maintainers a structured timeline to fix before public knowledge, and prevents the chaos of ad-hoc responses where legal, engineering, and communications improvise under pressure.
+
+### Receiving reports
+
+| Requirement | Rule |
+|-------------|------|
+| Contact method | Publish a `SECURITY.md` in the repo root (GitHub renders this on the Security tab) with an email address or a link to a private reporting mechanism (GitHub Private Vulnerability Reporting preferred). |
+| Acknowledgment | Acknowledge receipt within 2 business days. Confirm the report is being investigated. Do not disclose details of the investigation. |
+| Communication cadence | Update the reporter at least every 7 days until resolution. Silence erodes trust and incentivizes public disclosure. |
+| Safe harbor | State explicitly that good-faith security research will not result in legal action. Researchers who follow the disclosure policy are acting in the interest of the project. |
+| Scope | Define what is in scope (production services, published libraries, CLI tools) and what is out of scope (third-party dependencies with their own disclosure processes, test/staging environments). |
+
+### Disclosure timeline
+
+| Phase | Timeline | Action |
+|-------|----------|--------|
+| Report received | Day 0 | Acknowledge, assign handler, begin triage |
+| Triage complete | Day 0 + 5 | Confirm or deny vulnerability, assess severity, estimate fix timeline |
+| Fix developed | Day 0 + 45 | Patch ready, tested, reviewed |
+| Coordinated disclosure | Day 0 + 90 | Public advisory published, CVE requested if applicable, fix released |
+| Grace period | +14 days | If fix is not ready at day 90, negotiate extension with reporter. Maximum one extension of 14 days. After 104 days, the reporter may disclose publicly regardless. |
+
+WHY: 90 days is the industry-standard coordinated disclosure window (Google Project Zero, CERT/CC). It balances giving maintainers time to fix with not leaving users exposed indefinitely. The 14-day grace period acknowledges that complex fixes sometimes need more time, but caps the extension to prevent indefinite delay.
+
+### Publishing advisories
+
+- Use GitHub Security Advisories (GHSA) for public projects. This automatically requests a CVE ID and notifies Dependabot users.
+- Advisory must include: affected versions, fixed version, severity (CVSS), description of the vulnerability, description of the fix, and credit to the reporter (with their consent).
+- For libraries: publish the advisory before or simultaneously with the patched release. Never publish a patched release silently — downstream consumers need the advisory to know they must update.
+- For services: publish the advisory after the fix is deployed to all production environments. Disclosing before deployment creates a window of known-vulnerable exposure.
+
+### Internal discovery
+
+When a vulnerability is found internally (code review, automated scanning, testing):
+
+1. File a private tracking issue immediately. Do not discuss in public channels.
+2. Follow the same severity-based SLA as external CVEs (see CVE response SLAs above).
+3. If the vulnerability affects downstream consumers (published crate, API), follow the coordinated disclosure timeline above, treating the internal discovery date as Day 0.
+4. Request a CVE ID for any vulnerability in a published component, even if found internally. CVE IDs enable downstream consumers to track the issue in their own vulnerability management systems.
+
+WHY: Internal discoveries that skip the formal process tend to get quiet fixes without advisories. This leaves downstream consumers vulnerable and unaware. The process is the same regardless of who finds the bug.

--- a/standards/SHELL.md
+++ b/standards/SHELL.md
@@ -4,7 +4,7 @@
 >
 > Target: Bash 5.x. For scripts, CI pipelines, and automation. Use `just` for task running.
 >
-> **Key decisions:** shellcheck, just (not Make), set -euo pipefail, bats testing, flock locking, mktemp temp files, strict quoting.
+> **Key decisions:** shellcheck (CI-gated), just (not Make), set -euo pipefail, bats testing, flock locking, mktemp temp files, strict quoting, arrays over string-splitting, signal traps for resource cleanup.
 
 ---
 
@@ -20,6 +20,48 @@
   shellcheck script.sh
   bats tests/
  ```
+
+### Shellcheck CI integration
+
+Every shell script in the repo is linted on every PR. No exceptions, no per-file opt-outs. WHY: a linter that doesn't run on every change is advisory, not a gate.
+
+```yaml
+# .github/workflows/shellcheck.yml
+name: shellcheck
+on:
+  pull_request:
+    paths: ["**/*.sh", "**/*.bash"]
+  push:
+    branches: [main]
+    paths: ["**/*.sh", "**/*.bash"]
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shellcheck
+        run: sudo apt-get install -y shellcheck
+      - name: Lint all shell scripts
+        run: |
+          find . -name '*.sh' -o -name '*.bash' | xargs shellcheck --severity=warning --shell=bash
+```
+
+Configuration lives in `.shellcheckrc` at the repo root, not in per-file directives. WHY: scattered directives hide suppressions from review.
+
+```bash
+# .shellcheckrc
+shell=bash
+severity=warning
+# Only disable rules with a comment explaining WHY
+# disable=SC2059  # printf format strings are intentionally dynamic in log()
+```
+
+Rules for suppressions:
+
+- **Inline `# shellcheck disable=SCXXXX`**: allowed only when the suppression is local to a single line and the WHY comment is on the same line or the line above. Never blanket-disable at the top of a file.
+- **`.shellcheckrc` disable**: allowed only for project-wide rules that apply everywhere with a documented reason. Reviewers must approve additions.
+- **`--exclude` in CI**: never. If a rule fires, either fix the code or document the suppression in `.shellcheckrc`.
 
 ### just for task automation
 
@@ -192,6 +234,76 @@ Untrusted contexts: `body`, `title`, `head_ref`, `label`, `message`, `name`, `em
 
 ---
 
+## Signal handling
+
+Scripts that create resources (temp files, lock files, child processes, state files) must handle signals. WHY: `set -e` does not run cleanup on SIGTERM or SIGINT — only `trap` does. A script killed by `systemctl stop`, Ctrl-C, or a CI timeout that doesn't trap signals leaks resources.
+
+### Cleanup on exit and signals
+
+```bash
+cleanup() {
+    rm -rf -- "$tmpdir"
+    # Kill child processes if any were spawned
+    kill -- -$$ 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+```
+
+- **EXIT**: runs on normal exit, `exit N`, and `set -e` failures. This is your primary cleanup hook.
+- **INT**: Ctrl-C (SIGINT). Without this, interactive kills skip EXIT on some shells.
+- **TERM**: `kill`, `systemctl stop`, CI timeout. The default signal. Without this, graceful shutdown is impossible.
+- **Do not trap HUP** unless the script runs as a daemon. HUP means "reload config" for daemons and "terminal closed" for interactive scripts — conflating the two causes bugs.
+
+### Idempotent cleanup
+
+Cleanup functions must be idempotent. WHY: signals can arrive during cleanup itself, and EXIT runs after signal traps.
+
+```bash
+cleanup() {
+    # Guard: only run once
+    [[ "${_cleanup_done:-}" == "1" ]] && return
+    _cleanup_done=1
+
+    rm -rf -- "$tmpdir"
+}
+```
+
+### Propagating exit status through traps
+
+A trapped signal should re-raise to preserve the correct exit status for the parent. WHY: without re-raise, the parent sees exit 0 and believes the script succeeded.
+
+```bash
+trap 'cleanup; trap - INT; kill -INT $$' INT
+trap 'cleanup; trap - TERM; kill -TERM $$' TERM
+```
+
+This pattern: run cleanup, reset the trap to default, re-send the signal. The parent then sees the correct signal-killed exit status (128 + signal number).
+
+### Long-running scripts with child processes
+
+Scripts that spawn background work must forward signals to children. WHY: killing the parent does not automatically kill children — they become orphans.
+
+```bash
+child_pid=
+cleanup() {
+    if [[ -n "${child_pid:-}" ]]; then
+        kill -- "$child_pid" 2>/dev/null
+        wait "$child_pid" 2>/dev/null
+    fi
+    rm -rf -- "$tmpdir"
+}
+trap cleanup EXIT INT TERM
+
+long_running_command &
+child_pid=$!
+wait "$child_pid"
+child_pid=
+```
+
+Capture the PID, kill it in cleanup, `wait` to reap. Clear the PID after `wait` returns to make cleanup idempotent.
+
+---
+
 ## Style
 
 ### Functions
@@ -233,6 +345,76 @@ echo "${ref}"
 ```
 
 Note: macOS ships Bash 3.2 (GPLv2 licensing). If macOS compatibility is needed, either mandate `brew install bash` or avoid 5.x features.
+
+### Arrays
+
+Use arrays for lists of items. Never pack multiple values into a single string and split later. WHY: string-splitting breaks on whitespace, globs, and special characters. Arrays preserve element boundaries.
+
+**Indexed arrays** for ordered lists:
+
+```bash
+local -a files=()
+while IFS= read -r -d '' f; do
+    files+=("$f")
+done < <(find . -name '*.sh' -print0)
+
+# Iterate safely: quoted expansion preserves elements with spaces
+for f in "${files[@]}"; do
+    shellcheck "$f"
+done
+```
+
+- `"${array[@]}"` (quoted, `@`) expands each element as a separate word. This is the correct form for iteration and command arguments.
+- `"${array[*]}"` (quoted, `*`) joins all elements into a single string with the first character of IFS. Use only for display/logging, never for passing arguments.
+- `${array[@]}` (unquoted) subjects each element to word splitting and globbing. Never use this form.
+
+**Associative arrays** for key-value maps (Bash 4.0+):
+
+```bash
+declare -A service_ports=(
+    [adguard]=3000
+    [plex]=32400
+    [grafana]=3001
+)
+
+for name in "${!service_ports[@]}"; do
+    echo "${name} -> ${service_ports[$name]}"
+done
+```
+
+WHY associative arrays over parallel indexed arrays: parallel arrays (`names[0]`, `ports[0]`) drift when items are added or removed. Associative arrays bind key to value atomically.
+
+**Building command arguments:**
+
+```bash
+local -a curl_args=(
+    --silent
+    --fail
+    --max-time 30
+    --header "Authorization: Bearer ${token}"
+)
+
+if [[ "${verbose:-}" == "1" ]]; then
+    curl_args+=(--verbose)
+fi
+
+curl "${curl_args[@]}" "$url"
+```
+
+WHY: building commands with string concatenation breaks on arguments containing spaces, quotes, or glob characters. Arrays preserve argument boundaries exactly.
+
+**Array length and emptiness:**
+
+```bash
+# Length
+echo "${#files[@]} files found"
+
+# Emptiness check
+if (( ${#files[@]} == 0 )); then
+    echo "error: no files found" >&2
+    exit 1
+fi
+```
 
 ### No dead weight
 
@@ -280,3 +462,8 @@ TAP-compliant output works with CI runners. Use `bats-assert` and `bats-file` he
 10. **Missing `local` in functions**: variables leak to global scope
 11. **Manual temp file paths**: use `mktemp`, never `/tmp/myapp.$$`
 12. **`${{ }}` interpolation in GitHub Actions `run:`**: pass through `env:` instead
+13. **No signal traps**: scripts that create resources must `trap cleanup EXIT INT TERM`
+14. **String-packed lists instead of arrays**: `files="a b c"` breaks on spaces; use `files=(a b c)`
+15. **Unquoted `${array[@]}`**: always `"${array[@]}"` to preserve element boundaries
+16. **Per-file shellcheck disables**: suppressions go in `.shellcheckrc` or inline with WHY comments, never blanket-disabled at file top
+17. **`--exclude` in CI shellcheck invocation**: fix the code or document the suppression properly

--- a/standards/SQL.md
+++ b/standards/SQL.md
@@ -2,9 +2,21 @@
 
 > Additive to STANDARDS.md. Read that first. Everything here is SQL-specific.
 >
-> Covers: PostgreSQL, SQLite, Redshift, mneme Datalog, Room (Android). Dialect-specific notes are marked.
+> Primary dialect: **SQLite** (kanon uses rusqlite). PostgreSQL and Redshift notes where they diverge. Mneme Datalog and Room (Android) in appendix.
 >
-> **Key decisions:** Uppercase keywords, CTEs over subqueries, explicit columns, nullif division, PG identity columns, SQLite STRICT tables, mneme Datalog.
+> **Key decisions:** Uppercase keywords, CTEs over subqueries, explicit columns, nullif division, STRICT tables (SQLite), identity columns (PG), JSON as TEXT with json_each() for querying, index every FK and filter column.
+
+---
+
+## Dialect selection
+
+| Dialect | When | Configuration |
+|---------|------|---------------|
+| **SQLite** | Embedded/local databases, kanon internals, mobile (Room) | `.kanon.yml`: `dialect: sqlite` |
+| **PostgreSQL** | Server databases, multi-user OLTP, PG10+ features | `.kanon.yml`: `dialect: postgresql` |
+| **Redshift** | Data warehouse, columnar analytics | Follow PostgreSQL rules except where noted in § Redshift compatibility |
+
+Universal rules (Formatting, Naming, Structure, Testing) apply to all dialects. When behavior diverges, guidance appears under dialect-specific headings within each section or under the dedicated dialect sections (§ SQLite, § PostgreSQL). Portable SQL uses `CAST()` syntax and avoids dialect-specific extensions.
 
 ---
 
@@ -182,13 +194,426 @@ Rules:
 - SQLite in WAL mode is effectively `serializable` for writes (single writer). Configure `busy_timeout` instead of retrying manually.
 - Never weaken isolation "for performance" without proving the weaker level is correct for the workload
 
+### Concurrency patterns
+
+Transaction isolation levels prevent data anomalies at the database level. These patterns handle application-level concurrency where isolation alone is insufficient.
+
+#### Write skew
+
+Write skew occurs when two concurrent transactions read the same rows, make decisions based on those reads, and write non-conflicting rows -- but the combined result violates a business invariant.
+
+Example: two on-call doctors both read "2 doctors on-call", both decide to remove themselves, both commit successfully, leaving 0 doctors on-call. Neither transaction saw a conflict because they wrote different rows.
+
+Prevention by dialect:
+- **PostgreSQL**: Use `SERIALIZABLE` isolation. The database detects write skew and aborts one transaction. Always retry on serialization failure (`SQLSTATE 40001`).
+- **SQLite**: Single-writer architecture in WAL mode prevents write skew by default (writes are serialized).
+- **Application-level**: `SELECT ... FOR UPDATE` on the rows that inform the decision. This locks the read set, preventing concurrent modifications.
+
+```sql
+-- PostgreSQL: prevent write skew with explicit locking
+BEGIN;
+SELECT count(*) FROM oncall_doctors WHERE on_duty = true FOR UPDATE;
+-- decision logic in application
+UPDATE oncall_doctors SET on_duty = false WHERE doctor_id = ?;
+COMMIT;
+```
+
+#### Advisory locks (PostgreSQL)
+
+Use advisory locks for application-level mutual exclusion that does not map to row-level locking.
+
+```sql
+-- Session-level lock (held until session ends or explicit unlock)
+SELECT pg_advisory_lock(hashtext('migration-runner'));
+-- ... do work ...
+SELECT pg_advisory_unlock(hashtext('migration-runner'));
+
+-- Transaction-level lock (released at COMMIT/ROLLBACK)
+SELECT pg_advisory_xact_lock(hashtext('batch-processor'));
+
+-- Try without blocking (returns false if already held)
+SELECT pg_try_advisory_lock(hashtext('singleton-job'));
+```
+
+Use cases:
+- Singleton job execution (cron-like tasks that must not overlap)
+- Migration locking (prevent concurrent schema changes)
+- Rate limiting at the database level
+
+Key rules:
+- Use `hashtext()` or a consistent hashing scheme for lock IDs -- raw integer literals are collision-prone across unrelated code paths
+- Session-level locks survive transaction boundaries -- always explicitly unlock or use transaction-level variants
+- Advisory locks do not appear in `pg_locks` with meaningful names -- document the mapping between lock IDs and their purposes in application code
+
+#### Optimistic concurrency
+
+For low-contention workloads where locking would add unnecessary overhead:
+
+```sql
+-- Version column pattern
+UPDATE accounts
+SET balance = balance - 100, version = version + 1
+WHERE account_id = ? AND version = ?;
+-- If affected_rows = 0, another transaction modified the row. Retry.
+```
+
+Prefer optimistic concurrency when:
+- Conflicts are rare (<5% of transactions)
+- The retry cost is low (read + recompute + retry)
+- Row-level locking would create contention hotspots
+
+Prefer pessimistic locking (`FOR UPDATE`, advisory locks) when:
+- Conflicts are frequent
+- The computation between read and write is expensive
+- Correctness is more important than throughput
+
+---
+
+## JSON columns
+
+### Storage strategy
+
+Store JSON as `TEXT` in SQLite. There is no native JSON type; the json functions operate on TEXT values. Validate structure at the application boundary before insertion.
+
+**When to use JSON columns:**
+- Variable-length lists of simple values (e.g., crate names, file paths, tags)
+- Semi-structured metadata that varies between rows
+- Blob-like payloads consumed whole by the application (e.g., checkpoint snapshots, health snapshots)
+
+**When NOT to use JSON columns:**
+- Data you regularly filter or join on. Extract to a proper column or junction table instead.
+- Relational data with foreign key semantics. JSON defeats referential integrity.
+
+### SQLite JSON functions
+
+SQLite provides two function families: `json_*` (returns TEXT) and `jsonb_*` (returns binary, 3.45+). Use the `json_*` family unless profiling shows the binary variants improve performance on large documents.
+
+Core functions:
+
+| Function | Purpose | Example |
+|----------|---------|---------|
+| `json(value)` | Validate and minify | `json('{"a": 1}')` |
+| `json_extract(json, path)` | Extract scalar | `json_extract(config, '$.timeout')` |
+| `->` / `->>` | Extract (JSON / scalar) | `config ->> '$.timeout'` |
+| `json_each(json)` | Unnest array to rows | `FROM table, json_each(table.tags)` |
+| `json_group_array(value)` | Aggregate rows to array | `json_group_array(name)` |
+| `json_valid(value)` | Check well-formedness | `CHECK (json_valid(payload))` |
+
+### Querying JSON arrays with json_each
+
+The primary pattern for querying JSON array columns in kanon. Use `json_each()` as a table-valued function in a cross join:
+
+```sql
+-- Unnest a JSON array column to filter on individual elements
+SELECT sm.session_id, je.value AS crate_name
+FROM session_metadata sm, json_each(sm.crates) je
+WHERE je.value = 'phronesis'
+
+-- Aggregate across JSON array elements
+SELECT
+    je.value AS crate_name,
+    count(*) AS session_count,
+    sum(CASE WHEN sm.qa_verdict = 'PASS' THEN 1 ELSE 0 END) AS pass_count,
+FROM session_metadata sm, json_each(sm.crates) je
+WHERE sm.completed_at >= ?1
+GROUP BY je.value
+ORDER BY session_count DESC
+```
+
+Key rules:
+- The comma-join syntax (`FROM t, json_each(t.col)`) is an implicit cross join. Every row produces one output row per array element. Be aware of row multiplication in aggregations.
+- `je.value` gives the element value; `je.key` gives the array index (0-based).
+- For nested JSON objects, chain paths: `json_each(col, '$.items')`.
+- Parameterize filter values, not the JSON path.
+
+### Dynamic IN clauses with json_each
+
+When building an IN clause from application-provided lists, prefer `json_each()` over string-concatenated placeholders when the list is already JSON:
+
+```sql
+-- Application passes a JSON array as a single parameter
+SELECT * FROM sessions
+WHERE prompt_number IN (SELECT value FROM json_each(?1))
+```
+
+When the list comes from individual values (not already JSON), positional placeholders are acceptable:
+
+```sql
+-- Individual parameters: ?3, ?4, ?5 etc.
+WHERE je.value IN (?3, ?4, ?5)
+```
+
+### Enforcing JSON validity
+
+Use CHECK constraints on JSON columns for defense in depth:
+
+```sql
+CREATE TABLE events (
+    id      INTEGER PRIMARY KEY,
+    payload TEXT NOT NULL CHECK (json_valid(payload)),
+    tags    TEXT NOT NULL DEFAULT '[]' CHECK (json_valid(tags))
+) STRICT;
+```
+
+The application boundary is the primary validator; the CHECK constraint catches bugs that bypass validation.
+
+### PostgreSQL JSON
+
+PostgreSQL has native `json` and `jsonb` types. Use `jsonb` exclusively -- it is binary, indexable, and supports containment operators.
+
+| Operator | Purpose | Example |
+|----------|---------|---------|
+| `->` | Extract JSON element | `config -> 'timeout'` |
+| `->>` | Extract as text | `config ->> 'timeout'` |
+| `@>` | Contains | `tags @> '["urgent"]'` |
+| `?` | Key exists | `config ? 'timeout'` |
+| `jsonb_array_elements()` | Unnest array | `FROM jsonb_array_elements(tags)` |
+
+Index with GIN for containment/existence queries:
+
+```sql
+CREATE INDEX idx_events_tags ON events USING GIN (tags);
+-- Enables: WHERE tags @> '["urgent"]'
+```
+
+Use `JSON_TABLE` (PG17+) to convert JSON to relational rows in a `FROM` clause:
+
+```sql
+SELECT j.*
+FROM api_responses r,
+    json_table(
+        r.body, '$.items[*]'
+        COLUMNS (
+            id integer PATH '$.id',
+            name text PATH '$.name',
+            status text PATH '$.status'
+        )
+    ) AS j
+WHERE j.status = 'active'
+```
+
+Prefer `json_table` over chains of `json_extract_path` / `->>` for structured JSON.
+
+**Path queries** (`jsonb_path_query`, PG12+) for complex JSON traversal:
+
+```sql
+-- Find all items where price > 100
+SELECT jsonb_path_query(data, '$.items[*] ? (@.price > 100)') AS expensive_items
+FROM orders;
+
+-- Check existence (returns boolean)
+SELECT jsonb_path_exists(config, '$.features[*] ? (@ == "dark_mode")');
+
+-- Extract with default
+SELECT jsonb_path_query_first(config, '$.timeout') AS timeout
+FROM settings;
+```
+
+Prefer `jsonb_path_query` over chains of `->` / `->>` for:
+- Filtered array traversal (the `?` filter is more readable than subqueries)
+- Existence checks on nested structures
+- Queries that would otherwise require `jsonb_array_elements` + `WHERE`
+
+**Casting traps:**
+
+```sql
+-- PostgreSQL: idiomatic cast
+SELECT '{"a": 1}'::jsonb;
+
+-- Portable (but verbose)
+SELECT CAST('{"a": 1}' AS jsonb);
+
+-- TRAP: ->> returns text, not the original JSON type
+SELECT config ->> 'timeout';            -- returns TEXT '30', not INTEGER 30
+SELECT (config ->> 'timeout')::integer;  -- explicit cast needed for arithmetic
+
+-- TRAP: -> returns jsonb, ->> returns text
+SELECT config -> 'nested' -> 'key';     -- returns jsonb (for further traversal)
+SELECT config ->> 'key';                -- returns text (for comparison/output)
+```
+
+Rule: `->` for traversal (returns jsonb), `->>` for terminal extraction (returns text). Always cast `->>` results explicitly when using them in arithmetic or typed comparisons. Use `CAST()` instead of `::` when portability matters.
+
+---
+
+## Index strategy
+
+### When to index
+
+Index every column that appears in:
+- `WHERE` clauses (filter columns)
+- `JOIN ... ON` conditions (foreign keys)
+- `ORDER BY` clauses on large tables (>1K rows)
+- `GROUP BY` when used with selective `WHERE` filters
+
+Do NOT index:
+- Columns with very low cardinality (boolean flags on small tables) -- the planner will prefer a table scan
+- Tables under ~100 rows -- full scan is faster than index lookup
+- Write-heavy columns on write-dominated workloads without measuring the write penalty
+
+### Index naming
+
+Convention: `idx_{table}_{columns}` for regular indexes, `idx_{table}_{purpose}` for composite or special-purpose indexes.
+
+```sql
+CREATE INDEX idx_sessions_dispatch ON sessions(dispatch_id);
+CREATE INDEX idx_corrective_outcomes_lookup
+    ON corrective_outcomes(project, crate_name, failure_type);
+CREATE INDEX idx_pr_rebase_attempts_stale
+    ON pr_rebase_attempts(last_attempt_at);
+```
+
+### Composite indexes
+
+Column order matters. The index is a sorted tree; the leftmost column is the primary sort. Put the most selective (highest cardinality) column first, unless the access pattern always filters on a specific column.
+
+```sql
+-- Good: queries always filter on project, then narrow by crate_name and failure_type
+CREATE INDEX idx_corrective_outcomes_lookup
+    ON corrective_outcomes(project, crate_name, failure_type);
+
+-- The index above satisfies:
+--   WHERE project = ?                               (uses prefix)
+--   WHERE project = ? AND crate_name = ?            (uses prefix)
+--   WHERE project = ? AND crate_name = ? AND failure_type = ?  (full match)
+-- But NOT:
+--   WHERE crate_name = ?                            (skips prefix, no index use)
+```
+
+### Partial indexes (SQLite 3.8+, PostgreSQL)
+
+Index only the rows that matter. Reduces index size and write overhead.
+
+```sql
+-- Only index non-finished dispatches (the ones queries actually filter on)
+CREATE INDEX idx_dispatches_active
+    ON dispatches(status) WHERE status <> 'finished';
+
+-- Only index sessions with errors
+CREATE INDEX idx_sessions_errors
+    ON sessions(error_message) WHERE error_message IS NOT NULL;
+```
+
+Use partial indexes when:
+- A status column has one frequently queried value among many
+- Nullable columns are queried only for non-null rows
+- A small subset of rows dominates the query pattern
+
+### Covering indexes (SQLite 3.22+, PostgreSQL)
+
+A covering index includes all columns a query needs, avoiding the table lookup entirely. SQLite reads the index B-tree and never touches the main table.
+
+```sql
+-- If the common query is: SELECT project, completed_at FROM session_metadata WHERE project = ?
+CREATE INDEX idx_session_metadata_project_completed
+    ON session_metadata(project, completed_at);
+```
+
+The planner will use an index-only scan when all selected columns are in the index. Verify with `EXPLAIN QUERY PLAN` -- look for "USING COVERING INDEX".
+
+### SQLite-specific index behavior
+
+- `INTEGER PRIMARY KEY` is the rowid alias and is already the clustered index. Do not create a separate index on it.
+- `WITHOUT ROWID` tables use the PRIMARY KEY as the clustered index. Beneficial for composite-PK lookup tables.
+- SQLite has no `INCLUDE` clause for covering indexes (unlike PostgreSQL). To cover extra columns, add them to the index key.
+- `UNIQUE` constraints implicitly create indexes. Do not create redundant indexes on columns with UNIQUE constraints.
+- `REINDEX` rebuilds indexes after bulk inserts. Run it after initial data loads, not routinely.
+- `ANALYZE` populates the `sqlite_stat1` table that the query planner reads. Run after significant data changes so the planner has accurate statistics.
+
+### PostgreSQL-specific index features
+
+**INCLUDE clause** for covering indexes without affecting sort order:
+
+```sql
+CREATE INDEX idx_sessions_dispatch ON sessions(dispatch_id) INCLUDE (status, started_at);
+```
+
+**Expression indexes** for computed values:
+
+```sql
+CREATE INDEX idx_users_lower_email ON users (lower(email));
+```
+
+**GIN indexes** for jsonb, arrays, full-text search:
+
+```sql
+CREATE INDEX idx_events_tags ON events USING GIN (tags);
+```
+
+**BRIN indexes** for time-series and naturally ordered data:
+
+```sql
+CREATE INDEX idx_events_created_at ON events USING BRIN (created_at);
+```
+
+BRIN (Block Range INdex) stores min/max summaries per block of table pages. Extremely small (100-1000x smaller than B-tree) but only effective when physical row order correlates with index column order.
+
+| Index type | Best for | Size | Write overhead |
+|-----------|----------|------|----------------|
+| B-tree | Random access, range queries, any row ordering | Large | Moderate |
+| BRIN | Time-series, append-only, naturally ordered data | Tiny | Low |
+| GIN | jsonb containment, arrays, full-text search | Large | High |
+
+Use BRIN when:
+- Data is inserted roughly in order (timestamps, sequential IDs)
+- Table is large (>1M rows) and B-tree size is a concern
+- Queries filter on ranges, not exact values
+- Slight false-positive overhead is acceptable (BRIN eliminates blocks, not individual rows)
+
+Do NOT use BRIN when:
+- Row order does not correlate with column values (e.g., frequently updated status columns)
+- Point queries dominate (BRIN's block-level granularity wastes I/O)
+- Table is small (<100K rows) -- B-tree overhead is negligible
+
+**CONCURRENTLY** for zero-downtime index creation:
+
+```sql
+CREATE INDEX CONCURRENTLY idx_large_table_col ON large_table(col);
+```
+
+### Validating index effectiveness
+
+Always verify with the query planner before and after adding indexes.
+
+**SQLite:**
+
+```sql
+EXPLAIN QUERY PLAN SELECT ...;
+-- Look for: SEARCH ... USING INDEX (good)
+-- Watch for: SCAN TABLE (potential problem on large tables)
+```
+
+**PostgreSQL:**
+
+```sql
+EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT) SELECT ...;
+```
+
+Run 2-3 times to warm the cache before capturing the plan. See "Query plan analysis" section for interpretation.
+
 ---
 
 ## Query plan analysis
 
-Use `EXPLAIN ANALYZE` before optimizing. Intuition about query performance is unreliable.
+Use `EXPLAIN ANALYZE` (PostgreSQL) or `EXPLAIN QUERY PLAN` (SQLite) before optimizing. Intuition about query performance is unreliable.
 
-### What to look for (Priority order)
+### SQLite query plans
+
+`EXPLAIN QUERY PLAN` returns a tree of operations. Key terms:
+
+| Term | Meaning | Action |
+|------|---------|--------|
+| `SCAN TABLE` | Full table scan | Add index if table is large and query is selective |
+| `SEARCH ... USING INDEX` | Index lookup | Good -- verify it is the expected index |
+| `USING COVERING INDEX` | Index-only scan | Best case -- no table lookup needed |
+| `USE TEMP B-TREE` | Temporary sort | Consider adding an index to provide pre-sorted data |
+| `AUTOMATIC COVERING INDEX` | SQLite auto-created temp index | The planner thinks an index would help -- create a permanent one |
+
+SQLite does not have `EXPLAIN ANALYZE` with timing. Use `.timer on` in the CLI or measure from application code.
+
+### PostgreSQL query plans
+
+#### What to look for (Priority order)
 
 1. **Estimated vs actual rows**: the most important signal. If the planner estimates 10 rows but gets 100,000, every downstream decision is wrong. Fix: run `ANALYZE` to update statistics.
 2. **Seq Scan on large tables**: not always bad (small tables, high selectivity), but on >10K rows with a selective WHERE, investigate missing indexes.
@@ -199,14 +624,81 @@ Use `EXPLAIN ANALYZE` before optimizing. Intuition about query performance is un
 ### Conventions
 
 ```sql
--- Human reading (development)
+-- PostgreSQL: human reading (development)
 EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT) SELECT ...;
 
--- Production slow query logging
+-- PostgreSQL: production slow query logging
 -- Use auto_explain module with log_min_duration
+
+-- SQLite: query plan inspection
+EXPLAIN QUERY PLAN SELECT ...;
 ```
 
-Run the query 2-3 times to warm the cache before capturing the plan.
+---
+
+## Implicit casting gotchas
+
+SQL dialects handle type coercion differently. These differences cause silent data corruption or unexpected results when porting queries.
+
+### Integer division
+
+All three dialects truncate integer division (`SELECT 5 / 2` returns `2`). To get decimal results:
+
+```sql
+-- Portable: multiply by 1.0 to force float
+SELECT 5 * 1.0 / 2;                   -- 2.5 in all dialects
+
+-- PostgreSQL-only: cast syntax
+SELECT 5::numeric / 2;                -- 2.5
+
+-- Portable: explicit CAST
+SELECT CAST(5 AS REAL) / 2;           -- 2.5 (SQLite uses REAL, PostgreSQL uses numeric/float)
+```
+
+Use the multiply-by-1.0 pattern for portable code. The `::` cast operator is PostgreSQL-only.
+
+### Boolean handling
+
+| Dialect | Native boolean | Storage |
+|---------|---------------|---------|
+| PostgreSQL | Yes (`true`/`false`) | Native type |
+| SQLite | No | `INTEGER` (0/1) |
+| Redshift | No | `INTEGER` (0/1), use `CASE WHEN` |
+
+Portable pattern: store as `INTEGER` (0/1), compare with `= 1` / `= 0`, never rely on truthiness.
+
+### NULL in concatenation
+
+| Dialect | `'hello' \|\| NULL` | Behavior |
+|---------|---------------------|----------|
+| PostgreSQL | `NULL` | NULL propagates (SQL standard) |
+| SQLite | `'hello'` | NULL treated as empty string |
+
+Use `coalesce()` to make behavior explicit and portable:
+
+```sql
+SELECT 'hello' || coalesce(suffix, '') FROM ...;
+```
+
+### Type affinity (SQLite)
+
+SQLite uses type affinity, not strict types (unless STRICT mode). A `TEXT` column accepts integers, a `REAL` column accepts text. Comparisons between mismatched types use affinity rules that differ from PostgreSQL's strict type system.
+
+Defense: use STRICT tables (see § SQLite > STRICT tables). With STRICT, SQLite rejects type mismatches at insertion.
+
+### CAST portability
+
+| Syntax | PostgreSQL | SQLite | Redshift |
+|--------|-----------|--------|----------|
+| `CAST(x AS type)` | Yes | Yes | Yes |
+| `x::type` | Yes | No | No |
+| `TRY_CAST(x AS type)` | No | No | Yes (returns NULL on failure) |
+
+Rule: use `CAST()` for portable code. Use `::` only in PostgreSQL-specific contexts.
+
+For JSON casting specifically:
+- PostgreSQL: `value::jsonb` or `CAST(value AS jsonb)` -- both work, `::` is idiomatic
+- SQLite: no JSON cast -- use `json()` to validate and minify, `json_valid()` to check
 
 ---
 
@@ -227,79 +719,45 @@ Run the query 2-3 times to warm the cache before capturing the plan.
 
 ---
 
-## Dialect-Specific notes
+## SQLite
 
-### PostgreSQL
+Primary dialect for kanon. All tables use rusqlite via the phronesis crate.
 
-**Identity columns over SERIAL**: use `generated always as identity` for all new tables:
+### STRICT tables
 
-```sql
-CREATE TABLE sessions (
-    id integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    name text NOT NULL,
-    created_at timestamptz NOT NULL DEFAULT now()
-);
-```
-
-- SQL-standard (portable to DB2, Oracle)
-- Sequence tied to column in metadata (clean dumps, no orphaned sequences)
-- `generated always` prevents accidental manual inserts; `generated by default` allows them
-- SERIAL is legacy for PG >= 10
-
-**JSON_TABLE (PG17)**: converts JSON to relational rows in a `FROM` clause:
+All new tables must use STRICT mode. Enforces type checking and prevents silent data corruption from type mismatches.
 
 ```sql
-SELECT j.*
-FROM api_responses r,
-    json_table(
-        r.body, '$.items[*]'
-        COLUMNS (
-            id integer PATH '$.id',
-            name text PATH '$.name',
-            status text PATH '$.status'
-        )
-    ) AS j
-WHERE j.status = 'active'
-```
-
-Prefer `json_table` over chains of `json_extract_path` / `->>` for structured JSON.
-
-**MERGE with RETURNING (PG17):**
-
-```sql
-MERGE INTO inventory t
-USING incoming s ON t.sku = s.sku
-WHEN MATCHED THEN
-    UPDATE SET quantity = t.quantity + s.quantity
-WHEN NOT MATCHED THEN
-    INSERT (sku, quantity) VALUES (s.sku, s.quantity)
-RETURNING t.*;
-```
-
-### PostgreSQL / redshift
-
-- `dateadd()` not `interval` for date math (Redshift compatibility)
-- `convert_timezone('UTC', 'America/New_York', ts)` not `at time zone`
-- No native boolean in Redshift: `case when ... then 1 else 0 end`
-- Keep scripts under 30,000 characters (Redshift limit)
-- Redshift: `distkey` and `sortkey` on every table definition
-
-### SQLite
-
-**STRICT tables** for all new tables: enforces type checking:
-
-```sql
-CREATE TABLE sessions (
-    id integer PRIMARY KEY,
-    name text NOT NULL,
-    created_at text NOT NULL,
-    is_active integer NOT NULL DEFAULT 1
+CREATE TABLE IF NOT EXISTS sessions (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    is_active INTEGER NOT NULL DEFAULT 1
 ) STRICT;
 ```
 
-Combine with `without rowid` for composite primary key tables.
+Allowed types in STRICT mode: `INTEGER`, `REAL`, `TEXT`, `BLOB`, `ANY`. No `VARCHAR`, `BOOLEAN`, `DATETIME`.
 
-**UPSERT patterns:**
+Combine with `WITHOUT ROWID` for composite primary key tables where the PK is the natural lookup key.
+
+### Connection pragmas
+
+Configure on every new connection, in this order:
+
+```sql
+PRAGMA busy_timeout = 5000;    -- prevent SQLITE_BUSY on concurrent access
+PRAGMA journal_mode = WAL;     -- concurrent read/write
+PRAGMA synchronous = NORMAL;   -- safe with WAL, better throughput than FULL
+PRAGMA foreign_keys = ON;      -- enforce referential integrity (off by default)
+```
+
+`journal_mode=WAL` persists per-database (set once), but the others reset per-connection.
+
+### ID columns
+
+`INTEGER PRIMARY KEY` is the rowid alias. Use it for all single-column auto-incrementing keys. Do NOT use `AUTOINCREMENT` -- it adds overhead (tracking in `sqlite_sequence`) without benefit since `INTEGER PRIMARY KEY` already guarantees monotonically increasing IDs for inserts without explicit values.
+
+### UPSERT patterns
 
 ```sql
 -- Basic upsert: excluded.col refers to the would-have-been-inserted value
@@ -316,24 +774,74 @@ INSERT INTO counters (key, count) VALUES (?, 1)
 ON CONFLICT(key) DO UPDATE SET count = counters.count + 1;
 ```
 
-Prefer `do update` over `do nothing`: `do nothing` silently swallows data.
+Prefer `DO UPDATE` over `DO NOTHING`: `DO NOTHING` silently swallows data.
 
-**RETURNING clause** (3.35+): works on INSERT, UPDATE, DELETE:
+### RETURNING clause (3.35+)
+
+Works on INSERT, UPDATE, DELETE:
 
 ```sql
 INSERT INTO sessions (name) VALUES (?) RETURNING id, created_at;
 DELETE FROM sessions WHERE expired_at < ? RETURNING id;
 ```
 
-Caveat: with UPSERT `on conflict do nothing`, no row is returned when the conflict fires.
+Caveat: with UPSERT `ON CONFLICT DO NOTHING`, no row is returned when the conflict fires.
 
-**Other:**
-- `integer primary key` is the rowid alias: use it
-- `journal_mode=wal` for concurrent read/write (WAL2 does not exist in mainline SQLite)
+### Date/time handling
+
+SQLite has no native date type. Store as ISO 8601 TEXT (`2025-01-15T10:30:00Z`). This sorts correctly, is human-readable, and works with SQLite's built-in date functions (`date()`, `datetime()`, `strftime()`).
+
+For kanon: timestamps use RFC 3339 via jiff's `Timestamp::to_string()`.
+
+### Other
+
 - Parameterized queries always: never string interpolation
-- JSON functions available: `json()`, `json_extract()`, `->` / `->>`, `json_each()`, `json_group_array()`. Binary `jsonb_*` variants (3.45+) for better performance on large documents.
+- WAL2 does not exist in mainline SQLite -- do not reference it
 
-### Mneme datalog
+---
+
+## PostgreSQL
+
+### Identity columns over SERIAL
+
+Use `GENERATED ALWAYS AS IDENTITY` for all new tables:
+
+```sql
+CREATE TABLE sessions (
+    id integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+```
+
+- SQL-standard (portable to DB2, Oracle)
+- Sequence tied to column in metadata (clean dumps, no orphaned sequences)
+- `GENERATED ALWAYS` prevents accidental manual inserts; `GENERATED BY DEFAULT` allows them
+- SERIAL is legacy for PG >= 10
+
+### MERGE with RETURNING (PG17)
+
+```sql
+MERGE INTO inventory t
+USING incoming s ON t.sku = s.sku
+WHEN MATCHED THEN
+    UPDATE SET quantity = t.quantity + s.quantity
+WHEN NOT MATCHED THEN
+    INSERT (sku, quantity) VALUES (s.sku, s.quantity)
+RETURNING t.*;
+```
+
+### Redshift compatibility
+
+- `dateadd()` not `interval` for date math
+- `convert_timezone('UTC', 'America/New_York', ts)` not `AT TIME ZONE`
+- No native boolean: `CASE WHEN ... THEN 1 ELSE 0 END`
+- Keep scripts under 30,000 characters (Redshift limit)
+- `DISTKEY` and `SORTKEY` on every table definition
+
+---
+
+## Appendix: Mneme Datalog
 
 - Relations are the unit of storage. Rules are the unit of computation.
 - Atoms in rule bodies are positional: order maps to schema column order
@@ -346,7 +854,9 @@ Caveat: with UPSERT `on conflict do nothing`, no row is returned when the confli
 - HNSW vector indices integrate directly into Datalog queries with ad-hoc joins
 - Test rules with small fixture relations before running against production data
 
-### Room (Android)
+---
+
+## Appendix: Room (Android)
 
 - DAOs return `Flow<T>` for observable queries
 - Entity classes are data classes
@@ -357,19 +867,29 @@ Caveat: with UPSERT `on conflict do nothing`, no row is returned when the confli
 
 ## Anti-Patterns
 
-1. **`select *` in production queries**: name every column
-2. **Bare `left join` without thinking**: use inner join when both sides are required
+1. **`SELECT *` in production queries**: name every column
+2. **Bare `LEFT JOIN` without thinking**: use inner join when both sides are required
 3. **Division without `nullif`**: division by zero is always possible
 4. **Formatting in queries**: format at display layer, store raw values
 5. **Magic strings/dates**: parameterize or reference constants
 6. **CTE names like `cte1`, `temp`, `data`**: name must describe content
 7. **String interpolation in queries**: SQL injection. Parameterize always.
-8. **`!= null` instead of `is not null`**: SQL null semantics
+8. **`!= null` instead of `IS NOT NULL`**: SQL null semantics
 9. **Correlated subqueries where joins work**: performance trap
 10. **Missing indexes on join/filter columns**: check query plans
-11. **SERIAL in new PostgreSQL tables**: use `generated always as identity`
-12. **Non-STRICT SQLite tables**: use `strict` for type enforcement in new tables
+11. **SERIAL in new PostgreSQL tables**: use `GENERATED ALWAYS AS IDENTITY`
+12. **Non-STRICT SQLite tables**: use `STRICT` for type enforcement in new tables
 13. **Self-join for previous/next row**: use `lag()`/`lead()` window functions
-14. **Implicit window frame**: use explicit `rows between` for running aggregates. The default `range` frame produces unexpected results with duplicates.
-15. **Filtering on window function in same query**: window functions execute after `where`. Wrap in a CTE first.
-16. **Default isolation for read-then-write**: check-then-act patterns need `repeatable read` or higher, not `read committed`
+14. **Implicit window frame**: use explicit `ROWS BETWEEN` for running aggregates. The default `RANGE` frame produces unexpected results with duplicates.
+15. **Filtering on window function in same query**: window functions execute after `WHERE`. Wrap in a CTE first.
+16. **Default isolation for read-then-write**: check-then-act patterns need `REPEATABLE READ` or higher, not `READ COMMITTED`
+17. **JSON column without CHECK constraint**: use `CHECK (json_valid(col))` for defense in depth on JSON TEXT columns
+18. **Querying JSON for relational data**: if you regularly filter/join on a value inside JSON, extract it to a proper column
+19. **AUTOINCREMENT in SQLite**: use `INTEGER PRIMARY KEY` alone -- AUTOINCREMENT adds tracking overhead without benefit
+20. **Missing ANALYZE after bulk operations**: the query planner relies on `sqlite_stat1` statistics. Stale stats produce bad plans.
+21. **Redundant index on UNIQUE column**: UNIQUE constraints already create an implicit index
+22. **`::` cast in portable SQL**: use `CAST(x AS type)` for cross-dialect code; `::` is PostgreSQL-only
+23. **`->>` result used in arithmetic without cast**: `->>` returns text; cast explicitly before math (`(col ->> 'key')::integer`)
+24. **B-tree index on append-only timestamp column in large tables**: consider BRIN for 100-1000x smaller index with minimal query overhead
+25. **Advisory lock without documented ID mapping**: raw integer lock IDs become mystery constants; use `hashtext()` and document the mapping
+26. **Optimistic retry without version column**: `UPDATE ... WHERE id = ?` with no version check silently overwrites concurrent changes

--- a/standards/STANDARDS.md
+++ b/standards/STANDARDS.md
@@ -6,20 +6,26 @@
 
 | File | Scope |
 |------|-------|
-| **This file** | Universal principles: philosophy, comments, naming, errors, concurrency, config, testing, git, security, logging, writing, code review |
+| **This file** | Universal principles: philosophy, comments, naming, errors, concurrency, config, git, security, logging, observability contracts, writing, code review (testing → TESTING.md) |
 | REPO-SETUP.md | New project checklist: required files, directories, CI, Cargo.toml template, deny.toml baseline, verification script |
+| ENVIRONMENT.md | Environment variables, configuration files, secrets handling, feature flags, path resolution |
 | PLANNING.md | Project planning: phase structure, ROADMAP/STATE/PLAN/SUMMARY formats, lifecycle, migration |
 | RELEASES.md | Versioning policy, CHANGELOG format, release-please config, binary distribution, target matrix |
-| ARCHITECTURE.md | Dependency direction, crate boundaries, modularity, encapsulation, API surface rules |
+| ARCHITECTURE.md | Dependency direction, crate boundaries, modularity, encapsulation, API surface rules, feature flag propagation |
 | API.md | HTTP API design, request/response patterns, error responses, pagination, versioning |
-| CI.md | Required CI checks, workflow templates, merge gates, test sharding |
-| TESTING.md | Test naming, property tests, fuzz targets, mock patterns, test data policy, snapshot tests |
+| DEPLOYMENT.md | **Sole authority** for deployment: gates, merge policy, release timing, rollback, health check requirements, fleet management |
+| CI.md | CI tooling: which checks run, how they're configured, target matrices, test sharding, workflow generation |
+| TESTING.md | **Sole authority** for testing: principles, strategy, organization, coverage, test data, fuzz, benchmarks, property tests |
 | SECURITY.md | Credential handling, input validation, dependency audit, sandboxing, secret types |
-| OPERATIONS.md | Deployment, health checks, monitoring, runbooks, backup, hot reload |
-| PERFORMANCE.md | Resource budgets, benchmarks, profiling, binary size, build optimization |
-| STORAGE.md | Database patterns, migrations, SQLite configuration, backup, schema versioning |
+| OPERATIONS.md | Service-specific: runbooks, monitoring, backup, incident response, DNS, service management, observability |
+| PERFORMANCE.md | Resource budgets, benchmarks, profiling, binary size, build optimization, algorithmic complexity, regression detection |
+| SYSTEMD.md | Service units, timers, security hardening, resource limits, journald logging |
+| PODMAN.md | Pod architecture, container naming, volume mounts (SELinux), health checks, auto-update, systemd integration, rootless vs rootful, image pinning |
+| NGINX.md | Reverse proxy configuration, SSL/TLS, rate limiting, load balancing, security headers |
+| STORAGE.md | Database patterns, migrations, connection management, index rebuild, data versioning, consistency guarantees |
+| RESTIC.md | Restic backup: repository setup, operations, retention, restore, automation |
 | WRITING.md | Prose style, banned words, FK grade targeting, structural anti-patterns |
-| RUST.md | Rust-specific: edition, lints, error handling (snafu), async (tokio), dependencies, crate layout |
+| RUST.md | Rust-specific: edition, lints, snafu error enums, async (tokio), dependencies, crate layout |
 | PYTHON.md | Python-specific: uv, typing, async patterns |
 | TYPESCRIPT.md | TypeScript-specific: strict mode, framework patterns |
 | SHELL.md | Shell-specific: set -euo pipefail, quoting, portability |
@@ -29,6 +35,7 @@
 | KOTLIN.md | Kotlin-specific: coroutines, sealed classes |
 | CSHARP.md | C#-specific: async/await, nullable references |
 | CPP.md | C++-specific: smart pointers, RAII |
+| PROTOBUF.md | Proto3 schema design, gRPC patterns, JSON mapping, pagination, type wrappers, Rust codegen |
 
 ---
 
@@ -54,6 +61,12 @@ This applies at every level:
 - **Test fixtures**: mock providers, setup helpers, sample data. Shared test utilities module.
 - **Config defaults**: define in one place (config struct Default impl), reference from there. Never hardcode the same default in two files.
 
+**Derive, don't maintain.** If a value can be computed from a source of truth, compute it — don't store a copy that drifts. Rule exclusion lists derive from training data success rates. Blast radius derives from cargo metadata. Routing decisions derive from per-provider success rates. Planning docs derive from git history and issue trackers. Command documentation derives from `--help`, not static markdown. Every piece of manually maintained state that duplicates a computable fact is a bug waiting to diverge. The test: if the source of truth changes, does this value update automatically? If not, it's maintained, not derived, and it will go stale.
+
+This extends "define once" from code to state: configuration, documentation, dispatch routing, quality thresholds, and operational metrics should all trace back to a single authoritative source. When you find yourself writing the same information in two places, one of them should be a derivation of the other. If both are manual, build the derivation first, then delete the manual copy.
+
+**No workarounds.** If something is broken, fix it properly or log it as blocked and move on. Never build a workaround that becomes the permanent path. Each workaround hides the broken thing from attention, becomes load-bearing as other things depend on it, compounds as new workarounds stack on old ones, and makes the eventual fix harder. Silent failures are workarounds in disguise. If you can't fix it now, file an issue AND log a loud warning (log.error, not log.debug). The standard is: it gets built to the best standard we can, or it waits until we can. No stepping stones that become permanent.
+
 **No shortcuts.** Build the right thing from the start. If the SDK is better than the CLI wrapper, build the SDK. If the architecture needs three crates, build three crates. Don't ship a "quick version" you know you'll replace: time spent on throwaway work is stolen from the real thing. MVPs are for validating markets, not for code you're certain about.
 
 **Best tool for the job.** Every decision: language, library, architecture, data structure: is made on merit. No defaults by inertia. No "we've always done it this way." If the current tool is wrong, replace it. If a better option exists and the migration cost is justified, migrate. Comfort with a tool is not a reason to use it; fitness for the problem is.
@@ -63,6 +76,14 @@ This applies at every level:
 **Format at the boundary.** Percentages as decimals (0.42), currency as numbers, dates as timestamps internally. Format when rendering for display, not in queries or transforms.
 
 **Idempotent by design.** Operations that may be retried, replayed, or delivered more than once must produce the same result regardless of repetition. Use idempotency keys for API mutations. Design event handlers to tolerate duplicate delivery. Message processing, webhook handlers, and state transitions are the primary risk areas. If replaying an operation would corrupt state, the operation is broken.
+
+**Observability as contract.** If you can't see what a system is doing, you can't trust it to run without you. Every module must emit structured signals (logs, metrics, events) sufficient to diagnose failures without attaching a debugger. These emissions are not optional instrumentation: they are part of the module's public contract, with the same standing as its type signatures and error variants. Removing or changing an emitted event is a breaking change. Failing to emit a promised signal is a bug.
+
+This means:
+- **Async operations carry tracing spans.** Every `async fn` that performs I/O, crosses a process boundary, or takes more than trivial time is instrumented with a span that records its inputs, duration, and outcome. Correlation IDs propagate across span boundaries.
+- **Structured logging, not println.** All log output uses the structured logging framework (`tracing` in Rust, `loguru` in Python). No `println!`, no `eprintln!`, no `dbg!` in production paths. Structured fields enable machine parsing; interpolated strings do not.
+- **Long-running services expose health endpoints.** Any process that runs continuously (servers, workers, schedulers, stewards) exposes a health check that reports readiness and dependency status. A service that cannot report its own health is not production-ready.
+- **Modules document their observability contract.** Each module's doc comment includes the events it emits, the metrics it records, and the conditions under which each fires. Downstream consumers (dashboards, Vector pipelines, alert rules) depend on this contract. See § Logging and observability for the contract format.
 
 ---
 
@@ -226,7 +247,7 @@ Blank line between "set up" and "act" and between "act" and "return." No blank l
 | Timestamped files | `YYYYMMDD_description.ext` | `20260313_export.csv` |
 
 - `snake_case` for directories. No hyphens, no camelCase, no spaces.
-- Max 2–3 nesting levels inside any project. Flat > nested.
+- Max 2-3 nesting levels inside any project. Flat > nested.
 - No version numbers in filenames: version in file headers or git tags.
 
 ### Project structure
@@ -301,6 +322,14 @@ Every error must:
 - Use the language's error type: `Result`, exceptions, `sealed class` error hierarchies
 - Invalid data cannot exist past the point of construction
 
+### Exhaustive error types
+
+No catch-all error variants. `Other(String)`, `Unknown`, or `Unexpected` are escape hatches that erode type safety. Every error variant must represent a specific, matchable failure mode. If a new failure is possible, add a variant. If you have 30+ variants, consider whether a structured diagnostic (single struct with severity + message + trace) scales better than an enum.
+
+### Error boundaries
+
+Errors are converted at module and crate boundaries, propagated within them. When an error crosses a boundary, wrap it with context: what the callee was trying to do, not just what went wrong. The boundary layer translates implementation errors into domain errors. Internal errors never leak through public API surfaces.
+
 ### Resource lifecycle
 
 Acquired resources must have a defined cleanup path. Use RAII (`Drop` in Rust), `defer` (Go), `with`/context managers (Python), `using` (C#), `use` (Kotlin). Never rely on garbage collection or finalizers for resource cleanup. Database connections, file handles, and sockets are released as soon as work completes.
@@ -349,6 +378,16 @@ This project is maintained by a single developer with AI agents. Every design de
 - **Inject inward, never fetch.** Configuration values are pushed from the outermost layer (main, entry point) and injected into inner modules. Inner code receives config. It never reads environment variables or config files directly.
 - **Fail on invalid config at startup.** Validate all configuration during initialization with clear error messages. Don't discover bad config at 3 AM when the code path first executes.
 - **Sensible defaults for everything.** A fresh deployment with zero config should start, serve health, and explain what's missing. Not crash with a stack trace.
+
+### Policy and mechanism separation
+
+Behavioral parameters (thresholds, weights, timing, capacity limits, scoring coefficients) are **policy**. They belong in configuration. Code implements **mechanism** — how things work, not when/how-much/how-fast they trigger. If an agent or operator might reasonably want to tune a value, it is not a compile-time constant.
+
+- **Convention over configuration.** Every parameter has a default matching current behavior. Config only contains deviations. Zero-config deployments work identically to today.
+- **Single source of truth for defaults.** Every default value is defined exactly once: in a config struct `Default` impl or in `koina/defaults.rs`. Never duplicated across crates. CLI `default_value` attributes and scaffold templates reference the central definition, not a string literal.
+- **Three-tier classification.** (1) `const` — mathematical/algorithmic invariants that never change (nonce length, hash digest size). (2) Deployment-tunable — `aletheia.toml` values the operator sets per installation. (3) Per-agent-tunable — values agents adjust within operator-set bounds.
+- **Hot vs cold.** Every deployment-tunable parameter is classified as hot-reloadable (SIGHUP applies immediately) or cold (requires restart). See `taxis::reload::RESTART_PREFIXES`. Cold parameters: port bindings, TLS certs, auth mode, storage paths. Everything else is hot.
+- **Cross-parameter validation.** `taxis::validate` enforces that parameter combinations are valid at config load, not discovered at runtime.
 
 ### Deployment
 
@@ -440,55 +479,7 @@ Before writing anything (doc, config, code), ask:
 
 ## Testing
 
-### Behavior over implementation
-
-Test what the code **does**, not how it does it. If a refactor breaks your tests but doesn't break behavior, your tests are wrong.
-
-- One logical assertion per test
-- Descriptive names: `returns_empty_when_session_has_no_turns`, not `test_add` or `it_works`
-- Same-directory test files (colocated with source, not in a separate tree)
-
-### Property-Based testing
-
-Use property tests for:
-- Serialization round-trips (`deserialize(serialize(x)) == x`)
-- Algebraic properties (commutativity, associativity, idempotency)
-- State machine invariants
-- Edge case discovery at scale
-
-Example tests document expected behavior. Property tests catch the unexpected.
-
-### What to test
-
-Focus testing effort on behavior with consequences:
-- Boundary conditions (empty, one, many, max, overflow)
-- Error paths (invalid input, unavailable service, timeout, permission denied)
-- State transitions (especially concurrent access to shared state)
-- Serialization round-trips (`deserialize(serialize(x)) == x`)
-- Idempotency (replaying the same operation produces the same result)
-- Security boundaries (authentication, authorization, input validation)
-
-### No coverage targets
-
-Coverage is a vanity metric. Test the behavior that matters. Untested code should be deliberately untested (generated, or unreachable), not accidentally missed.
-
-### Test data policy
-
-All test data must be synthetic. No real personal information in test fixtures, assertions, or examples.
-
-**Standard test identities:**
-- Users: `alice`, `bob`, `charlie`
-- Emails: `alice@example.com`, `bob@example.org` (RFC 2606 reserved domains only)
-- Phones: `+1-555-0100` through `+1-555-0199` (ITU reserved for fiction)
-- IPs: `192.0.2.x`, `198.51.100.x`, `203.0.113.x` (RFC 5737 documentation ranges)
-- IPv6: `2001:db8::/32` (RFC 3849 documentation range)
-- Domains: `example.com`, `example.org`, `example.net`, `*.test` (RFC 2606/6761 reserved)
-
-**Never use:** real names, emails, usernames, internal IPs/hostnames, personal facts, credentials, or API keys. Never copy production data into test environments.
-
-**Test data builders:** Use builder/factory patterns with sensible defaults. Each test overrides only the fields it cares about. When a field is added to the struct, only the builder default needs updating: not every test.
-
-**Determinism:** Any randomized test data must be seeded. The seed must be logged or persisted. Proptest regression files, hypothesis databases, and equivalent fixtures are checked into version control.
+See TESTING.md — sole authority for testing principles, strategy, organization, coverage, test data policy, and quality expectations.
 
 ---
 
@@ -675,6 +666,83 @@ Access control fails closed. If authorization state is unknown or ambiguous, den
 - Routine success on hot paths (every request succeeded, every query returned)
 - Full request/response bodies at info level (use debug)
 - Redundant messages (logging both the throw and the catch of the same error)
+
+### Observability contracts
+
+Each module documents its observability emissions in its module-level doc comment. This is a contract: downstream consumers (Vector pipelines, GreptimeDB dashboards, alert rules, test assertions) depend on these signals existing with these names and fields.
+
+**Contract format:**
+
+```rust
+//! # Observability
+//!
+//! ## Events
+//! | Event | Level | Fields | Condition |
+//! |-------|-------|--------|-----------|
+//! | `prompt.dispatched` | info | `prompt_id`, `provider`, `project` | Prompt sent to worker |
+//! | `prompt.completed` | info | `prompt_id`, `duration_ms`, `outcome` | Worker returns result |
+//! | `prompt.failed` | error | `prompt_id`, `error`, `retries` | All retries exhausted |
+//!
+//! ## Metrics
+//! | Metric | Type | Labels | Condition |
+//! |--------|------|--------|-----------|
+//! | `dispatch.queue_depth` | gauge | `project` | Per scheduling cycle |
+//! | `dispatch.latency_ms` | histogram | `provider`, `outcome` | Per prompt completion |
+//!
+//! ## Spans
+//! | Span | Fields | Wraps |
+//! |------|--------|-------|
+//! | `dispatch_prompt` | `prompt_id`, `provider` | Full dispatch lifecycle |
+//! | `run_gate` | `prompt_id`, `gate_name` | Single gate check |
+```
+
+**Rules:**
+
+- Events use `noun.verb` naming: `prompt.dispatched`, `gate.passed`, `worktree.created`.
+- Metrics use `namespace.snake_case` naming: `dispatch.queue_depth`, `gate.pass_rate`.
+- Every event listed in the contract must have a corresponding `tracing` call in the module's code. A contract entry without an emission is a failing lint check.
+- Every `tracing::info!` or `tracing::error!` call in a module should appear in that module's contract. An emission without a contract entry is undocumented behavior.
+- Changing event names, removing fields, or altering emission conditions is a breaking change. Add new events freely; modify or remove through deprecation.
+- Span names are stable identifiers. Renaming a span breaks any downstream query that references it.
+
+### Tracing instrumentation
+
+**Spans on async operations:**
+
+```rust
+#[tracing::instrument(skip(self), fields(prompt_id = %prompt.id, provider = %provider))]
+async fn dispatch_prompt(&self, prompt: &Prompt, provider: &str) -> Result<Outcome> {
+    // span auto-records duration and outcome
+}
+```
+
+**Structured event emission:**
+
+```rust
+// WHY: Structured fields enable Vector/GreptimeDB pipeline parsing.
+// Interpolated strings require regex extraction downstream.
+tracing::info!(
+    prompt_id = %prompt.id,
+    provider = %provider,
+    duration_ms = elapsed.as_millis(),
+    outcome = %outcome,
+    "prompt.completed"
+);
+```
+
+**Health endpoints for long-running services:**
+
+```rust
+async fn health_check(&self) -> HealthStatus {
+    HealthStatus {
+        ready: self.is_ready(),
+        dependencies: vec![
+            ("database", self.db.ping().await.is_ok()),
+            ("queue", self.queue.is_connected()),
+        ],
+    }
+}
+```
 
 ---
 

--- a/standards/STORAGE.md
+++ b/standards/STORAGE.md
@@ -1,6 +1,6 @@
 # Storage
 
-> Standards for database access, migrations, connection management, and data integrity. Applies to any persistent storage layer.
+> Standards for database access, migrations, connection management, data integrity, index rebuild, versioning, and consistency guarantees. Applies to any persistent storage layer.
 
 ---
 
@@ -108,15 +108,187 @@ If an index can diverge from its source (e.g., search index vs database), the sy
 
 ---
 
+## Index rebuild
+
+WHY: Indices are derived state. Any derived state can diverge from its source. A system that cannot rebuild its indices from source data is a system that cannot recover from corruption.
+
+### Rebuild from source of truth
+
+Every index must be rebuildable from the authoritative data it indexes. The rebuild path is a first-class operation, not an emergency procedure. Test it regularly, not just when things break.
+
+Requirements:
+- **Documented command or function**: a single invocation rebuilds the index from scratch. No multi-step runbooks with manual SQL.
+- **Idempotent**: running rebuild twice produces the same result. Partial rebuilds from a crashed previous attempt do not corrupt the index.
+- **Progress reporting**: rebuilds on large datasets emit structured progress events (records processed, estimated time remaining). A rebuild that runs silently for hours is indistinguishable from a hang.
+
+### Incremental vs full rebuild
+
+Prefer incremental rebuild (process only changed records) for routine maintenance. Require full rebuild capability for corruption recovery.
+
+Incremental rebuild tracks a high-water mark (timestamp, sequence number, or change-data-capture cursor). The high-water mark is stored alongside the index, not in the source data. WHY: if the index is lost, the high-water mark should be lost too, triggering a full rebuild.
+
+### Rebuild without downtime
+
+Rebuild into a shadow copy, then swap atomically. Never rebuild in place on a live index.
+
+Pattern:
+1. Create new index alongside the live one
+2. Populate from source data
+3. Atomic swap (rename, pointer update, or config toggle)
+4. Verify the new index serves correct results
+5. Drop the old index
+
+WHY: in-place rebuild means queries hit a partially-built index during the rebuild window. Users see missing results and blame the search, not the rebuild.
+
+### Scheduled validation
+
+Run index-vs-source consistency checks on a schedule, not just on suspicion. The check compares record counts and samples random records for presence in the index. Log divergence as an error, not a warning. WHY: silent index drift is a recall failure that no user will report because they don't know what they're not seeing.
+
+### Rebuild vs repair
+
+When an index is suspected corrupt, choose rebuild over repair. Repair assumes the existing structure is mostly correct and patches specific entries. Rebuild assumes nothing and reconstructs from source.
+
+Use repair only when the corruption is localized and the repair tool can prove completeness (e.g., SQLite `REINDEX` on a single table with a known constraint violation). For custom indices (search, vector, graph), always rebuild from source.
+
+WHY: repair tools operate on the index's own data structures. If those structures are corrupt in a way the repair tool does not detect, the "repaired" index silently returns wrong results. Rebuild uses the source of truth, bypassing the corrupted structures entirely.
+
+### Validation after rebuild
+
+After every rebuild, verify the result before swapping it into service:
+- **Record count**: total records in the new index matches the source
+- **Sample verification**: random sample of records present and correct in the new index
+- **Known-answer queries**: a set of queries with known expected results returns those results against the new index
+- **Performance bounds**: query latency and memory footprint are within expected ranges for the dataset size
+
+Automated validation runs as part of the rebuild pipeline, not as a manual step. If validation fails, the rebuild is discarded and the previous index remains in service.
+
+WHY: a rebuild that completes without error is not the same as a rebuild that produced correct results. Embedding model bugs, truncated source data, and configuration drift can all produce a "successful" rebuild of a wrong index.
+
+### Rollback strategy
+
+The previous index version is retained until the new index is validated and serving correctly.
+
+Requirements:
+- **Retain the previous index** for at least one full validation cycle after cutover
+- **Store index metadata** alongside the index files: source data version, embedding model version, build timestamp, record count
+- **Rollback is an atomic swap** back to the previous index, using the same mechanism as the cutover (see § Rebuild without downtime)
+
+Never delete the previous index as part of the cutover step. Deletion is a separate operation that runs after the new index has been validated in production.
+
+WHY: if the new index passes automated validation but fails on real query patterns (distribution shift, edge cases not in the validation set), the only recovery is to swap back. Deleting the previous index during cutover turns a recoverable situation into an outage.
+
+---
+
+## Data versioning
+
+WHY: Data changes over time. Without versioning, you cannot answer "what did this record look like yesterday?" and you cannot safely roll back a bad data migration.
+
+### Schema versioning
+
+Schema versions are monotonic integers, tracked in the migration table (see § Migrations). The current schema version is queryable at runtime. Health checks and startup logs include the schema version. WHY: when debugging a production issue, the first question is "what schema is this instance running?" If you have to check migration history to answer that, you've already lost time.
+
+### Record-level versioning
+
+For data that supports concurrent or historical access, each record carries:
+- **version**: monotonic integer, incremented on every write
+- **updated_at**: timestamp of last modification
+
+Optimistic concurrency uses the version field: UPDATE ... WHERE version = $expected_version. If no rows are affected, the record was modified since the caller last read it. Fail explicitly; do not silently overwrite.
+
+WHY: last-write-wins is acceptable only when every writer has full context. In systems with multiple agents, API callers, or background jobs, last-write-wins silently destroys data.
+
+### Append-only history (when warranted)
+
+For audit-critical data (configuration changes, access grants, scoring decisions), use an append-only history table alongside the current-state table. The history table records every version of the record with the actor, timestamp, and change reason.
+
+Do not use this pattern for high-volume operational data (metrics, logs, vector embeddings). WHY: history tables on hot-path data become the largest table in the database and the slowest to query. Use time-series storage for that.
+
+### Migration versioning
+
+Data migrations (backfills, transformations) are versioned alongside schema migrations. A data migration that runs outside the migration framework is invisible to the next operator. Record:
+- What changed (table, column, transformation)
+- How many records were affected
+- Whether it is re-runnable
+
+### Index versioning
+
+When the embedding model, tokenizer, or similarity metric changes, the existing index is incompatible with new vectors. The index must be rebuilt, but the old index must continue serving until the new one is ready.
+
+WHY: embedding model changes produce vectors in a different space. Querying a v1 index with v2 vectors returns meaningless results. This is not gradual degradation — it is a complete failure that looks like "search is broken."
+
+Version strategy:
+- **Version prefix**: each index is namespaced by its model version (e.g., `v1/`, `v2/`). The version identifier includes the model name, model version, and any parameters that affect the embedding space (dimensionality, distance metric).
+- **Parallel build**: the new index is built alongside the live one. Source data is re-embedded with the new model and indexed into the new version namespace. The old index continues serving all queries during this process.
+- **Atomic cutover**: once the new index is fully built and validated (see § Validation after rebuild), switch the query path to the new version. The old index remains available for rollback.
+- **Stale version cleanup**: remove old index versions only after the new version has been validated in production for a defined retention period. Never remove the immediately previous version.
+
+Record the active index version in a metadata store. Health checks and startup logs include the index version. WHY: when recall degrades, the first diagnostic question is "which embedding model is this index built from?" If the answer requires inspecting index files, you have already lost time.
+
+---
+
+## Consistency guarantees
+
+WHY: Every storage system makes tradeoffs between consistency, availability, and performance. Document what your system actually guarantees so that callers don't assume stronger semantics than they get.
+
+### Document the guarantee
+
+Every storage layer's module-level documentation states its consistency model explicitly:
+- **Strict serializable**: all operations appear to execute in a single total order consistent with real time. State this only if you enforce it.
+- **Serializable**: all operations appear to execute in some total order (but not necessarily real-time order).
+- **Read-committed**: reads see only committed data, but two reads in the same transaction may see different snapshots.
+- **Eventual**: writes propagate asynchronously. Readers may see stale data for a bounded (documented) window.
+
+Do not claim stronger guarantees than you enforce. A system documented as "eventual" that actually provides serializable is fine. The reverse is a latent data corruption bug.
+
+### Cross-store consistency
+
+When data spans multiple stores (e.g., metadata in SQLite, vectors in a vector index, files on disk), document which store is the source of truth and what happens when they disagree.
+
+Rules:
+- **One source of truth per datum.** If a fact exists in two stores, one is authoritative and the other is derived. Document which is which.
+- **Detect divergence.** Periodic consistency checks compare derived stores against the source of truth. Log divergence as an error.
+- **Resolve toward the source of truth.** When divergence is detected, the derived store is rebuilt from the source, never the reverse. WHY: resolving toward the derived store means a corrupted index can corrupt the source data.
+
+### Write ordering
+
+Operations that must be visible together are written in a single transaction. If the stores do not share a transaction boundary (cross-database, database-plus-filesystem), use a two-phase approach:
+1. Write to the source of truth first
+2. Write to derived stores
+3. If step 2 fails, the record is in the source but missing from derived stores -- a state the rebuild mechanism (§ Index rebuild) can repair
+
+Never write to derived stores first. WHY: a record in the index but not in the database is worse than a record in the database but not in the index. The first is a dangling reference that causes errors; the second is a recall gap that the next rebuild fixes.
+
+### Crash consistency
+
+If the process crashes mid-operation, the storage system must recover to a consistent state on restart. This means:
+- **SQLite**: WAL mode with `PRAGMA journal_mode=wal`. Recovery is automatic on next open.
+- **File-based stores**: write-to-temp, fsync, rename. Never overwrite in place (see § Atomic persistence).
+- **Multi-file state**: use a manifest or write-ahead log to track which files constitute a consistent snapshot. On startup, verify the manifest and discard incomplete writes.
+
+### Replica consistency
+
+When indices are replicated across nodes or processes, document the replication model and its consistency bounds.
+
+WHY: a replicated index that claims to be "consistent" but actually has a 30-second propagation window will produce different results depending on which replica serves the query. Callers that assume strong consistency will build logic that intermittently fails.
+
+Rules:
+- **Document the consistency window.** State the maximum time between a write to the source and its visibility in all replicas. If the window is unbounded, state that explicitly — "eventually consistent with no upper bound" is a valid model, but callers must know.
+- **Read-after-write guarantee.** If a caller writes a record and immediately queries for it, define whether the query is guaranteed to see the write. If not, document the pattern callers should use (e.g., read from the primary, not from replicas, for read-after-write scenarios). Never silently serve stale reads after a write the caller just performed.
+- **Conflict resolution.** When replicas can accept writes independently (multi-primary, partitioned writes), define the conflict resolution strategy:
+  - **Last-write-wins (LWW)**: acceptable only when writes carry full state, not deltas. Document the clock source (wall clock, logical clock, hybrid).
+  - **Source-of-truth wins**: one replica is authoritative. Conflicts resolve by overwriting non-authoritative replicas from the source. This is the default for derived indices (see § Cross-store consistency).
+  - **Application-level merge**: conflicts are surfaced to the application for resolution. Use this only when automatic resolution would lose data.
+- **Replica lag monitoring.** Emit a metric for replication lag (time or sequence distance between primary and each replica). Alert when lag exceeds the documented consistency window. WHY: a consistency guarantee without monitoring is a hope, not a guarantee.
+
+---
+
 ## Error handling
+
+See STANDARDS.md § Error Handling for universal principles.
 
 ### is_transient()
 
 Database errors classify as transient (retry-safe) or permanent (don't retry). Connection drops, lock timeouts, and temporary unavailability are transient. Constraint violations, type mismatches, and syntax errors are permanent.
-
-### Context at boundary
-
-When a database error crosses a module boundary, wrap it with context: what operation was attempted, on what data, for what purpose. Raw "SQLITE_BUSY" helps nobody.
 
 ---
 

--- a/standards/SYSCTL.md
+++ b/standards/SYSCTL.md
@@ -1,0 +1,157 @@
+# Sysctl
+
+> Standards for Linux kernel sysctl configuration files (`/etc/sysctl.d/*.conf`, `/etc/sysctl.conf`).
+> Covers naming, security baselines, validation, and documentation.
+
+---
+
+## File locations
+
+- `/etc/sysctl.d/*.conf` - preferred location for drop-in configurations
+- `/etc/sysctl.conf` - legacy single file (avoid for new settings)
+
+## Naming
+
+Files in `/etc/sysctl.d/` must use the `NN-name.conf` convention:
+
+```
+/etc/sysctl.d/
+├── 10-console-messages.conf
+├── 50-security-hardening.conf
+└── 99-custom.conf
+```
+
+The numeric prefix controls load order. Lower numbers load first. Later files can override earlier ones.
+
+---
+
+## Format
+
+One parameter per line:
+
+```
+# WHY: Prevent SYN flood attacks by enabling TCP syncookies.
+net.ipv4.tcp_syncookies = 1
+```
+
+- Parameter path on the left, value on the right
+- Dots separate namespaces (`net.ipv4.tcp_syncookies`)
+- Values are numeric (integers or booleans as `0`/`1`)
+- Empty lines are ignored
+- Comments start with `#`
+
+---
+
+## Security baselines
+
+These parameters should be explicitly set in every security-hardening profile:
+
+| Parameter | Safe value | Rationale |
+|-----------|-----------|-----------|
+| `net.ipv4.tcp_syncookies` | `1` | Mitigate SYN flood DoS |
+| `fs.protected_symlinks` | `1` | Prevent symlink TOCTOU attacks |
+| `fs.protected_hardlinks` | `1` | Prevent hardlink privilege escalation |
+| `kernel.yama.ptrace_scope` | `1` or `2` | Restrict cross-process ptrace |
+| `kernel.kptr_restrict` | `1` or `2` | Hide kernel pointer addresses |
+| `net.ipv4.conf.all.send_redirects` | `0` | Disable ICMP redirect sending |
+| `net.ipv4.conf.default.send_redirects` | `0` | Disable ICMP redirect sending |
+| `net.ipv4.conf.all.accept_redirects` | `0` | Ignore ICMP redirect messages |
+| `net.ipv4.conf.default.accept_redirects` | `0` | Ignore ICMP redirect messages |
+| `net.ipv4.conf.all.log_martians` | `1` | Log spoofed, source-routed, or redirect packets |
+
+### Network coherence
+
+Redirect settings must be consistent across `all` and `default` interfaces:
+
+```
+# WHY: Ensure new and existing interfaces share the same redirect policy.
+net.ipv4.conf.all.accept_redirects = 0
+net.ipv4.conf.default.accept_redirects = 0
+```
+
+Setting one without the other is likely a mistake.
+
+### Filesystem protection
+
+`fs.protected_*` parameters must not be `0` on production systems:
+
+```
+fs.protected_symlinks = 1
+fs.protected_hardlinks = 1
+fs.protected_regular = 2
+```
+
+---
+
+## Validation
+
+### Boolean parameters
+
+Parameters that are semantically boolean must use exactly `0` or `1`:
+
+```
+# Correct
+net.ipv4.ip_forward = 0
+
+# Wrong
+net.ipv4.ip_forward = no
+net.ipv4.ip_forward = off
+```
+
+### Value ranges
+
+Parameters with documented kernel ranges must stay within them. Common ranges:
+
+| Parameter | Valid range |
+|-----------|-------------|
+| `kernel.yama.ptrace_scope` | `0` - `2` |
+| `kernel.kptr_restrict` | `0` - `2` |
+| `fs.protected_regular` | `0` - `2` |
+
+### Duplicate parameters
+
+The same parameter must not appear more than once in a single file. The kernel applies the last value, but duplicates usually indicate a copy-paste error.
+
+### Deprecated parameters
+
+Avoid parameters removed in modern kernels. Examples:
+- `kernel.exec-shield` (removed in Linux 5.7+)
+
+---
+
+## Comments
+
+Non-obvious parameters must have a structured `WHY` comment on the preceding line:
+
+```
+# WHY: SYN cookies trade cryptographic strength for DoS resilience.
+net.ipv4.tcp_syncookies = 1
+```
+
+Allowed tags follow the universal convention: `WHY`, `WARNING`, `NOTE`, `PERF`, `SAFETY`, `INVARIANT`, `TODO(#NNN)`, `FIXME(#NNN)`.
+
+---
+
+## Anti-patterns
+
+| Anti-pattern | Problem | Fix |
+|-------------|---------|-----|
+| `sysctl.d` file without numeric prefix | Load order is undefined | Rename to `NN-name.conf` |
+| Missing `tcp_syncookies` | Vulnerable to SYN floods | Add `net.ipv4.tcp_syncookies = 1` |
+| `send_redirects = 1` | Enables routing redirect abuse | Set to `0` |
+| `accept_redirects = 1` | Accepts routing redirect abuse | Set to `0` |
+| `log_martians = 0` | Silent packet anomalies | Set to `1` |
+| Duplicate parameter in same file | Later value silently wins | Remove duplicate |
+| Boolean as `yes`/`no` | Kernel expects `0`/`1` | Use numeric booleans |
+| Security parameter without comment | Rationale is lost | Add `WHY:` comment |
+| Inconsistent `all`/`default` values | New interfaces behave differently | Set both |
+
+---
+
+## Cross-references
+
+| Topic | Standard | Rules |
+|-------|----------|-------|
+| General comment conventions | STANDARDS.md | -- |
+| Security principles | SECURITY.md | -- |
+| Operations deployment | OPERATIONS.md | -- |

--- a/standards/SYSTEMD.md
+++ b/standards/SYSTEMD.md
@@ -1,0 +1,482 @@
+# Systemd
+
+> Additive to STANDARDS.md and OPERATIONS.md. Read those first. Everything here is systemd-specific.
+>
+> Covers: service units, timer units, security hardening, resource limits, journald logging, socket activation.
+>
+> **Key decisions:** service files in `config/systemd/`, `Type=notify` with sd-notify, `Restart=on-failure`, `DynamicUser=yes` where possible, hardening by default, structured JSON logging to journald.
+
+---
+
+## Service file structure
+
+### Location
+
+Service files live in `config/systemd/` at the project root. Copy or symlink to `/etc/systemd/system/` during deployment.
+
+```
+config/
+  systemd/
+    myapp.service
+    myapp.timer
+    myapp.socket
+```
+
+### Naming
+
+| File | Convention | Example |
+|------|------------|---------|
+| Service unit | `kebab-case.service` | `kanon-dispatcher.service` |
+| Timer unit | `kebab-case.timer` | `kanon-backup.timer` |
+| Socket unit | `kebab-case.socket` | `kanon-api.socket` |
+
+### Minimal service template
+
+```ini
+[Unit]
+Description=My Application
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=notify
+ExecStart=/usr/local/bin/myapp serve
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=5s
+
+# Security
+DynamicUser=yes
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+ReadWritePaths=/var/lib/myapp
+
+# Resource limits
+MemoryMax=512M
+TasksMax=100
+
+# Environment
+Environment="RUST_LOG=info"
+Environment="RUST_BACKTRACE=1"
+EnvironmentFile=-/etc/default/myapp
+
+[Install]
+WantedBy=multi-user.target
+```
+
+---
+
+## Service types
+
+| Type | Use | When |
+|------|-----|------|
+| `simple` | Foreground process, no readiness signal | Default for most services |
+| `notify` | Service signals readiness via sd-notify | **Preferred**: enables proper dependency ordering |
+| `exec` | Like simple, but waits for exec() | When you need fork safety |
+| `oneshot` | Single-shot commands | Migrations, initialization tasks |
+| `dbus` | D-Bus activated | Services exposing D-Bus interfaces |
+
+### Type=notify implementation
+
+Use the `sd-notify` protocol to signal readiness and watchdog keepalives:
+
+```rust
+// Rust with sd-notify crate or manual implementation
+use std::os::unix::net::UnixDatagram;
+use std::env;
+
+fn notify_ready() {
+    if let Some(notify_socket) = env::var_os("NOTIFY_SOCKET") {
+        let socket = UnixDatagram::unbound().ok()?;
+        let _ = socket.send_to(b"READY=1\n", notify_socket);
+    }
+}
+```
+
+Services must signal `READY=1` before systemd considers dependencies satisfied. Critical for services that other units depend on.
+
+---
+
+## Security hardening
+
+Apply hardening by default. Remove only when the service genuinely requires the capability.
+
+### Essential options (apply to all services)
+
+```ini
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+```
+
+### Capability bounding
+
+```ini
+# Drop all capabilities, add only what's needed
+CapabilityBoundingSet=
+AmbientCapabilities=
+
+# Example: needs to bind low ports
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+```
+
+### Namespace isolation
+
+```ini
+# Run as dynamic user (no system user needed)
+DynamicUser=yes
+
+# Or explicit user/group
+User=myapp
+Group=myapp
+
+# Private directories
+PrivateTmp=yes
+PrivateDevices=yes
+PrivateUsers=yes
+```
+
+### Filesystem restrictions
+
+```ini
+ProtectSystem=strict      # Read-only root filesystem
+ProtectHome=yes           # No access to /home
+ReadWritePaths=/var/lib/myapp /var/log/myapp
+ReadOnlyPaths=/etc/myapp
+InaccessiblePaths=/proc/sys /sys
+```
+
+### Network restrictions
+
+```ini
+# Fully isolated
+PrivateNetwork=yes
+
+# Or restrict to specific addresses
+IPAddressDeny=any
+IPAddressAllow=10.0.0.0/8
+IPAddressAllow=127.0.0.1
+
+# Disable specific protocols
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+```
+
+### System call filtering
+
+```ini
+# Allow only common safe syscalls (recommended)
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+
+# Or allowlist specific syscalls
+SystemCallFilter=~@mount @privileged @debug @cpu-emulation
+```
+
+---
+
+## Resource management
+
+### Memory limits
+
+```ini
+MemoryMax=512M            # Hard limit: OOM kill if exceeded
+MemoryHigh=400M           # Soft limit: throttle before hard limit
+MemorySwapMax=0           # Disable swap usage
+```
+
+### CPU limits
+
+```ini
+CPUQuota=80%              # Max 80% of one core
+CPUWeight=100             # 1-10000, default 100
+AllowedCPUs=0-3           # Pin to specific cores
+```
+
+### Task limits
+
+```ini
+TasksMax=100              # Prevent fork bombs
+LimitNOFILE=65536         # File descriptor limit
+LimitNPROC=100            # Max processes
+```
+
+### I/O limits
+
+```ini
+IOWeight=100              # 1-10000, default 100
+IOReadBandwidthMax=/var 10M
+IOWriteBandwidthMax=/var 10M
+```
+
+---
+
+## Restart and failure policies
+
+### Restart configuration
+
+```ini
+Restart=on-failure        # Restart on non-zero exit, unclean signal, timeout, watchdog
+RestartSec=5s             # Wait before restart
+StartLimitInterval=60s    # Time window for start limit
+StartLimitBurst=3         # Max starts within interval
+```
+
+| Restart value | Behavior |
+|---------------|----------|
+| `no` | Never restart |
+| `on-success` | Restart on clean exit (0) |
+| `on-failure` | **Default**: Restart on unclean exit |
+| `on-abnormal` | Restart on signal/timeout/watchdog |
+| `on-abort` | Restart on unclean signal |
+| `always` | Always restart |
+
+### Failure escalation
+
+```ini
+[Unit]
+OnFailure=failure-handler@%n.service
+
+[Service]
+Restart=on-failure
+RestartSec=10s
+StartLimitInterval=300s
+StartLimitBurst=5
+```
+
+Create `failure-handler@.service` to handle failures (alerts, cleanup, etc.).
+
+---
+
+## Logging
+
+### Journald integration
+
+Services log structured data to stderr/stdout. Journald captures and enriches:
+
+```ini
+[Service]
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=myapp
+```
+
+### Structured logging from Rust
+
+```rust
+// tracing-journald for native structured logging
+tracing_subscriber::fmt()
+    .json()
+    .with_writer(std::io::stderr)
+    .init();
+```
+
+### Log filtering
+
+```ini
+Environment="RUST_LOG=info,myapp=debug"
+```
+
+### Journald persistence
+
+```bash
+# /etc/systemd/journald.conf
+[Journal]
+Storage=persistent
+SystemMaxUse=500M
+MaxFileSec=1week
+```
+
+### Querying logs
+
+```bash
+journalctl -u myapp.service -f                    # Follow
+journalctl -u myapp.service --since "1 hour ago"  # Time range
+journalctl -u myapp.service -p err                # Errors only
+journalctl --user -u myapp.service                # User service
+```
+
+---
+
+## Timer units (cron replacement)
+
+Prefer systemd timers over cron for:
+- Dependency ordering (timer triggers service after dependencies)
+- Logging (all output in journal)
+- Resource control (inherits service limits)
+- Failure handling (restart policies apply)
+
+### Timer template
+
+```ini
+# myapp-backup.timer
+[Unit]
+Description=MyApp backup timer
+
+[Timer]
+OnCalendar=daily
+Persistent=true              # Run immediately if missed
+RandomizedDelaySec=1hour     # Spread load
+
+[Install]
+WantedBy=timers.target
+```
+
+```ini
+# myapp-backup.service
+[Unit]
+Description=MyApp backup
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/myapp backup
+User=myapp
+```
+
+### Calendar syntax
+
+| Expression | Meaning |
+|------------|---------|
+| `daily` | Every midnight |
+| `hourly` | Every hour |
+| `weekly` | Monday 00:00 |
+| `*:*:00` | Every minute |
+| `Mon *-*-1..7 02:00` | First Monday, 2 AM |
+| `Mon,Fri 08:00` | Monday and Friday at 8 AM |
+
+Enable with: `systemctl enable --now myapp-backup.timer`
+
+---
+
+## Socket activation
+
+Services can be socket-activated: systemd listens on the port, starts the service on first connection.
+
+### Socket unit
+
+```ini
+# myapp.socket
+[Unit]
+Description=MyApp socket
+
+[Socket]
+ListenStream=8080
+BindIPv6Only=both
+NoDelay=true
+
+[Install]
+WantedBy=sockets.target
+```
+
+### Service unit
+
+```ini
+# myapp.service
+[Unit]
+Description=MyApp
+Requires=myapp.socket
+
+[Service]
+Type=notify
+ExecStart=/usr/local/bin/myapp serve
+```
+
+### Receiving the socket
+
+```rust
+use std::os::unix::io::FromRawFd;
+use std::net::TcpListener;
+
+fn activate_socket() -> Option<TcpListener> {
+    let fds = sd_listen_fds()?;
+    if fds > 0 {
+        // fd 3 is the first passed socket
+        Some(unsafe { TcpListener::from_raw_fd(3) })
+    } else {
+        None
+    }
+}
+```
+
+Benefits:
+- Service starts on demand
+- Zero-downtime restarts (socket stays open)
+- Dependency ordering: socket ready before service starts
+
+---
+
+## Deployment
+
+### Installation
+
+```bash
+# Copy service files
+sudo cp config/systemd/*.service /etc/systemd/system/
+sudo cp config/systemd/*.timer /etc/systemd/system/
+
+# Reload daemon
+sudo systemctl daemon-reload
+
+# Enable services
+sudo systemctl enable myapp.service
+sudo systemctl enable myapp-backup.timer
+
+# Start
+sudo systemctl start myapp.service
+sudo systemctl start myapp-backup.timer
+```
+
+### Verification
+
+```bash
+systemctl status myapp.service           # Service state
+systemctl is-active myapp.service        # Exit 0 if active
+systemctl show myapp.service --property=MainPID
+systemd-analyze security myapp.service   # Security score
+systemd-analyze verify myapp.service     # Validate unit file
+```
+
+### Reload vs restart
+
+| Command | Use |
+|---------|-----|
+| `systemctl reload` | Config reload (SIGHUP), no downtime |
+| `systemctl restart` | Full process restart |
+| `systemctl try-restart` | Restart only if already running |
+
+---
+
+## Anti-patterns
+
+1. **Missing `Type=notify`**: Services signal readiness too early, breaking dependency chains
+2. **`Restart=always` on failing service**: Infinite crash loop, no backoff
+3. **No resource limits**: Memory leaks consume all RAM, affecting the whole system
+4. **`User=root` by default**: Run with least privilege
+5. **Hardcoded paths**: Use `EnvironmentFile` for deployment-specific values
+6. **Missing `After=network-online.target`**: Service starts before network is ready
+7. **No `ExecReload`**: Forces restart for config changes
+8. **Logging to files**: Use journald, avoid log rotation complexity
+9. **Cron jobs without logging**: Silent failures; use timers with `StandardError=journal`
+10. **`KillMode=none`**: Orphaned processes on stop; use `KillMode=mixed` or `control-group`
+
+---
+
+## Tooling
+
+| Command | Purpose |
+|---------|---------|
+| `systemctl status <unit>` | Service state and recent logs |
+| `systemctl cat <unit>` | Display effective unit file |
+| `systemctl edit --full <unit>` | Edit unit file override |
+| `journalctl -u <unit>` | View service logs |
+| `systemd-analyze security <unit>` | Security exposure score |
+| `systemd-analyze verify <unit>` | Validate unit file syntax |
+| `systemd-delta` | Show overridden configuration |

--- a/standards/TESTING.md
+++ b/standards/TESTING.md
@@ -1,10 +1,6 @@
 # Testing
 
-> Additive to STANDARDS.md. Covers testing strategy, organization, and expectations across all languages.
-
----
-
-See STANDARDS.md § Testing for core principles.
+> Sole authority for testing principles across all languages. Language-specific docs (RUST.md, PYTHON.md, etc.) cover framework choices and tooling only — they reference this file for principles.
 
 ---
 
@@ -28,6 +24,17 @@ Don't test private functions directly. Test them through the public API. If a pr
 - Direct delegation (fn that calls one other fn and returns)
 - Generated code (macros, derive)
 - Third-party library behavior (test your usage, not their code)
+
+## What to focus on
+
+Test behavior with consequences:
+
+- Boundary conditions (empty, one, many, max, overflow)
+- Error paths (invalid input, unavailable service, timeout, permission denied)
+- State transitions (especially concurrent access to shared state)
+- Serialization round-trips (`deserialize(serialize(x)) == x`)
+- Idempotency (replaying the same operation produces the same result)
+- Security boundaries (authentication, authorization, input validation)
 
 ---
 
@@ -68,6 +75,10 @@ Pattern: `verb_condition` or `condition_produces_result`.
 
 ## Test quality
 
+### Behavior over implementation
+
+Test what the code **does**, not how it does it. If a refactor breaks your tests but doesn't break behavior, your tests are wrong.
+
 ### One assertion per behavior
 
 A test should verify one behavior. Multiple assertions are acceptable when they verify facets of the same behavior, not when they test unrelated things.
@@ -94,6 +105,217 @@ Prefer real implementations over mocks when practical. A test hitting a real SQL
 
 Test error cases with the same rigor as success cases. Every `Result::Err` variant should have at least one test that triggers it.
 
+### Idempotency
+
+Every state-modifying operation must have a test proving idempotency: running it N times produces the same result as running it once. This enforces the "Idempotent by design" principle in STANDARDS.md.
+
+**Required test pattern:** call the operation, capture resulting state, call it again with identical input, assert state is unchanged.
+
+**Naturally idempotent operations** (PUT replacing a resource, DELETE removing it, GET reading it) still need tests proving the property holds. A PUT that increments a counter on each call is not idempotent despite being a PUT.
+
+**Operations requiring explicit idempotency mechanisms** (POST creating resources, side-effecting event handlers, message consumers) must use idempotency keys, content hashes, or deduplication checks. The test must verify the mechanism: send the same request with the same idempotency key twice, assert the side effect occurred once.
+
+**API handlers:**
+
+```rust
+#[tokio::test]
+async fn create_prompt_is_idempotent() {
+    let app = test_app().await;
+    let request = CreatePromptRequest {
+        idempotency_key: "req-abc-123".into(),
+        title: "fix lint violation".into(),
+        // ...
+    };
+
+    let first = app.create_prompt(request.clone()).await.unwrap();
+    let second = app.create_prompt(request.clone()).await.unwrap();
+
+    assert_eq!(first.id, second.id);
+    assert_eq!(app.count_prompts().await, 1);
+}
+```
+
+**Event handlers:**
+
+```rust
+#[tokio::test]
+async fn pr_merged_handler_tolerates_replay() {
+    let (bus, store) = test_event_system().await;
+    let event = PrMergedEvent { pr_number: 42, sha: "abc123".into() };
+
+    bus.emit(event.clone()).await;
+    bus.emit(event.clone()).await;
+    bus.emit(event.clone()).await;
+
+    assert_eq!(store.archived_count().await, 1);
+}
+```
+
+**CLI state mutations (bookkeeper, triage, steward):**
+
+```rust
+#[tokio::test]
+async fn bookkeeper_archive_is_idempotent() {
+    let env = test_worktree().await;
+    env.create_merged_pr("prompt-1800.md").await;
+
+    bookkeeper_archive(&env.config).await.unwrap();
+    let state_after_first = env.snapshot_archive().await;
+
+    bookkeeper_archive(&env.config).await.unwrap();
+    let state_after_second = env.snapshot_archive().await;
+
+    assert_eq!(state_after_first, state_after_second);
+}
+
+#[tokio::test]
+async fn triage_generate_is_idempotent() {
+    let env = test_worktree().await;
+    env.create_open_issue(770, "add idempotency testing").await;
+
+    triage_generate(&env.config).await.unwrap();
+    let prompts_first = env.list_prompts().await;
+
+    triage_generate(&env.config).await.unwrap();
+    let prompts_second = env.list_prompts().await;
+
+    assert_eq!(prompts_first, prompts_second);
+}
+```
+
+**Idempotency key patterns:**
+
+| Pattern | When to use | Example |
+|---------|------------|---------|
+| Request ID | Client-supplied, API mutations | `Idempotency-Key` header |
+| Event ID | Event bus delivery | `event.id` field on every emitted event |
+| Content hash | File operations, prompt generation | SHA-256 of canonical input |
+| Source reference | Archive, sync, triage | Issue number, PR number, file path |
+
+The idempotency key must be part of the operation's input, not generated internally. Internal UUIDs cannot detect duplicates because each invocation generates a new one.
+
+---
+
+## Flake policy
+
+A flaky test is a test that produces different results on the same code. It is always a bug — in the test, in the code under test, or in the test infrastructure. Flakes erode trust: developers learn to ignore failures, CI becomes a slot machine, and real regressions hide behind "just retry it." This section defines how to detect, contain, and eliminate flakes.
+
+WHY: Without a systematic flake policy, the response to flakes is always ad hoc: someone retries, someone ignores, someone disables the test. Each response is a workaround that hides the problem. A policy makes flake handling deterministic and visible.
+
+### Detection
+
+A test is flaky when it fails on a commit where it previously passed, and the failure is not reproducible on demand. Detection methods, in order of reliability:
+
+1. **CI bisection.** If a test fails on a commit that did not touch its code or dependencies, it is a flake candidate. Confirm by re-running the exact commit in isolation.
+2. **Nextest retries.** A test that fails then passes on retry within the same CI run is a confirmed flake. Nextest records this in JUnit output (`flakyTests` element). Extract and report these automatically.
+3. **Historical analysis.** A test that has failed on 3+ unrelated PRs within a 14-day window is a flake, even if each individual failure was dismissed.
+
+WHY: Detection must not depend on human judgment. Humans under deadline pressure classify everything as "probably a flake" and retry. Automated detection based on retry records and cross-PR failure correlation removes that bias.
+
+Every detected flake produces a tracking issue tagged `flake` with: test name, failure message, affected commits, and detection method. No flake is addressed without a tracking issue.
+
+### Disable threshold
+
+A test that fails in more than 1% of CI runs is flaky. Disable it immediately with `#[ignore]` and an issue reference:
+
+```rust
+#[test]
+#[ignore = "flaky: port conflict in parallel runs — see #456"]
+fn integration_connects_to_service() {
+    // ...
+}
+```
+
+Every `#[ignore]` attribute must include a comment or reason string referencing a tracking issue. Bare `#[ignore]` without an issue reference is a lint violation (`TESTING/ignore-no-issue`). The issue tracks root-cause investigation and has an SLA (see Resolution SLAs below).
+
+WHY: `#[ignore]` is visible in the source, greppable, and enforced by the linter. It prevents the test from running by default while keeping it in the codebase for re-enablement. The 1% threshold is low enough to catch flakes early but high enough to avoid false positives from one-off infrastructure hiccups.
+
+### Quarantine
+
+For tests that need continued execution for signal gathering (frequency analysis, root-cause narrowing), quarantine via nextest overrides instead of `#[ignore]`:
+
+```toml
+# .config/nextest.toml
+[profile.default.overrides]
+# Quarantined: flaky — see #NNN
+filter = "test(=crate::module::flaky_test_name)"
+retries = 5
+test-group = "quarantine"
+```
+
+Quarantined tests:
+- **Run on every CI invocation.** Skipping them hides whether they're still failing and prevents detecting when a fix lands.
+- **Do not block merge.** Their failures are reported but non-fatal.
+- **Carry a tracking issue number** in the override comment. No anonymous quarantines.
+- **Are reviewed weekly.** If a quarantined test has passed consistently for 14 days, remove the quarantine. If it has not been fixed within the SLA, escalate or delete.
+
+WHY: Quarantine is containment, not resolution. It stops the bleeding (CI blockage) while preserving signal (the test still runs). The tracking issue and weekly review prevent quarantine from becoming a graveyard where tests go to be forgotten.
+
+### Retry policy
+
+Nextest retries exist to detect flakes, not to hide them.
+
+| Context | Retries | Rationale |
+|---------|---------|-----------|
+| CI default | 3 | Enough to distinguish flakes from deterministic failures. A test that fails 4 consecutive times on the same commit is not flaky — it is broken. |
+| Quarantined tests | 5 | Higher retry count gathers signal on flake frequency for root-cause analysis. |
+| Local development | 0 | Developers must see failures immediately. Retries on local runs train developers to ignore the first failure. |
+| Release gate | 0 | Release builds must pass without retries. Any test that cannot pass deterministically does not gate a release — it must be quarantined or fixed first. |
+
+WHY: Retries are a diagnostic tool. Used correctly, they identify flakes for quarantine. Used incorrectly (high retry counts everywhere, no tracking), they become a system-wide workaround that makes flakes invisible. The retry count is deliberately low: three retries catch flakes without hiding persistent failures.
+
+A test that passes on retry is not "passing." It is flaky and must be tracked. CI pipelines must report retry-passed tests distinctly from clean-passed tests.
+
+### Flake budget
+
+Each project has a flake budget: the maximum number of tests that may be quarantined at any time.
+
+| Project size | Budget |
+|-------------|--------|
+| < 500 tests | 3 |
+| 500–2000 tests | 5 |
+| > 2000 tests | 2% of test count, rounded down |
+
+When the budget is exceeded, no new features merge until quarantined tests are resolved below the budget. The budget is enforced in CI: a gate check counts quarantined tests and fails if over budget.
+
+WHY: Without a budget, quarantine grows without bound. A project with 40 quarantined tests has not contained its flakes — it has normalized them. The budget creates back-pressure: every new quarantine consumes a scarce resource, forcing teams to fix existing flakes before adding new ones.
+
+### Resolution SLAs
+
+Every flake tracking issue has a resolution deadline based on severity:
+
+| Severity | Definition | SLA |
+|----------|-----------|-----|
+| Critical | Flake in release-gate or security test | 3 business days |
+| High | Flake in integration test or cross-crate test | 7 business days |
+| Normal | Flake in unit test | 14 business days |
+| Low | Flake in benchmark or non-blocking test | 30 business days |
+
+Resolution means one of:
+1. **Root-cause fix.** The underlying cause (timing, shared state, resource leak, test ordering) is identified and eliminated. The test is unquarantined.
+2. **Test rewrite.** The test is rewritten to avoid the flaky condition. The new test is proven stable over 50+ consecutive green runs before unquarantining.
+3. **Test deletion.** If the behavior cannot be tested deterministically and the test provides no unique coverage, delete it. A flaky test that covers the same path as a deterministic test adds negative value.
+
+If the SLA expires without resolution, the test is escalated: it appears in the weekly review as overdue, and no new quarantines are permitted until the overdue item is resolved or explicitly accepted at a higher severity SLA.
+
+WHY: SLAs prevent the "we'll get to it" pattern where flake issues accumulate indefinitely. The escalation mechanism — blocking new quarantines when SLAs are breached — ensures that unresolved flakes cannot be ignored by simply quarantining more tests. Resolution has a defined meaning: the flake is gone, not just managed.
+
+### Common flake root causes
+
+Address these during investigation. Most flakes trace to a small number of patterns:
+
+| Root cause | Fix |
+|-----------|-----|
+| Wall-clock timing (`sleep`, `Instant::now`) | Use `tokio::time::pause()`, inject clocks |
+| Port conflicts (hardcoded ports in parallel tests) | Use port 0 (OS-assigned) or `portpicker` |
+| Shared filesystem state (temp dirs, fixture files) | Unique temp dirs per test via `tempfile` |
+| Test ordering dependence (shared `static mut`, leaked state) | Reset state in setup, use `#[serial]` only as last resort |
+| Resource exhaustion (file descriptors, threads, connections) | Explicit cleanup in test teardown, bounded pools |
+| External service flakiness (DNS, network, third-party API) | Mock at the boundary, never depend on external services in CI |
+| Async race conditions (missing `await`, unbounded channels) | Use deterministic async test harness, assert on completion signals not timing |
+
+WHY: Most flake investigations stall at "it's intermittent, I can't reproduce it." This table provides a starting checklist that resolves the majority of flakes. When the root cause is not in this list, add it — the table is a living document.
+
 ---
 
 ## Coverage expectations
@@ -104,6 +326,26 @@ No numeric coverage target. Coverage metrics reward testing code and penalize te
 - Every error variant has at least one test that produces it
 - Every match arm with non-logic has a test
 - Critical paths (auth, payment, data persistence) have integration tests
+
+---
+
+## Test data policy
+
+All test data must be synthetic. No real personal information in test fixtures, assertions, or examples.
+
+**Standard test identities:**
+- Users: `alice`, `bob`, `charlie`
+- Emails: `alice@example.com`, `bob@example.org` (RFC 2606 reserved domains only)
+- Phones: `+1-555-0100` through `+1-555-0199` (ITU reserved for fiction)
+- IPs: `192.0.2.x`, `198.51.100.x`, `203.0.113.x` (RFC 5737 documentation ranges)
+- IPv6: `2001:db8::/32` (RFC 3849 documentation range)
+- Domains: `example.com`, `example.org`, `example.net`, `*.test` (RFC 2606/6761 reserved)
+
+**Never use:** real names, emails, usernames, internal IPs/hostnames, personal facts, credentials, or API keys. Never copy production data into test environments.
+
+**Test data builders:** Use builder/factory patterns with sensible defaults. Each test overrides only the fields it cares about. When a field is added to the struct, only the builder default needs updating, not every test.
+
+**Determinism:** Any randomized test data must be seeded. The seed must be logged or persisted. Proptest regression files, hypothesis databases, and equivalent fixtures are checked into version control.
 
 ---
 
@@ -120,6 +362,27 @@ Run fuzz targets periodically (CI nightly or pre-release), not on every PR.
 Performance-sensitive code gets benchmarks, not just tests. Use `criterion` or `divan`. Benchmarks live in `benches/` and run separately from tests.
 
 Benchmark before optimizing. Benchmark after optimizing. Commit both results.
+
+### Benchmark baselines
+
+Benchmark baselines are committed after each release. The baseline is the reference point for detecting performance regressions in subsequent development.
+
+**Baseline workflow:**
+1. After tagging a release, run the full benchmark suite: `cargo bench -- --save-baseline release-vX.Y.Z`
+2. Commit the baseline output to `benches/baselines/` in version control
+3. CI compares every PR's benchmark results against the current baseline
+
+**CI regression detection:** CI runs benchmarks against the committed baseline and flags regressions exceeding 10%:
+
+```bash
+cargo bench -- --baseline release-vX.Y.Z --save-baseline pr-$PR_NUMBER
+# Compare and fail on >10% regression
+critcmp release-vX.Y.Z pr-$PR_NUMBER --threshold 10
+```
+
+A regression exceeding 10% is a CI failure. The PR author must either fix the regression, justify it in the PR body with evidence, or update the baseline with reviewer approval.
+
+WHY: Without committed baselines, benchmarks only detect regressions relative to the previous run — which may itself be regressed. Anchoring to release baselines provides a stable reference. The 10% threshold balances noise tolerance (benchmark variance is typically 2-5%) against catching meaningful regressions.
 
 ---
 
@@ -138,6 +401,77 @@ pub async fn assert_component_compliance<T>(spec: &ComponentSpec, f: impl Future
 
 This catches observability regressions: if a refactor removes a metric emission, the test fails even though the functional behavior is unchanged.
 
+## Trace assertion patterns
+
+Observability contracts (see STANDARDS.md § Logging and observability) are testable. Use `tracing-test` to capture spans and events, then assert that the module emits what its contract promises.
+
+### Capturing events in tests
+
+```rust
+use tracing_test::traced_test;
+
+#[tokio::test]
+#[traced_test]
+async fn dispatch_emits_completion_event() {
+    let dispatcher = Dispatcher::new(mock_config());
+
+    dispatcher.dispatch_prompt(&prompt, "test-provider").await.unwrap();
+
+    // Assert the contracted event was emitted with required fields
+    assert!(logs_contain("prompt.completed"));
+    assert!(logs_contain("prompt_id"));
+    assert!(logs_contain("duration_ms"));
+}
+```
+
+### Asserting span structure
+
+```rust
+#[tokio::test]
+#[traced_test]
+async fn gate_check_creates_span() {
+    let gate = Gate::new(mock_config());
+
+    gate.run(&prompt).await.unwrap();
+
+    // Assert the contracted span exists
+    assert!(logs_contain("run_gate"));
+    assert!(logs_contain("gate_name"));
+}
+```
+
+### Testing contract completeness
+
+For modules with observability contracts, write a test that exercises every documented event and verifies emission. This test is the enforcement mechanism: if a refactor removes an event, this test fails.
+
+```rust
+#[tokio::test]
+#[traced_test]
+async fn observability_contract_complete() {
+    // Exercise success path
+    let result = module.process(&valid_input).await;
+    assert!(result.is_ok());
+    assert!(logs_contain("input.processed"));
+
+    // Exercise error path
+    let result = module.process(&invalid_input).await;
+    assert!(result.is_err());
+    assert!(logs_contain("input.rejected"));
+}
+```
+
+### What to assert
+
+| Contract element | Assertion |
+|-----------------|-----------|
+| Event name | `logs_contain("event.name")` |
+| Required field present | `logs_contain("field_name")` |
+| Correct log level | `logs_contain("ERROR")` for error events |
+| Span creation | `logs_contain("span_name")` |
+| Span fields | `logs_contain("field=value")` within span context |
+
+Do not assert on exact log message text or field values that vary per run (timestamps, UUIDs). Assert on event names, field presence, and log levels.
+
 ## Mock components as real implementations
 
 Mocks implement the same traits as production code. They compose into real topologies for integration testing. A mock that returns hardcoded data through a different interface than production code tests the mock, not the system.
@@ -155,6 +489,22 @@ For stateful systems, use property-based testing with action sequence generation
 5. Assert system state matches model state
 
 Persist regression corpus (minimal failing cases) in git via `proptest-regressions/`.
+
+### Proptest regression management
+
+`proptest-regressions/` directories must be committed to version control. These files contain minimal failing inputs that reproduce past bugs — losing them means losing regression coverage.
+
+**CI verification:** CI must verify that `proptest-regressions/` is not listed in `.gitignore`. A pipeline step checks this explicitly:
+
+```bash
+# Fail if any gitignore rule excludes proptest regression files
+if git check-ignore -q proptest-regressions/ 2>/dev/null; then
+  echo "ERROR: proptest-regressions/ is gitignored — regression corpus must be tracked"
+  exit 1
+fi
+```
+
+WHY: Proptest generates regression files automatically when a test fails, but developers sometimes gitignore them as noise. Losing the regression corpus silently removes coverage for previously-discovered edge cases. The CI check makes this a hard failure rather than an invisible drift.
 
 ## Test runner configuration
 

--- a/standards/TYPESCRIPT.md
+++ b/standards/TYPESCRIPT.md
@@ -15,7 +15,7 @@
 - **State:** Redux Toolkit (`@reduxjs/toolkit` + `react-redux`)
 - **Testing:** Vitest + React Testing Library
 - **Bundler:** Vite
-- **Linter + Formatter:** Biome (preferred) or ESLint + typescript-eslint + Prettier
+- **Linter + Formatter:** Biome (see § Biome vs ESLint decision tree)
 - **Build/validate:**
   ```bash
   tsc --noEmit
@@ -38,6 +38,154 @@
   }
  ```
  `erasableSyntaxOnly` bans `enum`, `namespace`, and constructor parameter properties. This aligns with the type-stripping direction (Node `--experimental-strip-types`, Deno native TS). Use `as const` objects instead of enums.
+
+### Biome vs ESLint
+
+Default to Biome. Fall back to ESLint only when a required lint rule has no Biome equivalent.
+
+| Criterion | Biome | ESLint + typescript-eslint + Prettier |
+|-----------|-------|--------------------------------------|
+| Speed | 10-100x faster. Written in Rust. | Slow on large monorepos. |
+| Config surface | Single `biome.json`. Format + lint unified. | Three configs (`.eslintrc`, `.prettierrc`, tsconfig-eslint). |
+| Plugin ecosystem | Limited. No custom rule API yet. | Extensive: `eslint-plugin-jsx-a11y`, `eslint-plugin-react-hooks`, `eslint-plugin-import-x`. |
+| Type-aware rules | Partial. Growing. | Full via typescript-eslint with `parserOptions.project`. |
+
+**Decision tree:**
+
+1. Does the project need `eslint-plugin-jsx-a11y` or other plugin-only rules that Biome lacks? If yes, use ESLint.
+2. Is the project a monorepo where lint speed blocks CI? Biome's speed advantage matters most here.
+3. Otherwise, default to Biome. Fewer moving parts, faster feedback.
+
+WHY: Biome eliminates the Prettier-ESLint conflict surface (formatting fights, overlapping rules) and runs in a fraction of the time. The tradeoff is ecosystem breadth. When Biome covers what you need, the simplicity wins.
+
+When using ESLint, always pair with `typescript-eslint` flat config and `eslint-plugin-import-x` (maintained fork of `eslint-plugin-import`). Never use the deprecated `eslint-plugin-import`.
+
+---
+
+## Monorepo patterns
+
+### Package manager: pnpm
+
+pnpm workspaces for monorepos. WHY: strict dependency isolation (no phantom deps), disk-efficient via content-addressable store, workspace protocol for local packages.
+
+```yaml
+# pnpm-workspace.yaml
+packages:
+  - 'apps/*'
+  - 'packages/*'
+```
+
+### Workspace protocol
+
+Reference internal packages with `workspace:*`. pnpm resolves these to the local version at install time and replaces with the real version at publish time.
+
+```jsonc
+// apps/desktop/package.json
+{
+    "dependencies": {
+        "@project/ui": "workspace:*",
+        "@project/shared-types": "workspace:*"
+    }
+}
+```
+
+WHY: `workspace:*` makes internal dependencies explicit and prevents accidental resolution to a stale registry version. pnpm errors if the referenced package does not exist in the workspace.
+
+### Package structure
+
+```
+monorepo/
+├── pnpm-workspace.yaml
+├── biome.json              # workspace-root config, shared by all packages
+├── tsconfig.base.json      # shared compiler options, extended by each package
+├── apps/
+│   ├── desktop/            # Tauri app
+│   │   ├── package.json
+│   │   ├── tsconfig.json   # extends ../../tsconfig.base.json
+│   │   └── src/
+│   └── web/                # Web-only build
+│       ├── package.json
+│       ├── tsconfig.json
+│       └── src/
+└── packages/
+    ├── ui/                 # Shared React components
+    │   ├── package.json
+    │   └── src/
+    ├── shared-types/       # Types shared across apps (no runtime code)
+    │   ├── package.json
+    │   └── src/
+    └── api-client/         # Typed API/IPC wrappers
+        ├── package.json
+        └── src/
+```
+
+Rules:
+
+- **Shared config at root.** `tsconfig.base.json`, `biome.json`, and `.npmrc` live at the workspace root. Packages extend, never duplicate. WHY: config drift across packages causes inconsistent behavior that surfaces as CI-only failures.
+- **`packages/` for libraries, `apps/` for deployables.** Libraries export typed APIs. Apps import them. Libraries never import from apps.
+- **Types-only packages have zero runtime dependencies.** `shared-types` contains interfaces, branded types, and `as const` objects. No `lodash`, no `date-fns`, nothing that ships bytes.
+- **Each package has its own `package.json`.** Even types-only packages. pnpm needs it for resolution.
+
+### Shared tsconfig
+
+```jsonc
+// tsconfig.base.json (workspace root)
+{
+    "compilerOptions": {
+        "target": "ES2024",
+        "lib": ["ES2024", "DOM", "DOM.Iterable"],
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "strict": true,
+        "noUncheckedIndexedAccess": true,
+        "erasableSyntaxOnly": true,
+        "skipLibCheck": true,
+        "composite": true,
+        "declaration": true,
+        "declarationMap": true
+    }
+}
+
+// apps/desktop/tsconfig.json
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "dist",
+        "rootDir": "src"
+    },
+    "include": ["src"],
+    "references": [
+        { "path": "../../packages/ui" },
+        { "path": "../../packages/shared-types" }
+    ]
+}
+```
+
+`composite: true` and `references` enable incremental builds via `tsc --build`. WHY: without project references, `tsc` type-checks the entire workspace on every change. With references, only changed packages and their dependents are rechecked.
+
+### Build ordering
+
+pnpm respects dependency topology. `pnpm run --filter ...apps/desktop build` builds dependencies first.
+
+```bash
+# Build a specific app and everything it depends on
+pnpm run --filter ...apps/desktop build
+
+# Type-check entire workspace
+pnpm run --recursive typecheck
+
+# Run tests only for packages changed since main
+pnpm run --filter "...[origin/main]" test
+```
+
+WHY: `--filter` with `...` prefix includes transitive dependencies. The `[origin/main]` syntax runs only changed packages, keeping CI fast as the monorepo grows.
+
+### Anti-patterns
+
+- **Hoisting everything to the root `node_modules`.** Use pnpm's strict mode (`.npmrc`: `shamefully-hoist=false`). Hoisting hides dependency errors that break in production.
+- **Circular dependencies between packages.** If `@project/ui` imports from `@project/api-client` and vice versa, extract the shared type into `@project/shared-types`.
+- **Different TypeScript versions across packages.** One `typescript` version in the root `package.json`. Packages inherit it.
+- **Running `tsc` without `--build` in a monorepo.** `tsc --noEmit` does not respect project references. Use `tsc --build --noEmit` or per-package type-check scripts.
 
 ---
 
@@ -472,6 +620,32 @@ function LegacyWidget() {
 }
 ```
 
+**When to use `"use no memo"`:**
+
+The compiler assumes React's Rules of Hooks and pure render functions. Opt out when the component intentionally violates these assumptions:
+
+| Scenario | Why opt out |
+|----------|-------------|
+| Component reads from a mutable external store without `useSyncExternalStore` | Compiler may cache a stale read. The component must re-render on every call to observe the mutation. |
+| Component relies on render-time side effects for measurement (e.g., `getBoundingClientRect` in render) | Compiler may skip the re-execution if inputs appear unchanged. |
+| Third-party library passes mutable refs as props and expects them to be read fresh each render | Compiler cannot track mutations to ref objects passed from outside. |
+| Gradual migration: component has not yet been audited for Rules of React compliance | Safer to exclude than to ship memoization bugs. Audit and remove `"use no memo"` as part of migration. |
+
+Do not use `"use no memo"` for:
+- Performance tuning (the compiler memoizes more granularly than you can manually)
+- Components that "seem to break" without investigation (diagnose the actual rule violation first)
+
+**What the compiler can and cannot infer:**
+
+| Can infer | Cannot infer |
+|-----------|-------------|
+| Memoization of JSX elements, hook return values, and intermediate variables | Side effects hidden behind opaque function calls (e.g., a function that mutates a closed-over variable) |
+| Dependency tracking for conditional branches (better than manual `useMemo` deps) | Mutations to objects shared across components via refs or module-level variables |
+| Callback stability for event handlers defined inline | Whether a third-party hook follows the Rules of Hooks internally |
+| Granular re-render skipping at the expression level, not just the component level | Effects of `eval()`, dynamic `import()`, or Proxy-based reactivity systems |
+
+WHY: the compiler operates on static analysis of the component's source code. It trusts that functions are pure and hooks follow the rules. When those assumptions hold, the compiler produces strictly better memoization than any manual approach. When they do not hold, `"use no memo"` is the correct escape hatch, not a performance knob.
+
 **Manual memoization rules:**
 
 - **With compiler:** Do not write `useMemo`, `useCallback`, `React.memo`. The compiler handles it. Manual memoization is dead code.
@@ -805,9 +979,136 @@ Tauri 2 uses capability-based permissions. Frontend code runs in a sandbox: back
 
 ---
 
+## Layered architecture
+
+### Layer model
+
+```
+Request → Handler → Service → Repository → Data Source
+                ↑           ↑            ↑
+             Validation   Business     Persistence
+             + DTO map    logic        abstraction
+```
+
+Each layer depends only on the layer below it. No skipping layers. No upward imports.
+
+WHY: layering isolates change. A database migration touches the repository layer. A new business rule touches the service layer. A UI redesign touches the handler layer. Without layering, a database change propagates through the entire codebase.
+
+### Layer responsibilities
+
+| Layer | Owns | Does NOT own |
+|-------|------|-------------|
+| **Handler** (component/route) | Input validation, DTO→domain mapping, error→UI mapping, loading/error states | Business rules, data fetching logic |
+| **Service** (hook/thunk) | Business rules, orchestration, domain validation | UI concerns, persistence details |
+| **Repository** (API client/IPC wrapper) | Data access, serialization, caching strategy | Business rules, UI concerns |
+
+### Validation placement
+
+Validate at each boundary for what that boundary owns:
+
+```typescript
+// Handler layer: validate shape and format
+function ImportPage() {
+    function handleSubmit(formData: FormData) {
+        const path = formData.get('path');
+        if (typeof path !== 'string' || path.trim() === '') {
+            return; // UI validation: shape
+        }
+        dispatch(importLibrary(path));
+    }
+    // ...
+}
+
+// Service layer: validate business rules
+export const importLibrary = createAsyncThunk(
+    'library/import',
+    async (path: string, { rejectWithValue }) => {
+        if (!path.endsWith('/') && !path.includes('.')) {
+            return rejectWithValue({ kind: 'invalid_path', path });
+        }
+        return invoke<ImportReport>('import_library', { path });
+    },
+);
+
+// Repository layer: validate wire format
+function parseAlbumResponse(raw: unknown): Album {
+    return AlbumSchema.parse(raw); // valibot/zod at the boundary
+}
+```
+
+WHY: handler validation prevents invalid data from reaching the service. Service validation enforces business invariants. Repository validation ensures wire data matches expected shapes. Each layer trusts its inputs only because the layer above validated them.
+
+### DTO flow
+
+Domain types live in the service/domain layer. Wire types (DTOs) live at boundaries. Map between them explicitly.
+
+```typescript
+// Wire type: matches backend serde output (snake_case)
+interface AlbumDto {
+    id: string;
+    title: string;
+    artist_name: string;
+    track_count: number;
+    duration_ms: number;
+}
+
+// Domain type: used throughout the frontend (camelCase)
+interface Album {
+    id: AlbumId;
+    title: string;
+    artistName: string;
+    trackCount: number;
+    durationMs: number;
+}
+
+// Map at the repository boundary
+function toAlbum(dto: AlbumDto): Album {
+    return {
+        id: createAlbumId(dto.id),
+        title: dto.title,
+        artistName: dto.artist_name,
+        trackCount: dto.track_count,
+        durationMs: dto.duration_ms,
+    };
+}
+```
+
+WHY: if the backend renames a field, exactly one mapping function changes. Without the boundary map, snake_case field names leak through every component and hook. Branded types (`AlbumId`) are constructed at this boundary, enforcing type safety from the earliest possible point.
+
+### File organization by layer
+
+```
+src/
+├── domain/             # Types, branded IDs, business constants
+│   ├── album.ts
+│   └── track.ts
+├── services/           # Thunks, business logic, orchestration
+│   ├── library-service.ts
+│   └── playback-service.ts
+├── repositories/       # IPC wrappers, API clients, schema validation
+│   ├── album-repository.ts
+│   └── track-repository.ts
+├── store/              # Redux slices, selectors, store config
+│   ├── store.ts
+│   ├── slices/
+│   └── hooks.ts
+├── components/         # React components (handler layer)
+│   ├── album-list.tsx
+│   └── track-item.tsx
+└── pages/              # Route-level components with Suspense boundaries
+    ├── library-page.tsx
+    └── settings-page.tsx
+```
+
+Components import from `services/` and `store/`. Services import from `repositories/` and `domain/`. Repositories import from `domain/` only. No reverse dependencies.
+
+---
+
 ## Testing
 
-See STANDARDS.md § Testing and TESTING.md for universal test principles.
+See TESTING.md for all testing principles (naming, isolation, coverage, test data, property testing).
+
+TypeScript-specific framework choices and patterns:
 
 ### Framework and configuration
 
@@ -835,26 +1136,9 @@ afterEach(() => {
 });
 ```
 
-### Test organization
-
-Colocated test files, same directory as source.
-
-```
-src/
-  components/
-    track-item.tsx
-    track-item.test.tsx
-  stores/
-    player-store.ts
-    player-store.test.ts
-  lib/
-    format-duration.ts
-    format-duration.test.ts
-```
-
 ### Component testing
 
-React Testing Library: test behavior, not implementation details.
+React Testing Library for component tests.
 
 ```typescript
 import { render, screen } from '@testing-library/react';
@@ -869,75 +1153,19 @@ it('calls onPlay when play button is clicked', async () => {
 
     expect(onPlay).toHaveBeenCalledWith(mockTrack.id);
 });
-
-it('displays track duration in mm:ss format', () => {
-    render(<TrackItem track={{ ...mockTrack, durationMs: 185000 }} />);
-    expect(screen.getByText('3:05')).toBeInTheDocument();
-});
 ```
 
 ### Mocking
 
-Mock at module boundaries. Prefer `vi.spyOn` (type-safe, scoped) over `vi.mock` (hoisted, file-wide).
-
-```typescript
-// Preferred: vi.spyOn for targeted mocking
-import * as api from '../api/tracks';
-
-it('loads albums from backend', async () => {
-    const spy = vi.spyOn(api, 'fetchAlbums').mockResolvedValue([mockAlbum]);
-    render(<AlbumList />);
-    await screen.findByText(mockAlbum.title);
-    expect(spy).toHaveBeenCalledOnce();
-});
-
-// vi.mock for module replacement (when spyOn won't work)
-// Use vi.hoisted to avoid hoisting pitfalls
-const mockInvoke = vi.hoisted(() => vi.fn());
-vi.mock('@tauri-apps/api/core', () => ({
-    invoke: mockInvoke,
-}));
-
-beforeEach(() => {
-    mockInvoke.mockReset();
-});
-
-it('loads albums via Tauri IPC', async () => {
-    mockInvoke.mockResolvedValue([mockAlbum]);
-    const albums = await listAlbums();
-    expect(mockInvoke).toHaveBeenCalledWith('list_albums');
-});
-```
+Prefer `vi.spyOn` (type-safe, scoped) over `vi.mock` (hoisted, file-wide). Use `vi.hoisted` when `vi.mock` is needed.
 
 ### Store testing
 
 Test Redux slices with a real store instance. No mocking the store.
 
-```typescript
-import { configureStore } from '@reduxjs/toolkit';
-import { queueReducer, enqueue } from './queue-slice';
-
-it('enqueues tracks in order', () => {
-    const store = configureStore({ reducer: { queue: queueReducer } });
-    store.dispatch(enqueue(trackA));
-    store.dispatch(enqueue(trackB));
-    expect(store.getState().queue.items).toEqual([trackA, trackB]);
-});
-```
-
 ### Resource cleanup with `using`
 
-`using` declarations (TS 5.2+) replace manual `afterEach` for test resources:
-
-```typescript
-it('queries the database', async () => {
-    await using db = await TestDb.create();
-    await db.seed(fixtures);
-    const result = await db.query('SELECT count(*) FROM tracks');
-    expect(result.count).toBe(5);
-    // db automatically cleaned up: no afterEach needed
-});
-```
+`using` declarations (TS 5.2+) replace manual `afterEach` for test resources.
 
 ### No snapshot tests
 
@@ -1008,6 +1236,87 @@ function App() {
 - Heavy computation belongs in Rust, not TypeScript: use commands for anything CPU-bound
 - Large data transfers: prefer streaming events over single large `invoke` payloads
 - Image handling: let Rust resize/thumbnail, send paths not blobs to the frontend
+
+### Core Web Vitals
+
+WHY: Core Web Vitals are Google's user-experience metrics. They measure what users actually feel: loading speed, interactivity, and visual stability. Poor scores degrade user experience and search ranking for web builds. Tauri desktop builds benefit from the same discipline since the rendering engine is a webview.
+
+#### Metrics and budgets
+
+| Metric | What it measures | Good | Poor | Budget |
+|--------|-----------------|------|------|--------|
+| **LCP** (Largest Contentful Paint) | When the main content finishes rendering | ≤ 2.5s | > 4.0s | ≤ 1.5s for app shells |
+| **INP** (Interaction to Next Paint) | Responsiveness to user input (replaces FID) | ≤ 200ms | > 500ms | ≤ 100ms for media controls |
+| **CLS** (Cumulative Layout Shift) | Visual stability during load and interaction | ≤ 0.1 | > 0.25 | ≤ 0.05 |
+| **FCP** (First Contentful Paint) | When the first content pixel renders | ≤ 1.8s | > 3.0s | ≤ 1.0s |
+| **TTFB** (Time to First Byte) | Server/backend response time | ≤ 800ms | > 1800ms | ≤ 200ms for local IPC |
+
+INP replaced First Input Delay (FID) in March 2024. INP measures all interactions across the page lifecycle, not just the first one. Optimize for INP.
+
+#### Measurement
+
+Use the `web-vitals` library in production to capture real user metrics. Do not rely solely on Lighthouse: lab scores miss real-world variance.
+
+```typescript
+import { onLCP, onINP, onCLS } from 'web-vitals';
+
+function reportMetric(metric: { name: string; value: number; id: string }) {
+    // Send to your analytics/observability pipeline
+    navigator.sendBeacon('/api/vitals', JSON.stringify(metric));
+}
+
+onLCP(reportMetric);
+onINP(reportMetric);
+onCLS(reportMetric);
+```
+
+For Tauri desktop builds, log vitals to the Rust backend via `invoke` instead of `sendBeacon`.
+
+#### Common LCP violations and fixes
+
+| Violation | Fix |
+|-----------|-----|
+| Render-blocking CSS/JS | Inline critical CSS. Defer non-critical scripts. |
+| Unoptimized hero images | Use `width`/`height` attributes (prevents layout shift). Serve modern formats (WebP/AVIF). Lazy-load below-the-fold images only. |
+| Client-side data fetch before render | Prefetch data in the route loader or start the fetch before rendering the component (see `use()` hook pattern). |
+| Large JavaScript bundles | Code-split at route boundaries. Audit with `npx vite-bundle-visualizer`. |
+
+#### Common CLS violations and fixes
+
+| Violation | Fix |
+|-----------|-----|
+| Images without dimensions | Always set `width` and `height` on `<img>` elements. Use CSS `aspect-ratio` for responsive images. |
+| Dynamically injected content | Reserve space with skeleton placeholders. Never insert content above the user's viewport. |
+| Web fonts causing FOUT/FOIT | Use `font-display: swap` with a matching fallback font. Use `size-adjust` on the fallback to minimize shift. |
+| Animations that trigger layout | Animate only `transform` and `opacity`. Never animate `width`, `height`, `top`, `left`, or `margin`. |
+
+#### Common INP violations and fixes
+
+| Violation | Fix |
+|-----------|-----|
+| Long-running event handlers | Move heavy work into `startTransition()`. Yield to the main thread with `scheduler.yield()` (or `setTimeout(0)` as fallback). |
+| Synchronous Redux dispatches blocking paint | Wrap non-urgent dispatches in `startTransition`. Keep urgent interactions (play/pause, seek) synchronous. |
+| Large component trees re-rendering on interaction | React Compiler handles this when enabled. Without compiler, profile with React DevTools and memoize the hot path. |
+
+#### Performance budgets in CI
+
+Track bundle size and vitals in CI. Fail the build if budgets are exceeded.
+
+```typescript
+// vite.config.ts — build size warning
+export default defineConfig({
+    build: {
+        rollupOptions: {
+            output: {
+                // Warn if any chunk exceeds 250KB gzipped
+                experimentalMinChunkSize: 1000,
+            },
+        },
+    },
+});
+```
+
+Use `bundlesize` or Vite's built-in `build.chunkSizeWarningLimit` as a gate. Track the main chunk, vendor chunk, and total JS payload independently.
 
 ---
 

--- a/standards/UDEV.md
+++ b/standards/UDEV.md
@@ -1,0 +1,225 @@
+# Udev
+
+> Additive to STANDARDS.md. Read that first. Everything here is udev-specific.
+>
+> Covers: udev rules for hardware detection, USB serial devices, device permissions, systemd integration.
+>
+> **Key decisions:** 99-prefix for custom rules, dialout group for serial, TAG+="systemd" for service binding, ATTRS over ATTR for parent matching, udevadm for testing.
+
+---
+
+## Rule syntax
+
+Udev rules are declarative condition-action pairs. One rule per line. Conditions are AND-combined unless `,` is replaced with `|`. Actions are comma-separated after the `=` or `+=` operator.
+
+### Rule structure
+
+```
+CONDITION1, CONDITION2, ... ACTION1, ACTION2, ...
+```
+
+Conditions match device attributes. Actions set properties, symlinks, or run commands.
+
+### Common condition keys
+
+| Key | Matches | Example |
+|-----|---------|---------|
+| `SUBSYSTEM` | Kernel subsystem | `SUBSYSTEM=="tty"` |
+| `KERNEL` | Device name | `KERNEL=="ttyUSB*"` |
+| `ATTR{name}` | sysfs attribute | `ATTR{idVendor}=="067b"` |
+| `ATTRS{name}` | Parent device attribute (walks up tree) | `ATTRS{idVendor}=="067b"` |
+| `ENV{key}` | Environment variable | `ENV{ID_BUS}=="usb"` |
+| `TAGS` | Device tag | `TAGS=="systemd"` |
+| `ACTION` | add/remove/change/bind/unbind | `ACTION=="add"` |
+
+### Common action keys
+
+| Key | Effect | Example |
+|-----|--------|---------|
+| `MODE` | File permissions | `MODE="0660"` |
+| `GROUP` | Device group | `GROUP="dialout"` |
+| `OWNER` | Device owner | `OWNER="root"` |
+| `SYMLINK+=` | Create additional symlinks | `SYMLINK+="radio_%n"` |
+| `TAG+=` | Add systemd tag | `TAG+="systemd"` |
+| `ENV{SYSTEMD_WANTS}+=` | Trigger service start | `ENV{SYSTEMD_WANTS}+="radio-daemon.service"` |
+| `RUN+=` | Execute command (use sparingly) | `RUN+="/usr/bin/logger new device"` |
+
+---
+
+## File naming
+
+Rules live in `/etc/udev/rules.d/` (custom) or `/lib/udev/rules.d/` (package defaults). Files are processed in lexical order.
+
+### Naming convention
+
+| Prefix | Purpose | Example |
+|--------|---------|---------|
+| `50-` | Hardware defaults | `50-usb-serial.rules` |
+| `70-` | Distribution defaults | `70-persistent-net.rules` |
+| `99-` | **Site-local overrides** | `99-radio-devices.rules` |
+
+**Use `99-` prefix for all custom rules.** This ensures they override distribution defaults. Single digits before the hyphen; `100-` sorts before `99-`.
+
+---
+
+## USB serial device rules
+
+USB-to-serial adapters require matching on parent USB device attributes (VID:PID) while operating on the tty child.
+
+### Pattern for USB serial devices
+
+```udev
+# Match parent USB device attributes, apply to tty child
+SUBSYSTEM=="tty", ATTRS{idVendor}=="067b", ATTRS{idProduct}=="2303", 
+    GROUP="dialout", MODE="0660", SYMLINK+="radio_pl2303_%n"
+
+# CH340 cable
+SUBSYSTEM=="tty", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7523", 
+    GROUP="dialout", MODE="0660", SYMLINK+="radio_ch340_%n"
+
+# CP2102 cable
+SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", 
+    GROUP="dialout", MODE="0660", SYMLINK+="radio_cp2102_%n"
+```
+
+### Key requirements
+
+- Use `ATTRS` (not `ATTR`) for VID/PID matching. `ATTR` only checks the immediate device; `ATTRS` walks up the device tree to find USB attributes.
+- Always set `GROUP="dialout"` for serial devices. Users need dialout group membership to access.
+- Use `%n` in symlinks for enumeration (ttyUSB0 → radio_pl2303_0).
+
+### Common USB serial chips
+
+| Chip | VID:PID | Notes |
+|------|---------|-------|
+| Prolific PL2303 | `067b:2303` | Most common. Clones are rampant but work on Linux. |
+| WinChipHead CH340 | `1a86:7523` | Reliable, cheap. |
+| Silicon Labs CP2102 | `10c4:ea60` | Higher-end cables. |
+| FTDI FT232R | `0403:6001` | Less common for Baofeng. |
+
+---
+
+## Permissions
+
+Serial devices default to `root:root` with mode `0600`. Applications need access.
+
+### Required permission pattern
+
+```udev
+GROUP="dialout", MODE="0660"
+```
+
+### User membership
+
+Users must be in the `dialout` group:
+
+```bash
+sudo usermod -aG dialout $USER
+# Re-login required for group change to take effect
+```
+
+Document this requirement in application setup instructions.
+
+---
+
+## Systemd integration
+
+Bind services to hardware presence. Start a service when a specific device appears; stop it when the device disappears.
+
+### Pattern: service activation on device
+
+```udev
+# Rule: 99-radio-monitor.rules
+SUBSYSTEM=="tty", ATTRS{idVendor}=="067b", ATTRS{idProduct}=="2303", 
+    TAG+="systemd", ENV{SYSTEMD_WANTS}+="radio-daemon@%k.service"
+```
+
+```ini
+# Service: /etc/systemd/system/radio-daemon@.service
+[Unit]
+Description=Radio daemon for %i
+StopWhenUnneeded=yes
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/radio-daemon /dev/%i
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### Key systemd udev variables
+
+| Variable | Purpose |
+|----------|---------|
+| `TAG+="systemd"` | Required. Tells systemd to create a device unit. |
+| `ENV{SYSTEMD_WANTS}` | Start this service when device appears. |
+| `ENV{SYSTEMD_USER_WANTS}` | Start user service (after logind session). |
+| `%k` | Device kernel name (ttyUSB0) in service template. |
+| `%n` | Device number (0 for ttyUSB0). |
+
+---
+
+## Testing and debugging
+
+Use `udevadm` to test rules without rebooting or unplugging hardware.
+
+### Test workflow
+
+```bash
+# 1. Identify the device path
+ls -la /sys/class/tty/ttyUSB0/device/
+
+# 2. Test rule matching (dry run)
+sudo udevadm test /sys/class/tty/ttyUSB0 2>&1 | less
+
+# 3. Check current device properties
+udevadm info -a -n /dev/ttyUSB0
+
+# 4. Monitor real-time events
+sudo udevadm monitor --environment --udev
+
+# 5. Reload rules after editing
+sudo udevadm control --reload-rules
+sudo udevadm trigger --subsystem-match=tty
+```
+
+### Debugging checklist
+
+| Problem | Check |
+|---------|-------|
+| Rule not matching | Use `ATTRS` not `ATTR` for parent USB attributes. |
+| Wrong device node permissions | Verify `GROUP="dialout"` and user group membership. |
+| Symlink not created | Check for typos in `SYMLINK+=` (note the `+=`). |
+| Service not starting | Verify `TAG+="systemd"` and template service syntax. |
+
+---
+
+## Anti-Patterns
+
+1. **`ATTR` instead of `ATTRS` for USB attributes.** `ATTR{idVendor}` on a tty device never matches. USB attributes live on the parent device.
+
+2. **Missing dialout group.** Applications fail with permission denied. Always set `GROUP="dialout"` for serial devices.
+
+3. **Hardcoded device names.** `/dev/ttyUSB0` varies by enumeration order. Use symlinks (via `SYMLINK+=`) or stable paths in `/dev/serial/by-id/`.
+
+4. **`RUN+=` for service management.** Use `ENV{SYSTEMD_WANTS}` instead. `RUN` commands race with systemd; ordering is unreliable.
+
+5. **Numeric prefix > 99.** `100-foo.rules` sorts before `99-local.rules`. Use exactly two digits.
+
+6. **Bare `ACTION=="add"` on child devices.** USB children may already exist when the rule is processed. Match on attributes, not just action.
+
+7. **Overly broad rules.** `SUBSYSTEM=="tty"` without VID/PID matches all serial ports. Be specific to avoid affecting unrelated hardware.
+
+---
+
+## Conventions
+
+1. **Use `99-` prefix** for all site-local rules.
+2. **Use `ATTRS` for USB matching.** `ATTR` only checks immediate device.
+3. **Always set `GROUP="dialout"`** for serial devices.
+4. **Use `SYMLINK+=` for stable aliases.** Never rely on `ttyUSB*` enumeration order.
+5. **Use `TAG+="systemd"` for service binding.** Not `RUN+=` scripts.
+6. **Test with `udevadm test`** before applying changes.
+7. **Reload with `udevadm control --reload-rules`** after edits.

--- a/standards/WORKFLOW.md
+++ b/standards/WORKFLOW.md
@@ -123,7 +123,7 @@ The rendered output:
 
 ## Directive
 
-You are an engineer. Implement this task completely.
+Implement this task completely.
 Write the code, run the tests, fix any issues, commit, push, open a PR.
 Do not analyze or summarize the prompt. Execute it.
 
@@ -182,6 +182,26 @@ Note file and line. Do not fix. Do not investigate deeply. Move on.
 | Blast Radius | Scope boundary | Agent modifies unrelated files, creates merge conflicts |
 | Validation Gate | Pre-PR checks | Broken PRs waste CI and review cycles |
 | Observations | Knowledge capture | Findings from ephemeral sessions are permanently lost |
+
+#### Acceptance criteria specificity
+
+Every acceptance criterion must reference a specific file, function, or structural change observable in a PR diff. QA evaluates criteria by examining the diff — criteria that require runtime execution, CI results, or external state produce systematic false negatives and waste corrective prompt cycles.
+
+**Diff-visible criteria** (use these):
+
+| Instead of | Write |
+|-----------|-------|
+| "`cargo test -p X` passes" | "Test file `src/X/tests.rs` contains test function `test_Y` covering case Z" |
+| "All tests pass" | "Module `X` contains `#[cfg(test)] mod tests` with tests for A, B, and C" |
+| "`cargo clippy` clean" | "No `unwrap()` calls outside test modules; errors use `snafu::ResultExt`" |
+| "Closes #NNN" | "Function `X` in `path/to/file.rs` returns `Result<T, Error>` (fixes #NNN behavior)" |
+| "Issue #NNN requirements are satisfied" | "Struct `Config` has field `timeout: Duration`; `process()` respects it via `tokio::time::timeout`" |
+| "CI green" | "Validation gate commands listed in Validation Gate section produce no errors" |
+| "No regressions" | "Existing public API signatures in `src/lib.rs` are unchanged" |
+
+**Why this matters:** The QA evaluator examines the PR diff, not runtime output. A criterion like "`cargo test` passes" looks like a FAIL from the diff (no evidence of test execution results), even when the code is correct. The prompt validation pipeline rejects non-diff-visible criteria before dispatch.
+
+**Rule:** If a criterion requires executing a command or checking a system outside the PR diff to evaluate, it is not diff-visible. Rewrite it to describe the artifact that executing the command would verify.
 
 #### Framing rules
 
@@ -347,13 +367,13 @@ Runs after each dispatch group completes. The verdicts determine what happens ne
 5. Flag: changes outside declared blast radius, project-specific anti-patterns
 6. Aggregate: PASS (all criteria met), PARTIAL (some met), FAIL (critical criteria unmet)
 
-**Verdicts drive the dispatch loop:**
+**Verdicts drive the dispatch loop.** See DEPLOYMENT.md (deployment gates) for the verdict-to-action mapping and merge eligibility rules.
 
-| Verdict | Next group | Merge | Follow-up |
-|---------|-----------|-------|-----------|
-| PASS | Proceeds | Auto-merge eligible | None |
-| PARTIAL | Proceeds | Hold for architect | Corrective prompts auto-generated |
-| FAIL | Dependents blocked, independents continue | Hold | Diagnostic generated |
+| Verdict | Next group | Follow-up |
+|---------|-----------|-----------|
+| PASS | Proceeds | Merge policy evaluation (DEPLOYMENT.md) |
+| PARTIAL | Proceeds | Corrective prompts auto-generated |
+| FAIL | Dependents blocked, independents continue | Diagnostic generated |
 
 **Corrective prompt generation:** On PARTIAL or FAIL, the dispatcher generates a targeted fix prompt. Inputs: original prompt, failed criteria, the PR diff, and QA evidence. A standard-capability model writes a new prompt scoped to exactly the unmet criteria. This queues as a follow-up wave that runs before the next planned batch.
 
@@ -390,15 +410,7 @@ MAX_CONCURRENT=2         # parallel validation jobs
 - **Diff size cap:** If the fix exceeds 2x the original change scope, abort and flag for human review. This catches agents that "fix" a test failure by rewriting half the module
 - **Model tier:** Always standard capability. Fix agents do mechanical work, not design
 
-**Tiered auto-merge:**
-
-| Condition | Action |
-|-----------|--------|
-| QA PASS + CI green + single-module blast radius | Auto-merge |
-| QA PASS + CI green + multi-module blast radius | Merge, notify architect for observation triage |
-| QA PARTIAL or hold flag | Hold for architect |
-| Touches public API surface | Hold for architect |
-| R-type prompt (research, no PR) | Move prompt to done/ |
+**Tiered auto-merge:** See DEPLOYMENT.md (merge policy) for the full merge decision table. The CI manager evaluates each PR against the tiered policy after validation passes.
 
 #### Layer 3: observation triage (post-merge, automated)
 
@@ -505,7 +517,7 @@ The system can fail at every stage. Recognizing failure modes and their remediat
 
 *Signal:* Corrective prompts that produce identical diffs to the original. The "fix" changes nothing because nothing was broken.
 
-*Remediation:* Improve acceptance criteria specificity. "All tests pass" is not verifiable from a diff. "Test file X exists with test function Y that covers case Z" is. The QA evaluator can only assess what the diff shows. Criteria must be diff-visible.
+*Remediation:* The classifier now detects criteria requiring runtime execution or external state (e.g., "`cargo test` passes", "Closes #NNN") and auto-resolves them as NOT_VERIFIABLE instead of FAIL. The prompt validation pipeline rejects such criteria before dispatch. For remaining criteria, improve specificity: "Test file X exists with test function Y that covers case Z" is diff-visible. See the "Acceptance criteria specificity" section above for rewrite patterns.
 
 **Agent drift.** A worker session wanders from the task. It refactors adjacent code, adds features not in the prompt, or "improves" things outside the blast radius.
 
@@ -549,7 +561,7 @@ Not cost tracking. System health signals that indicate whether the pipeline itse
 |--------|---------|----------|--------|
 | **Corrective prompt rate** | <10% of prompts need correction | >20% | Planner is under-specifying. Review acceptance criteria quality |
 | **Stuck rate** | <5% of sessions | >15% | Prompts are too large. Decompose further, or increase max_turns |
-| **QA false positive rate** | <5% of FAIL verdicts are wrong | >15% | Acceptance criteria are not diff-visible. Rewrite to reference concrete artifacts |
+| **QA false positive rate** | <5% of FAIL verdicts are wrong | >15% | Acceptance criteria are not diff-visible. Run prompt validation to catch them pre-dispatch. See "Acceptance criteria specificity" |
 | **Fix agent success rate** | >80% of fix agents resolve the failure | <50% | Failures are too complex for mechanical fixes. Reduce MAX_FIX_AGENTS, let corrective prompts handle it |
 | **Prompt-to-merge cycle time** | Batch completes in one dispatch run | Frequent multi-wave corrections before merge | Prompt quality issue or dependency misordering in execution plan |
 | **Observation-to-issue rate** | >90% of observations become tracked items | <50% triage, overflow accumulating | Tighten severity threshold, switch to digest mode |


### PR DESCRIPTION
## Summary

Pulls the canonical Greek-naming methodology doc from \`kanon/crates/basanos/standards/GNOMON.md\` (254 lines). The local copy was missing the entire \"Naming review gate\" section (L1-L4 process gate added by forkwright/kanon#766).

| | Before | After |
|---|---|---|
| Hash | \`8221e3a84433e2ccc1f0572ed5980c94\` | \`45898de19932f4a293fef76eda3ec454\` |
| Lines | 178 | 254 |
| Has Naming Review Gate | ✗ | ✓ |

\`+76 / -0\` — pure addition. Thumos's previous GNOMON.md was a clean subset of canonical, just behind on the review gate work.

## Note on location

Thumos keeps this file at \`standards/GNOMON.md\` (uppercase, matching kanon's convention), while aletheia/harmonia/akroasis keep it at \`docs/gnomon.md\`. Location reconciliation across the ecosystem is tracked separately as part of the broader standards/ cleanup.

## Long-term mechanism

Once forkwright/kanon#1004 (\`kanon sync --standards\`) lands, this file will be kept in lockstep automatically.

Refs forkwright/kanon#1004.

Gate-Passed: kanon 0.1.0