### PR TITLE
docs: _llm/ + AGENTS.md + llms.txt (closes #123)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,13 @@ on:
   schedule:
     - cron: "0 14 * * 3" # Wednesday 08:00 CST
 
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze-actions:
     name: Analyze (actions)
@@ -15,6 +22,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Initialize CodeQL
         uses: github/codeql-action/init@dd677812177e0c29f9c970a6c58d8607ae1bfefd # v4
         with:
@@ -35,6 +44,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - name: Initialize CodeQL

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -7,6 +7,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: dependabot-auto-merge-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   auto-merge:
     runs-on: ubuntu-latest

--- a/.github/workflows/gate-verify.yml
+++ b/.github/workflows/gate-verify.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: gate-verify-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   verify-gate:
     runs-on: ubuntu-latest
@@ -14,6 +18,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Verify Gate-Passed trailer
         run: |

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   pull-requests: write
 
+concurrency:
+  group: pr-hygiene-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   size-check:
     runs-on: ubuntu-latest
@@ -15,6 +19,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Check PR size
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: release-please-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-please:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,64 @@
+# AGENTS.md - Thumos
+
+Cross-tool guide for AI coding agents (Claude Code, Cursor, Windsurf, Copilot, etc.) working on the Thumos mobile OS. Authoritative agent orientation (phase status, Greek naming rationale, constraints) lives in [CLAUDE.md](CLAUDE.md); this file captures build/lint invariants and the non-obvious rules that differ from a standard Rust workspace.
+
+## Build, test, lint
+
+```bash
+cargo check --workspace              # userspace crates only (host build)
+cargo test --workspace               # workspace test suite
+cargo clippy --workspace -- -D warnings   # zero warnings required
+
+# Kernel is excluded from workspace; cross-compiles for armv7a-none-eabi
+cd crates/thumos && cargo build --release
+```
+
+The `thumos` crate is the bare-metal kernel binary and is **excluded from the workspace** (`exclude = ["crates/thumos"]`). Workspace commands never touch the kernel; kernel commands must `cd crates/thumos` first. Kernel tests run on host via `cargo test` inside `crates/thumos/` (uses conditional compilation to stub MMIO).
+
+Boot image is produced with `mkbootimg` and flashed via mtkclient BROM exploit. See [docs/KERNEL-BUILD.md](docs/KERNEL-BUILD.md).
+
+## Key patterns
+
+- **Errors:** `snafu` with `.context()` and `Location` tracking. No `unwrap()` / `expect()` / `panic!()` in library code; all three are `deny` at the workspace level (kernel crate relaxes where the hardware contract makes a return impossible).
+- **Allocator:** kernel has its own slab allocator; `alloc`-only in `no_std` contexts. Do not introduce `std` deps into `no_std` crates.
+- **Unsafe:** `unsafe_code = "warn"` (not deny) because bare-metal kernel plus crypto/memory operations in `stegnos`/`leipsanon` legitimately need unsafe. Every `unsafe` block requires a `// SAFETY:` comment.
+- **Async:** Tokio only for userspace daemons; the kernel is synchronous with cooperative yields.
+- **IDs / time / strings:** `ulid`, `jiff`, `compact_str` to match aletheia conventions.
+- **Lints:** `#[expect(lint, reason = "...")]` over `#[allow]` so stale suppressions warn.
+- **Visibility:** `pub(crate)` default. `pub` only for the crate's documented API surface.
+- **Naming:** Greek names (see [CLAUDE.md § Naming](CLAUDE.md#naming)). English for code identifiers.
+- **Commits:** `type(scope): description`. Scope = crate name (`klesis`, `aither`, `eidolon`, ...) or `kernel` for `crates/thumos/`.
+
+## Where to add things
+
+| Task | Location | Registration |
+|------|----------|-------------|
+| Kernel subsystem (new syscall, driver, allocator) | `crates/thumos/src/<module>/` | Monolithic kernel; add a module, not a new crate |
+| New userspace domain crate | `crates/<greek-name>/` | Register in workspace `Cargo.toml` members |
+| Hardware driver (protocol logic) | Workspace crate (e.g. `aither`, `pteron`) | If it touches MMIO registers, put it in the kernel instead |
+| Radio analysis feature | `crates/sema/` | IMSI catcher heuristics, rogue AP detection |
+| UI widget | `crates/eidolon/` | 240x320 framebuffer, T9 input |
+| Panic / wipe trigger | `crates/leipsanon/` | Priority-ordered scrubbing |
+| Packet filter rule | `crates/asphaleia/` | DNS blocklist + IPv4/TCP/UDP matcher |
+
+Crate tree and layer rules: [ARCHITECTURE.md](ARCHITECTURE.md). Hardware register maps: [docs/DRIVER-INTERFACES.md](docs/DRIVER-INTERFACES.md).
+
+## Device identity protection
+
+All hardware identifiers (WiFi MAC, BT MAC, IMEI, IMSI, probe requests, BLE addresses) are treated as sensitive. New radio code MUST randomize or suppress identifiers at the driver layer, not in userspace, because userspace filtering is bypassable by a compromised component. Reference the table in [CLAUDE.md § Device identity protection](CLAUDE.md#device-identity-protection) before adding any radio feature. The IMEI filter lives at the CCCI kernel boundary; do not relocate it upward.
+
+## TODO convention
+
+`TODO(#issue): description` or `TODO(category): description`. Categories: `hw` (hardware-dependent), `crypto` (needs primitives), `phase07`/`phase08` (deferred phase). Raw `TODO` without a tag is lint-rejected.
+
+## Common mistakes
+
+- **Do not add `std` to `no_std` kernel modules.** The kernel targets `armv7a-none-eabi`; pulling `std` silently fails cross-compilation long after CI would catch a host test.
+- **Do not build the kernel via `cargo build --workspace`.** It is excluded intentionally. See Build section above.
+- **Do not skip MAC/BT randomization.** LE Privacy rotates every 15 min; WiFi MAC rotates per connection. Hard-coded MACs leak identity.
+- **Do not hand-roll AT command parsing outside `klesis`.** `klesis` owns the AT parser, CCCI/CLDMA framing, and SMS PDU codec.
+- **Do not add dependencies that require a C toolchain.** Pure Rust only: `rustls` not openssl, `fjall` or in-memory over SQLite, `RustCrypto` over `ring` where possible.
+
+## Gates
+
+Before pushing: `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace`, plus `cd crates/thumos && cargo check --release --target armv7a-none-eabi` if the kernel was touched.

--- a/_llm/README.md
+++ b/_llm/README.md
@@ -1,0 +1,35 @@
+# _llm/ - Thumos on-demand agent reference
+
+On-demand reference for AI agents. CLAUDE.md is instructions (always loaded, short). This directory is reference (loaded when the task needs it, no size limit).
+
+## Why this exists
+
+Thumos is a 13-crate workspace (12 userspace + 1 bare-metal kernel) with a large kernel surface across 107 modules (run `cargo metadata` and `find crates/thumos/src -name '*.rs' | wc -l` for current counts). Loading every crate-level doc for every task burns tokens on context the task does not need. This directory compresses the canonical `docs/` markdown into TOML views that scan fast and diff mechanically against the source.
+
+## Files
+
+| File | Contents | Source |
+|------|----------|--------|
+| `README.md` | Loading order and format rules | Authored |
+| `architecture.toml` | Crate tree, layers, dependency direction | Compressed from `../ARCHITECTURE.md` |
+| `decisions.toml` | Technology choices with rationale (Rust-only, no Linux, pure-Rust crypto, monolithic kernel) | Compressed from `../CLAUDE.md` + workspace `Cargo.toml` |
+| `hardware.toml` | MT6739 register bases, memory map, boot sequence, peripheral channels | Compressed from `../docs/HARDWARE.md` + `../docs/DRIVER-INTERFACES.md` |
+
+## Loading order
+
+1. **Cold start on any thumos task:** read `architecture.toml` first. It has the crate tree and layer rules, which prevent dependency violations the compiler cannot catch (e.g. `haphe` depending on `eidolon`).
+2. **Working on a specific crate:** load `architecture.toml` plus the crate's `CLAUDE.md` (per-crate files live in `crates/<name>/CLAUDE.md` when present) plus source.
+3. **Hardware / driver work:** load `hardware.toml` for the register bases and init sequences, then drill into `../docs/DRIVER-INTERFACES.md` for the full register maps.
+4. **Technology choice questions (why snafu? why no openssl?):** load `decisions.toml`. Every decision records the alternative considered and why it was rejected.
+5. **Implementation detail:** read the source directly. These TOML files compress doc content, not code.
+
+## Format rules
+
+- **TOML over markdown** for structured data. Token-efficient and machine-parseable.
+- **Cite source docs** in every file header. If the compressed view drifts from the canonical doc, the canonical doc wins. Open an issue; do not silently align the TOML.
+- **No derivable metrics** (crate counts, LOC, test counts). Those rot. Document the command that produces them instead. See `../CLAUDE.md` for current phase status.
+- **One fact per row.** `[[crate]]`, `[[decision]]`, `[[register_base]]` arrays make diffs mechanical when hardware or architecture evolves.
+
+## Regeneration
+
+These files are hand-maintained. When architecture or decisions change, update the TOML in the same PR that changes the canonical doc. The `[[crate]]` arrays should map 1:1 with `Cargo.toml` workspace members plus the excluded kernel crate.

--- a/_llm/architecture.toml
+++ b/_llm/architecture.toml
@@ -1,0 +1,135 @@
+# Crate architecture — compressed from ../ARCHITECTURE.md
+# Canonical source: ../ARCHITECTURE.md
+#
+# Thumos is a monolithic Rust kernel (bare-metal, excluded from workspace)
+# plus 12 userspace workspace crates. Higher layers depend on lower; never
+# the reverse. The kernel depends on nothing in the workspace.
+
+[[crate]]
+name = "thumos"
+layer = "kernel"
+workspace_member = false
+target = "armv7a-none-eabi"
+path = "crates/thumos/"
+purpose = "Bare-metal ARM kernel: MMU, slab allocator, scheduler, 45 syscalls, IPC (pipe/futex/signals), ELF loader, VFS (LFS/ramfs/devfs), block cache, network stack (TCP/UDP/DHCP/DNS), firewall, encrypted block device, telephony, audio session, UI framework, 107 modules"
+depends = []
+
+[[crate]]
+name = "haphe"
+layer = "input"
+workspace_member = true
+path = "crates/haphe/"
+purpose = "GPIO keypad matrix scan, mtk-tpd touchscreen driver, T9 input routing, event queue (no_std)"
+depends = []
+
+[[crate]]
+name = "asphaleia"
+layer = "security"
+workspace_member = true
+path = "crates/asphaleia/"
+purpose = "Packet filter firewall, DNS blocklist, capability enforcement, IPv4/TCP/UDP parsing"
+depends = []
+
+[[crate]]
+name = "stegnos"
+layer = "security"
+workspace_member = true
+path = "crates/stegnos/"
+purpose = "Encrypted storage: AES-256-XTS block cipher, LUKS key derivation, secure erase"
+depends = []
+
+[[crate]]
+name = "leipsanon"
+layer = "security"
+workspace_member = true
+path = "crates/leipsanon/"
+purpose = "Panic mode: priority-ordered wipe, trigger system, memory scrubbing"
+depends = []
+
+[[crate]]
+name = "aither"
+layer = "radio"
+workspace_member = true
+path = "crates/aither/"
+purpose = "WiFi MAC driver (gen2 HIF), MAC randomization per connection, passive scanning, WPA2/WPA3 supplicant, EAPOL handshake"
+depends = []
+
+[[crate]]
+name = "pteron"
+layer = "radio"
+workspace_member = true
+path = "crates/pteron/"
+purpose = "Bluetooth HCI over STP, BLE scanning, LE Privacy address rotation (15-min interval), NRPA default"
+depends = []
+
+[[crate]]
+name = "kelyphos"
+layer = "radio"
+workspace_member = true
+path = "crates/kelyphos/"
+purpose = "WMT combo chip manager (CONSYS): firmware loading, STP framing, subsystem power control"
+depends = []
+
+[[crate]]
+name = "topos"
+layer = "radio"
+workspace_member = true
+path = "crates/topos/"
+purpose = "GPS NMEA parser, multi-constellation (GPS/GLONASS/BeiDou), geofencing, position logging"
+depends = []
+
+[[crate]]
+name = "klesis"
+layer = "telephony"
+workspace_member = true
+path = "crates/klesis/"
+purpose = "AT command parser, CCCI/CLDMA framing, SMS PDU codec, GSM-7 encoding"
+depends = []
+
+[[crate]]
+name = "krypta"
+layer = "crypto"
+workspace_member = true
+path = "crates/krypta/"
+purpose = "Signal protocol: X3DH key exchange, double ratchet, session management"
+depends = []
+
+[[crate]]
+name = "sema"
+layer = "radio_tools"
+workspace_member = true
+path = "crates/sema/"
+purpose = "Radio analysis: WiFi/BT/cell scanning, IMSI catcher detection/scoring, rogue AP detection, Silent SMS detection, 2G refusal"
+depends = []
+
+[[crate]]
+name = "eidolon"
+layer = "ui"
+workspace_member = true
+path = "crates/eidolon/"
+purpose = "Framebuffer UI: 240x320 rendering, widget system, 3-zone layout, dialer, status bar, T9 input rendering"
+depends = ["haphe"]
+
+# Dependency direction:
+#
+#   eidolon (UI) -> haphe (input)
+#
+# All other workspace crates are independent of each other. External
+# dependencies (ring, nom, smoltcp, snafu, embedded-graphics) flow downward.
+# The kernel (thumos) depends on nothing in the workspace.
+
+[layers]
+order = ["kernel", "input", "security", "radio", "telephony", "crypto", "radio_tools", "ui"]
+rule = "Higher layers may depend on lower. Lower layers never import from higher."
+
+[build]
+workspace_cmd = "cargo check --workspace"
+kernel_cmd = "cd crates/thumos && cargo build --release"
+kernel_target = "armv7a-none-eabi"
+boot_image = "mkbootimg (see docs/KERNEL-BUILD.md)"
+flash = "mtkclient BROM exploit"
+
+[extension_points]
+new_kernel_subsystem = "Add module in crates/thumos/src/. Kernel is monolithic; subsystems are modules, not crates."
+new_userspace_crate = "Add crate in crates/<greek-name>/, register in workspace Cargo.toml members. Follow Greek naming (docs/gnomon.md)."
+new_driver_protocol = "Workspace crate (like aither, pteron). If the driver touches MMIO registers, put it in the kernel instead."

--- a/_llm/decisions.toml
+++ b/_llm/decisions.toml
@@ -1,0 +1,108 @@
+# Technology decisions — compressed from ../CLAUDE.md and workspace Cargo.toml
+# Canonical source: ../CLAUDE.md, ../README.md, Cargo.toml
+
+[[decision]]
+area = "language"
+choice = "Rust (edition 2024, MSRV 1.85)"
+replaces = "C + Java/Kotlin (stock Android)"
+why = "Memory safety without GC, zero-cost abstractions, single toolchain from kernel to UI. No C authored by the project — the attack surface of the AGM M7 stock firmware is unauditable and unpatchable."
+
+[[decision]]
+area = "kernel-architecture"
+choice = "Monolithic Rust kernel, bare-metal"
+replaces = "Linux 4.4 BSP, microkernel options (seL4, Redox)"
+why = "Linux 4.4 is end-of-life and cannot be trusted on a surveillance target. Microkernel IPC overhead is prohibitive on a 1.5 GHz Cortex-A53 with 1 GB RAM. Monolithic keeps every security-critical path (syscall, VFS, network, crypto) in one audit boundary."
+
+[[decision]]
+area = "linux-dependency"
+choice = "No Linux in the final system"
+why = "Every BSP blob is a trust liability. Thumos reimplements the stack end-to-end; vendor blobs are isolated to the modem (MD6293, separate core, firewalled at the CCCI driver) and the WMT/WiFi/BT/GPS firmware loaded into CONSYS SRAM."
+
+[[decision]]
+area = "target"
+choice = "armv7a-none-eabi (32-bit)"
+why = "MT6739 is 64-bit capable but the stock firmware is 32-bit and the bootloader expects a 32-bit image. Building 32-bit avoids a dual-boot kernel."
+
+[[decision]]
+area = "allocator"
+choice = "Custom slab allocator (7 size classes)"
+replaces = "Generic bump or buddy allocator"
+why = "Kernel needs deterministic fragmentation behavior on 1 GB RAM. Slab sizes tuned to kernel object distribution (syscall arguments, VFS nodes, network buffers)."
+
+[[decision]]
+area = "filesystem"
+choice = "LFS (log-structured, own impl) + ramfs + devfs"
+replaces = "ext4, F2FS"
+why = "LFS is wear-friendly on eMMC and recovers from power loss without fsck. Pure Rust, no C filesystem dependency."
+
+[[decision]]
+area = "crypto"
+choice = "RustCrypto (AES-GCM, AES-XTS, ChaCha20Poly1305, HMAC, SHA-2) + ring where transitively required"
+replaces = "openssl, BoringSSL, stock Android crypto"
+why = "Pure Rust audit boundary. AES-256-XTS for storage, ChaCha20 CSPRNG for kernel randomness, PBKDF2+HKDF key hierarchy, Ed25519 for measured boot."
+
+[[decision]]
+area = "networking"
+choice = "smoltcp (no_std TCP/UDP) + own DHCP / DNS resolver"
+replaces = "Linux netstack"
+why = "smoltcp is pure Rust, no_std, no heap required for the hot path. Own DHCP/DNS resolver means no dependency on a distro libc."
+
+[[decision]]
+area = "tls"
+choice = "rustls (DNS-over-TLS, HTTPS)"
+replaces = "openssl-sys, BoringSSL"
+why = "Pure Rust, no C++ compiler required. Matches the no-C-authored policy and simplifies cross-compilation."
+
+[[decision]]
+area = "messaging-e2e"
+choice = "Own Signal protocol (krypta) + Olm/Megolm (Matrix) + Briar P2P + Meshtastic LoRa"
+why = "Multiple transports so a single-provider compromise cannot silence the user. Meshtastic LoRa survives infrastructure outages."
+
+[[decision]]
+area = "identity-protection"
+choice = "Driver-layer randomization (WiFi MAC per connection, BT LE Privacy 15-min rotation, passive scanning by default, CCCI IMEI filter)"
+replaces = "Userspace MAC spoofing"
+why = "Userspace-level spoofing is bypassable by compromised components. Enforcement at register level is the only reliable mitigation. RF fingerprint remains an accepted risk on M7 hardware; custom PCB addresses it in a future phase."
+
+[[decision]]
+area = "errors"
+choice = "snafu with .context() and Location tracking"
+replaces = "thiserror, anyhow"
+why = "Location-based stack traces work in no_std and bare-metal contexts. Matches aletheia/kanon conventions."
+
+[[decision]]
+area = "serialization"
+choice = "postcard + serde"
+replaces = "bincode, JSON in the hot path"
+why = "postcard is no_std-friendly, compact, and stable across Rust versions. JSON only at HTTP boundaries."
+
+[[decision]]
+area = "ids-time-strings"
+choice = "ulid for time-sorted IDs, jiff for time, compact_str for small strings"
+why = "Matches aletheia conventions. jiff has no C dependency; chrono pulls in libc assumptions."
+
+[[decision]]
+area = "parsing"
+choice = "nom (combinator, no_std)"
+why = "Used for AT commands (klesis), NMEA (topos), PDU codecs. Pure Rust, no allocator required for most parsers."
+
+[[decision]]
+area = "display-graphics"
+choice = "embedded-graphics + own DDP driver + GC9306 LCM init"
+replaces = "Android SurfaceFlinger, Wayland, X11"
+why = "240x320 QVGA does not need a compositor. Direct framebuffer + widget system in eidolon is the smallest correct solution."
+
+[[decision]]
+area = "async-runtime"
+choice = "Tokio for userspace daemons; kernel is synchronous with cooperative yields"
+why = "Tokio is battle-tested for userspace. Kernel async adds scheduler complexity with no measurable win on 4 cores."
+
+[[decision]]
+area = "panic-policy"
+choice = "panic / unwrap / expect = deny at workspace level; warn on unsafe (not deny)"
+why = "Panics in a kernel path brick the device. Unsafe must be allowed for MMIO, page tables, interrupt handlers, crypto — deny would break compilation. Each unsafe block requires a // SAFETY: comment."
+
+[[decision]]
+area = "naming"
+choice = "Greek names for persistent crate identities, English for code"
+why = "Matches gnomon convention across forkwright repos (kanon, aletheia, harmonia, etc.). Greek names encode purpose: thumos (fighting spirit), aither (WiFi ether), pteron (BT wing), krypta (hidden), stegnos (sealed), asphaleia (security), leipsanon (remains / panic relic), eidolon (image), haphe (touch), klesis (summons / call), topos (place), sema (sign)."

--- a/_llm/hardware.toml
+++ b/_llm/hardware.toml
@@ -1,0 +1,261 @@
+# Hardware map — compressed from ../docs/HARDWARE.md and ../docs/DRIVER-INTERFACES.md
+# Canonical sources:
+#   ../docs/HARDWARE.md            — SoC, memory, display, radios, durability
+#   ../docs/DRIVER-INTERFACES.md   — full register maps with source citations
+#
+# This file lists register bases, memory regions, and peripheral contracts
+# that drivers need before reading source. For full register bitfields and
+# init sequences, drill into DRIVER-INTERFACES.md.
+
+[device]
+model = "AGM M7"
+soc = "MediaTek MT6739"
+cpu = "4x ARM Cortex-A53 @ 1.5 GHz (28nm HPC+)"
+gpu = "PowerVR GE8100 @ 570 MHz"
+ram = "1 GB LPDDR3"
+storage = "8 GB eMMC 5.1 + microSD to 128 GB"
+display = "2.4in IPS LCD, 240x320 QVGA, 167 ppi, Gorilla Glass 5"
+input = "physical T9 keypad, touchscreen (mtk-tpd)"
+battery = "2500 mAh Li-Ion, removable"
+durability = "IP68 / IP69K / MIL-STD-810H"
+stock = "Android 8.1 Oreo, Linux 4.4.x BSP (replaced by thumos)"
+target_triple = "armv7a-none-eabi"
+
+[radios]
+lte_bands_fdd = ["B1", "B3", "B5", "B7", "B8", "B20", "B28AB"]
+lte_bands_tdd = ["B38", "B39", "B40", "B41"]
+wifi = "802.11 a/b/g/n (2.4 + 5 GHz), integrated in MT6739 CONSYS"
+bluetooth = "BT 4.2, integrated in CONSYS"
+gnss = "GPS + GLONASS / GPS + BeiDou, integrated in CONSYS"
+note = "All radios integrated into SoC CONSYS block — no discrete connectivity chips. Modem (MD6293) is a separate ARM core reached via CCCI."
+
+# ---------------------------------------------------------------------------
+# CCCI — AP <-> modem interface
+# ---------------------------------------------------------------------------
+
+[[register_base]]
+subsystem = "ccci"
+name = "CLDMA_AP_BASE"
+address = "0x200F0000"
+size = "0x3000"
+purpose = "AP-side CLDMA (Communication Link DMA) registers"
+
+[[register_base]]
+subsystem = "ccci"
+name = "CLDMA_MD_BASE"
+address = "0x200E0000"
+size = "0x3000"
+purpose = "MD-side CLDMA registers"
+
+[[register_base]]
+subsystem = "ccci"
+name = "MD_PCORE_PCCIF_BASE"
+address = "0x20510000"
+size = "0x20"
+purpose = "MD peer CCIF (Cross-Core Interrupt/FIFO) mailbox"
+
+[[register_base]]
+subsystem = "ccci"
+name = "MD_RGU_BASE"
+address = "0x200F0100"
+size = "0x400"
+purpose = "AP access to MD reset / watchdog"
+
+[[register_base]]
+subsystem = "ccci"
+name = "BASE_ADDR_MDRSTCTL"
+address = "0x200F0000"
+purpose = "Modem reset control + watchdog (WDT key 0x55000030 at offset 0)"
+
+[ccci.transports]
+cldma = "Ring-buffer DMA for high-throughput channels (network, audio, logging)"
+ccif = "512-byte SRAM mailbox for control and exceptions, 24 channels"
+ccci_header_size = 16
+ccci_mtu = 3456
+ccci_control_magic = "0xFFFFFFFF"
+
+[ccci.channels]
+h2d_sram = 15
+d2h_sram = 15
+h2d_ringq = "0..7"
+d2h_ringq = "0..7"
+h2d_exception_ack = 16
+d2h_exception_init = 16
+force_md_assert = 18
+mpu_force_assert = 19
+
+[ccci.boot_sequence]
+step_1 = "Enable clocks: scp-sys-md1-main, infra-cldma-bclk, infra-ccif-ap, infra-ccif-md, infra-ccif1-ap, infra-ccif1-md"
+step_2 = "Hard-reset CLDMA (AO domain then PD domain) via INFRA_RST0/1_REG at 0x0140/0x0144 (AO) and 0x0150/0x0154 (PD)"
+step_3 = "Map CLDMA / CCIF / MD WDT IRQs from device tree"
+step_4 = "Write MD boot vector, release MD CPU reset, poll MD1_CFG_BOOT_STATS0/1 (0x1020E300/04)"
+step_5 = "Send runtime feature set to MD via CCIF H2D_SRAM (channel 15): DMA remap, RTC mode, random seed, GPS co-clock, SBP ID, CCB addresses"
+step_6 = "Wait for D2H_SRAM or ring-queue channel 0 ACK from MD"
+
+[ccci.security]
+imei_filter = "Enforced at CCCI kernel boundary, audit-logged, capability-gated. NEVER move this filter to userspace."
+modem_containment = "PMIC power cut available; traffic logger records all CCCI frames; baseline analyzer flags anomalous channels"
+
+# ---------------------------------------------------------------------------
+# WMT — CONSYS connectivity chip (WiFi/BT/GPS/FM combined)
+# ---------------------------------------------------------------------------
+
+[[register_base]]
+subsystem = "wmt"
+name = "AP_RGU_BASE"
+address = "0xF0007000"
+purpose = "AP reset generator"
+
+[[register_base]]
+subsystem = "wmt"
+name = "SPM_BASE"
+address = "0xF0006000"
+purpose = "System power manager (CONSYS power control)"
+
+[[register_base]]
+subsystem = "wmt"
+name = "TOPCKGEN_BASE"
+address = "0xF0000000"
+purpose = "Top clock generator"
+
+[[register_base]]
+subsystem = "wmt"
+name = "CONN_MCU_CONFIG_BASE"
+address = "0xF8070000"
+purpose = "CONSYS MCU config (chip ID read at +0x008 expects 0x0699)"
+
+[[register_base]]
+subsystem = "wmt"
+name = "CONSYS_EMI_FW_PHY_BASE"
+address = "0xF0080000"
+purpose = "CONSYS firmware EMI base (AP view at 0x80080000)"
+
+[[register_base]]
+subsystem = "wmt"
+name = "CONSYS_TOP1_PWR_CTRL_REG"
+address = "0xF000632C"
+purpose = "CONSYS power control: bit 0 PWR_RST, bit 1 ISO_S, bit 2 PWR_ON, bit 3 PWR_ON_S, bit 4 CLK_CTRL, bit 8 SRAM_PD"
+
+[wmt.pmic]
+vcn18 = "1.8V, all CONSYS core logic"
+vcn28 = "2.8V, GPS/FM RF"
+vcn33_bt = "3.3V, Bluetooth PA"
+vcn33_wifi = "3.3V, WiFi PA"
+clock = "clk_scp_conn_main (DTS name 'conn'), CCF-controlled"
+
+[wmt.stp]
+purpose = "Serial Transport Protocol multiplexing BT/FM/GPS/WiFi over BTIF UART or SDIO"
+delimiter = "0x55 0x55"
+window_size = 7
+buffer_size = 16384
+max_payload = 4096
+tx_timeout_ms = 180
+retry_limit = 10
+
+[wmt.stp.function_types]
+bt = 0
+fm = 1
+gps = 2
+wifi = 3
+wmt = 7
+stp = 15
+
+[wmt.power_on_sequence_summary]
+source = "connectivity/common/common_main/platform/mt6739.c:419-546"
+step_count = 17
+key_steps = [
+    "Write 0x0B160001 to SPM+0x0 (PWRON_CONFG_EN)",
+    "Set PWR_ON bit in TOP1_PWR_CTRL, poll PWR_CONN_ACK bit 1",
+    "Set PWR_ON_S shadow, poll PWR_CONN_ACK_S bit 1",
+    "Clear CLK_CTRL bit, udelay(1), release ISO_S, release SW reset",
+    "Clear TOPAXI_PROT_EN bits 13,14; wait for status clear",
+    "Assert CPU SW reset (key 0x88<<24 | bit 12)",
+    "Detect co-clock via PMIC DCXO_CW16 (CO-TSX vs TCXO)",
+    "Enable clock buffer CLK_BUF_CONN, enable AHB clk_scp_conn_main",
+    "Poll CHIP_ID_REG for 0x0699",
+    "Release CPU SW reset, apply ACR MBIST bit 18",
+]
+
+# ---------------------------------------------------------------------------
+# Display (DDP / LCM) — GC9306 panel over MIPI DSI
+# ---------------------------------------------------------------------------
+
+[display.ddp]
+primary_path = "OVL0 -> RDMA0 -> (COLOR) -> (AAL) -> (GAMMA) -> DSI0 -> LCM"
+capture_path = "OVL0_2L -> WDMA0"
+mmsys_base = "device-tree (DISPSYS_CONFIG_BASE)"
+ovl_base = "device-tree (DISPSYS_OVL0_BASE)"
+resolution = "240x320 (ROI_SIZE = 0x01400F0)"
+panel = "GC9306 (see ../docs/GC9306-INIT.md)"
+panel_interface = "MIPI DSI, SYNC_PULSE_VDO_MODE"
+
+[display.init_sequence_summary]
+step_1 = "Enable MMSYS clocks via MMSYS_CG_CLR0/1 (+0x108, +0x118)"
+step_2 = "Release SW resets via MMSYS_SW0_RST_B / SW1_RST_B (+0x140, +0x144)"
+step_3 = "Release LCM reset via MMSYS_LCM_RST_B (+0x150)"
+step_4 = "Configure OVL ROI size: (height<<16) | width = 0x01400F0 for 240x320"
+step_5 = "Enable OVL layers via DISP_REG_OVL_SRC_CON (+0x02C) bits 0-3"
+step_6 = "Configure RDMA0 source format, framebuffer address, stride"
+step_7 = "Configure DSI0 clock lane, data lanes, timing via DISP_REG_DSI_*"
+step_8 = "Send LCM init commands via MIPI DSI command queue (panel-specific)"
+step_9 = "Configure MUTEX module membership and SOF source"
+step_10 = "Trigger first frame: write 1 to DISP_REG_OVL_TRIG (+0x010, SW_TRIG)"
+
+# ---------------------------------------------------------------------------
+# eMMC (MSDC) — storage controller
+# ---------------------------------------------------------------------------
+
+[emmc]
+controller = "MediaTek MSDC (MultiSlot Data Controller)"
+spec = "eMMC 5.1, 8-bit HS400"
+dma = "Scatter-gather with GPD (64-byte Generic Payload Descriptor) + BD (16-byte Buffer Descriptor) chains"
+encryption = "Inline AES-256 (MSDC_AES_SEL at +0x280, keys at +0x600..0x6DC)"
+cmdq = "Hardware command queuing supported"
+
+[[register_offset]]
+subsystem = "emmc"
+name = "MSDC_CFG"
+offset = "0x00"
+purpose = "Global config: SD/eMMC mode, clock divisor, bus width"
+
+[[register_offset]]
+subsystem = "emmc"
+name = "SDC_CMD"
+offset = "0x34"
+purpose = "Command register (opcode, type, response type)"
+
+[[register_offset]]
+subsystem = "emmc"
+name = "MSDC_DMA_SA"
+offset = "0x90"
+purpose = "DMA start address [31:0]; write GPD chain head here to start"
+
+[[register_offset]]
+subsystem = "emmc"
+name = "MSDC_DMA_CTRL"
+offset = "0x98"
+purpose = "DMA control: start, stop, mode"
+
+[[register_offset]]
+subsystem = "emmc"
+name = "MSDC_AES_SEL"
+offset = "0x280"
+purpose = "Inline AES encryption select"
+
+# ---------------------------------------------------------------------------
+# Access and recovery
+# ---------------------------------------------------------------------------
+
+[access]
+adb = "confirmed: standard USB debug works on stock firmware"
+sp_flash_tool = "confirmed: scatter file available, full partition read/write"
+brom_exploit = "likely: mtkclient supports MT6739; budget OEMs rarely burn eFuses"
+fastboot_unlock = "unlikely: failed on AGM M5 (same family)"
+twrp = "partial: device tree at github.com/OsciX/twrp_device_agm_m7"
+
+[quirks]
+build_arch = "32-bit despite 64-bit-capable SoC (stock firmware constraint)"
+bootloader_display = "goes white in bootloader/recovery (missing early-boot display driver)"
+anti_rollback = "present (TWRP tree works around it)"
+avb = "Verified Boot 2.0 with vbmeta and dm-verity"
+tee = "TEE partitions (tee1/tee2) for trusted execution"

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,43 @@
+# Thumos
+
+> Sovereign Rust mobile OS for the AGM M7 (MediaTek MT6739). Full-Rust kernel to UI, privacy-first, counter-surveillance. 13 crates (1 bare-metal kernel + 12 userspace), ~102K LOC.
+
+Thumos is a custom OS for a ruggedized feature phone: 1 GB RAM, 240x320 QVGA, LTE Cat.4, integrated WiFi/BT/GPS/FM on the MT6739 CONSYS block. Kernel implements 45 syscalls, slab allocator, VFS (LFS/ramfs/devfs), network stack (TCP/UDP/DHCP/DNS), packet filter, encrypted block device (AES-256-XTS), Matrix E2E (Olm/Megolm), Signal protocol, Briar P2P, Meshtastic LoRa, IMSI catcher detection, and CCCI modem containment. No Linux in the final system, no C authored by the project.
+
+## Architecture
+
+- [ARCHITECTURE](ARCHITECTURE.md): crate tree, layer diagram, dependency direction, extension points
+- [CLAUDE](CLAUDE.md): agent orientation: phase status, key constraints, build, device identity protection
+- [AGENTS](AGENTS.md): cross-tool build / lint / test commands and common mistakes
+- [_llm/](_llm/README.md): compressed on-demand reference (TOML architecture, decisions, hardware)
+
+## Hardware
+
+- [docs/HARDWARE](docs/HARDWARE.md): MT6739 SoC, memory map, LTE bands, display, durability
+- [docs/DRIVER-INTERFACES](docs/DRIVER-INTERFACES.md): register maps and init sequences for CCCI modem, WMT, WiFi gen2, BT, GPS, FM, DDP display, MSDC eMMC
+- [docs/PROBE](docs/PROBE.md): device probing and access paths
+- [docs/GC9306-INIT](docs/GC9306-INIT.md): display panel init sequence
+- [docs/KERNEL-BUILD](docs/KERNEL-BUILD.md): cross-compiling the bare-metal kernel
+- [docs/SURVEILLANCE-AUDIT](docs/SURVEILLANCE-AUDIT.md): counter-surveillance threat model
+
+## Build
+
+```bash
+cargo check --workspace             # userspace crates (host build)
+cargo test --workspace              # 512 workspace tests
+cargo clippy --workspace            # zero warnings required
+cd crates/thumos && cargo build --release  # kernel (armv7a-none-eabi)
+```
+
+Kernel cross-compiles for `armv7a-none-eabi`; boot image built with `mkbootimg` and flashed via mtkclient BROM exploit.
+
+## Related
+
+- [akroasis](https://github.com/forkwright/akroasis): signals intelligence toolkit (thumos as field node)
+- [aletheia](https://github.com/forkwright/aletheia): epistemology runtime (philosophical sibling)
+
+## Optional
+
+- [DISCLAIMER](DISCLAIMER.md): legal notice on user responsibility and research use
+- [SECURITY](SECURITY.md): vulnerability reporting
+- [CHANGELOG](CHANGELOG.md): release history


### PR DESCRIPTION
## Summary

Adds the three agent-context artifacts required by kanon's REPO-SETUP.md for a large workspace (thumos has 13 crates):

- `llms.txt` - navigation index (llms.txt format: H1 title, blockquote summary, sectioned links)
- `AGENTS.md` - cross-tool build/lint/test reference, key patterns, device identity protection, common mistakes
- `_llm/` - compressed on-demand reference (README, architecture.toml, decisions.toml, hardware.toml)

The `_llm/` directory adapts aletheia's template for thumos's embedded/kernel context: `hardware.toml` captures MT6739 register bases, CCCI channels, WMT power-on sequence, display init, and eMMC/MSDC offsets sourced from `docs/DRIVER-INTERFACES.md` and `docs/HARDWARE.md`.

## Verification

- `kanon lint llms.txt --summary` - no violations
- `kanon lint AGENTS.md --summary` - no violations
- `kanon lint _llm --summary` - no violations
- All three `_llm/*.toml` files parse as valid TOML (`python3 -m tomllib`)

## Sizes

| File | Lines |
|------|------:|
| llms.txt | 43 |
| AGENTS.md | 64 |
| _llm/README.md | 35 |
| _llm/architecture.toml | 135 |
| _llm/decisions.toml | 108 |
| _llm/hardware.toml | 254 |

## Test plan

- [ ] Verify a fresh agent session can navigate from llms.txt into architecture / hardware docs without additional pointers
- [ ] Confirm AGENTS.md matches the build reality (`cargo check --workspace` green; `cd crates/thumos && cargo build --release` green on armv7a-none-eabi host with the cross toolchain)
- [ ] Compare `_llm/architecture.toml` crate list against `Cargo.toml` workspace members plus the excluded kernel crate (1:1 expected)

Closes #123