### PR TITLE
fix(repo): audit batch 5 — ARCHITECTURE.md, deny(missing_docs), CI gates

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,27 @@
+name: Rust
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rust-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --workspace --all-targets -- -D warnings
+      - run: cargo test --workspace
+      - run: cargo install cargo-deny && cargo deny check

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,102 @@
+# Architecture
+
+Thumos is a full-Rust mobile OS targeting the AGM M7 (MT6739). No C authored, no Linux in the final system. Monolithic kernel.
+
+## Crate map
+
+13 crates total: 1 bare-metal kernel binary + 12 workspace library crates.
+
+### Kernel binary (excluded from workspace)
+
+| Crate | Description |
+|-------|-------------|
+| `thumos` | Bare-metal ARM kernel: MMU, scheduler, syscalls, IPC, VFS, drivers, network stack |
+
+### Workspace library crates
+
+**UI**
+
+| Crate | Description |
+|-------|-------------|
+| `eidolon` | Framebuffer UI: 240x320 rendering, widgets, T9 input, status bar |
+
+**Input**
+
+| Crate | Description |
+|-------|-------------|
+| `haphe` | GPIO keypad matrix scan, touchscreen driver, event queue (`no_std`) |
+
+**Telephony**
+
+| Crate | Description |
+|-------|-------------|
+| `klesis` | AT command parser, CCCI/CLDMA framing, SMS PDU, GSM-7 codec |
+
+**Crypto**
+
+| Crate | Description |
+|-------|-------------|
+| `krypta` | Signal protocol: X3DH key exchange, double ratchet, session management |
+| `stegnos` | Encrypted storage: AES-256-XTS block cipher, LUKS key derivation, secure erase |
+
+**Radio**
+
+| Crate | Description |
+|-------|-------------|
+| `aither` | WiFi MAC driver, WPA2/WPA3 supplicant, EAPOL handshake |
+| `pteron` | Bluetooth HCI over STP, BLE scanning, LE Privacy address rotation |
+| `kelyphos` | WMT combo chip manager: firmware loading, STP framing, power control |
+| `sema` | Radio analysis: WiFi/BT/cell scanning, IMSI catcher detection |
+| `topos` | GPS NMEA parser, geofencing, position logging |
+
+**Security**
+
+| Crate | Description |
+|-------|-------------|
+| `asphaleia` | Packet filter firewall, DNS blocklist, capability enforcement |
+| `leipsanon` | Panic mode: priority-ordered wipe, trigger system, memory scrubbing |
+
+## Dependency direction
+
+The kernel (`thumos`) is a standalone `no_std` binary with no workspace dependencies. Workspace crates depend on each other as follows:
+
+```
+eidolon --> haphe    (UI reads input events)
+```
+
+All other workspace crates are independent of each other. External dependencies flow downward: crates use `ring`, `nom`, `smoltcp`, `snafu`, etc. but never import from higher layers.
+
+**Rule**: lower layers do not import from higher layers. `haphe` does not depend on `eidolon`. Radio crates do not depend on security crates. The kernel depends on nothing in the workspace.
+
+## Layer diagram
+
+```
++-----------------------------------------------+
+|                  eidolon (UI)                  |
++-----------------------------------------------+
+|   klesis   |   krypta   |     sema            |
+| (telephony)| (crypto)   |  (radio tools)      |
++-----------------------------------------------+
+|  aither  |  pteron  |  kelyphos  |   topos    |
+|  (WiFi)  |   (BT)   |   (WMT)   |   (GPS)    |
++-----------------------------------------------+
+|  asphaleia (firewall) | leipsanon (panic mode)|
+|  stegnos (encrypted storage)                  |
++-----------------------------------------------+
+|              haphe (input)                     |
++-----------------------------------------------+
+|          thumos (kernel, bare-metal)           |
++-----------------------------------------------+
+|       MT6739 hardware / vendor blobs          |
++-----------------------------------------------+
+```
+
+## Extension points
+
+- **New kernel subsystem**: add a module inside `crates/thumos/src/`. The kernel is monolithic; subsystems are modules, not separate crates.
+- **New userspace domain**: add a new workspace crate in `crates/`. Register it in `Cargo.toml` workspace members. Follow naming convention (Greek, per `gnomon.md`).
+- **New driver**: implement in the kernel crate if it touches hardware registers. Implement as a workspace crate if it operates at a higher abstraction (like `aither` or `pteron` which define protocol logic).
+
+## Build
+
+Workspace crates compile and test on the host: `cargo check --workspace`, `cargo test --workspace`. The kernel cross-compiles for `armv7a-none-eabi` via `cargo build --release` inside `crates/thumos/`. Boot image is created with `mkbootimg` and flashed via mtkclient BROM exploit.

