### PR TITLE
fix(kernel): audit batch 7 — TODO format, plan gap refs, cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,11 @@ Thumos treats all hardware identifiers as sensitive. Every radio driver implemen
 | BLE advertisements | Non-resolvable private address (NRPA) by default |
 | RF fingerprint | Accepted risk on M7 hardware. Custom PCB future addresses this. |
 
+## TODO convention
+
+Format: `TODO(#issue): description` or `TODO(category): description`
+Categories: hw (hardware-dependent), crypto (needs crypto primitives), phase07/phase08 (deferred to future phase)
+
 ## Build
 
 Workspace compiles on host (`cargo check/test`). Kernel cross-compiles for `armv7a-none-eabi` via `cargo build --release` in `crates/thumos/` (the bare-metal kernel binary, excluded from the main workspace). Boot image created with mkbootimg, flashed via mtkclient BROM exploit.

--- a/crates/thumos/src/fd.rs
+++ b/crates/thumos/src/fd.rs
@@ -88,6 +88,8 @@ pub struct StatBuf {
 /// For pipe file descriptors, the pipe identity is encoded in `flags`
 /// (see `pipe.rs` for the encoding). `mount_idx` and `inode_id` are
 /// unused for pipes.
+///
+/// TODO(#84): close-on-exec flag (O_CLOEXEC) -- not tracked in current FileDescriptor
 #[derive(Clone, Copy)]
 pub struct FileDescriptor {
     /// Index into the global MountTable identifying the filesystem.
@@ -234,6 +236,7 @@ impl FdTable {
 /// one process uses filesystem syscalls at a time in the cooperative scheduler.
 ///
 /// TODO(#32): migrate to per-process fd tables when Process struct supports it.
+/// TODO(#84): per-process fd tables -- current global table doesn't support concurrent processes
 pub(crate) static mut FD_TABLE: FdTable = FdTable::new();
 
 /// Global mount table for VFS dispatch.

--- a/crates/thumos/src/pipe.rs
+++ b/crates/thumos/src/pipe.rs
@@ -251,7 +251,7 @@ pub fn sys_pipe(fds_ptr: u32) -> u32 {
     // Write the two fd numbers to userspace.
     // SAFETY: fds_ptr is validated non-null above. We write 8 bytes (two u32s).
     // Wave 4 will add proper bounds validation; this matches the existing syscall
-    // pattern in fd.rs (TODO #0).
+    // pattern in fd.rs (TODO(#84): plan gaps).
     unsafe {
         let fds = fds_ptr as *mut u32;
         core::ptr::write(fds, read_fd);

--- a/crates/thumos/src/socket.rs
+++ b/crates/thumos/src/socket.rs
@@ -288,6 +288,7 @@ unsafe fn alloc_ephemeral_port() -> Option<u16> {
 /// # Returns
 /// File descriptor number on success, negative errno on failure.
 pub fn sys_socket(domain: u32, sock_type: u32, _protocol: u32) -> u32 {
+    // TODO(#84): IPv6 (AF_INET6) -- only AF_INET supported
     if domain != AF_INET {
         return EAFNOSUPPORT;
     }
@@ -451,6 +452,8 @@ pub fn sys_bind(fd: u32, addr_ptr: u32, addr_len: u32) -> u32 {
 ///
 /// # Returns
 /// EOPNOTSUPP — full listen/accept is deferred to a future phase.
+///
+/// TODO(#84): listen/accept -- currently returns EOPNOTSUPP
 pub fn sys_listen(_fd: u32, _backlog: u32) -> u32 {
     EOPNOTSUPP
 }
@@ -459,6 +462,8 @@ pub fn sys_listen(_fd: u32, _backlog: u32) -> u32 {
 ///
 /// # Returns
 /// EOPNOTSUPP — full listen/accept is deferred to a future phase.
+///
+/// TODO(#84): listen/accept -- currently returns EOPNOTSUPP
 pub fn sys_accept(_fd: u32, _addr_ptr: u32, _addr_len_ptr: u32) -> u32 {
     EOPNOTSUPP
 }

--- a/crates/thumos/src/wifi.rs
+++ b/crates/thumos/src/wifi.rs
@@ -132,6 +132,7 @@ pub enum WifiSecurity {
     /// WPA2-Personal (PSK / CCMP).
     Wpa2Personal,
     /// WPA3-Personal (SAE).
+    /// TODO(#84): WPA3-SAE handshake -- enum variant defined but exchange not implemented
     Wpa3Sae,
 }
 
@@ -324,7 +325,7 @@ impl Drop for Ptk {
 /// will be implemented when the kernel crypto subsystem is added.
 #[must_use]
 pub fn derive_pmk(_passphrase: &[u8], _ssid: &[u8]) -> [u8; PMK_LEN] {
-    // TODO(crypto): implement PBKDF2-HMAC-SHA1 (4096 iterations, 32-byte output)
+    // TODO(#72): implement PBKDF2-HMAC-SHA1 (4096 iterations, 32-byte output)
     // per IEEE 802.11-2020, section 12.4.4.3.1.
     // Requires: HMAC-SHA1 primitive (not yet in kernel).
     [0u8; PMK_LEN]
@@ -349,7 +350,7 @@ pub fn derive_ptk(
     _aa: &[u8; 6],
     _spa: &[u8; 6],
 ) -> Ptk {
-    // TODO(crypto): implement PRF-384 via HMAC-SHA1 counter construction
+    // TODO(#72): implement PRF-384 via HMAC-SHA1 counter construction
     // per IEEE 802.11-2020, section 12.7.1.2.
     Ptk {
         kck: [0u8; KCK_LEN],
@@ -368,7 +369,7 @@ pub fn derive_ptk(
 /// **Stubbed**: returns zeroed MIC. Requires HMAC-SHA1 primitive.
 #[must_use]
 pub fn compute_mic(_kck: &[u8; KCK_LEN], _data: &[u8]) -> [u8; MIC_LEN] {
-    // TODO(crypto): implement HMAC-SHA1 truncated to 128 bits.
+    // TODO(#72): implement HMAC-SHA1 truncated to 128 bits.
     [0u8; MIC_LEN]
 }
 
@@ -813,7 +814,7 @@ impl WpaHandshake {
                 }
                 self.replay_counter = key_frame.replay_counter;
 
-                // TODO(crypto): verify MIC using KCK from PTK
+                // TODO(#72): verify MIC using KCK from PTK
                 // let expected_mic = compute_mic(&ptk.kck, frame_with_zeroed_mic);
 
                 self.state = HandshakeState::SendMsg4;
@@ -848,7 +849,7 @@ impl WpaHandshake {
                     nonce: self.snonce,
                     iv: [0u8; IV_LEN],
                     rsc: 0,
-                    mic: [0u8; MIC_LEN], // TODO(crypto): compute MIC with KCK
+                    mic: [0u8; MIC_LEN], // TODO(#72): compute MIC with KCK
                     key_data: Vec::new(),
                 };
                 Some(EapolFrame {
@@ -869,7 +870,7 @@ impl WpaHandshake {
                     nonce: [0u8; NONCE_LEN],
                     iv: [0u8; IV_LEN],
                     rsc: 0,
-                    mic: [0u8; MIC_LEN], // TODO(crypto): compute MIC with KCK
+                    mic: [0u8; MIC_LEN], // TODO(#72): compute MIC with KCK
                     key_data: Vec::new(),
                 };
                 Some(EapolFrame {


### PR DESCRIPTION
Closes #81. Partially addresses #72, #84. Standardizes TODO format to TODO(#issue): or TODO(category):. Adds issue cross-refs at code locations for deferred features (per-process fd, close-on-exec, WPA3-SAE, listen/accept, IPv6). Documents convention in CLAUDE.md.