### PR TITLE
fix(docs): audit batch 3 — dead refs, doc accuracy, misleading sections

### DIFF
--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -1,0 +1,4 @@
+# release-please auto-generates CHANGELOG.md from conventional commits.
+# REPO-SETUP.md says to omit it, but release-please creates it automatically
+# and removing it would break the release workflow.
+RELEASES/changelog-present:CHANGELOG.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,11 +10,11 @@ Thumos is a custom Rust mobile OS targeting the AGM M7 (MT6739).
 
 ## Architecture
 
-Full Rust from kernel to UI. No C we author, no Linux in the final system. Monolithic kernel (pyknosis).
+Full Rust from kernel to UI. No C we author, no Linux in the final system. Monolithic kernel.
 
 | Layer | Status | Notes |
 |-------|--------|-------|
-| Kernel (thumos) | Phase 05 | MMU, slab allocator, GIC, timer, scheduler, 34 syscalls, IPC (pipe, futex, signals), ELF loader, VFS (Filesystem trait, MountTable, path resolution), LFS (log-structured persistent filesystem with compaction), ramfs (hierarchical, writable), devfs, block cache (LRU, 1MB), 256-fd table, ChaCha20 CSPRNG, watchdog, capabilities, DVFS |
+| Kernel (thumos) | Phase 06 | MMU, slab allocator, GIC, timer, scheduler, 45 syscalls, IPC (pipe, futex, signals), ELF loader, VFS (Filesystem trait, MountTable, path resolution), LFS (log-structured persistent filesystem with compaction), ramfs (hierarchical, writable), devfs, block cache (LRU, 1MB), 256-fd table, ChaCha20 CSPRNG, watchdog, capabilities, DVFS, network stack (TCP/UDP sockets, DHCP, DNS resolver), firewall (packet filter, DNS blocklist), wall clock |
 | eMMC driver | Phase 03 | MSDC controller, PIO + DMA, GPD/BD descriptors |
 | Display driver | Phase 03 | DDP pipeline (OVL→RDMA→DSI→LCM), GC9306 init/sleep/wake/backlight |
 | CCCI modem driver | Phase 03 | CLDMA ring buffers, CCIF mailbox, identity containment, packet validation |
@@ -34,7 +34,7 @@ Full Rust from kernel to UI. No C we author, no Linux in the final system. Monol
 
 ## Key constraints
 
-- 13 crates (12 workspace userspace + `thumos` kernel binary, excluded from workspace), ~48K LOC (27.7K kernel + 20K userspace), 308 host tests + 156 filesystem tests, zero clippy warnings. Phase 05 (filesystem) complete.
+- 13 crates (12 workspace userspace + `thumos` kernel binary, excluded from workspace), ~53K LOC (35K kernel + 18.4K userspace), 1,047 tests (572 kernel + 475 workspace, including 114 filesystem tests), zero clippy warnings. Phase 06 (networking) complete.
 - 1 GB RAM: every megabyte matters. No unnecessary services.
 - 240x320 display: no standard Android UI. Custom framebuffer or TUI.
 - Keypad + touchscreen input. T9-style or menu navigation.

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ sema (radio tools) + aither (WiFi) + pteron (BT) + topos (GPS)
 klesis (AT commands, CCCI transport, SMS PDU) + krypta (Signal protocol)
 kelyphos (WMT combo chip STP framing) + haphe (input routing)
 ──────────────────────────────────────────────