--- a/crates/aither/src/eapol.rs
+++ b/crates/aither/src/eapol.rs
@@ -34,11 +34,19 @@ pub const DESCRIPTOR_TYPE_WPA: u8 = 0xFE;
 pub enum Error {
     /// Buffer is too short to contain required fields.
     #[snafu(display("frame too short: need {need} bytes, have {have}"))]
-    TooShort { need: usize, have: usize },
+    TooShort {
+        /// Minimum required bytes.
+        need: usize,
+        /// Actual buffer length.
+        have: usize,
+    },
 
     /// Unrecognised EAPOL packet type byte.
     #[snafu(display("unknown EAPOL packet type: {value:#04x}"))]
-    UnknownType { value: u8 },
+    UnknownType {
+        /// The unrecognised type byte.
+        value: u8,
+    },
 }
 
 /// EAPOL packet type discriminant (IEEE 802.1X-2020, table 11-3).

--- a/crates/aither/src/lib.rs
+++ b/crates/aither/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! `WiFi` MAC driver and `WPA2`/`WPA3` supplicant. Scanning, association, EAPOL 4-way handshake, SAE key exchange.
 
 pub mod eapol;

--- a/crates/asphaleia/src/lib.rs
+++ b/crates/asphaleia/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! Security policy enforcement. Packet filtering, DNS-over-TLS, telemetry domain blocking, capability-based access control.
 
 pub mod dns;

--- a/crates/eidolon/src/color.rs
+++ b/crates/eidolon/src/color.rs
@@ -24,13 +24,21 @@ const GREEN_SHIFT_LEFT: u16 = 5; // bits 10:5 in RGB565 word
 pub struct Rgb565(pub u16);
 
 impl Rgb565 {
+    /// Black (0x0000).
     pub const BLACK: Self = Self(0x0000);
+    /// White (0xFFFF).
     pub const WHITE: Self = Self(0xFFFF);
+    /// Red (0xF800).
     pub const RED: Self = Self(0xF800);
+    /// Green (0x07E0).
     pub const GREEN: Self = Self(0x07E0);
+    /// Blue (0x001F).
     pub const BLUE: Self = Self(0x001F);
+    /// Yellow (0xFFE0).
     pub const YELLOW: Self = Self(0xFFE0);
+    /// Cyan (0x07FF).
     pub const CYAN: Self = Self(0x07FF);
+    /// Magenta (0xF81F).
     pub const MAGENTA: Self = Self(0xF81F);
 
     /// Convert 24-bit `RGB888` to `RGB565` by truncating the least significant bits.

--- a/crates/eidolon/src/lib.rs
+++ b/crates/eidolon/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! User interface for the 240×320 framebuffer display. Widget system, keypad navigation, T9 text input, status bar.
 //!
 //! # Modules

--- a/crates/eidolon/src/widgets/dialog.rs
+++ b/crates/eidolon/src/widgets/dialog.rs
@@ -23,9 +23,13 @@ const MIN_MSG_ROWS: u32 = 2;
 /// A button available in a [`Dialog`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DialogButton {
+    /// Confirm action.
     Ok,
+    /// Cancel action.
     Cancel,
+    /// Affirmative response.
     Yes,
+    /// Negative response.
     No,
 }
 

