### PR TITLE
fix(kernel): audit batch 2 — cache eviction, IPC routing, WPA timing, key zeroize

### DIFF
--- a/crates/aither/src/wpa.rs
+++ b/crates/aither/src/wpa.rs
@@ -35,6 +35,10 @@ pub const MIC_LEN: usize = 16;
 /// Pairwise Transient Key components.
 ///
 /// Derived FROM the PMK by PTK = PRF-384(PMK, "Pairwise key expansion", …).
+///
+/// Implements [`Drop`] to zero key material, preventing it from persisting
+/// in memory after use. Uses `write_volatile` to prevent the compiler from
+/// optimizing away the zeroing.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Ptk {
     /// Key Confirmation Key: used to compute and verify MIC.
@@ -43,6 +47,28 @@ pub struct Ptk {
     pub kek: [u8; KEK_LEN],
     /// Temporal Key: used for data frame encryption (AES-CCMP).
     pub tk: [u8; TK_LEN],
+}
+
+impl Drop for Ptk {
+    // WHY: write_volatile is the only way to prevent the compiler from
+    // eliding zeroing as a dead store. This is a security requirement for
+    // key material cleanup. The unsafe blocks access only valid mutable
+    // references to initialized memory within the struct.
+    #[allow(unsafe_code)]
+    fn drop(&mut self) {
+        for byte in &mut self.kck {
+            // SAFETY: byte is a valid mutable reference to initialized memory.
+            unsafe { std::ptr::write_volatile(byte, 0); }
+        }
+        for byte in &mut self.kek {
+            // SAFETY: byte is a valid mutable reference to initialized memory.
+            unsafe { std::ptr::write_volatile(byte, 0); }
+        }
+        for byte in &mut self.tk {
+            // SAFETY: byte is a valid mutable reference to initialized memory.
+            unsafe { std::ptr::write_volatile(byte, 0); }
+        }
+    }
 }
 
 /// Derive the Pairwise Master Key FROM a passphrase and SSID.
@@ -139,10 +165,29 @@ pub fn compute_mic(kck: &[u8; KCK_LEN], data: &[u8]) -> [u8; MIC_LEN] {
 
 /// Verify that `expected_mic` matches the MIC computed over `data` with `kck`.
 ///
+/// Uses constant-time comparison to prevent timing side-channel attacks.
 /// Returns `true` only when the MIC is correct.
 #[must_use]
 pub fn verify_mic(kck: &[u8; KCK_LEN], data: &[u8], expected_mic: &[u8; MIC_LEN]) -> bool {
-    compute_mic(kck, data) == *expected_mic
+    let computed = compute_mic(kck, data);
+    constant_time_eq(&computed, expected_mic)
+}
+
+/// Constant-time byte slice comparison.
+///
+/// Compares all bytes regardless of early differences, preventing timing
+/// side-channel attacks that could leak information about secret key material.
+/// Returns `true` only when both slices have equal length and identical content.
+#[must_use]
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
 }
 
 /// WPA2 PRF function  -  HMAC-SHA1 counter construction.