-thumos kernel (MMU, slab allocator, scheduler, IPC, signals, 34 syscalls)
+thumos kernel (MMU, slab allocator, scheduler, IPC, signals, 45 syscalls)
 MT6739 hardware (modem on separate core, firewalled at CCCI driver level)
 ```
 
 ## Status
 
-Phase 04 complete (2026-04-08). 13 crates (12 userspace workspace members plus the `thumos` kernel binary, excluded from the main workspace for bare-metal builds), 486 workspace tests, ~39K LOC (19.3K kernel, 20K userspace). Kernel implements 34 syscalls including fork/exec/waitpid, mmap/brk/mprotect, pipe/futex IPC, POSIX signals (sigaction/kill/sigreturn), clock_gettime/nanosleep. Slab allocator (7 size classes), ChaCha20 CSPRNG (RFC 8439), capability-based access control, DVFS power management, watchdog timer. Hardware drivers: eMMC (MSDC), display (DDP + GC9306), WiFi MAC (randomization), BT HCI (LE Privacy), WMT, CCCI modem containment, USB ACM, GPIO keypad, touchscreen.
+Phase 06 complete (2026-04-09). 13 crates (12 userspace workspace members plus the `thumos` kernel binary, excluded from the main workspace for bare-metal builds), 1,047 tests (572 kernel + 475 workspace), ~53K LOC (35K kernel, 18.4K userspace). Kernel implements 45 syscalls including fork/exec/waitpid, mmap/brk/mprotect, pipe/futex IPC, POSIX signals (sigaction/kill/sigreturn), clock_gettime/nanosleep, network sockets (TCP/UDP/bind/listen/accept/connect/sendto/recvfrom). Slab allocator (7 size classes), ChaCha20 CSPRNG, capability-based access control, DVFS power management, watchdog timer, VFS with LFS/ramfs/devfs, firewall with DNS blocklist, DHCP client, DNS resolver. Hardware drivers: eMMC (MSDC), display (DDP + GC9306), WiFi MAC (randomization), BT HCI (LE Privacy), WMT, CCCI modem containment, USB ACM, GPIO keypad, touchscreen, GPS (NMEA), Bluetooth (STP/HCI).
 
 ## Related
 

--- a/crates/thumos/link.ld
+++ b/crates/thumos/link.ld
@@ -1,4 +1,4 @@
-/* Linker script for thumos pyknosis on MT6739 */
+/* Linker script for thumos on MT6739 */
 /* Kernel loads at 0x40008000 (same as Linux on this platform) */
 
 ENTRY(_start)

--- a/crates/thumos/src/console.rs
+++ b/crates/thumos/src/console.rs
@@ -145,7 +145,7 @@ impl Console {
     }
 
     fn cmd_version(&mut self) {
-        let _ = self.serial.write_str("thumos/pyknosis v0.1.0\r\n");
+        let _ = self.serial.write_str("thumos v0.1.0\r\n");
         let _ = self.serial
             .write_str("Rust monolithic kernel for MT6739\r\n");
     }

--- a/crates/thumos/src/csprng.rs
+++ b/crates/thumos/src/csprng.rs
@@ -23,7 +23,11 @@
 //!     On single-core ARMv7 this is safe because the caller disables IRQs
 //!     implicitly through the critical-section contract of the kernel.
 //!
-//! ChaCha20 implemented per RFC 8439 §2.1–§2.3.
+//! ChaCha20 block cipher with 64-bit counter extension (Linux kernel convention).
+//! Core quarter-round arithmetic follows RFC 8439 §2.1. State layout differs:
+//! uses 64-bit counter (state[12-13]) + 64-bit nonce (state[14-15]) instead of
+//! RFC 8439's 32-bit counter + 96-bit nonce. The CSPRNG is seeded from hardware
+//! entropy, so the layout difference does not affect cryptographic strength.
 
 // ---------------------------------------------------------------------------
 // ChaCha20 constants

--- a/crates/thumos/src/devfs.rs
+++ b/crates/thumos/src/devfs.rs
@@ -175,10 +175,6 @@ impl DevFs {
 
 impl Filesystem for DevFs {
     /// Returns 0, the root directory inode.
-    ///
-    /// # Errors
-    ///
-    /// This method is infallible.
     fn root_inode(&self) -> u32 {
         ROOT_INODE
     }

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -275,7 +275,7 @@ pub unsafe fn run() -> ! {
     let _ = serial.write_str("\r\n");
     let _ = serial
         .write_str("================================\r\n");
-    let _ = serial.write_str("  THUMOS / pyknosis v0.1.0\r\n");
+    let _ = serial.write_str("  THUMOS v0.1.0\r\n");
     let _ = serial.write_str("  Sovereign OS for MT6739\r\n");
     let _ = serial
         .write_str("================================\r\n");

--- a/crates/thumos/src/main.rs
+++ b/crates/thumos/src/main.rs
@@ -1,4 +1,4 @@
-//! Thumos kernel: pyknosis
+//! Thumos kernel
 //!
 //! Bare-metal Rust kernel for the MT6739. ARM boot stub is inline
 //! assembly that sets up the stack and zeros BSS before jumping to

--- a/crates/thumos/src/vfs.rs
+++ b/crates/thumos/src/vfs.rs
@@ -55,10 +55,6 @@ impl VfsError {
     ///
     /// Returns the value that would be placed in r0 for a failed syscall on
     /// ARM Linux (e.g., `ENOENT` -> `0u32.wrapping_sub(2)` = `0xFFFF_FFFE`).
-    ///
-    /// # Errors
-    ///
-    /// This method is infallible.
     pub const fn to_errno(self) -> u32 {
         let raw = match self {
             Self::NotFound => 2,
@@ -138,10 +134,6 @@ pub struct DirEntry {
 /// filesystem instances.
 pub trait Filesystem {
     /// Return the inode ID of the filesystem root directory.
-    ///
-    /// # Errors
-    ///
-    /// This method is infallible; it always returns a valid root inode ID.
     fn root_inode(&self) -> u32;
 
     /// Retrieve metadata for an inode.

--- a/docs/full-props.txt
+++ b/docs/full-props.txt
@@ -1,3 +1,10 @@
+# AGM M7 (MT6739) Android system properties dump (`adb shell getprop`).
+# Captured from stock Android 8.1 firmware. Used as reference for SoC
+# configuration, Dalvik tuning, radio interface names, and hardware
+# feature flags during thumos kernel and driver development.
+#
+# Not consumed by any build process.
+
 [Build.BRAND]: [MTK]
 [af.modem_1.epof]: [0]
 [af.music.outputid]: [3]

--- a/vendor/haocheng/README.md
+++ b/vendor/haocheng/README.md
@@ -1,0 +1,27 @@
+# vendor/haocheng
+
+Vendored MT6739 driver reference code from the Haocheng BSP (Board Support Package)
+shipped with the AGM M7.
+
+## Purpose
+
+These files are used as **reference documentation only** during kernel development.
+They provide register offsets, hardware initialization sequences, and GPIO/feature
+bindings for the MT6739 SoC as configured by the Haocheng ODM.
+
+## Build status
+
+**Not compiled.** Nothing in this directory is included in any Cargo build or
+linked into the thumos kernel. The files exist solely to be read by developers
+while writing Rust drivers that target the same hardware.
+
+## Contents
+
+- `drivers/hct_include/hct_project_all_config.h` -- GPIO and feature configuration
+  bindings for the AGM M7 board variant. Currently a stub header (feature bindings
+  absent; kernel boots without LCM probing).
+
+## License
+
+The original header file contained no license header or copyright notice. The
+vendored stub retains the same absence. Treat as proprietary reference material.


### PR DESCRIPTION
Closes #56, #57, #73, #77, #79, #80, #82. Removes pyknosis refs (5 files), updates CLAUDE.md+README.md to Phase 06 reality (53K LOC, 1047 tests), documents ChaCha20 deviation, removes misleading # Errors on infallible methods, labels vendor/ and docs/ artifacts, adds .kanon-lint-ignore for CHANGELOG.md.