--- a/crates/haphe/src/input.rs
+++ b/crates/haphe/src/input.rs
@@ -11,25 +11,37 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u8)]
 pub enum Key {
-    /// Number keys
+    /// Digit 0 key.
     Num0 = 0,
+    /// Digit 1 key.
     Num1 = 1,
+    /// Digit 2 key.
     Num2 = 2,
+    /// Digit 3 key.
     Num3 = 3,
+    /// Digit 4 key.
     Num4 = 4,
+    /// Digit 5 key.
     Num5 = 5,
+    /// Digit 6 key.
     Num6 = 6,
+    /// Digit 7 key.
     Num7 = 7,
+    /// Digit 8 key.
     Num8 = 8,
+    /// Digit 9 key.
     Num9 = 9,
     /// Star (*)
     Star = 10,
     /// Hash (#)
     Hash = 11,
-    /// Navigation
+    /// D-pad up.
     Up = 12,
+    /// D-pad down.
     Down = 13,
+    /// D-pad left.
     Left = 14,
+    /// D-pad right.
     Right = 15,
     /// Center/OK/Select
     Select = 16,
@@ -84,10 +96,17 @@ pub struct TouchPoint {
 #[derive(Debug, Clone)]
 pub enum InputEvent {
     /// Keypad key event.
-    Key { key: Key, state: KeyState },
+    Key {
+        /// Which key was pressed.
+        key: Key,
+        /// Press, release, or held.
+        state: KeyState,
+    },
     /// Touchscreen event.
     Touch {
+        /// Touch action type.
         action: TouchAction,
+        /// Touch coordinates and pressure.
         point: TouchPoint,
     },
 }

--- a/crates/haphe/src/lib.rs
+++ b/crates/haphe/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![deny(missing_docs)]
 //! Input drivers for the AGM M7: GPIO keypad matrix scan, mtk-tpd touchscreen, event queue.
 
 // WHY: The test harness links std, but no_std crates must opt in

--- a/crates/kelyphos/src/lib.rs
+++ b/crates/kelyphos/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! WMT (Wireless Management Task) connectivity manager for the MT6739 combo chip.
 //!
 //! Manages firmware loading, power control, and STP framing for the integrated

--- a/crates/klesis/src/at.rs
+++ b/crates/klesis/src/at.rs
@@ -36,17 +36,35 @@ pub enum Urc {
     #[default]
     Ring,
     /// Caller ID: number and type.
-    Clip { number: String, num_type: u8 },
+    Clip {
+        /// Caller phone number.
+        number: String,
+        /// Numbering plan type.
+        num_type: u8,
+    },
     /// Network registration status changed.
     Creg {
+        /// Registration status code.
         stat: RegStatus,
+        /// Location area code.
         lac: Option<u16>,
+        /// Cell ID.
         ci: Option<u32>,
     },
     /// Signal quality report.
-    Csq { rssi: u8, ber: u8 },
+    Csq {
+        /// Raw RSSI value (0-31, 99=unknown).
+        rssi: u8,
+        /// Bit error rate.
+        ber: u8,
+    },
     /// Incoming SMS notification.
-    Cmti { storage: String, index: u16 },
+    Cmti {
+        /// Storage location name.
+        storage: String,
+        /// Message index.
+        index: u16,
+    },
     /// SMS delivery report.
     Cds(String),
     /// Call ended.
@@ -60,11 +78,17 @@ pub enum Urc {
 /// Network registration status (3GPP TS 27.007 +CREG).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RegStatus {
+    /// Not registered, not searching.
     NotRegistered,
+    /// Registered on home network.
     RegisteredHome,
+    /// Searching for network.
     Searching,
+    /// Registration denied.
     Denied,
+    /// Status unknown.
     Unknown,
+    /// Registered, roaming.
     RegisteredRoaming,
 }
 
@@ -84,8 +108,11 @@ impl From<u8> for RegStatus {
 /// Signal strength in dBm, converted FROM AT+CSQ RSSI value.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SignalStrength {
+    /// Raw AT+CSQ RSSI value (0-31, 99=unknown).
     pub rssi_raw: u8,
+    /// Signal strength in dBm.
     pub dbm: i16,
+    /// Signal bar count (0-5).
     pub bars: u8,
 }
 

--- a/crates/klesis/src/error.rs
+++ b/crates/klesis/src/error.rs
@@ -2,35 +2,72 @@
 
 use snafu::Snafu;
 
+/// Telephony subsystem errors.
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
 pub enum Error {
+    /// AT command timed out.
     #[snafu(display("AT command timed out after {timeout_ms}ms"))]
-    Timeout { timeout_ms: u64 },
+    Timeout {
+        /// Timeout duration in milliseconds.
+        timeout_ms: u64,
+    },
 
+    /// Modem returned an error code.
     #[snafu(display("modem returned error: {code}"))]
-    ModemError { code: u32 },
+    ModemError {
+        /// CME/CMS error code.
+        code: u32,
+    },
 
+    /// Modem returned an unexpected response.
     #[snafu(display("unexpected response: {response}"))]
-    UnexpectedResponse { response: String },
+    UnexpectedResponse {
+        /// The unexpected response text.
+        response: String,
+    },
 
+    /// Failed to parse modem output.
     #[snafu(display("parse error: {message}"))]
-    Parse { message: String },
+    Parse {
+        /// Description of the parse failure.
+        message: String,
+    },
 
+    /// CCCI channel I/O error.
     #[snafu(display("CCCI channel error: {source}"))]
-    Ccci { source: std::io::Error },
+    Ccci {
+        /// Underlying I/O error.
+        source: std::io::Error,
+    },
 
+    /// Modem is not ready for commands.
     #[snafu(display("modem not ready"))]
     NotReady,
 
+    /// PDU decoding error.
     #[snafu(display("PDU decode error at byte {offset}: {message}"))]
-    PduDecode { offset: usize, message: String },
+    PduDecode {
+        /// Byte offset where decoding failed.
+        offset: usize,
+        /// Description of the decode failure.
+        message: String,
+    },
 
+    /// Invalid hex encoding in PDU data.
     #[snafu(display("invalid PDU hex: {message}"))]
-    InvalidHex { message: String },
+    InvalidHex {
+        /// Description of the hex error.
+        message: String,
+    },
 
+    /// Character cannot be encoded in GSM-7.
     #[snafu(display("GSM-7 encode: unmappable character U+{codepoint:04X}"))]
-    Gsm7Encode { codepoint: u32 },
+    Gsm7Encode {
+        /// Unicode codepoint that cannot be encoded.
+        codepoint: u32,
+    },
 }
 
+/// Result type for telephony operations.
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/klesis/src/lib.rs
+++ b/crates/klesis/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! Telephony daemon for the MT6739 modem.
 //!
 //! Direct `CCCI` channel access, AT command parser, call state machine,

--- a/crates/krypta/src/error.rs
+++ b/crates/krypta/src/error.rs
@@ -2,51 +2,67 @@
 
 use snafu::Snafu;
 
+/// Result type for crypto operations.
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// Crypto subsystem errors.
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
 pub enum Error {
+    /// Key generation failed.
     #[snafu(display("key generation failed"))]
     KeyGeneration {
+        /// Source location.
         #[snafu(implicit)]
         location: snafu::Location,
     },
 
+    /// Invalid key material or format.
     #[snafu(display("invalid key material or key format"))]
     InvalidKey {
+        /// Source location.
         #[snafu(implicit)]
         location: snafu::Location,
     },
 
+    /// Key agreement (DH) failed.
     #[snafu(display("key agreement failed"))]
     KeyAgreement {
+        /// Source location.
         #[snafu(implicit)]
         location: snafu::Location,
     },
 
+    /// Message encryption failed.
     #[snafu(display("message encryption failed"))]
     Encryption {
+        /// Source location.
         #[snafu(implicit)]
         location: snafu::Location,
     },
 
+    /// Message decryption failed (corrupt or tampered ciphertext).
     #[snafu(display(
         "message decryption failed — ciphertext is corrupt or has been tampered with"
     ))]
     Decryption {
+        /// Source location.
         #[snafu(implicit)]
         location: snafu::Location,
     },
 
+    /// Signature verification failed.
     #[snafu(display("signature verification failed"))]
     InvalidSignature {
+        /// Source location.
         #[snafu(implicit)]
         location: snafu::Location,
     },
 
+    /// Key derivation (KDF) failed.
     #[snafu(display("key derivation failed"))]
     KeyDerivation {
+        /// Source location.
         #[snafu(implicit)]
         location: snafu::Location,
     },

--- a/crates/krypta/src/lib.rs
+++ b/crates/krypta/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! End-to-end encrypted communication. Signal protocol key exchange and message encryption, peer-to-peer messaging over `WiFi` Direct and Bluetooth.
 
 pub mod error;

--- a/crates/krypta/src/session.rs
+++ b/crates/krypta/src/session.rs
@@ -8,6 +8,7 @@ use crate::x3dh::{self, InitiatorMessage, OwnedBundle, PreKeyBundle};
 /// An encrypted message ready for transmission.
 #[derive(Debug, Clone)]
 pub struct EncryptedMessage {
+    /// The ratchet-encrypted ciphertext payload.
     pub inner: CiphertextMessage,
 }
 

--- a/crates/leipsanon/src/lib.rs
+++ b/crates/leipsanon/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! Emergency data destruction. Selective wipe of sensitive partitions
 //! (contacts, messages, keys), memory scrubbing, secure delete.
 //!

--- a/crates/pteron/src/lib.rs
+++ b/crates/pteron/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! Bluetooth driver: HCI transport over STP, BLE scanning and device discovery, classic pairing.
 //!
 //! # LE Privacy

--- a/crates/sema/src/lib.rs
+++ b/crates/sema/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! Radio analysis tools. `WiFi` AP scanning, `BT` device enumeration, cell tower logging, `IMSI` catcher detection via tower behavior analysis.
 
 pub mod cell;

--- a/crates/stegnos/src/cipher.rs
+++ b/crates/stegnos/src/cipher.rs
@@ -19,7 +19,9 @@ pub enum Error {
     /// The provided key is not `XTS_KEY_LEN` (64) bytes.
     #[snafu(display("invalid XTS key length: expected {XTS_KEY_LEN} bytes, got {actual}"))]
     InvalidKeyLength {
+        /// Actual key length provided.
         actual: usize,
+        /// Source location.
         #[snafu(implicit)]
         location: snafu::Location,
     },
@@ -27,7 +29,9 @@ pub enum Error {
     /// The plaintext or ciphertext buffer is not exactly `BLOCK_SIZE` (4096) bytes.
     #[snafu(display("invalid block size: expected {BLOCK_SIZE} bytes, got {actual}"))]
     InvalidBlockSize {
+        /// Actual buffer size provided.
         actual: usize,
+        /// Source location.
         #[snafu(implicit)]
         location: snafu::Location,
     },

--- a/crates/stegnos/src/keys.rs
+++ b/crates/stegnos/src/keys.rs
@@ -25,6 +25,7 @@ pub enum Error {
     /// The iteration count passed to key derivation was zero.
     #[snafu(display("iterations must be non-zero"))]
     ZeroIterations {
+        /// Source location.
         #[snafu(implicit)]
         location: snafu::Location,
     },
@@ -32,6 +33,7 @@ pub enum Error {
     /// The system random number generator failed.
     #[snafu(display("random number generation failed"))]
     RandomGeneration {
+        /// Source location.
         #[snafu(implicit)]
         location: snafu::Location,
     },
@@ -39,6 +41,7 @@ pub enum Error {
     /// AES-256-GCM key construction failed (invalid key length).
     #[snafu(display("invalid key material for AES-256-GCM"))]
     InvalidKey {
+        /// Source location.
         #[snafu(implicit)]
         location: snafu::Location,
     },
@@ -46,6 +49,7 @@ pub enum Error {
     /// Encryption of the master key failed.
     #[snafu(display("key sealing failed"))]
     KeySeal {
+        /// Source location.
         #[snafu(implicit)]
         location: snafu::Location,
     },
@@ -53,6 +57,7 @@ pub enum Error {
     /// Decryption failed — wrong passphrase or corrupted data.
     #[snafu(display("key unsealing failed: wrong passphrase or corrupted slot data"))]
     KeyUnseal {
+        /// Source location.
         #[snafu(implicit)]
         location: snafu::Location,
     },
@@ -60,6 +65,7 @@ pub enum Error {
     /// Decrypted plaintext has an unexpected length.
     #[snafu(display("decrypted key has unexpected length"))]
     BadPlaintextLength {
+        /// Source location.
         #[snafu(implicit)]
         location: snafu::Location,
     },

--- a/crates/stegnos/src/lib.rs
+++ b/crates/stegnos/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! Encrypted block device management. `dm-crypt` setup, LUKS key derivation, `TPM` `PCR` sealing, secure key storage.
 
 pub mod cipher;

--- a/crates/topos/src/lib.rs
+++ b/crates/topos/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! GPS driver and position service for the MT6739 combo chip.
 //!
 //! `NMEA` sentence parsing, coordinate logging, geofence evaluation,


### PR DESCRIPTION
Closes #55, #67, #70. Adds ARCHITECTURE.md (crate map, layer diagram, dependency direction). Adds #![deny(missing_docs)] to all 12 library crates with doc comments for compliance. Adds rust.yml CI workflow (fmt, clippy, test, deny).