### PR TITLE
fix(kernel): audit batch 4 — Display, must_use, non_exhaustive compliance

### DIFF
--- a/crates/thumos/src/block.rs
+++ b/crates/thumos/src/block.rs
@@ -36,6 +36,7 @@ pub const SECTORS_PER_BLOCK: usize = BLOCK_SIZE / SECTOR_SIZE;
 
 /// Errors that can occur during block device operations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum BlockError {
     /// A low-level I/O error occurred during the transfer.
     IoError,
@@ -116,6 +117,7 @@ impl MemBlockDevice {
     /// # Errors
     ///
     /// Returns [`BlockError::InvalidArgument`] if `sector_count` is zero.
+    #[must_use]
     pub fn new(sector_count: u64) -> Result<Self, BlockError> {
         if sector_count == 0 {
             return Err(BlockError::InvalidArgument);
@@ -223,7 +225,7 @@ mod msdc_wrapper {
         /// # Errors
         ///
         /// Returns [`BlockError::DeviceNotReady`] if hardware initialization fails.
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code, reason = "MMIO register access requires raw pointer dereference")]
         pub unsafe fn init(&mut self) -> Result<(), BlockError> {
             // SAFETY: caller guarantees the MSDC register block is mapped, and
             // this is called exactly once after power-on per the function contract.
@@ -234,7 +236,7 @@ mod msdc_wrapper {
     }
 
     impl BlockDevice for MsdcBlockDevice {
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code, reason = "MMIO register access requires raw pointer dereference")]
         fn read_sectors(&self, lba: u64, count: u32, buf: &mut [u8]) -> Result<(), BlockError> {
             if !self.controller.is_initialized() {
                 return Err(BlockError::DeviceNotReady);
@@ -273,7 +275,7 @@ mod msdc_wrapper {
             Ok(())
         }
 
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code, reason = "MMIO register access requires raw pointer dereference")]
         fn write_sectors(&mut self, lba: u64, count: u32, buf: &[u8]) -> Result<(), BlockError> {
             if !self.controller.is_initialized() {
                 return Err(BlockError::DeviceNotReady);
@@ -331,6 +333,7 @@ pub use msdc_wrapper::MsdcBlockDevice;
 ///
 /// Returns [`BlockError`] if the underlying sector read fails or the
 /// block address is out of bounds.
+#[must_use]
 pub fn read_block(
     dev: &dyn BlockDevice,
     block_num: u64,
@@ -349,6 +352,7 @@ pub fn read_block(
 ///
 /// Returns [`BlockError`] if the underlying sector write fails or the
 /// block address is out of bounds.
+#[must_use]
 pub fn write_block(
     dev: &mut dyn BlockDevice,
     block_num: u64,

--- a/crates/thumos/src/bluetooth.rs
+++ b/crates/thumos/src/bluetooth.rs
@@ -93,6 +93,17 @@ pub enum BtError {
     EncodingError,
 }
 
+impl core::fmt::Display for BtError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::HardwareTimeout => write!(f, "hardware timeout"),
+            Self::NotInitialized => write!(f, "BT not initialized"),
+            Self::InvalidState => write!(f, "invalid BT state"),
+            Self::EncodingError => write!(f, "HCI encoding error"),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // BT state machine
 // ---------------------------------------------------------------------------
@@ -114,6 +125,18 @@ pub enum BtState {
     Error(BtError),
 }
 
+impl core::fmt::Display for BtState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Off => write!(f, "off"),
+            Self::Initializing => write!(f, "initializing"),
+            Self::Ready => write!(f, "ready"),
+            Self::Scanning => write!(f, "scanning"),
+            Self::Error(e) => write!(f, "error: {e}"),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // BLE device representation
 // ---------------------------------------------------------------------------
@@ -133,6 +156,18 @@ pub struct BleDevice {
     pub adv_data: [u8; MAX_ADV_DATA_LEN],
     /// Number of valid bytes in `adv_data`.
     pub adv_data_len: u8,
+}
+
+impl core::fmt::Display for BleDevice {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x} ({}dBm)",
+            self.address[0], self.address[1], self.address[2],
+            self.address[3], self.address[4], self.address[5],
+            self.rssi,
+        )
+    }
 }
 
 impl BleDevice {
@@ -404,6 +439,7 @@ impl<H: BtHwOps> BtAdapter<H> {
     /// Initialize the BT adapter: power on, HCI reset, set random address.
     ///
     /// Transitions from `Off` to `Ready` on success, or to `Error` on failure.
+    #[must_use]
     pub fn init(&mut self, current_tick_ms: u64) -> Result<(), BtError> {
         if self.state != BtState::Off {
             return Err(BtError::InvalidState);
@@ -440,6 +476,7 @@ impl<H: BtHwOps> BtAdapter<H> {
     /// Rotate the random address if the rotation interval has elapsed.
     ///
     /// Should be called periodically. Returns `true` if the address was rotated.
+    #[must_use]
     pub fn maybe_rotate_address(&mut self, current_tick_ms: u64) -> Result<bool, BtError> {
         if current_tick_ms.saturating_sub(self.address_set_at) < ADDRESS_ROTATION_MS {
             return Ok(false);
@@ -455,6 +492,7 @@ impl<H: BtHwOps> BtAdapter<H> {
     /// Start a BLE passive scan.
     ///
     /// Sets scan parameters (passive, random address, accept all) then enables scanning.
+    #[must_use]
     pub fn start_scan(&mut self) -> Result<(), BtError> {
         match self.state {
             BtState::Ready => {}
@@ -478,6 +516,7 @@ impl<H: BtHwOps> BtAdapter<H> {
     }
 
     /// Stop the BLE passive scan.
+    #[must_use]
     pub fn stop_scan(&mut self) -> Result<(), BtError> {
         if self.state != BtState::Scanning {
             return Err(BtError::InvalidState);

--- a/crates/thumos/src/clock.rs
+++ b/crates/thumos/src/clock.rs
@@ -59,6 +59,7 @@ const NTP_UNIX_OFFSET: u64 = 2_208_988_800;
 ///
 /// Variants are ordered by trust level (highest first).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[non_exhaustive]
 pub enum ClockSource {
     /// GPS-derived time — atomic clocks on satellites.
     Gps,
@@ -70,6 +71,18 @@ pub enum ClockSource {
     Manual,
     /// No time source available.
     None,
+}
+
+impl core::fmt::Display for ClockSource {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Gps => write!(f, "GPS"),
+            Self::Ntp => write!(f, "NTP"),
+            Self::ModemRtc => write!(f, "modem RTC"),
+            Self::Manual => write!(f, "manual"),
+            Self::None => write!(f, "none"),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/thumos/src/dhcp.rs
+++ b/crates/thumos/src/dhcp.rs
@@ -35,6 +35,7 @@ pub const DHCP_TIMEOUT_MS: u64 = 30_000;
 
 /// Events emitted by the DHCP client on each poll cycle.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum DhcpEvent {
     /// No state change since last poll.
     None,
@@ -56,6 +57,26 @@ pub struct DhcpConfig {
     pub dns_servers: Vec<Ipv4Address>,
 }
 
+impl core::fmt::Display for DhcpEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::None => write!(f, "no DHCP event"),
+            Self::Configured(config) => write!(f, "DHCP configured: {config}"),
+            Self::Deconfigured => write!(f, "DHCP deconfigured"),
+        }
+    }
+}
+
+impl core::fmt::Display for DhcpConfig {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.address)?;
+        if let Some(gw) = self.gateway {
+            write!(f, " gw {gw}")?;
+        }
+        Ok(())
+    }
+}
+
 /// DHCP client that wraps a smoltcp DHCPv4 socket.
 ///
 /// Owns a socket handle into the [`NetworkStack`]'s socket set. On each
@@ -74,11 +95,21 @@ pub struct DhcpClient {
 
 /// Errors from DHCP client creation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum DhcpError {
     /// The socket set is full; cannot add the DHCPv4 socket.
     SocketSetFull,
     /// Failed to apply the gateway route.
     RouteTableFull,
+}
+
+impl core::fmt::Display for DhcpError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::SocketSetFull => write!(f, "socket set full"),
+            Self::RouteTableFull => write!(f, "route table full"),
+        }
+    }
 }
 
 impl From<NetError> for DhcpError {
@@ -100,6 +131,7 @@ impl DhcpClient {
     ///
     /// Returns `Err(DhcpError::SocketSetFull)` if the socket set has
     /// reached [`MAX_SOCKETS`].
+    #[must_use]
     pub fn new<D: Device>(stack: &mut NetworkStack<D>) -> Result<Self, DhcpError> {
         if stack.socket_count() >= MAX_SOCKETS {
             return Err(DhcpError::SocketSetFull);

--- a/crates/thumos/src/dns.rs
+++ b/crates/thumos/src/dns.rs
@@ -62,6 +62,7 @@ const DNS_HEADER_SIZE: usize = 12;
 
 /// Errors from DNS resolution.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum DnsError {
     /// The hostname is empty or otherwise invalid.
     InvalidName,
@@ -77,6 +78,20 @@ pub enum DnsError {
     SendError,
     /// The DNS response was malformed.
     MalformedResponse,
+}
+
+impl core::fmt::Display for DnsError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::InvalidName => write!(f, "invalid hostname"),
+            Self::Timeout => write!(f, "DNS query timed out"),
+            Self::ServerError => write!(f, "DNS server error"),
+            Self::NoRecords => write!(f, "no DNS records found"),
+            Self::SocketError => write!(f, "DNS socket allocation failed"),
+            Self::SendError => write!(f, "DNS query send failed"),
+            Self::MalformedResponse => write!(f, "malformed DNS response"),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -427,6 +442,7 @@ impl DnsResolver {
     /// This is a non-blocking "start resolve" — the caller must poll the
     /// network stack and call [`poll_resolve`](Self::poll_resolve) to
     /// check for results, since bare-metal kernels cannot block on I/O.
+    #[must_use]
     pub fn resolve<D: Device>(
         &mut self,
         _stack: &mut NetworkStack<D>,
@@ -459,6 +475,7 @@ impl DnsResolver {
     /// Returns the wire-format bytes and the transaction ID. The caller
     /// is responsible for sending this via a UDP socket to the
     /// appropriate DNS server on port 53.
+    #[must_use]
     pub fn build_query(&mut self, hostname: &str) -> Result<(Vec<u8>, u16), DnsError> {
         let txid = self.next_txid;
         self.next_txid = self.next_txid.wrapping_add(1);
@@ -469,6 +486,7 @@ impl DnsResolver {
     /// Process a DNS response and cache the result.
     ///
     /// Returns the resolved address on success.
+    #[must_use]
     pub fn process_response(
         &mut self,
         hostname: &str,

--- a/crates/thumos/src/firewall.rs
+++ b/crates/thumos/src/firewall.rs
@@ -97,6 +97,7 @@ const SURVEILLANCE_DOMAINS: &[&str] = &[
 
 /// Action to take on a packet after rule evaluation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Action {
     /// Forward the packet.
     Allow,
@@ -108,6 +109,7 @@ pub enum Action {
 
 /// Traffic direction relative to the device.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Direction {
     /// Traffic arriving from an external interface.
     Inbound,
@@ -117,6 +119,7 @@ pub enum Direction {
 
 /// Layer-4 protocol selector for a [`FilterRule`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Protocol {
     /// Match TCP segments.
     Tcp,
@@ -124,6 +127,25 @@ pub enum Protocol {
     Udp,
     /// Match ICMP messages.
     Icmp,
+}
+
+impl core::fmt::Display for Action {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Allow => write!(f, "allow"),
+            Self::Deny => write!(f, "deny"),
+            Self::Log => write!(f, "log"),
+        }
+    }
+}
+
+impl core::fmt::Display for Direction {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Inbound => write!(f, "inbound"),
+            Self::Outbound => write!(f, "outbound"),
+        }
+    }
 }
 
 /// An IPv4 address represented as four octets.
@@ -153,6 +175,19 @@ pub struct FilterRule {
     pub action: Action,
 }
 
+impl core::fmt::Display for FilterRule {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{} {}", self.direction, self.action)?;
+        if let Some(proto) = self.protocol {
+            write!(f, " {proto:?}")?;
+        }
+        if let Some(port) = self.dst_port {
+            write!(f, " port {port}")?;
+        }
+        Ok(())
+    }
+}
+
 /// Packet statistics tracked by the firewall.
 #[derive(Debug, Clone, Default)]
 pub struct FirewallStats {
@@ -162,6 +197,16 @@ pub struct FirewallStats {
     pub packets_denied: u64,
     /// Total DNS queries blocked by the domain blocklist.
     pub dns_blocked: u64,
+}
+
+impl core::fmt::Display for FirewallStats {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "allowed={}, denied={}, dns_blocked={}",
+            self.packets_allowed, self.packets_denied, self.dns_blocked,
+        )
+    }
 }
 
 /// Packet filter combining an ordered rule set, a DNS domain blocklist,

--- a/crates/thumos/src/gps.rs
+++ b/crates/thumos/src/gps.rs
@@ -67,6 +67,19 @@ pub enum GpsError {
     InvalidState,
 }
 
+impl core::fmt::Display for GpsError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::HardwareTimeout => write!(f, "hardware timeout"),
+            Self::NotInitialized => write!(f, "GPS not initialized"),
+            Self::NoFix => write!(f, "no GPS fix"),
+            Self::ParseError => write!(f, "NMEA parse error"),
+            Self::ChecksumMismatch => write!(f, "NMEA checksum mismatch"),
+            Self::InvalidState => write!(f, "invalid GPS state"),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // GPS state machine
 // ---------------------------------------------------------------------------
@@ -84,6 +97,17 @@ pub enum GpsState {
     FixAcquired,
     /// A fatal error occurred.
     Error(GpsError),
+}
+
+impl core::fmt::Display for GpsState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Off => write!(f, "off"),
+            Self::Searching => write!(f, "searching"),
+            Self::FixAcquired => write!(f, "fix acquired"),
+            Self::Error(e) => write!(f, "error: {e}"),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -108,6 +132,17 @@ pub struct GpsPosition {
     pub satellite_count: u8,
 }
 
+impl core::fmt::Display for GpsPosition {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // Display as degrees with 6 decimal places (microdegree precision).
+        let lat_deg = self.latitude / 1_000_000;
+        let lat_frac = (self.latitude % 1_000_000).unsigned_abs();
+        let lon_deg = self.longitude / 1_000_000;
+        let lon_frac = (self.longitude % 1_000_000).unsigned_abs();
+        write!(f, "{lat_deg}.{lat_frac:06}, {lon_deg}.{lon_frac:06}")
+    }
+}
+
 /// UTC date and time extracted from RMC sentences.
 ///
 /// Used by the clock module to synchronize the system clock from GPS.
@@ -125,6 +160,17 @@ pub struct GpsTime {
     pub minute: u8,
     /// Second (0-59).
     pub second: u8,
+}
+
+impl core::fmt::Display for GpsTime {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+            self.year, self.month, self.day,
+            self.hour, self.minute, self.second,
+        )
+    }
 }
 
 impl GpsTime {
@@ -359,6 +405,7 @@ fn parse_altitude_mm(bytes: &[u8]) -> Option<i32> {
 /// Returns `GpsError::ChecksumMismatch` if the checksum is invalid.
 /// Returns `GpsError::NoFix` if fix quality is 0.
 /// Returns `GpsError::ParseError` if the sentence cannot be parsed.
+#[must_use]
 pub fn parse_gga(sentence: &[u8]) -> Result<GpsPosition, GpsError> {
     validate_checksum(sentence)?;
 
@@ -411,6 +458,7 @@ pub fn parse_gga(sentence: &[u8]) -> Result<GpsPosition, GpsError> {
 /// Returns `GpsError::ChecksumMismatch` if the checksum is invalid.
 /// Returns `GpsError::NoFix` if status is 'V' (void).
 /// Returns `GpsError::ParseError` if the sentence cannot be parsed.
+#[must_use]
 pub fn parse_rmc(sentence: &[u8]) -> Result<(GpsPosition, GpsTime), GpsError> {
     validate_checksum(sentence)?;
 
@@ -655,6 +703,7 @@ impl<H: GpsHwOps> GpsReceiver<H> {
     }
 
     /// Initialize the GPS receiver: power on and begin searching.
+    #[must_use]
     pub fn init(&mut self) -> Result<(), GpsError> {
         if self.state != GpsState::Off {
             return Err(GpsError::InvalidState);
@@ -712,6 +761,7 @@ impl<H: GpsHwOps> GpsReceiver<H> {
     }
 
     /// Shut down the GPS receiver.
+    #[must_use]
     pub fn shutdown(&mut self) -> Result<(), GpsError> {
         self.hw.power_off()?;
         self.state = GpsState::Off;

--- a/crates/thumos/src/lfs.rs
+++ b/crates/thumos/src/lfs.rs
@@ -379,6 +379,7 @@ pub struct Lfs {
 ///
 /// - [`LfsError::BlockIo`] if any block write fails.
 /// - [`LfsError::InvalidSuperblock`] if the device is too small.
+#[must_use]
 pub fn format(dev: &mut dyn BlockDevice) -> Result<(), LfsError> {
     let total_sectors = dev.sector_count();
     let total_blocks = total_sectors / SECTORS_PER_BLOCK as u64;
@@ -489,6 +490,7 @@ pub fn format(dev: &mut dyn BlockDevice) -> Result<(), LfsError> {
 /// - [`LfsError::InvalidSuperblock`] if the superblock magic/version is wrong.
 /// - [`LfsError::Corrupt`] if neither checkpoint is valid.
 /// - [`LfsError::BlockIo`] if any block read fails.
+#[must_use]
 pub fn mount(mut dev: Box<dyn BlockDevice>) -> Result<Lfs, LfsError> {
     let mut cache = BlockCache::new();
 

--- a/crates/thumos/src/lfs_checkpoint.rs
+++ b/crates/thumos/src/lfs_checkpoint.rs
@@ -90,6 +90,7 @@ impl CheckpointHeader {
     /// # Errors
     ///
     /// Returns [`LfsError::Corrupt`] if the magic number does not match.
+    #[must_use]
     pub fn from_block(buf: &[u8; BLOCK_SIZE]) -> Result<Self, LfsError> {
         if buf.len() < HEADER_SERIALIZED_SIZE {
             return Err(LfsError::Corrupt);

--- a/crates/thumos/src/lfs_imap.rs
+++ b/crates/thumos/src/lfs_imap.rs
@@ -21,6 +21,7 @@ use crate::cache::BlockCache;
 
 /// Errors specific to LFS operations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum LfsError {
     /// A low-level block I/O error occurred.
     BlockIo(BlockError),
@@ -32,6 +33,18 @@ pub enum LfsError {
     NoFreeSegments,
     /// An inode was not found in the imap.
     InodeNotFound,
+}
+
+impl core::fmt::Display for LfsError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::BlockIo(e) => write!(f, "block I/O error: {e}"),
+            Self::Corrupt => write!(f, "filesystem data corrupt"),
+            Self::InvalidSuperblock => write!(f, "invalid superblock"),
+            Self::NoFreeSegments => write!(f, "no free segments"),
+            Self::InodeNotFound => write!(f, "inode not found"),
+        }
+    }
 }
 
 impl From<BlockError> for LfsError {
@@ -136,6 +149,7 @@ impl LfsImap {
     ///
     /// Returns [`LfsError::Corrupt`] if the buffer is too short or contains
     /// invalid data.
+    #[must_use]
     pub fn deserialize(buf: &[u8]) -> Result<Self, LfsError> {
         if buf.len() < IMAP_HEADER_SIZE {
             return Err(LfsError::Corrupt);

--- a/crates/thumos/src/lfs_writer.rs
+++ b/crates/thumos/src/lfs_writer.rs
@@ -60,6 +60,7 @@ impl LfsWriter {
     /// # Errors
     ///
     /// Returns [`LfsError::NoFreeSegments`] if no segments are available.
+    #[must_use]
     pub fn new(seg_mgr: &mut LfsSegmentManager) -> Result<Self, LfsError> {
         let seg = seg_mgr.allocate().ok_or(LfsError::NoFreeSegments)?;
         Ok(Self {

--- a/crates/thumos/src/net.rs
+++ b/crates/thumos/src/net.rs
@@ -66,6 +66,7 @@ const DEFAULT_MTU: usize = 1514;
 
 /// Errors returned by network stack operations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum NetError {
     /// Socket set is full; cannot add another socket.
     SocketSetFull,
@@ -73,6 +74,16 @@ pub enum NetError {
     InvalidHandle,
     /// Route table is full.
     RouteTableFull,
+}
+
+impl core::fmt::Display for NetError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::SocketSetFull => write!(f, "socket set full"),
+            Self::InvalidHandle => write!(f, "invalid socket handle"),
+            Self::RouteTableFull => write!(f, "route table full"),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -227,6 +238,7 @@ impl<D: Device> NetworkStack<D> {
     /// Set the default IPv4 gateway for the interface.
     ///
     /// Returns `Err(NetError::RouteTableFull)` if the route table is full.
+    #[must_use]
     pub fn set_default_gateway(&mut self, gateway: Ipv4Address) -> Result<(), NetError> {
         self.iface
             .routes_mut()
@@ -239,6 +251,7 @@ impl<D: Device> NetworkStack<D> {
     ///
     /// Returns `Err(NetError::SocketSetFull)` if [`MAX_SOCKETS`] has been
     /// reached.
+    #[must_use]
     pub fn add_tcp_socket(&mut self) -> Result<SocketHandle, NetError> {
         if self.socket_count >= MAX_SOCKETS {
             return Err(NetError::SocketSetFull);
@@ -255,6 +268,7 @@ impl<D: Device> NetworkStack<D> {
     ///
     /// Returns `Err(NetError::SocketSetFull)` if [`MAX_SOCKETS`] has been
     /// reached.
+    #[must_use]
     pub fn add_udp_socket(&mut self) -> Result<SocketHandle, NetError> {
         if self.socket_count >= MAX_SOCKETS {
             return Err(NetError::SocketSetFull);

--- a/crates/thumos/src/socket.rs
+++ b/crates/thumos/src/socket.rs
@@ -801,7 +801,7 @@ pub fn sys_recvfrom(
                         let src_ip = match meta.endpoint.addr {
                             IpAddress::Ipv4(v4) => v4,
                             // Only IPv4 supported in this phase.
-                            #[allow(unreachable_patterns)]
+                            #[expect(unreachable_patterns, reason = "future IPv6 support will add variants to IpAddress")]
                             _ => Ipv4Address::UNSPECIFIED,
                         };
                         let sa = SockaddrIn::new(meta.endpoint.port, src_ip);

--- a/crates/thumos/src/vfs.rs
+++ b/crates/thumos/src/vfs.rs
@@ -27,6 +27,7 @@ use alloc::vec::Vec;
 /// Each variant corresponds to a POSIX error number. Use `to_errno()` to
 /// obtain the two's complement negation suitable for returning to userspace.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum VfsError {
     /// Entry not found (ENOENT = 2).
     NotFound,
@@ -48,6 +49,23 @@ pub enum VfsError {
     PermissionDenied,
     /// Too many links (EMLINK = 31).
     TooManyLinks,
+}
+
+impl core::fmt::Display for VfsError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::NotFound => write!(f, "not found"),
+            Self::NotADirectory => write!(f, "not a directory"),
+            Self::IsADirectory => write!(f, "is a directory"),
+            Self::AlreadyExists => write!(f, "already exists"),
+            Self::NotEmpty => write!(f, "directory not empty"),
+            Self::InvalidPath => write!(f, "invalid path"),
+            Self::NoSpace => write!(f, "no space left on device"),
+            Self::IoError => write!(f, "I/O error"),
+            Self::PermissionDenied => write!(f, "permission denied"),
+            Self::TooManyLinks => write!(f, "too many links"),
+        }
+    }
 }
 
 impl VfsError {
@@ -78,6 +96,7 @@ impl VfsError {
 
 /// Type of a filesystem inode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum InodeType {
     /// Regular file.
     RegularFile,
@@ -89,6 +108,18 @@ pub enum InodeType {
     BlockDevice,
     /// Symbolic link.
     Symlink,
+}
+
+impl core::fmt::Display for InodeType {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::RegularFile => write!(f, "regular file"),
+            Self::Directory => write!(f, "directory"),
+            Self::CharDevice => write!(f, "char device"),
+            Self::BlockDevice => write!(f, "block device"),
+            Self::Symlink => write!(f, "symlink"),
+        }
+    }
 }
 
 /// Metadata for a single inode, returned by `Filesystem::stat`.
@@ -106,6 +137,12 @@ pub struct InodeStat {
     pub block_count: u32,
 }
 
+impl core::fmt::Display for InodeStat {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "inode {} ({}, {} bytes)", self.inode_id, self.inode_type, self.size)
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Directory entry
 // ---------------------------------------------------------------------------
@@ -119,6 +156,12 @@ pub struct DirEntry {
     pub inode_id: u32,
     /// Type of the inode this entry refers to.
     pub inode_type: InodeType,
+}
+
+impl core::fmt::Display for DirEntry {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{} (inode {}, {})", self.name, self.inode_id, self.inode_type)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -274,6 +317,7 @@ impl MountTable {
     /// - `VfsError::InvalidPath` if the path does not start with `/`.
     /// - `VfsError::AlreadyExists` if the path is already mounted.
     /// - `VfsError::NoSpace` if all mount slots are occupied.
+    #[must_use]
     pub fn mount(&mut self, path: &str, fs: Box<dyn Filesystem>) -> Result<(), VfsError> {
         if !path.starts_with('/') {
             return Err(VfsError::InvalidPath);
@@ -407,6 +451,7 @@ impl Default for MountTable {
 /// - `VfsError::InvalidPath` if the path is empty or does not start with `/`.
 /// - `VfsError::NotFound` if any path component cannot be found.
 /// - `VfsError::NotADirectory` if a non-terminal component is not a directory.
+#[must_use]
 pub fn resolve_path(mounts: &MountTable, path: &str) -> Result<(usize, u32), VfsError> {
     if path.is_empty() || !path.starts_with('/') {
         return Err(VfsError::InvalidPath);

--- a/crates/thumos/src/wifi.rs
+++ b/crates/thumos/src/wifi.rs
@@ -74,6 +74,24 @@ pub enum WifiError {
     NotInitialized,
 }
 
+impl core::fmt::Display for WifiError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::HardwareTimeout => write!(f, "hardware timeout"),
+            Self::AssociationFailed => write!(f, "association failed"),
+            Self::HandshakeFailed => write!(f, "WPA handshake failed"),
+            Self::FrameTooShort { need, have } => {
+                write!(f, "frame too short: need {need} bytes, have {have}")
+            }
+            Self::UnknownEapolType { value } => {
+                write!(f, "unknown EAPOL type: 0x{value:02x}")
+            }
+            Self::NetworkNotFound => write!(f, "network not found"),
+            Self::NotInitialized => write!(f, "WiFi not initialized"),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // WiFi state machine
 // ---------------------------------------------------------------------------
@@ -538,6 +556,7 @@ pub struct EapolFrame {
 /// Returns [`WifiError::FrameTooShort`] when the slice cannot satisfy the
 /// declared packet length, and [`WifiError::UnknownEapolType`] for
 /// unrecognised packet type bytes.
+#[must_use]
 pub fn eapol_parse(data: &[u8]) -> Result<EapolFrame, WifiError> {
     if data.len() < EAPOL_HEADER_LEN {
         return Err(WifiError::FrameTooShort {
@@ -1025,6 +1044,7 @@ impl<H: WifiHwOps> WifiDriver<H> {
     /// # Errors
     ///
     /// Returns `WifiError` if the hardware scan cannot be started.
+    #[must_use]
     pub fn start_scan(&mut self) -> Result<(), WifiError> {
         // Fresh MAC for each scan (privacy)
         self.mac = generate_random_mac();


### PR DESCRIPTION
Closes #53, #54, #60, #75, #76. Display impls on 8 error types + 15 non-error types. #[must_use] on ~25 Result-returning pub functions. #[non_exhaustive] on 11 public enums. 4 #[allow] → #[expect] with reasons.