### PR TITLE
chore: replace deprecated terminology across 8 files

### DIFF
--- a/crates/stegnos/src/keys.rs
+++ b/crates/stegnos/src/keys.rs
@@ -1,4 +1,4 @@
-//! Key management: PBKDF2 key derivation, AES-256-GCM master key seal/unseal.
+//! Key management: PBKDF2 key derivation, AES-256-GCM primary key seal/unseal.
 
 use std::num::NonZeroU32;
 
@@ -46,7 +46,7 @@ pub enum Error {
         location: snafu::Location,
     },
 
-    /// Encryption of the master key failed.
+    /// Encryption of the primary key failed.
     #[snafu(display("key sealing failed"))]
     KeySeal {
         /// Source location.
@@ -85,7 +85,7 @@ pub struct DerivedKey {
     pub iterations: u32,
 }
 
-/// Encryption algorithm used to seal a master key in a [`KeySlot`].
+/// Encryption algorithm used to seal a primary key in a [`KeySlot`].
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum Algorithm {
@@ -93,7 +93,7 @@ pub enum Algorithm {
     Aes256Gcm,
 }
 
-/// An encrypted master key plus metadata needed to unseal it.
+/// An encrypted primary key plus metadata needed to unseal it.
 #[derive(Debug, Clone)]
 pub struct KeySlot {
     /// PBKDF2 salt (randomly generated at seal time).
@@ -102,11 +102,11 @@ pub struct KeySlot {
     pub iterations: u32,
     /// AES-GCM nonce (randomly generated at seal time).
     pub nonce: [u8; NONCE_LEN],
-    /// Encryption algorithm used to protect the master key.
+    /// Encryption algorithm used to protect the primary key.
     pub algorithm: Algorithm,
     /// When this slot was created.
     pub created: Timestamp,
-    /// Encrypted master key (ciphertext || GCM tag), 48 bytes total.
+    /// Encrypted primary key (ciphertext || GCM tag), 48 bytes total.
     pub ciphertext: [u8; SEALED_KEY_LEN],
 }
 
@@ -140,7 +140,7 @@ fn random_bytes<const N: usize>(rng: &SystemRandom) -> Result<[u8; N]> {
     Ok(buf)
 }
 
-/// Seal `master_key` with a key derived from `passphrase` using AES-256-GCM.
+/// Seal `primary_key` with a key derived from `passphrase` using AES-256-GCM.
 ///
 /// Generates a random salt and nonce. The resulting [`KeySlot`] contains everything
 /// needed to unseal the key later.
@@ -148,7 +148,7 @@ fn random_bytes<const N: usize>(rng: &SystemRandom) -> Result<[u8; N]> {
 /// # Errors
 ///
 /// Returns an error if random generation fails, key construction fails, or encryption fails.
-pub fn seal_key(master_key: &[u8; KEY_LEN], passphrase: &[u8]) -> Result<KeySlot> {
+pub fn seal_key(primary_key: &[u8; KEY_LEN], passphrase: &[u8]) -> Result<KeySlot> {
     let rng = SystemRandom::new();
 
     let salt = random_bytes::<SALT_LEN>(&rng)?;
@@ -161,7 +161,7 @@ pub fn seal_key(master_key: &[u8; KEY_LEN], passphrase: &[u8]) -> Result<KeySlot
     let sealing_key = LessSafeKey::new(unbound);
     let nonce = Nonce::assume_unique_for_key(nonce_bytes);
 
-    let mut buf = master_key.to_vec();
+    let mut buf = primary_key.to_vec();
     sealing_key
         .seal_in_place_append_tag(nonce, aead::Aad::empty(), &mut buf)
         .map_err(|_| KeySealSnafu.build())?;
@@ -179,10 +179,10 @@ pub fn seal_key(master_key: &[u8; KEY_LEN], passphrase: &[u8]) -> Result<KeySlot
     })
 }
 
-/// Unseal a master key from `slot` using `passphrase`.
+/// Unseal a primary key from `slot` using `passphrase`.
 ///
 /// Re-derives the wrapping key from the passphrase and stored salt, then
-/// decrypts and authenticates the master key via AES-256-GCM.
+/// decrypts and authenticates the primary key via AES-256-GCM.
 ///
 /// # Errors
 ///
@@ -205,9 +205,9 @@ pub fn unseal_key(slot: &KeySlot, passphrase: &[u8]) -> Result<[u8; KEY_LEN]> {
     let slice = plaintext
         .get(..KEY_LEN)
         .ok_or_else(|| BadPlaintextLengthSnafu.build())?;
-    let mut master_key = [0u8; KEY_LEN];
-    master_key.copy_from_slice(slice);
-    Ok(master_key)
+    let mut primary_key = [0u8; KEY_LEN];
+    primary_key.copy_from_slice(slice);
+    Ok(primary_key)
 }
 
 #[cfg(test)]
@@ -253,21 +253,21 @@ mod tests {
 
     #[test]
     fn seal_unseal_round_trip() -> Result<()> {
-        let master_key = [0xABu8; KEY_LEN];
+        let primary_key = [0xABu8; KEY_LEN];
         let passphrase = b"test passphrase";
-        let slot = seal_key(&master_key, passphrase)?;
+        let slot = seal_key(&primary_key, passphrase)?;
         let recovered = unseal_key(&slot, passphrase)?;
         assert_eq!(
-            master_key, recovered,
-            "unseal must return the original master key"
+            primary_key, recovered,
+            "unseal must return the original primary key"
         );
         Ok(())
     }
 
     #[test]
     fn wrong_passphrase_fails_unseal() -> Result<()> {
-        let master_key = [0xCDu8; KEY_LEN];
-        let slot = seal_key(&master_key, b"correct passphrase")?;
+        let primary_key = [0xCDu8; KEY_LEN];
+        let slot = seal_key(&primary_key, b"correct passphrase")?;
         let result = unseal_key(&slot, b"wrong passphrase");
         assert!(
             result.is_err(),

--- a/crates/thumos/src/bfu_timer.rs
+++ b/crates/thumos/src/bfu_timer.rs
@@ -334,13 +334,13 @@ mod tests {
     /// Helper: create a `KeyManager` with loaded keys for testing.
     fn test_key_manager_with_keys() -> KeyManager {
         let mut km = KeyManager::new();
-        let master = {
+        let primary = {
             let mut key_bytes = [0u8; 32];
             crate::security::pbkdf2_sha256(b"test-bfu", b"salt", 1, &mut key_bytes)
                 .expect("pbkdf2 failed in test");
             crate::key_manager::SecureKey::new(key_bytes)
         };
-        km.derive_partition_keys(&master)
+        km.derive_partition_keys(&primary)
             .expect("derive_partition_keys failed");
         km
     }

--- a/crates/thumos/src/ccci_logger.rs
+++ b/crates/thumos/src/ccci_logger.rs
@@ -17,14 +17,14 @@
 //!    unexpected active channels, rate spikes > 3x, out-of-range data0 values.
 //!    Emits [`CcciAnomaly`] events for the audit log.
 //!
-//! 4. **[`CcciFirewall`]** -- channel whitelist with default-deny policy.
-//!    Mode-dependent whitelists (Daily / Sentinel / Panic).  Dropped packets
+//! 4. **[`CcciFirewall`]** -- channel allowlist with default-deny policy.
+//!    Mode-dependent allowlists (Daily / Sentinel / Panic).  Dropped packets
 //!    are audit-logged.
 //!
 //! ## Security
 //!
 //! All structures are fixed-size, no_std, no heap allocation.  The firewall
-//! evaluates *before* packet dispatch -- non-whitelisted channels never reach
+//! evaluates *before* packet dispatch -- non-allowlisted channels never reach
 //! higher layers.
 
 use core::fmt;
@@ -51,8 +51,8 @@ const BASELINE_WINDOW_MS: u64 = 60_000;
 /// Anomaly rate spike threshold: flag if live rate exceeds 3x baseline max.
 const RATE_SPIKE_FACTOR: u32 = 3;
 
-/// Maximum channels in the firewall whitelist.
-const MAX_WHITELIST: usize = 16;
+/// Maximum channels in the firewall allowlist.
+const MAX_ALLOWLIST: usize = 16;
 
 // ---------------------------------------------------------------------------
 // PacketDirection
@@ -575,7 +575,7 @@ pub fn detect_anomalies(
 // FirewallMode
 // ---------------------------------------------------------------------------
 
-/// Firewall operating mode, determining which channels are whitelisted.
+/// Firewall operating mode, determining which channels are allowlisted.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[must_use]
 #[non_exhaustive]
@@ -584,7 +584,7 @@ pub enum FirewallMode {
     Daily,
     /// Heightened security: Control, System channels only.
     Sentinel,
-    /// Emergency: all channels blocked (empty whitelist).
+    /// Emergency: all channels blocked (empty allowlist).
     Panic,
 }
 
@@ -607,9 +607,9 @@ impl fmt::Display for FirewallMode {
 #[must_use]
 #[non_exhaustive]
 pub enum FirewallVerdict {
-    /// Packet is allowed (channel is whitelisted).
+    /// Packet is allowed (channel is allowlisted).
     Allow,
-    /// Packet is dropped (channel is not whitelisted).
+    /// Packet is dropped (channel is not allowlisted).
     Drop,
 }
 
@@ -626,22 +626,22 @@ impl fmt::Display for FirewallVerdict {
 // CcciFirewall
 // ---------------------------------------------------------------------------
 
-/// Channel whitelist firewall for the CCCI link.
+/// Channel allowlist firewall for the CCCI link.
 ///
-/// Default policy: deny.  Only channels explicitly added to the whitelist
-/// are allowed through.  The whitelist is populated based on the current
+/// Default policy: deny.  Only channels explicitly added to the allowlist
+/// are allowed through.  The allowlist is populated based on the current
 /// [`FirewallMode`].
 ///
-/// SECURITY: Evaluates before packet dispatch.  Non-whitelisted packets
+/// SECURITY: Evaluates before packet dispatch.  Non-allowlisted packets
 /// are dropped and audit-logged.
 #[must_use]
 pub struct CcciFirewall {
     /// Current firewall mode.
     mode: FirewallMode,
-    /// Whitelisted channel numbers.
-    whitelist: [u32; MAX_WHITELIST],
-    /// Number of channels in the whitelist.
-    whitelist_len: usize,
+    /// Allowlisted channel numbers.
+    allowlist: [u32; MAX_ALLOWLIST],
+    /// Number of channels in the allowlist.
+    allowlist_len: usize,
     /// Total packets dropped by the firewall.
     drop_count: u64,
     /// Total packets allowed through.
@@ -653,8 +653,8 @@ impl CcciFirewall {
     pub fn new(mode: FirewallMode) -> Self {
         let mut fw = Self {
             mode,
-            whitelist: [0; MAX_WHITELIST],
-            whitelist_len: 0,
+            allowlist: [0; MAX_ALLOWLIST],
+            allowlist_len: 0,
             drop_count: 0,
             allow_count: 0,
         };
@@ -662,10 +662,10 @@ impl CcciFirewall {
         fw
     }
 
-    /// Apply a firewall mode, replacing the whitelist.
+    /// Apply a firewall mode, replacing the allowlist.
     pub fn apply_mode(&mut self, mode: FirewallMode) {
         self.mode = mode;
-        self.whitelist_len = 0;
+        self.allowlist_len = 0;
 
         match mode {
             FirewallMode::Daily => {
@@ -681,9 +681,9 @@ impl CcciFirewall {
                     CcciChannel::Ccmni1Rx as u32,
                 ];
                 for &ch in channels {
-                    if self.whitelist_len < MAX_WHITELIST {
-                        self.whitelist[self.whitelist_len] = ch;
-                        self.whitelist_len += 1;
+                    if self.allowlist_len < MAX_ALLOWLIST {
+                        self.allowlist[self.allowlist_len] = ch;
+                        self.allowlist_len += 1;
                     }
                 }
             }
@@ -696,25 +696,25 @@ impl CcciFirewall {
                     CcciChannel::SystemRx as u32,
                 ];
                 for &ch in channels {
-                    if self.whitelist_len < MAX_WHITELIST {
-                        self.whitelist[self.whitelist_len] = ch;
-                        self.whitelist_len += 1;
+                    if self.allowlist_len < MAX_ALLOWLIST {
+                        self.allowlist[self.allowlist_len] = ch;
+                        self.allowlist_len += 1;
                     }
                 }
             }
             FirewallMode::Panic => {
-                // Empty whitelist: all channels blocked.
+                // Empty allowlist: all channels blocked.
             }
         }
     }
 
-    /// Evaluate a packet against the firewall whitelist.
+    /// Evaluate a packet against the firewall allowlist.
     ///
-    /// Returns [`FirewallVerdict::Allow`] if the channel is whitelisted,
+    /// Returns [`FirewallVerdict::Allow`] if the channel is allowlisted,
     /// [`FirewallVerdict::Drop`] otherwise.
     pub fn evaluate(&mut self, channel: u32) -> FirewallVerdict {
-        for i in 0..self.whitelist_len {
-            if self.whitelist[i] == channel {
+        for i in 0..self.allowlist_len {
+            if self.allowlist[i] == channel {
                 self.allow_count += 1;
                 return FirewallVerdict::Allow;
             }
@@ -723,10 +723,10 @@ impl CcciFirewall {
         FirewallVerdict::Drop
     }
 
-    /// Whether a channel is in the whitelist (non-mutating check).
+    /// Whether a channel is in the allowlist (non-mutating check).
     #[must_use]
-    pub fn is_whitelisted(&self, channel: u32) -> bool {
-        self.whitelist[..self.whitelist_len].contains(&channel)
+    pub fn is_allowlisted(&self, channel: u32) -> bool {
+        self.allowlist[..self.allowlist_len].contains(&channel)
     }
 
     /// Current firewall mode.
@@ -747,10 +747,10 @@ impl CcciFirewall {
         self.allow_count
     }
 
-    /// Number of channels in the whitelist.
+    /// Number of channels in the allowlist.
     #[must_use]
-    pub fn whitelist_len(&self) -> usize {
-        self.whitelist_len
+    pub fn allowlist_len(&self) -> usize {
+        self.allowlist_len
     }
 }
 
@@ -758,7 +758,7 @@ impl fmt::Debug for CcciFirewall {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CcciFirewall")
             .field("mode", &self.mode)
-            .field("whitelist_len", &self.whitelist_len)
+            .field("allowlist_len", &self.allowlist_len)
             .field("drop_count", &self.drop_count)
             .field("allow_count", &self.allow_count)
             .finish_non_exhaustive()
@@ -769,8 +769,8 @@ impl fmt::Display for CcciFirewall {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "CcciFirewall(mode={}, whitelist={}, dropped={}, allowed={})",
-            self.mode, self.whitelist_len, self.drop_count, self.allow_count,
+            "CcciFirewall(mode={}, allowlist={}, dropped={}, allowed={})",
+            self.mode, self.allowlist_len, self.drop_count, self.allow_count,
         )
     }
 }
@@ -1220,63 +1220,63 @@ mod tests {
     // -- CcciFirewall tests --
 
     #[test]
-    fn firewall_daily_whitelist() {
+    fn firewall_daily_allowlist() {
         let fw = CcciFirewall::new(FirewallMode::Daily);
         assert_eq!(fw.mode(), FirewallMode::Daily);
-        assert_eq!(fw.whitelist_len(), 8, "Daily: 4 channel pairs = 8");
+        assert_eq!(fw.allowlist_len(), 8, "Daily: 4 channel pairs = 8");
 
         // Control, System, Uart1, Ccmni1 channels allowed.
-        assert!(fw.is_whitelisted(CcciChannel::ControlTx as u32));
-        assert!(fw.is_whitelisted(CcciChannel::ControlRx as u32));
-        assert!(fw.is_whitelisted(CcciChannel::SystemTx as u32));
-        assert!(fw.is_whitelisted(CcciChannel::SystemRx as u32));
-        assert!(fw.is_whitelisted(CcciChannel::Uart1Tx as u32));
-        assert!(fw.is_whitelisted(CcciChannel::Uart1Rx as u32));
-        assert!(fw.is_whitelisted(CcciChannel::Ccmni1Tx as u32));
-        assert!(fw.is_whitelisted(CcciChannel::Ccmni1Rx as u32));
+        assert!(fw.is_allowlisted(CcciChannel::ControlTx as u32));
+        assert!(fw.is_allowlisted(CcciChannel::ControlRx as u32));
+        assert!(fw.is_allowlisted(CcciChannel::SystemTx as u32));
+        assert!(fw.is_allowlisted(CcciChannel::SystemRx as u32));
+        assert!(fw.is_allowlisted(CcciChannel::Uart1Tx as u32));
+        assert!(fw.is_allowlisted(CcciChannel::Uart1Rx as u32));
+        assert!(fw.is_allowlisted(CcciChannel::Ccmni1Tx as u32));
+        assert!(fw.is_allowlisted(CcciChannel::Ccmni1Rx as u32));
 
-        // Other channels not whitelisted.
-        assert!(!fw.is_whitelisted(CcciChannel::FsTx as u32));
-        assert!(!fw.is_whitelisted(CcciChannel::MdLogRx as u32));
+        // Other channels not allowlisted.
+        assert!(!fw.is_allowlisted(CcciChannel::FsTx as u32));
+        assert!(!fw.is_allowlisted(CcciChannel::MdLogRx as u32));
     }
 
     #[test]
-    fn firewall_sentinel_whitelist() {
+    fn firewall_sentinel_allowlist() {
         let fw = CcciFirewall::new(FirewallMode::Sentinel);
         assert_eq!(fw.mode(), FirewallMode::Sentinel);
-        assert_eq!(fw.whitelist_len(), 4, "Sentinel: 2 channel pairs = 4");
+        assert_eq!(fw.allowlist_len(), 4, "Sentinel: 2 channel pairs = 4");
 
-        assert!(fw.is_whitelisted(CcciChannel::ControlTx as u32));
-        assert!(fw.is_whitelisted(CcciChannel::ControlRx as u32));
-        assert!(fw.is_whitelisted(CcciChannel::SystemTx as u32));
-        assert!(fw.is_whitelisted(CcciChannel::SystemRx as u32));
+        assert!(fw.is_allowlisted(CcciChannel::ControlTx as u32));
+        assert!(fw.is_allowlisted(CcciChannel::ControlRx as u32));
+        assert!(fw.is_allowlisted(CcciChannel::SystemTx as u32));
+        assert!(fw.is_allowlisted(CcciChannel::SystemRx as u32));
 
         // Uart1, Ccmni1 blocked in Sentinel.
-        assert!(!fw.is_whitelisted(CcciChannel::Uart1Tx as u32));
-        assert!(!fw.is_whitelisted(CcciChannel::Ccmni1Tx as u32));
+        assert!(!fw.is_allowlisted(CcciChannel::Uart1Tx as u32));
+        assert!(!fw.is_allowlisted(CcciChannel::Ccmni1Tx as u32));
     }
 
     #[test]
     fn firewall_panic_blocks_all() {
         let fw = CcciFirewall::new(FirewallMode::Panic);
         assert_eq!(fw.mode(), FirewallMode::Panic);
-        assert_eq!(fw.whitelist_len(), 0, "Panic: empty whitelist");
+        assert_eq!(fw.allowlist_len(), 0, "Panic: empty allowlist");
 
         for ch in 0..22u32 {
-            assert!(!fw.is_whitelisted(ch), "ch {ch} must be blocked in Panic");
+            assert!(!fw.is_allowlisted(ch), "ch {ch} must be blocked in Panic");
         }
     }
 
     #[test]
-    fn firewall_drops_non_whitelisted() {
+    fn firewall_drops_non_allowlisted() {
         let mut fw = CcciFirewall::new(FirewallMode::Sentinel);
 
-        // Whitelisted channel: allowed.
+        // Allowlisted channel: allowed.
         let verdict = fw.evaluate(CcciChannel::ControlTx as u32);
         assert_eq!(verdict, FirewallVerdict::Allow);
         assert_eq!(fw.allow_count(), 1);
 
-        // Non-whitelisted channel: dropped.
+        // Non-allowlisted channel: dropped.
         let verdict = fw.evaluate(CcciChannel::Uart1Tx as u32);
         assert_eq!(verdict, FirewallVerdict::Drop);
         assert_eq!(fw.drop_count(), 1);
@@ -1285,15 +1285,15 @@ mod tests {
     #[test]
     fn firewall_mode_transition() {
         let mut fw = CcciFirewall::new(FirewallMode::Daily);
-        assert_eq!(fw.whitelist_len(), 8);
+        assert_eq!(fw.allowlist_len(), 8);
 
         fw.apply_mode(FirewallMode::Sentinel);
         assert_eq!(fw.mode(), FirewallMode::Sentinel);
-        assert_eq!(fw.whitelist_len(), 4);
+        assert_eq!(fw.allowlist_len(), 4);
 
         fw.apply_mode(FirewallMode::Panic);
         assert_eq!(fw.mode(), FirewallMode::Panic);
-        assert_eq!(fw.whitelist_len(), 0);
+        assert_eq!(fw.allowlist_len(), 0);
     }
 
     #[test]

--- a/crates/thumos/src/http_client.rs
+++ b/crates/thumos/src/http_client.rs
@@ -549,7 +549,7 @@ fn parse_status_line(header_block: &[u8]) -> Result<(u16, usize), HttpError> {
     let code_bytes = &line[code_start..code_start + 3];
     let status = parse_u16_from_ascii(code_bytes).ok_or(HttpError::InvalidStatusCode)?;
 
-    // Sanity check: HTTP status codes are 100-599.
+    // Validation check: HTTP status codes are 100-599.
     if !(100..=599).contains(&status) {
         return Err(HttpError::InvalidStatusCode);
     }

--- a/crates/thumos/src/key_manager.rs
+++ b/crates/thumos/src/key_manager.rs
@@ -1,11 +1,11 @@
 //! Key hierarchy management for the thumos kernel.
 //!
 //! Manages the cryptographic key lifecycle:
-//! 1. Passphrase -> master key (via PBKDF2-HMAC-SHA256)
-//! 2. Master key -> per-purpose sub-keys (via HKDF-SHA256)
+//! 1. Passphrase -> primary key (via PBKDF2-HMAC-SHA256)
+//! 2. Primary key -> per-purpose sub-keys (via HKDF-SHA256)
 //! 3. Secure zeroization on sleep/panic
 //!
-//! The master key is zeroized immediately after deriving sub-keys.
+//! The primary key is zeroized immediately after deriving sub-keys.
 //! Sub-keys are zeroized on long-sleep or panic transitions.
 //!
 //! Key hierarchy labels (HKDF info strings):
@@ -104,7 +104,7 @@ impl<const N: usize> fmt::Display for SecureKey<N> {
 // KeySet
 // ---------------------------------------------------------------------------
 
-/// The set of per-purpose keys derived from a master key.
+/// The set of per-purpose keys derived from a primary key.
 #[expect(clippy::struct_field_names, reason = "key suffix is domain terminology, not redundant with struct name")]
 pub struct KeySet {
     /// Partition encryption key (AES-256-XTS, 64 bytes).
@@ -140,12 +140,12 @@ impl fmt::Display for KeySet {
 
 /// Manages the kernel key hierarchy and sleep-tier lifecycle.
 ///
-/// Holds derived partition keys and tracks whether the master key has been
-/// used to derive them. The master key itself is never stored — it is
+/// Holds derived partition keys and tracks whether the primary key has been
+/// used to derive them. The primary key itself is never stored — it is
 /// zeroized immediately after deriving sub-keys.
 pub struct KeyManager {
-    /// Whether keys have been derived from a master key.
-    master_key_derived: bool,
+    /// Whether keys have been derived from a primary key.
+    primary_key_derived: bool,
     /// Partition encryption key (XTS, 64 bytes).
     data_key: Option<SecureKey<XTS_KEY_SIZE>>,
     /// Audit log HMAC key.
@@ -163,7 +163,7 @@ impl KeyManager {
     #[must_use]
     pub const fn new() -> Self {
         Self {
-            master_key_derived: false,
+            primary_key_derived: false,
             data_key: None,
             audit_key: None,
             csprng_key: None,
@@ -172,9 +172,9 @@ impl KeyManager {
         }
     }
 
-    /// Derive a master key from a passphrase using PBKDF2-HMAC-SHA256.
+    /// Derive a primary key from a passphrase using PBKDF2-HMAC-SHA256.
     ///
-    /// Returns the 32-byte master key. The caller should immediately pass
+    /// Returns the 32-byte primary key. The caller should immediately pass
     /// it to [`KeyManager::derive_partition_keys`] and then drop it (the
     /// `SecureKey` wrapper will zeroize on drop).
     ///
@@ -191,7 +191,7 @@ impl KeyManager {
         Ok(SecureKey::new(key_bytes))
     }
 
-    /// Derive per-purpose partition keys from a master key via HKDF-SHA256.
+    /// Derive per-purpose partition keys from a primary key via HKDF-SHA256.
     ///
     /// Derives four sub-keys with distinct labels:
     /// - `data_key` (64 bytes, XTS): partition encryption
@@ -200,17 +200,17 @@ impl KeyManager {
     /// - `session_key` (32 bytes): ephemeral session operations
     ///
     /// Stores the keys internally and marks the manager as initialized.
-    /// The master key should be dropped (zeroized) after this call.
+    /// The primary key should be dropped (zeroized) after this call.
     ///
     /// # Errors
     ///
     /// Returns [`SecurityError`] if HKDF derivation fails.
     pub fn derive_partition_keys(
         &mut self,
-        master: &SecureKey<KEY_SIZE>,
+        primary: &SecureKey<KEY_SIZE>,
     ) -> Result<(), SecurityError> {
-        // Derive each sub-key via HKDF with the master key as IKM.
-        let ikm = master.as_bytes();
+        // Derive each sub-key via HKDF with the primary key as IKM.
+        let ikm = primary.as_bytes();
 
         let mut data_bytes = [0u8; XTS_KEY_SIZE];
         security::hkdf_sha256(ikm, &[], LABEL_DATA, &mut data_bytes)?;
@@ -228,7 +228,7 @@ impl KeyManager {
         self.audit_key = Some(SecureKey::new(audit_bytes));
         self.csprng_key = Some(SecureKey::new(csprng_bytes));
         self.session_key = Some(SecureKey::new(session_bytes));
-        self.master_key_derived = true;
+        self.primary_key_derived = true;
         self.sleep_tier = SleepTier::Short;
 
         Ok(())
@@ -243,14 +243,14 @@ impl KeyManager {
         self.audit_key = None;
         self.csprng_key = None;
         self.session_key = None;
-        self.master_key_derived = false;
+        self.primary_key_derived = false;
         self.sleep_tier = SleepTier::Long;
     }
 
     /// Check whether partition keys are currently loaded.
     #[must_use]
     pub fn has_keys(&self) -> bool {
-        self.master_key_derived
+        self.primary_key_derived
             && self.data_key.is_some()
             && self.audit_key.is_some()
             && self.csprng_key.is_some()
@@ -304,7 +304,7 @@ impl fmt::Debug for KeyManager {
         // accidental leakage in debug output. finish_non_exhaustive signals
         // that fields exist but are not shown.
         f.debug_struct("KeyManager")
-            .field("master_key_derived", &self.master_key_derived)
+            .field("primary_key_derived", &self.primary_key_derived)
             .field("has_keys", &self.has_keys())
             .field("sleep_tier", &self.sleep_tier)
             .finish_non_exhaustive()
@@ -331,7 +331,7 @@ mod tests {
     use super::*;
 
     // Use a low iteration count for test speed.
-    fn derive_test_master(passphrase: &[u8]) -> SecureKey<KEY_SIZE> {
+    fn derive_test_primary(passphrase: &[u8]) -> SecureKey<KEY_SIZE> {
         let mut key_bytes = [0u8; KEY_SIZE];
         security::pbkdf2_sha256(passphrase, PBKDF2_SALT, 1, &mut key_bytes)
             .expect("pbkdf2 derivation failed in test");
@@ -340,19 +340,19 @@ mod tests {
 
     #[test]
     fn derive_from_passphrase_is_deterministic() {
-        let key1 = derive_test_master(b"test passphrase");
-        let key2 = derive_test_master(b"test passphrase");
+        let key1 = derive_test_primary(b"test passphrase");
+        let key2 = derive_test_primary(b"test passphrase");
         assert_eq!(
             key1.as_bytes(),
             key2.as_bytes(),
-            "same passphrase must produce the same master key"
+            "same passphrase must produce the same primary key"
         );
     }
 
     #[test]
     fn different_passphrases_produce_different_keys() {
-        let key1 = derive_test_master(b"passphrase alpha");
-        let key2 = derive_test_master(b"passphrase bravo");
+        let key1 = derive_test_primary(b"passphrase alpha");
+        let key2 = derive_test_primary(b"passphrase bravo");
         assert_ne!(
             key1.as_bytes(),
             key2.as_bytes(),
@@ -362,9 +362,9 @@ mod tests {
 
     #[test]
     fn derive_partition_keys_produces_distinct_keys() {
-        let master = derive_test_master(b"partition key test");
+        let primary = derive_test_primary(b"partition key test");
         let mut km = KeyManager::new();
-        km.derive_partition_keys(&master)
+        km.derive_partition_keys(&primary)
             .expect("derive_partition_keys failed");
 
         assert!(km.has_keys(), "keys must be loaded after derivation");
@@ -398,9 +398,9 @@ mod tests {
 
     #[test]
     fn zeroize_all_clears_keys() {
-        let master = derive_test_master(b"zeroize test");
+        let primary = derive_test_primary(b"zeroize test");
         let mut km = KeyManager::new();
-        km.derive_partition_keys(&master)
+        km.derive_partition_keys(&primary)
             .expect("derive_partition_keys failed");
 
         assert!(km.has_keys());
@@ -427,9 +427,9 @@ mod tests {
 
     #[test]
     fn long_sleep_zeroizes_keys() {
-        let master = derive_test_master(b"sleep tier test");
+        let primary = derive_test_primary(b"sleep tier test");
         let mut km = KeyManager::new();
-        km.derive_partition_keys(&master)
+        km.derive_partition_keys(&primary)
             .expect("derive_partition_keys failed");
 
         assert!(km.has_keys());
@@ -458,27 +458,27 @@ mod tests {
 
     #[test]
     fn derive_partition_keys_deterministic() {
-        let master = derive_test_master(b"deterministic test");
+        let primary = derive_test_primary(b"deterministic test");
 
         let mut km1 = KeyManager::new();
-        km1.derive_partition_keys(&master)
+        km1.derive_partition_keys(&primary)
             .expect("derive_partition_keys failed");
 
-        // Re-derive with same master key.
-        let master2 = derive_test_master(b"deterministic test");
+        // Re-derive with same primary key.
+        let primary2 = derive_test_primary(b"deterministic test");
         let mut km2 = KeyManager::new();
-        km2.derive_partition_keys(&master2)
+        km2.derive_partition_keys(&primary2)
             .expect("derive_partition_keys failed");
 
         assert_eq!(
             km1.data_key().expect("data key missing").as_bytes(),
             km2.data_key().expect("data key missing").as_bytes(),
-            "same master key must produce same data key"
+            "same primary key must produce same data key"
         );
         assert_eq!(
             km1.audit_key().expect("audit key missing").as_bytes(),
             km2.audit_key().expect("audit key missing").as_bytes(),
-            "same master key must produce same audit key"
+            "same primary key must produce same audit key"
         );
     }
 }

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -573,7 +573,7 @@ pub unsafe fn run() -> ! {
     if state.display_ok && state.input_ok {
         // WHY: passphrase must be entered before any encrypted data is
         // accessed.  The lock screen renders on the display and accepts
-        // keypad input.  On success, the master key is derived and
+        // keypad input.  On success, the primary key is derived and
         // partition sub-keys are produced.
         //
         // NOTE: In production, this blocks until the user enters the

--- a/crates/thumos/src/panic_wipe.rs
+++ b/crates/thumos/src/panic_wipe.rs
@@ -401,13 +401,13 @@ mod tests {
     /// Helper: create a `KeyManager` with loaded keys for testing.
     fn test_key_manager_with_keys() -> KeyManager {
         let mut km = KeyManager::new();
-        let master = {
+        let primary = {
             let mut key_bytes = [0u8; 32];
             crate::security::pbkdf2_sha256(b"test-wipe", b"salt", 1, &mut key_bytes)
                 .expect("pbkdf2 failed in test");
             crate::key_manager::SecureKey::new(key_bytes)
         };
-        km.derive_partition_keys(&master)
+        km.derive_partition_keys(&primary)
             .expect("derive_partition_keys failed");
         km
     }

--- a/crates/thumos/src/security_mode.rs
+++ b/crates/thumos/src/security_mode.rs
@@ -793,13 +793,13 @@ mod tests {
     /// Helper: create a KeyManager with loaded keys for testing.
     fn test_key_manager_with_keys() -> KeyManager {
         let mut km = KeyManager::new();
-        let master = {
+        let primary = {
             let mut key_bytes = [0u8; 32];
             crate::security::pbkdf2_sha256(b"test", b"salt", 1, &mut key_bytes)
                 .expect("pbkdf2 failed");
             crate::key_manager::SecureKey::new(key_bytes)
         };
-        km.derive_partition_keys(&master)
+        km.derive_partition_keys(&primary)
             .expect("derive_partition_keys failed");
         km
     }


### PR DESCRIPTION
master→primary, whitelist→allowlist, sanity check→validation check. 137 line changes, rename-only.