--- a/crates/thumos/src/cache.rs
+++ b/crates/thumos/src/cache.rs
@@ -99,7 +99,7 @@ impl BlockCache {
     /// write-back fails.
     pub fn read(
         &mut self,
-        dev: &dyn BlockDevice,
+        dev: &mut dyn BlockDevice,
         block_num: u64,
         buf: &mut [u8; BLOCK_SIZE],
     ) -> Result<(), BlockError> {
@@ -110,8 +110,9 @@ impl BlockCache {
             return Ok(());
         }
 
-        // Cache miss — need to load from device.
-        let idx = self.allocate_entry();
+        // Cache miss — need to load from device. Allocation may write back
+        // a dirty evictee.
+        let idx = self.allocate_entry(dev)?;
 
         // Read SECTORS_PER_BLOCK sectors from the device into the entry.
         let lba = block_num * SECTORS_PER_BLOCK as u64;
@@ -130,20 +131,21 @@ impl BlockCache {
     ///
     /// The data is written to a cache entry and marked dirty. It is NOT
     /// immediately written to the device — call [`BlockCache::flush`] to
-    /// commit dirty entries.
+    /// commit dirty entries. If a dirty entry must be evicted to make room,
+    /// it is written back to `dev` first.
     ///
     /// # Errors
     ///
     /// Returns [`BlockError`] if evicting a dirty entry for the new write fails.
     pub fn write(
         &mut self,
-        _dev: &dyn BlockDevice,
+        dev: &mut dyn BlockDevice,
         block_num: u64,
         buf: &[u8; BLOCK_SIZE],
     ) -> Result<(), BlockError> {
         let idx = match self.find_entry(block_num) {
             Some(idx) => idx,
-            None => self.allocate_entry(),
+            None => self.allocate_entry(dev)?,
         };
 
         self.entries[idx].data.copy_from_slice(buf);
@@ -206,25 +208,29 @@ impl BlockCache {
     }
 
     /// Find a free entry or evict the LRU entry. Returns the index of the
-    /// entry to use. Dirty data in an evicted entry is discarded — callers
-    /// must flush before operations that might cause eviction if dirty data
-    /// must be preserved.
-    fn allocate_entry(&mut self) -> usize {
+    /// entry to use. If the evicted entry is dirty, it is written back to
+    /// the device before eviction.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BlockError`] if writing back a dirty evicted entry fails.
+    fn allocate_entry(&mut self, dev: &mut dyn BlockDevice) -> Result<usize, BlockError> {
         // First, look for an invalid (free) entry.
         if let Some(idx) = self.entries.iter().position(|e| !e.valid) {
-            return idx;
+            return Ok(idx);
         }
 
         // All entries are valid — evict the LRU entry (lowest counter).
         let idx = self.lru_victim();
 
-        // NOTE: dirty data is silently discarded on eviction. The design
-        // requires callers to flush() before reads that might evict dirty
-        // entries. This is acceptable for our single-threaded bare-metal
-        // use case where the flush/write pattern is controlled.
+        // Write back dirty data before eviction to prevent data loss.
+        if self.entries[idx].dirty {
+            self.write_back(dev, idx)?;
+        }
+
         self.entries[idx].dirty = false;
         self.entries[idx].valid = false;
-        idx
+        Ok(idx)
     }
 
     /// Find the index of the least-recently-used (lowest counter) valid entry.
@@ -284,11 +290,11 @@ mod tests {
 
     #[test]
     fn read_fills_cache_on_miss() {
-        let dev = test_device();
+        let mut dev = test_device();
         let mut cache = BlockCache::new();
         let mut buf = [0u8; BLOCK_SIZE];
 
-        cache.read(&dev, 0, &mut buf).expect("read failed");
+        cache.read(&mut dev, 0, &mut buf).expect("read failed");
 
         // After read, entry should be cached.
         assert!(cache.find_entry(0).is_some(), "block 0 should be cached");
@@ -298,16 +304,16 @@ mod tests {
 
     #[test]
     fn read_hits_cache_on_second_access() {
-        let dev = test_device();
+        let mut dev = test_device();
         let mut cache = BlockCache::new();
         let mut buf = [0u8; BLOCK_SIZE];
 
         // First read — cache miss, fills from device.
-        cache.read(&dev, 5, &mut buf).expect("first read failed");
+        cache.read(&mut dev, 5, &mut buf).expect("first read failed");
         let counter_after_first = cache.counter;
 
         // Second read — should be a cache hit (counter increments but no device I/O).
-        cache.read(&dev, 5, &mut buf).expect("second read failed");
+        cache.read(&mut dev, 5, &mut buf).expect("second read failed");
         let counter_after_second = cache.counter;
 
         assert_eq!(
@@ -320,11 +326,11 @@ mod tests {
 
     #[test]
     fn write_marks_entry_dirty() {
-        let dev = test_device();
+        let mut dev = test_device();
         let mut cache = BlockCache::new();
         let data = pattern_block(0xAB);
 
-        cache.write(&dev, 3, &data).expect("write failed");
+        cache.write(&mut dev, 3, &data).expect("write failed");
 
         let idx = cache.find_entry(3).expect("block 3 should be cached");
         assert!(cache.entries[idx].dirty, "written entry should be dirty");
@@ -339,7 +345,7 @@ mod tests {
         let data = pattern_block(0xCD);
 
         // Write to cache (block 2).
-        cache.write(&dev, 2, &data).expect("cache write failed");
+        cache.write(&mut dev, 2, &data).expect("cache write failed");
 
         // Verify device is still zeroed at block 2's sectors.
         let mut verify = vec![0u8; BLOCK_SIZE];
@@ -370,29 +376,27 @@ mod tests {
     #[test]
     fn evict_writes_dirty_entry_before_replacing() {
         // Use a large device so we have enough blocks beyond cache capacity.
-        let dev = MemBlockDevice::new(4096).expect("failed to create large device");
+        let mut dev = MemBlockDevice::new(4096).expect("failed to create large device");
         let mut cache = BlockCache::new();
 
         // Fill all 256 cache entries with dirty writes.
         for i in 0..CACHE_ENTRIES {
             let data = pattern_block((i & 0xFF) as u8);
             cache
-                .write(&dev, i as u64, &data)
+                .write(&mut dev, i as u64, &data)
                 .expect("fill write failed");
         }
 
         // All entries should be valid and dirty now.
         assert!(cache.entries.iter().all(|e| e.valid && e.dirty));
 
-        // Flush to device so dirty data is persisted, then verify state.
-        let mut flush_dev = MemBlockDevice::new(4096).expect("new device");
-        cache.flush(&mut flush_dev).expect("flush failed");
-
         // Write a new block that forces eviction of the LRU entry (block 0,
         // which was written first and has the lowest counter).
+        // The evicted dirty entry should be written back to the device
+        // automatically by allocate_entry.
         let evict_data = pattern_block(0xFF);
         cache
-            .write(&dev, 999, &evict_data)
+            .write(&mut dev, 999, &evict_data)
             .expect("eviction write failed");
 
         // Block 999 should now be in the cache.
@@ -402,29 +406,39 @@ mod tests {
             cache.find_entry(0).is_none(),
             "block 0 should have been evicted"
         );
+
+        // Verify the evicted dirty block 0 was written back to the device.
+        let mut verify = [0u8; BLOCK_SIZE];
+        dev.read_sectors(0, SECTORS_PER_BLOCK as u32, &mut verify)
+            .expect("device read of evicted block failed");
+        assert_eq!(
+            verify,
+            pattern_block(0x00),
+            "evicted dirty block 0 must have been flushed to device"
+        );
     }
 
     #[test]
     fn lru_evicts_least_recently_used() {
-        let dev = MemBlockDevice::new(4096).expect("failed to create device");
+        let mut dev = MemBlockDevice::new(4096).expect("failed to create device");
         let mut cache = BlockCache::new();
 
         // Fill the cache with blocks 0..255.
         for i in 0..CACHE_ENTRIES {
             let mut buf = [0u8; BLOCK_SIZE];
             cache
-                .read(&dev, i as u64, &mut buf)
+                .read(&mut dev, i as u64, &mut buf)
                 .expect("fill read failed");
         }
 
         // Touch block 0 again to make it recently used.
         let mut buf = [0u8; BLOCK_SIZE];
-        cache.read(&dev, 0, &mut buf).expect("touch read failed");
+        cache.read(&mut dev, 0, &mut buf).expect("touch read failed");
 
         // Now insert a new block (256) — should evict block 1 (the true LRU),
         // not block 0 (which was just touched).
         cache
-            .read(&dev, 256, &mut buf)
+            .read(&mut dev, 256, &mut buf)
             .expect("eviction read failed");
 
         assert!(
@@ -440,13 +454,13 @@ mod tests {
 
     #[test]
     fn invalidate_clears_all_entries() {
-        let dev = test_device();
+        let mut dev = test_device();
         let mut cache = BlockCache::new();
 
         // Fill some entries.
         let mut buf = [0u8; BLOCK_SIZE];
-        cache.read(&dev, 0, &mut buf).expect("read failed");
-        cache.read(&dev, 1, &mut buf).expect("read failed");
+        cache.read(&mut dev, 0, &mut buf).expect("read failed");
+        cache.read(&mut dev, 1, &mut buf).expect("read failed");
 
         assert!(cache.find_entry(0).is_some());
         assert!(cache.find_entry(1).is_some());
@@ -475,11 +489,11 @@ mod tests {
 
         // Write to block 0.
         let data = pattern_block(0x42);
-        cache.write(&dev, 0, &data).expect("write block 0 failed");
+        cache.write(&mut dev, 0, &data).expect("write block 0 failed");
 
         // Read it back from cache.
         let mut buf = [0u8; BLOCK_SIZE];
-        cache.read(&dev, 0, &mut buf).expect("read block 0 failed");
+        cache.read(&mut dev, 0, &mut buf).expect("read block 0 failed");
         assert_eq!(buf, data);
 
         // Flush and verify on device.
@@ -497,7 +511,7 @@ mod tests {
         let mut cache = BlockCache::new();
         let data = pattern_block(0xEE);
 
-        cache.write(&dev, 7, &data).expect("write failed");
+        cache.write(&mut dev, 7, &data).expect("write failed");
         cache.sync(&mut dev).expect("sync failed");
 
         let idx = cache.find_entry(7).expect("block 7 should be cached");
@@ -509,14 +523,14 @@ mod tests {
 
     #[test]
     fn write_then_read_returns_cached_data() {
-        let dev = test_device();
+        let mut dev = test_device();
         let mut cache = BlockCache::new();
         let data = pattern_block(0x77);
 
-        cache.write(&dev, 10, &data).expect("write failed");
+        cache.write(&mut dev, 10, &data).expect("write failed");
 
         let mut buf = [0u8; BLOCK_SIZE];
-        cache.read(&dev, 10, &mut buf).expect("read failed");
+        cache.read(&mut dev, 10, &mut buf).expect("read failed");
         assert_eq!(buf, data, "read should return the cached write data");
     }
 }

--- a/crates/thumos/src/ipc.rs
+++ b/crates/thumos/src/ipc.rs
@@ -102,44 +102,146 @@ impl Inbox {
     }
 }
 
+/// Number of inbox slots, matching the maximum number of processes.
+const MAX_INBOX_PROCS: usize = 16;
+
+/// Error code for "no such process" (ESRCH equivalent for ARM Linux).
+pub const ESRCH: i32 = -3;
+
 /// Process inboxes. Indexed by PID.
-static mut INBOXES: [Inbox; 16] = {
+static mut INBOXES: [Inbox; MAX_INBOX_PROCS] = {
     const NEW_INBOX: Inbox = Inbox::new();
-    [NEW_INBOX; 16]
+    [NEW_INBOX; MAX_INBOX_PROCS]
 };
 
-/// Send a message to a process. Non-blocking: returns false if inbox full.
+/// Validate a PID is within the inbox array bounds.
+///
+/// Returns the PID as a `usize` index, or `Err(ESRCH)` if the PID
+/// cannot be converted or exceeds the maximum process count.
+fn validate_pid(pid: Pid) -> Result<usize, i32> {
+    let idx = usize::from(pid);
+    if idx >= MAX_INBOX_PROCS {
+        return Err(ESRCH);
+    }
+    Ok(idx)
+}
+
+/// Send a message to a process. Non-blocking: returns false if inbox full
+/// or the target PID is invalid.
 pub fn send(to: Pid, mut msg: Message) -> bool {
+    let idx = match validate_pid(to) {
+        Ok(i) => i,
+        Err(_) => return false,
+    };
     msg.from = process::current_pid();
     // SAFETY: INBOXES is a static array indexed by PID. addr_of_mut! avoids
     // creating an intermediate reference to the static mut. Single-core kernel
     // with interrupts disabled at call sites ensures exclusive access.
     unsafe {
         let inboxes = &mut *core::ptr::addr_of_mut!(INBOXES);
-        inboxes[usize::try_from(to).unwrap_or_default()].push(msg)
+        inboxes[idx].push(msg)
     }
 }
 
-/// Receive a message FROM our inbox. Non-blocking: returns None if empty.
+/// Receive a message FROM our inbox. Non-blocking: returns None if empty
+/// or current PID is invalid.
 pub fn recv() -> Option<Message> {
     let pid = process::current_pid();
+    let idx = validate_pid(pid).ok()?;
     // SAFETY: INBOXES is a static array indexed by PID. addr_of_mut! avoids
     // creating an intermediate reference to the static mut. Single-core kernel
     // with interrupts disabled at call sites ensures exclusive access.
     unsafe {
         let inboxes = &mut *core::ptr::addr_of_mut!(INBOXES);
-        inboxes[usize::try_from(pid).unwrap_or_default()].pop()
+        inboxes[idx].pop()
     }
 }
 
-/// Check if our inbox has messages.
+/// Check if our inbox has messages. Returns false if the current PID is invalid.
 pub fn has_messages() -> bool {
     let pid = process::current_pid();
+    let idx = match validate_pid(pid) {
+        Ok(i) => i,
+        Err(_) => return false,
+    };
     // SAFETY: INBOXES is a static array indexed by PID. addr_of! avoids
     // creating an intermediate reference to the static mut. Read-only access
     // here; single-core kernel ensures no concurrent mutation.
     unsafe {
         let inboxes = &*core::ptr::addr_of!(INBOXES);
-        !inboxes[usize::try_from(pid).unwrap_or_default()].is_empty()
+        !inboxes[idx].is_empty()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_pid_accepts_valid_pids() {
+        for pid in 0..MAX_INBOX_PROCS as u8 {
+            assert!(
+                validate_pid(pid).is_ok(),
+                "pid {pid} should be valid"
+            );
+            assert_eq!(validate_pid(pid), Ok(pid as usize));
+        }
+    }
+
+    #[test]
+    fn validate_pid_rejects_out_of_range() {
+        // PIDs at or above MAX_INBOX_PROCS must be rejected.
+        assert_eq!(validate_pid(MAX_INBOX_PROCS as u8), Err(ESRCH));
+        assert_eq!(validate_pid(u8::MAX), Err(ESRCH));
+        assert_eq!(validate_pid(200), Err(ESRCH));
+    }
+
+    #[test]
+    fn validate_pid_never_routes_to_zero() {
+        // The old bug: invalid PIDs silently routed to pid 0 (init).
+        // Verify that an invalid PID returns an error, not Ok(0).
+        let result = validate_pid(MAX_INBOX_PROCS as u8);
+        assert!(result.is_err(), "invalid PID must not succeed");
+        assert_ne!(result, Ok(0), "invalid PID must never route to pid 0");
+    }
+
+    #[test]
+    fn inbox_push_pop_round_trips() {
+        let mut inbox = Inbox::new();
+        assert!(inbox.is_empty());
+
+        let msg = Message::new(42, b"hello");
+        assert!(inbox.push(msg));
+        assert!(!inbox.is_empty());
+
+        let popped = inbox.pop();
+        assert!(popped.is_some());
+        let popped = popped.as_ref();
+        assert_eq!(popped.map(|m| m.tag), Some(42));
+        assert_eq!(popped.map(|m| m.payload()), Some(b"hello".as_slice()));
+        assert!(inbox.is_empty());
+    }
+
+    #[test]
+    fn inbox_rejects_when_full() {
+        let mut inbox = Inbox::new();
+        for i in 0..INBOX_SIZE {
+            let msg = Message::new(i as u32, &[]);
+            assert!(inbox.push(msg), "push {i} should succeed");
+        }
+        assert!(inbox.is_full());
+
+        let msg = Message::new(999, &[]);
+        assert!(!inbox.push(msg), "push to full inbox must return false");
+    }
+
+    #[test]
+    fn inbox_pop_empty_returns_none() {
+        let mut inbox = Inbox::new();
+        assert!(inbox.pop().is_none());
     }
 }

--- a/crates/thumos/src/lfs.rs
+++ b/crates/thumos/src/lfs.rs
@@ -489,17 +489,17 @@ pub fn format(dev: &mut dyn BlockDevice) -> Result<(), LfsError> {
 /// - [`LfsError::InvalidSuperblock`] if the superblock magic/version is wrong.
 /// - [`LfsError::Corrupt`] if neither checkpoint is valid.
 /// - [`LfsError::BlockIo`] if any block read fails.
-pub fn mount(dev: Box<dyn BlockDevice>) -> Result<Lfs, LfsError> {
+pub fn mount(mut dev: Box<dyn BlockDevice>) -> Result<Lfs, LfsError> {
     let mut cache = BlockCache::new();
 
     // Read superblock.
     let mut sb_buf = [0u8; BLOCK_SIZE];
-    cache.read(dev.as_ref(), SUPERBLOCK_BLOCK, &mut sb_buf)?;
+    cache.read(dev.as_mut(), SUPERBLOCK_BLOCK, &mut sb_buf)?;
     let superblock = LfsSuperblock::from_block(&sb_buf)?;
 
     // Pick the latest checkpoint.
     let (checkpoint, _slot_block) = lfs_checkpoint::pick_latest(
-        dev.as_ref(),
+        dev.as_mut(),
         &mut cache,
         superblock.checkpoint_block_a,
         superblock.checkpoint_block_b,
@@ -507,7 +507,7 @@ pub fn mount(dev: Box<dyn BlockDevice>) -> Result<Lfs, LfsError> {
 
     // Load imap from checkpoint.
     let imap = LfsImap::load_from_disk(
-        dev.as_ref(),
+        dev.as_mut(),
         &mut cache,
         checkpoint.imap_block,
         checkpoint.imap_block_count,
@@ -518,7 +518,7 @@ pub fn mount(dev: Box<dyn BlockDevice>) -> Result<Lfs, LfsError> {
     let mut block_buf = [0u8; BLOCK_SIZE];
     for i in 0..checkpoint.segment_bitmap_count {
         cache.read(
-            dev.as_ref(),
+            dev.as_mut(),
             checkpoint.segment_bitmap_block + u64::from(i),
             &mut block_buf,
         )?;
@@ -561,10 +561,10 @@ impl Lfs {
             .ok_or(VfsError::NotFound)?;
 
         let mut buf = [0u8; BLOCK_SIZE];
-        let dev = self.dev.borrow();
+        let mut dev = self.dev.borrow_mut();
         let mut cache = self.cache.borrow_mut();
         cache
-            .read(dev.as_ref(), block_num, &mut buf)
+            .read(dev.as_mut(), block_num, &mut buf)
             .map_err(|_| VfsError::IoError)?;
 
         // Each block can hold multiple inodes. For format(), we write
@@ -675,10 +675,10 @@ impl Lfs {
             }
 
             let mut buf = [0u8; BLOCK_SIZE];
-            let dev = self.dev.borrow();
+            let mut dev = self.dev.borrow_mut();
             let mut cache = self.cache.borrow_mut();
             cache
-                .read(dev.as_ref(), block_num, &mut buf)
+                .read(dev.as_mut(), block_num, &mut buf)
                 .map_err(|_| VfsError::IoError)?;
 
             let entries = Self::parse_dir_entries(&buf);
@@ -881,10 +881,10 @@ impl Filesystem for Lfs {
 
             let mut block_buf = [0u8; BLOCK_SIZE];
             {
-                let dev = self.dev.borrow();
+                let mut dev = self.dev.borrow_mut();
                 let mut cache = self.cache.borrow_mut();
                 cache
-                    .read(dev.as_ref(), block_num, &mut block_buf)
+                    .read(dev.as_mut(), block_num, &mut block_buf)
                     .map_err(|_| VfsError::IoError)?;
             }
 
@@ -944,7 +944,7 @@ impl Filesystem for Lfs {
                 let existing_block = inode.direct[block_index];
                 if existing_block != 0 {
                     cache
-                        .read(dev.as_ref(), existing_block, &mut block_buf)
+                        .read(dev.as_mut(), existing_block, &mut block_buf)
                         .map_err(|_| VfsError::IoError)?;
                 }
             }
@@ -1137,7 +1137,7 @@ impl Filesystem for Lfs {
             let block_num = self.imap.get(target_id).ok_or(VfsError::NotFound)?;
             let mut buf = [0u8; BLOCK_SIZE];
             cache
-                .read(dev.as_ref(), block_num, &mut buf)
+                .read(dev.as_mut(), block_num, &mut buf)
                 .map_err(|_| VfsError::IoError)?;
             DiskInode::read_from(&buf, 0).map_err(|_| VfsError::IoError)?
         };

--- a/crates/thumos/src/lfs_checkpoint.rs
+++ b/crates/thumos/src/lfs_checkpoint.rs
@@ -188,7 +188,7 @@ pub fn write_checkpoint(
 /// - [`LfsError::BlockIo`] if the block read fails.
 /// - [`LfsError::Corrupt`] if the magic number does not match.
 pub fn read_checkpoint(
-    dev: &dyn BlockDevice,
+    dev: &mut dyn BlockDevice,
     cache: &mut BlockCache,
     slot_block: u64,
 ) -> Result<CheckpointHeader, LfsError> {
@@ -208,7 +208,7 @@ pub fn read_checkpoint(
 /// Returns [`LfsError::Corrupt`] if neither checkpoint slot is valid.
 /// Returns [`LfsError::BlockIo`] if block reads fail on both slots.
 pub fn pick_latest(
-    dev: &dyn BlockDevice,
+    dev: &mut dyn BlockDevice,
     cache: &mut BlockCache,
     slot_a_block: u64,
     slot_b_block: u64,
@@ -315,7 +315,7 @@ mod tests {
             .expect("write checkpoint");
 
         let mut cache2 = BlockCache::new();
-        let restored = read_checkpoint(&dev, &mut cache2, 1).expect("read checkpoint");
+        let restored = read_checkpoint(&mut dev, &mut cache2, 1).expect("read checkpoint");
 
         assert_eq!(restored.magic, CHECKPOINT_MAGIC);
         assert_eq!(restored.sequence, 42);
@@ -364,7 +364,7 @@ mod tests {
 
         let mut cache2 = BlockCache::new();
         let (latest, slot) =
-            pick_latest(&dev, &mut cache2, 1, 5).expect("pick latest");
+            pick_latest(&mut dev, &mut cache2, 1, 5).expect("pick latest");
 
         assert_eq!(latest.sequence, 20, "should pick higher sequence");
         assert_eq!(slot, 5, "should return slot B block");
@@ -396,7 +396,7 @@ mod tests {
 
         let mut cache2 = BlockCache::new();
         let (latest, slot) =
-            pick_latest(&dev, &mut cache2, 1, 100).expect("pick with corrupt B");
+            pick_latest(&mut dev, &mut cache2, 1, 100).expect("pick with corrupt B");
 
         assert_eq!(latest.sequence, 5);
         assert_eq!(slot, 1, "should pick the valid slot");
@@ -404,11 +404,11 @@ mod tests {
 
     #[test]
     fn pick_latest_returns_error_when_both_corrupt() {
-        let dev = test_device();
+        let mut dev = test_device();
         let mut cache = BlockCache::new();
 
         // Both slots are zeroed (invalid magic).
-        let result = pick_latest(&dev, &mut cache, 1, 5);
+        let result = pick_latest(&mut dev, &mut cache, 1, 5);
         assert!(
             matches!(result, Err(LfsError::Corrupt)),
             "expected Corrupt when both checkpoint slots are invalid"

--- a/crates/thumos/src/lfs_compact.rs
+++ b/crates/thumos/src/lfs_compact.rs
@@ -351,7 +351,7 @@ mod tests {
 
         // Verify the data is intact.
         let mut buf = [0u8; BLOCK_SIZE];
-        cache.read(&dev, block_after, &mut buf).expect("read relocated");
+        cache.read(&mut dev, block_after, &mut buf).expect("read relocated");
         let restored = DiskInode::read_from(&buf, 0).expect("parse");
         assert_eq!(restored.size, 42);
         assert_eq!(restored.inode_type, INODE_TYPE_FILE);

--- a/crates/thumos/src/lfs_imap.rs
+++ b/crates/thumos/src/lfs_imap.rs
@@ -214,7 +214,7 @@ impl LfsImap {
     /// - [`LfsError::BlockIo`] if any block read fails.
     /// - [`LfsError::Corrupt`] if the deserialized data is invalid.
     pub fn load_from_disk(
-        dev: &dyn BlockDevice,
+        dev: &mut dyn BlockDevice,
         cache: &mut BlockCache,
         start_block: u64,
         block_count: u32,
@@ -313,7 +313,7 @@ mod tests {
 
         // Create a fresh cache to prove we're reading from disk.
         let mut cache2 = BlockCache::new();
-        let restored = LfsImap::load_from_disk(&dev, &mut cache2, start_block, block_count)
+        let restored = LfsImap::load_from_disk(&mut dev, &mut cache2, start_block, block_count)
             .expect("load should succeed");
 
         assert_eq!(restored.len(), 50);

--- a/crates/thumos/src/lfs_writer.rs
+++ b/crates/thumos/src/lfs_writer.rs
@@ -336,7 +336,7 @@ mod tests {
 
         // Read the block back and verify the inode data.
         let mut buf = [0u8; BLOCK_SIZE];
-        cache.read(&dev, block, &mut buf).expect("read back");
+        cache.read(&mut dev, block, &mut buf).expect("read back");
         let restored = DiskInode::read_from(&buf, 0).expect("parse inode");
         assert_eq!(restored.inode_type, INODE_TYPE_FILE);
         assert_eq!(restored.size, 100);
@@ -367,10 +367,10 @@ mod tests {
 
         // Verify data round-trips.
         let mut buf = [0u8; BLOCK_SIZE];
-        cache.read(&dev, block1, &mut buf).expect("read block 1");
+        cache.read(&mut dev, block1, &mut buf).expect("read block 1");
         assert!(buf.iter().all(|&b| b == 0xAA));
 
-        cache.read(&dev, block2, &mut buf).expect("read block 2");
+        cache.read(&mut dev, block2, &mut buf).expect("read block 2");
         assert!(buf.iter().all(|&b| b == 0xBB));
     }
 
@@ -407,7 +407,7 @@ mod tests {
         cache.flush(&mut dev).expect("flush");
         let header_block = seg_mgr.segment_start_block(initial_segment);
         let mut buf = [0u8; BLOCK_SIZE];
-        cache.read(&dev, header_block, &mut buf).expect("read header");
+        cache.read(&mut dev, header_block, &mut buf).expect("read header");
 
         // Verify the magic and block count in the header.
         let magic = u32::from_le_bytes(buf[0..4].try_into().expect("magic bytes"));
@@ -460,7 +460,7 @@ mod tests {
 
         // Read the checkpoint back.
         let mut cache2 = BlockCache::new();
-        let header = lfs_checkpoint::read_checkpoint(&dev, &mut cache2, 1)
+        let header = lfs_checkpoint::read_checkpoint(&mut dev, &mut cache2, 1)
             .expect("read checkpoint");
 
         assert_eq!(header.magic, CHECKPOINT_MAGIC);
@@ -469,7 +469,7 @@ mod tests {
 
         // Load the imap from the checkpoint and verify.
         let restored_imap = LfsImap::load_from_disk(
-            &dev,
+            &mut dev,
             &mut cache2,
             header.imap_block,
             header.imap_block_count,
@@ -485,7 +485,7 @@ mod tests {
         let mut buf = [0u8; BLOCK_SIZE];
         for i in 0..header.segment_bitmap_count {
             cache2
-                .read(&dev, header.segment_bitmap_block + u64::from(i), &mut buf)
+                .read(&mut dev, header.segment_bitmap_block + u64::from(i), &mut buf)
                 .expect("read seg bitmap");
             seg_data.extend_from_slice(&buf);
         }

--- a/crates/thumos/src/wifi.rs
+++ b/crates/thumos/src/wifi.rs
@@ -181,6 +181,16 @@ impl WifiConfig {
     }
 }
 
+impl Drop for WifiConfig {
+    fn drop(&mut self) {
+        // Zero passphrase material on drop.
+        for byte in &mut self.passphrase {
+            // SAFETY: byte is a valid mutable reference to initialized memory.
+            unsafe { core::ptr::write_volatile(byte, 0); }
+        }
+    }
+}
+
 /// A single scan result from the WiFi firmware.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScanResult {
@@ -251,6 +261,10 @@ pub const MIC_LEN: usize = 16;
 /// Pairwise Transient Key components.
 ///
 /// Derived from the PMK by PTK = PRF-384(PMK, "Pairwise key expansion", ...).
+///
+/// Implements [`Drop`] to zero key material, preventing it from persisting
+/// in memory after the handshake completes. Uses `write_volatile` to prevent
+/// the compiler from optimizing away the zeroing.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Ptk {
     /// Key Confirmation Key: used to compute and verify MIC.
@@ -259,6 +273,25 @@ pub struct Ptk {
     pub kek: [u8; KEK_LEN],
     /// Temporal Key: used for data frame encryption (AES-CCMP).
     pub tk: [u8; TK_LEN],
+}
+
+impl Drop for Ptk {
+    fn drop(&mut self) {
+        // WHY: write_volatile prevents the compiler from eliding the zeroing
+        // as a dead store, ensuring key material is actually cleared from memory.
+        for byte in &mut self.kck {
+            // SAFETY: byte is a valid mutable reference to initialized memory.
+            unsafe { core::ptr::write_volatile(byte, 0); }
+        }
+        for byte in &mut self.kek {
+            // SAFETY: byte is a valid mutable reference to initialized memory.
+            unsafe { core::ptr::write_volatile(byte, 0); }
+        }
+        for byte in &mut self.tk {
+            // SAFETY: byte is a valid mutable reference to initialized memory.
+            unsafe { core::ptr::write_volatile(byte, 0); }
+        }
+    }
 }
 
 /// Derive the Pairwise Master Key from a passphrase and SSID.
@@ -319,6 +352,38 @@ pub fn derive_ptk(
 pub fn compute_mic(_kck: &[u8; KCK_LEN], _data: &[u8]) -> [u8; MIC_LEN] {
     // TODO(crypto): implement HMAC-SHA1 truncated to 128 bits.
     [0u8; MIC_LEN]
+}
+
+/// Verify that `expected_mic` matches the MIC computed over `data` with `kck`.
+///
+/// Uses constant-time comparison to prevent timing side-channel attacks.
+/// Returns `true` only when the MIC is correct.
+///
+/// # Current status
+///
+/// **Stubbed**: relies on the stubbed `compute_mic`. Will produce correct
+/// results once the kernel crypto subsystem provides HMAC-SHA1.
+#[must_use]
+pub fn verify_mic(kck: &[u8; KCK_LEN], data: &[u8], expected_mic: &[u8; MIC_LEN]) -> bool {
+    let computed = compute_mic(kck, data);
+    constant_time_eq(&computed, expected_mic)
+}
+
+/// Constant-time byte slice comparison.
+///
+/// Compares all bytes regardless of early differences, preventing timing
+/// side-channel attacks that could leak information about secret key material.
+/// Returns `true` only when both slices have equal length and identical content.
+#[must_use]
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
 }
 
 // ---------------------------------------------------------------------------
@@ -797,6 +862,21 @@ impl WpaHandshake {
             }
             _ => None,
         }
+    }
+}
+
+impl Drop for WpaHandshake {
+    fn drop(&mut self) {
+        // Zero nonces — they contribute to key derivation and are sensitive.
+        for byte in &mut self.anonce {
+            // SAFETY: byte is a valid mutable reference to initialized memory.
+            unsafe { core::ptr::write_volatile(byte, 0); }
+        }
+        for byte in &mut self.snonce {
+            // SAFETY: byte is a valid mutable reference to initialized memory.
+            unsafe { core::ptr::write_volatile(byte, 0); }
+        }
+        // The PTK is zeroed by its own Drop impl when this Option is dropped.
     }
 }
 


### PR DESCRIPTION
Closes #49, #50, #52, #63. Cache now flushes dirty entries on eviction. IPC validates PID bounds. WPA MIC uses constant-time comparison. WiFi key material zeroed on drop via write_volatile.