### PR TITLE
Task: Fix RUST/format-single-var violations in thumos

### DIFF
--- a/crates/sema/src/cell.rs
+++ b/crates/sema/src/cell.rs
@@ -947,10 +947,10 @@ mod tests {
 
     #[test]
     fn threat_level_display() {
-        assert_eq!(format!("{}", ThreatLevel::Low), "LOW");
-        assert_eq!(format!("{}", ThreatLevel::Medium), "MEDIUM");
-        assert_eq!(format!("{}", ThreatLevel::High), "HIGH");
-        assert_eq!(format!("{}", ThreatLevel::Critical), "CRITICAL");
+        assert_eq!(ThreatLevel::Low.to_string(), "LOW");
+        assert_eq!(ThreatLevel::Medium.to_string(), "MEDIUM");
+        assert_eq!(ThreatLevel::High.to_string(), "HIGH");
+        assert_eq!(ThreatLevel::Critical.to_string(), "CRITICAL");
     }
 
     #[test]
@@ -988,11 +988,11 @@ mod tests {
 
     #[test]
     fn cipher_algorithm_display() {
-        assert_eq!(format!("{}", CipherAlgorithm::A5_0), "A5/0 (no encryption)");
-        assert_eq!(format!("{}", CipherAlgorithm::A5_1), "A5/1");
-        assert_eq!(format!("{}", CipherAlgorithm::A5_2), "A5/2");
-        assert_eq!(format!("{}", CipherAlgorithm::A5_3), "A5/3");
-        assert_eq!(format!("{}", CipherAlgorithm::A5_4), "A5/4");
+        assert_eq!(CipherAlgorithm::A5_0.to_string(), "A5/0 (no encryption)");
+        assert_eq!(CipherAlgorithm::A5_1.to_string(), "A5/1");
+        assert_eq!(CipherAlgorithm::A5_2.to_string(), "A5/2");
+        assert_eq!(CipherAlgorithm::A5_3.to_string(), "A5/3");
+        assert_eq!(CipherAlgorithm::A5_4.to_string(), "A5/4");
     }
 
     #[test]

--- a/crates/thumos/src/audio_route.rs
+++ b/crates/thumos/src/audio_route.rs
@@ -585,19 +585,19 @@ mod tests {
     #[test]
     fn audio_route_display() {
         assert_eq!(
-            alloc::format!("{}", AudioRoute::Earpiece),
+            AudioRoute::Earpiece.to_string(),
             "earpiece",
         );
         assert_eq!(
-            alloc::format!("{}", AudioRoute::Speaker),
+            AudioRoute::Speaker.to_string(),
             "speaker",
         );
         assert_eq!(
-            alloc::format!("{}", AudioRoute::BluetoothA2dp),
+            AudioRoute::BluetoothA2dp.to_string(),
             "bluetooth",
         );
         assert_eq!(
-            alloc::format!("{}", AudioRoute::UsbDac),
+            AudioRoute::UsbDac.to_string(),
             "USB DAC",
         );
     }
@@ -605,11 +605,11 @@ mod tests {
     #[test]
     fn session_kind_display() {
         assert_eq!(
-            alloc::format!("{}", SessionKind::VoiceCall),
+            SessionKind::VoiceCall.to_string(),
             "voice call",
         );
         assert_eq!(
-            alloc::format!("{}", SessionKind::Music),
+            SessionKind::Music.to_string(),
             "music",
         );
     }

--- a/crates/thumos/src/audit.rs
+++ b/crates/thumos/src/audit.rs
@@ -854,15 +854,15 @@ mod tests {
     #[test]
     fn event_type_display() {
         assert_eq!(
-            alloc::format!("{}", AuditEventType::AuthFail),
+            AuditEventType::AuthFail.to_string(),
             "AUTH_FAIL"
         );
         assert_eq!(
-            alloc::format!("{}", AuditEventType::PanicTrigger),
+            AuditEventType::PanicTrigger.to_string(),
             "PANIC_TRIGGER"
         );
         assert_eq!(
-            alloc::format!("{}", AuditEventType::DuressAttempt),
+            AuditEventType::DuressAttempt.to_string(),
             "DURESS_ATTEMPT"
         );
     }
@@ -875,7 +875,7 @@ mod tests {
         let (older, newer) = log.recent(1);
         let entries: alloc::vec::Vec<&AuditEntry> =
             older.iter().chain(newer.iter()).collect();
-        let display = alloc::format!("{}", entries[0]);
+        let display = entries[0].to_string();
         assert!(display.contains("42000"), "display must contain timestamp");
         assert!(display.contains("MODE_CHANGE"), "display must contain event type");
         assert!(display.contains("Daily->Sentinel"), "display must contain detail");
@@ -891,13 +891,13 @@ mod tests {
 
     #[test]
     fn audit_error_display() {
-        let no_key = alloc::format!("{}", AuditError::NoKey);
+        let no_key = AuditError::NoKey.to_string();
         assert!(no_key.contains("not available"), "NoKey display: {no_key}");
 
-        let tampered = alloc::format!("{}", AuditError::ChainTampered);
+        let tampered = AuditError::ChainTampered.to_string();
         assert!(tampered.contains("tampering"), "ChainTampered display: {tampered}");
 
-        let empty = alloc::format!("{}", AuditError::Empty);
+        let empty = AuditError::Empty.to_string();
         assert!(empty.contains("empty"), "Empty display: {empty}");
     }
 

--- a/crates/thumos/src/bfu_timer.rs
+++ b/crates/thumos/src/bfu_timer.rs
@@ -584,10 +584,10 @@ mod tests {
         assert!(s.contains("running"), "Display must show state");
         assert!(s.contains("elapsed=0ms"), "Display must show elapsed time");
 
-        let action_s = alloc::format!("{}", BfuAction::Reboot);
+        let action_s = BfuAction::Reboot.to_string();
         assert!(action_s.contains("reboot"), "BfuAction Display must describe action");
 
-        let state_s = alloc::format!("{}", BfuTimerState::Expired);
+        let state_s = BfuTimerState::Expired.to_string();
         assert_eq!(state_s, "expired");
     }
 

--- a/crates/thumos/src/ccci_logger.rs
+++ b/crates/thumos/src/ccci_logger.rs
@@ -1323,8 +1323,8 @@ mod tests {
 
     #[test]
     fn packet_direction_display() {
-        assert_eq!(alloc::format!("{}", PacketDirection::Tx), "TX");
-        assert_eq!(alloc::format!("{}", PacketDirection::Rx), "RX");
+        assert_eq!(PacketDirection::Tx.to_string(), "TX");
+        assert_eq!(PacketDirection::Rx.to_string(), "RX");
     }
 
     // -- CcciLogEntry Display --
@@ -1350,15 +1350,15 @@ mod tests {
     #[test]
     fn anomaly_kind_display() {
         assert!(
-            alloc::format!("{}", AnomalyKind::UnexpectedChannel)
+            AnomalyKind::UnexpectedChannel.to_string()
                 .contains("unexpected"),
         );
         assert!(
-            alloc::format!("{}", AnomalyKind::RateSpike)
+            AnomalyKind::RateSpike.to_string()
                 .contains("spike"),
         );
         assert!(
-            alloc::format!("{}", AnomalyKind::Data0OutOfRange)
+            AnomalyKind::Data0OutOfRange.to_string()
                 .contains("range"),
         );
     }
@@ -1383,17 +1383,17 @@ mod tests {
 
     #[test]
     fn firewall_verdict_display() {
-        assert_eq!(alloc::format!("{}", FirewallVerdict::Allow), "ALLOW");
-        assert_eq!(alloc::format!("{}", FirewallVerdict::Drop), "DROP");
+        assert_eq!(FirewallVerdict::Allow.to_string(), "ALLOW");
+        assert_eq!(FirewallVerdict::Drop.to_string(), "DROP");
     }
 
     // -- FirewallMode Display --
 
     #[test]
     fn firewall_mode_display() {
-        assert_eq!(alloc::format!("{}", FirewallMode::Daily), "Daily");
-        assert_eq!(alloc::format!("{}", FirewallMode::Sentinel), "Sentinel");
-        assert_eq!(alloc::format!("{}", FirewallMode::Panic), "Panic");
+        assert_eq!(FirewallMode::Daily.to_string(), "Daily");
+        assert_eq!(FirewallMode::Sentinel.to_string(), "Sentinel");
+        assert_eq!(FirewallMode::Panic.to_string(), "Panic");
     }
 
     // -- ChannelStats Display --

--- a/crates/thumos/src/ekphrasis.rs
+++ b/crates/thumos/src/ekphrasis.rs
@@ -1643,9 +1643,9 @@ Let me know if you need anything else."#;
 
     #[test]
     fn ws_opcode_display() {
-        assert_eq!(alloc::format!("{}", WsOpcode::Text), "text");
-        assert_eq!(alloc::format!("{}", WsOpcode::Binary), "binary");
-        assert_eq!(alloc::format!("{}", WsOpcode::Close), "close");
+        assert_eq!(WsOpcode::Text.to_string(), "text");
+        assert_eq!(WsOpcode::Binary.to_string(), "binary");
+        assert_eq!(WsOpcode::Close.to_string(), "close");
     }
 
     #[test]

--- a/crates/thumos/src/fm_radio.rs
+++ b/crates/thumos/src/fm_radio.rs
@@ -976,10 +976,10 @@ mod tests {
 
     #[test]
     fn fm_state_display() {
-        assert_eq!(alloc::format!("{}", FmState::Off), "off");
-        assert_eq!(alloc::format!("{}", FmState::On), "on");
+        assert_eq!(FmState::Off.to_string(), "off");
+        assert_eq!(FmState::On.to_string(), "on");
         assert_eq!(
-            alloc::format!("{}", FmState::Tuned { frequency_khz: 98_500 }),
+            FmState::Tuned { frequency_khz: 98_500 }.to_string(),
             "tuned to 98.5 MHz"
         );
     }

--- a/crates/thumos/src/nous.rs
+++ b/crates/thumos/src/nous.rs
@@ -827,11 +827,11 @@ mod tests {
     #[test]
     fn preset_display() {
         assert_eq!(
-            alloc::format!("{}", CapabilityPreset::Advisor),
+            CapabilityPreset::Advisor.to_string(),
             "ADVISOR"
         );
         assert_eq!(
-            alloc::format!("{}", CapabilityPreset::Autonomous),
+            CapabilityPreset::Autonomous.to_string(),
             "AUTONOMOUS"
         );
     }

--- a/crates/thumos/src/panic_wipe.rs
+++ b/crates/thumos/src/panic_wipe.rs
@@ -570,7 +570,7 @@ mod tests {
         assert!(plan_s.contains("6 targets"), "WipePlan Display must show count");
         assert!(plan_s.contains("keys"), "WipePlan Display must list keys");
 
-        let target_s = alloc::format!("{}", WipeTarget::CallHistory);
+        let target_s = WipeTarget::CallHistory.to_string();
         assert_eq!(target_s, "call history");
 
         let beacon = DistressBeacon {

--- a/crates/thumos/src/screen_nous.rs
+++ b/crates/thumos/src/screen_nous.rs
@@ -1090,15 +1090,15 @@ mod tests {
 
     #[test]
     fn message_origin_display() {
-        assert_eq!(alloc::format!("{}", MessageOrigin::User), "You");
-        assert_eq!(alloc::format!("{}", MessageOrigin::Nous), "Nous");
+        assert_eq!(MessageOrigin::User.to_string(), "You");
+        assert_eq!(MessageOrigin::Nous.to_string(), "Nous");
     }
 
     #[test]
     fn proposal_state_display() {
-        assert_eq!(alloc::format!("{}", ProposalState::Pending), "pending");
-        assert_eq!(alloc::format!("{}", ProposalState::Confirmed), "confirmed");
-        assert_eq!(alloc::format!("{}", ProposalState::Cancelled), "cancelled");
+        assert_eq!(ProposalState::Pending.to_string(), "pending");
+        assert_eq!(ProposalState::Confirmed.to_string(), "confirmed");
+        assert_eq!(ProposalState::Cancelled.to_string(), "cancelled");
     }
 
     #[test]

--- a/crates/thumos/src/screen_threat.rs
+++ b/crates/thumos/src/screen_threat.rs
@@ -625,14 +625,14 @@ mod tests {
     fn alert_type_display() {
         use alloc::format;
 
-        assert_eq!(format!("{}", ThreatAlertType::ImsiCatcher), "IMSI_CATCHER");
-        assert_eq!(format!("{}", ThreatAlertType::BleTracker), "BLE_TRACKER");
-        assert_eq!(format!("{}", ThreatAlertType::DeauthAttack), "DEAUTH_ATTACK");
-        assert_eq!(format!("{}", ThreatAlertType::CcciAnomaly), "CCCI_ANOMALY");
-        assert_eq!(format!("{}", ThreatAlertType::GeofenceBreach), "GEOFENCE_BREACH");
-        assert_eq!(format!("{}", ThreatAlertType::SilentSms), "SILENT_SMS");
-        assert_eq!(format!("{}", ThreatAlertType::WapPushRejected), "WAP_PUSH_REJECTED");
-        assert_eq!(format!("{}", ThreatAlertType::ModemAnomaly), "MODEM_ANOMALY");
+        assert_eq!(ThreatAlertType::ImsiCatcher.to_string(), "IMSI_CATCHER");
+        assert_eq!(ThreatAlertType::BleTracker.to_string(), "BLE_TRACKER");
+        assert_eq!(ThreatAlertType::DeauthAttack.to_string(), "DEAUTH_ATTACK");
+        assert_eq!(ThreatAlertType::CcciAnomaly.to_string(), "CCCI_ANOMALY");
+        assert_eq!(ThreatAlertType::GeofenceBreach.to_string(), "GEOFENCE_BREACH");
+        assert_eq!(ThreatAlertType::SilentSms.to_string(), "SILENT_SMS");
+        assert_eq!(ThreatAlertType::WapPushRejected.to_string(), "WAP_PUSH_REJECTED");
+        assert_eq!(ThreatAlertType::ModemAnomaly.to_string(), "MODEM_ANOMALY");
     }
 
     #[test]
@@ -660,19 +660,19 @@ mod tests {
     fn threat_level_display() {
         use alloc::format;
 
-        assert_eq!(format!("{}", ThreatLevel::Low), "LOW");
-        assert_eq!(format!("{}", ThreatLevel::Medium), "MEDIUM");
-        assert_eq!(format!("{}", ThreatLevel::High), "HIGH");
-        assert_eq!(format!("{}", ThreatLevel::Critical), "CRITICAL");
+        assert_eq!(ThreatLevel::Low.to_string(), "LOW");
+        assert_eq!(ThreatLevel::Medium.to_string(), "MEDIUM");
+        assert_eq!(ThreatLevel::High.to_string(), "HIGH");
+        assert_eq!(ThreatLevel::Critical.to_string(), "CRITICAL");
     }
 
     #[test]
     fn firewall_mode_display() {
         use alloc::format;
 
-        assert_eq!(format!("{}", FirewallMode::Open), "OPEN");
-        assert_eq!(format!("{}", FirewallMode::Restricted), "RESTRICTED");
-        assert_eq!(format!("{}", FirewallMode::Blocked), "BLOCKED");
+        assert_eq!(FirewallMode::Open.to_string(), "OPEN");
+        assert_eq!(FirewallMode::Restricted.to_string(), "RESTRICTED");
+        assert_eq!(FirewallMode::Blocked.to_string(), "BLOCKED");
     }
 
     #[test]

--- a/crates/thumos/src/secure_boot.rs
+++ b/crates/thumos/src/secure_boot.rs
@@ -1465,13 +1465,13 @@ mod tests {
     /// Test Display impl for SecureBootError.
     #[test]
     fn error_display() {
-        let msg = alloc::format!("{}", SecureBootError::ImageTooShort);
+        let msg = SecureBootError::ImageTooShort.to_string();
         assert!(msg.contains("too short"), "ImageTooShort display must mention 'too short'");
 
-        let msg = alloc::format!("{}", SecureBootError::InvalidSignature);
+        let msg = SecureBootError::InvalidSignature.to_string();
         assert!(msg.contains("verification failed"), "InvalidSignature display");
 
-        let msg = alloc::format!("{}", SecureBootError::WrongPublicKey);
+        let msg = SecureBootError::WrongPublicKey.to_string();
         assert!(msg.contains("does not match"), "WrongPublicKey display");
     }
 

--- a/crates/thumos/src/security.rs
+++ b/crates/thumos/src/security.rs
@@ -1173,11 +1173,11 @@ mod tests {
     #[test]
     fn sleep_tier_display() {
         assert_eq!(
-            alloc::format!("{}", SleepTier::Short),
+            SleepTier::Short.to_string(),
             "Short (PIN unlock)"
         );
         assert_eq!(
-            alloc::format!("{}", SleepTier::Long),
+            SleepTier::Long.to_string(),
             "Long (passphrase required)"
         );
     }

--- a/crates/thumos/src/security_mode.rs
+++ b/crates/thumos/src/security_mode.rs
@@ -1183,20 +1183,20 @@ mod tests {
         assert!(s.contains("Daily"), "Display must show mode");
         assert!(s.contains("covert=false"), "Display must show covert state");
 
-        let mode_s = alloc::format!("{}", SecurityMode::Sentinel);
+        let mode_s = SecurityMode::Sentinel.to_string();
         assert_eq!(mode_s, "Sentinel");
 
-        let policy_s = alloc::format!("{}", base_policy(SecurityMode::Daily));
+        let policy_s = base_policy(SecurityMode::Daily).to_string();
         assert!(policy_s.contains("cell=true"));
 
         let event = PanicEvent { triggered_at: 42, keys_zeroized: true };
         let event_s = alloc::format!("{event}");
         assert!(event_s.contains("42"));
 
-        let err_s = alloc::format!("{}", ModeTransitionError::PinRequired);
+        let err_s = ModeTransitionError::PinRequired.to_string();
         assert!(err_s.contains("PIN"));
 
-        let act_s = alloc::format!("{}", PanicActivation::KeyCombo);
+        let act_s = PanicActivation::KeyCombo.to_string();
         assert!(act_s.contains("key combo"));
     }
 
@@ -1301,13 +1301,13 @@ mod tests {
 
     #[test]
     fn threat_response_display() {
-        let cut = alloc::format!("{}", ThreatResponse::ModemPowerCut);
+        let cut = ThreatResponse::ModemPowerCut.to_string();
         assert!(cut.contains("power cut"));
 
-        let restrict = alloc::format!("{}", ThreatResponse::FirewallRestricted);
+        let restrict = ThreatResponse::FirewallRestricted.to_string();
         assert!(restrict.contains("restricted"));
 
-        let none = alloc::format!("{}", ThreatResponse::None);
+        let none = ThreatResponse::None.to_string();
         assert!(none.contains("none"));
     }
 }


### PR DESCRIPTION
Dispatched by kimi-dispatch from prompt: `thumos-format-single-var.md`

Kimi CLI v1.30.0 — worktree-isolated, sequential execution.

```
Prompt: /tmp/thumos-format-single-var.md
Branch: refactor/thumos-format-single-var-20260415T110443Z
Kimi exit: 0
Commits: 1
```