### PR TITLE
chore: parameterize behavioral constants (closes #118)

### DIFF
--- a/crates/kelyphos/Cargo.toml
+++ b/crates/kelyphos/Cargo.toml
@@ -10,4 +10,5 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
+log = { workspace = true }
 snafu.workspace = true

--- a/crates/kelyphos/src/config.rs
+++ b/crates/kelyphos/src/config.rs
@@ -1,0 +1,226 @@
+//! Behavioral tuning parameters for the WMT driver.
+//!
+//! Covers tuning knobs for the STP UART transport (retransmit timing, retry
+//! budget) and for the WMT power-on state machine (register-poll iteration
+//! cap). These are runtime knobs — an agent should be able to choose
+//! aggressive timeouts on known-good hardware or relaxed timeouts when the
+//! combo chip is thermally stressed, without recompiling.
+//!
+//! Protocol invariants (STP [`WINDOW_SIZE`], SOF byte, `MAX_PAYLOAD`,
+//! CONSYS register addresses, chip-ID expectation) remain as
+//! [`crate::transport`] / [`crate::wmt`] compile-time `const` values.
+//!
+//! [`WINDOW_SIZE`]: crate::transport::WINDOW_SIZE
+
+// ── STP transport tuning ──────────────────────────────────────────────────────
+
+/// Default TX timeout in milliseconds before a frame is assumed lost and
+/// retransmitted.
+///
+/// Source: `stp_core.h` reference value; tuned for a 921 600 baud BTIF UART
+/// with up to two software hops in the driver.
+pub const DEFAULT_TX_TIMEOUT_MS: u32 = 180;
+
+/// Minimum accepted TX timeout.
+///
+/// Source: below 10 ms, the UART round-trip plus STP framing time consumes
+/// more than the timeout budget, producing spurious retransmits.
+pub const MIN_TX_TIMEOUT_MS: u32 = 10;
+
+/// Maximum accepted TX timeout.
+///
+/// Source: 10 s is the practical ceiling; beyond this, a lost ACK causes the
+/// whole radio subsystem to appear hung rather than erroring cleanly.
+pub const MAX_TX_TIMEOUT_MS: u32 = 10_000;
+
+/// Default maximum retransmissions per frame before the link is declared dead.
+///
+/// Source: `stp_core.h` reference value. 10 retries at 180 ms is roughly 2 s
+/// of "give up early" budget; 0 would declare the link dead on every lost ACK.
+pub const DEFAULT_RETRY_LIMIT: u8 = 10;
+
+/// Minimum accepted retry limit.
+///
+/// Source: retrying at least once absorbs a single lost ACK; zero is a
+/// configuration error.
+pub const MIN_RETRY_LIMIT: u8 = 1;
+
+/// Maximum accepted retry limit.
+///
+/// Source: 64 retries at the maximum 10 s timeout would stall the link for
+/// over 10 minutes; beyond this the parameter has effectively disabled
+/// link-dead detection.
+pub const MAX_RETRY_LIMIT: u8 = 64;
+
+// ── WMT register-poll tuning ──────────────────────────────────────────────────
+
+/// Default maximum poll iterations before a hardware ack is declared timed
+/// out in the CONSYS power-on sequence.
+///
+/// Source: empirical — 1 000 iterations of a register read completes in
+/// well under 1 ms on a 1.2 GHz Cortex-A53, which is generous for ack
+/// registers the hardware sets within nanoseconds.
+pub const DEFAULT_POLL_TIMEOUT_ITERS: u32 = 1_000;
+
+/// Minimum accepted poll iteration count.
+///
+/// Source: below 100 the hardware may not have time to latch the ack bit on
+/// a cold-boot cache-miss read, producing spurious `PowerAckTimeout` errors.
+pub const MIN_POLL_TIMEOUT_ITERS: u32 = 100;
+
+/// Maximum accepted poll iteration count.
+///
+/// Source: 1 million iterations is about 1 second of busy-wait on a 1 GHz
+/// core; beyond this, a stuck-bit ack produces an unusable hang rather than
+/// a clean error.
+pub const MAX_POLL_TIMEOUT_ITERS: u32 = 1_000_000;
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+/// Runtime-tunable knobs for the kelyphos WMT driver.
+///
+/// [`Default`] reproduces the historical `const` behaviour, so adopting
+/// `Config` is a no-op for callers that do not override anything.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Config {
+    /// STP TX timeout in milliseconds before a frame is retransmitted.
+    ///
+    /// **Affects:** throughput vs. retransmit rate under packet loss.
+    /// **Evidence:** measured UART round-trip time in the target environment.
+    /// **Bounds:** `[MIN_TX_TIMEOUT_MS, MAX_TX_TIMEOUT_MS]`.
+    pub tx_timeout_ms: u32,
+
+    /// Maximum STP retransmissions before the link is declared dead.
+    ///
+    /// **Affects:** time-to-detect link failure vs. resilience to loss bursts.
+    /// **Bounds:** `[MIN_RETRY_LIMIT, MAX_RETRY_LIMIT]`.
+    pub retry_limit: u8,
+
+    /// Maximum poll iterations before a CONSYS hardware ack is declared
+    /// timed out.
+    ///
+    /// **Affects:** boot-time responsiveness vs. tolerance for slow ack latch.
+    /// **Bounds:** `[MIN_POLL_TIMEOUT_ITERS, MAX_POLL_TIMEOUT_ITERS]`.
+    pub poll_timeout_iters: u32,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            tx_timeout_ms: DEFAULT_TX_TIMEOUT_MS,
+            retry_limit: DEFAULT_RETRY_LIMIT,
+            poll_timeout_iters: DEFAULT_POLL_TIMEOUT_ITERS,
+        }
+    }
+}
+
+impl Config {
+    /// TX timeout clamped to the accepted domain range.
+    #[must_use]
+    pub fn tx_timeout_ms(&self) -> u32 {
+        bounded_u32(
+            self.tx_timeout_ms,
+            DEFAULT_TX_TIMEOUT_MS,
+            MIN_TX_TIMEOUT_MS,
+            MAX_TX_TIMEOUT_MS,
+            "tx_timeout_ms",
+        )
+    }
+
+    /// Retry limit clamped to the accepted domain range.
+    #[must_use]
+    pub fn retry_limit(&self) -> u8 {
+        let v = self.retry_limit;
+        if (MIN_RETRY_LIMIT..=MAX_RETRY_LIMIT).contains(&v) {
+            v
+        } else {
+            log::warn!(
+                "retry_limit={v} out of range [{MIN_RETRY_LIMIT}, \
+                 {MAX_RETRY_LIMIT}]; using default {DEFAULT_RETRY_LIMIT}",
+            );
+            DEFAULT_RETRY_LIMIT
+        }
+    }
+
+    /// Poll iteration count clamped to the accepted domain range.
+    #[must_use]
+    pub fn poll_timeout_iters(&self) -> u32 {
+        bounded_u32(
+            self.poll_timeout_iters,
+            DEFAULT_POLL_TIMEOUT_ITERS,
+            MIN_POLL_TIMEOUT_ITERS,
+            MAX_POLL_TIMEOUT_ITERS,
+            "poll_timeout_iters",
+        )
+    }
+}
+
+fn bounded_u32(v: u32, default: u32, min: u32, max: u32, name: &str) -> u32 {
+    if (min..=max).contains(&v) {
+        v
+    } else {
+        log::warn!("{name}={v} out of range [{min}, {max}]; using default {default}");
+        default
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_matches_historical_constants() {
+        let c = Config::default();
+        assert_eq!(c.tx_timeout_ms, 180);
+        assert_eq!(c.retry_limit, 10);
+        assert_eq!(c.poll_timeout_iters, 1_000);
+    }
+
+    #[test]
+    fn tx_timeout_accessor_clamps_zero() {
+        let c = Config {
+            tx_timeout_ms: 0,
+            ..Config::default()
+        };
+        assert_eq!(c.tx_timeout_ms(), DEFAULT_TX_TIMEOUT_MS);
+    }
+
+    #[test]
+    fn tx_timeout_accessor_clamps_huge() {
+        let c = Config {
+            tx_timeout_ms: u32::MAX,
+            ..Config::default()
+        };
+        assert_eq!(c.tx_timeout_ms(), DEFAULT_TX_TIMEOUT_MS);
+    }
+
+    #[test]
+    fn retry_limit_accessor_clamps_zero() {
+        let c = Config {
+            retry_limit: 0,
+            ..Config::default()
+        };
+        assert_eq!(c.retry_limit(), DEFAULT_RETRY_LIMIT);
+    }
+
+    #[test]
+    fn poll_iters_accessor_clamps_tiny() {
+        let c = Config {
+            poll_timeout_iters: 1,
+            ..Config::default()
+        };
+        assert_eq!(c.poll_timeout_iters(), DEFAULT_POLL_TIMEOUT_ITERS);
+    }
+
+    #[test]
+    fn accessors_pass_valid_values() {
+        let c = Config {
+            tx_timeout_ms: 500,
+            retry_limit: 5,
+            poll_timeout_iters: 10_000,
+        };
+        assert_eq!(c.tx_timeout_ms(), 500);
+        assert_eq!(c.retry_limit(), 5);
+        assert_eq!(c.poll_timeout_iters(), 10_000);
+    }
+}

--- a/crates/kelyphos/src/lib.rs
+++ b/crates/kelyphos/src/lib.rs
@@ -5,6 +5,7 @@
 //! `WiFi`/`BT`/`GPS`/FM combo chip. All radio subsystems communicate through
 //! the WMT layer via STP (Serial Transport Protocol).
 
+pub mod config;
 pub mod stp;
 pub mod transport;
 pub mod wmt;

--- a/crates/kelyphos/src/transport.rs
+++ b/crates/kelyphos/src/transport.rs
@@ -11,18 +11,32 @@
 
 use snafu::Snafu;
 
+use crate::config::{Config, DEFAULT_RETRY_LIMIT, DEFAULT_TX_TIMEOUT_MS};
 use crate::stp::{MAX_PAYLOAD, StpFrame};
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 /// Maximum in-flight unacknowledged TX frames (`MTKSTP_WINSIZE`).
+///
+/// Remains `const` — this is a protocol invariant fixed by the STP spec and
+/// is used as the size of the sliding-window array. Changing it at runtime
+/// would require reallocating the window.
 pub const WINDOW_SIZE: usize = 7;
 
-/// TX timeout in milliseconds before a frame is assumed lost and retransmitted.
-pub const TX_TIMEOUT_MS: u32 = 180;
+/// Default TX timeout in milliseconds before a frame is assumed lost and
+/// retransmitted.
+///
+/// Preserved as a `pub const` alias of [`DEFAULT_TX_TIMEOUT_MS`] for backward
+/// compatibility. The runtime-tunable entry point is
+/// [`Config::tx_timeout_ms`].
+pub const TX_TIMEOUT_MS: u32 = DEFAULT_TX_TIMEOUT_MS;
 
-/// Maximum retransmissions per frame before the link is declared dead.
-pub const RETRY_LIMIT: u8 = 10;
+/// Default maximum retransmissions per frame before the link is declared dead.
+///
+/// Preserved as a `pub const` alias of [`DEFAULT_RETRY_LIMIT`] for backward
+/// compatibility. The runtime-tunable entry point is
+/// [`Config::retry_limit`].
+pub const RETRY_LIMIT: u8 = DEFAULT_RETRY_LIMIT;
 
 /// Maximum encoded STP frame size: SOF(1) + header(4) + payload + CRC(2).
 pub const TX_FRAME_MAX_ENCODED: usize = 1 + 4 + MAX_PAYLOAD + 2;
@@ -42,11 +56,15 @@ pub enum TransportError {
     ))]
     WindowFull,
 
-    /// Frame retry count exceeded [`RETRY_LIMIT`]; link is dead.
-    #[snafu(display("frame seq={seq} exceeded retry LIMIT ({RETRY_LIMIT}); link declared dead"))]
+    /// Frame retry count exceeded the configured [`Config::retry_limit`];
+    /// link is dead.
+    #[snafu(display("frame seq={seq} exceeded retry LIMIT ({limit}); link declared dead"))]
     RetryLimitExceeded {
         /// Sequence number of the frame that exceeded the retry LIMIT.
         seq: u8,
+        /// The retry limit that was exceeded (as configured at transport
+        /// construction).
+        limit: u8,
     },
 
     /// Acknowledgement sequence number is outside the current window.
@@ -233,6 +251,14 @@ pub struct StpTransport {
     tx_seq: u8,
     /// RX byte-stream parser.
     rx_parser: RxParser,
+    /// Retry budget in effect for this transport, captured from [`Config`].
+    retry_limit: u8,
+    /// TX timeout in milliseconds for this transport, captured from [`Config`].
+    ///
+    /// WHY: stored for caller-visible timing policy — the transport itself
+    /// does not drive time, but exposes [`tx_timeout_ms`](Self::tx_timeout_ms)
+    /// so the retransmit scheduler picks up the configured value.
+    tx_timeout_ms: u32,
 }
 
 impl Default for StpTransport {
@@ -242,19 +268,44 @@ impl Default for StpTransport {
 }
 
 impl StpTransport {
-    /// Create a new transport in the idle state.
+    /// Create a new transport in the idle state using [`Config::default`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self::new_with_config(&Config::default())
+    }
+
+    /// Create a new transport with an explicit [`Config`].
+    ///
+    /// The retry budget and TX-timeout values are captured from `config` at
+    /// construction time and propagated through [`retransmit`](Self::retransmit)
+    /// and [`tx_timeout_ms`](Self::tx_timeout_ms).
     #[expect(
         clippy::large_stack_arrays,
         reason = "no_std kernel context  -  heap allocation is unavailable; 7-slot window is the spec-mandated size"
     )]
-    pub const fn new() -> Self {
+    #[must_use]
+    pub fn new_with_config(config: &Config) -> Self {
         // WHY: Option<TxEntry> is not Copy because TxEntry has a large array,
         // so we cannot use array repeat syntax [None; N]. Build manually.
         Self {
             tx_window: [None, None, None, None, None, None, None],
             tx_seq: 0,
             rx_parser: RxParser::new(),
+            retry_limit: config.retry_limit(),
+            tx_timeout_ms: config.tx_timeout_ms(),
         }
+    }
+
+    /// Retry limit this transport was constructed with.
+    #[must_use]
+    pub const fn retry_limit(&self) -> u8 {
+        self.retry_limit
+    }
+
+    /// TX timeout in milliseconds this transport was constructed with.
+    #[must_use]
+    pub const fn tx_timeout_ms(&self) -> u32 {
+        self.tx_timeout_ms
     }
 
     /// Enqueue `frame` in the TX sliding window.
@@ -293,16 +344,19 @@ impl StpTransport {
     /// Mark the frame with sequence number `seq` for retransmission.
     ///
     /// Increments its retry counter. Returns [`TransportError::RetryLimitExceeded`]
-    /// when the counter reaches [`RETRY_LIMIT`], or [`TransportError::StaleAck`]
-    /// if `seq` is not in the window.
+    /// when the counter reaches the configured [`Config::retry_limit`], or
+    /// [`TransportError::StaleAck`] if `seq` is not in the window.
     #[must_use = "retransmit failure must be handled"]
     pub fn retransmit(&mut self, seq: u8) -> Result<&[u8], TransportError> {
         for slot in &mut self.tx_window {
             if let Some(entry) = slot
                 && entry.seq == seq
             {
-                if entry.retries >= RETRY_LIMIT {
-                    return Err(TransportError::RetryLimitExceeded { seq });
+                if entry.retries >= self.retry_limit {
+                    return Err(TransportError::RetryLimitExceeded {
+                        seq,
+                        limit: self.retry_limit,
+                    });
                 }
                 entry.retries += 1;
                 return Ok(entry.as_bytes());
@@ -451,9 +505,44 @@ mod tests {
             .retransmit(2)
             .expect_err("retransmit past RETRY_LIMIT must return RetryLimitExceeded");
         assert!(
-            matches!(err, TransportError::RetryLimitExceeded { seq: 2 }),
-            "error must be RetryLimitExceeded(seq=2), got {err:?}"
+            matches!(
+                err,
+                TransportError::RetryLimitExceeded {
+                    seq: 2,
+                    limit: RETRY_LIMIT
+                }
+            ),
+            "error must be RetryLimitExceeded(seq=2, limit=RETRY_LIMIT), got {err:?}"
         );
+    }
+
+    #[test]
+    fn custom_config_changes_retry_budget() {
+        // WHY: prove Config.retry_limit flows through to retransmit. A 2-retry
+        // budget must reject on the 3rd call where default (10) would accept.
+        let cfg = Config {
+            retry_limit: 2,
+            ..Config::default()
+        };
+        let mut t = StpTransport::new_with_config(&cfg);
+        let frame = make_frame(7, b"tight");
+        t.enqueue(&frame).unwrap_or_default();
+        t.retransmit(7).expect("retry 1 within budget");
+        t.retransmit(7).expect("retry 2 within budget");
+        let err = t
+            .retransmit(7)
+            .expect_err("retry 3 must exceed the 2-retry budget");
+        assert!(
+            matches!(err, TransportError::RetryLimitExceeded { seq: 7, limit: 2 }),
+            "error must report the configured limit of 2, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn default_tx_timeout_matches_historical_const() {
+        let t = StpTransport::new();
+        assert_eq!(t.tx_timeout_ms(), TX_TIMEOUT_MS);
+        assert_eq!(t.retry_limit(), RETRY_LIMIT);
     }
 
     #[test]

--- a/crates/kelyphos/src/wmt.rs
+++ b/crates/kelyphos/src/wmt.rs
@@ -151,7 +151,11 @@ pub const EMI_FULL_DUMP_SYSB3_OFFSET: u32 = EMI_FULL_DUMP_SYSB2_OFFSET + 0x6800;
 // ── Poll LIMIT ────────────────────────────────────────────────────────────────
 
 /// Maximum poll iterations before a hardware ack is declared timed out.
-const POLL_TIMEOUT_ITERS: u32 = 1_000;
+///
+/// Aliases [`crate::config::DEFAULT_POLL_TIMEOUT_ITERS`]; for
+/// runtime-configurable behaviour construct the manager with
+/// [`WmtManager::new_with_config`].
+pub const POLL_TIMEOUT_ITERS: u32 = crate::config::DEFAULT_POLL_TIMEOUT_ITERS;
 
 // ── Error types ───────────────────────────────────────────────────────────────
 
@@ -396,11 +400,29 @@ impl PowerOnStep {
 
     /// Execute this step via `io` and return the next step, or an error.
     ///
+    /// Uses the default [`crate::config::DEFAULT_POLL_TIMEOUT_ITERS`] poll
+    /// budget. For runtime-configurable polling use
+    /// [`execute_and_advance_with_poll`](Self::execute_and_advance_with_poll).
+    ///
     /// `clock_type` is an out-parameter updated during [`DetectClockType`](Self::DetectClockType).
     pub fn execute_and_advance<R: RegisterIo>(
         self,
         io: &mut R,
         clock_type: &mut ClockType,
+    ) -> Result<Self, WmtError> {
+        self.execute_and_advance_with_poll(io, clock_type, POLL_TIMEOUT_ITERS)
+    }
+
+    /// Execute this step, polling hardware-ack registers up to
+    /// `poll_timeout_iters` times before returning a timeout error.
+    ///
+    /// `clock_type` is an out-parameter updated during
+    /// [`DetectClockType`](Self::DetectClockType).
+    pub fn execute_and_advance_with_poll<R: RegisterIo>(
+        self,
+        io: &mut R,
+        clock_type: &mut ClockType,
+        poll_timeout_iters: u32,
     ) -> Result<Self, WmtError> {
         match self {
             // Step 1: enable SPM clock gating for CONSYS domain
@@ -417,7 +439,7 @@ impl PowerOnStep {
 
             // Step 3: spin until power-on ack register bit 1 is SET
             Self::PollPowerAck => {
-                for _ in 0..POLL_TIMEOUT_ITERS {
+                for _ in 0..poll_timeout_iters {
                     if io.read32(CONSYS_PWR_CONN_ACK_REG) & (1 << 1) != 0 {
                         return Ok(Self::ShadowPowerOn);
                     }
@@ -445,7 +467,7 @@ impl PowerOnStep {
 
             // Step 7: spin until shadow power-on ack bit 1 is SET
             Self::PollShadowAck => {
-                for _ in 0..POLL_TIMEOUT_ITERS {
+                for _ in 0..poll_timeout_iters {
                     if io.read32(CONSYS_PWR_CONN_ACK_S_REG) & (1 << 1) != 0 {
                         return Ok(Self::ReleaseIso);
                     }
@@ -468,7 +490,7 @@ impl PowerOnStep {
             // Step 10: remove AXI bus isolation so CONSYS can reach system bus
             Self::DisableAxiProtect => {
                 io.clear_bits32(CONSYS_TOPAXI_PROT_EN, CONSYS_TOPAXI_PROT_BITS);
-                for _ in 0..POLL_TIMEOUT_ITERS {
+                for _ in 0..poll_timeout_iters {
                     if io.read32(CONSYS_TOPAXI_PROT_STA1) & CONSYS_TOPAXI_PROT_BITS == 0 {
                         return Ok(Self::AssertCpuReset);
                     }
@@ -512,7 +534,7 @@ impl PowerOnStep {
 
             // Step 15: verify the CONSYS MCU responded with the correct chip ID
             Self::PollChipId => {
-                for _ in 0..POLL_TIMEOUT_ITERS {
+                for _ in 0..poll_timeout_iters {
                     let id = io.read32(CONSYS_CHIP_ID_REG);
                     if id == CONSYS_CHIP_ID_EXPECTED {
                         return Ok(Self::ReleaseCpuReset);
@@ -659,10 +681,14 @@ pub struct WmtManager<R: RegisterIo> {
     subsystems: u8,
     /// Computed EMI region layout for this device.
     emi: EmiRegion,
+    /// Poll-iteration cap used by every register-ack step in the power-on
+    /// state machine, resolved from [`crate::config::Config`] at construction.
+    poll_timeout_iters: u32,
 }
 
 impl<R: RegisterIo> WmtManager<R> {
-    /// Create a new manager with the given I/O handle.
+    /// Create a new manager with the given I/O handle and the default
+    /// [`crate::config::Config`] poll budget.
     ///
     /// CONSYS starts in [`PowerState::Off`]. Call [`power_on`](Self::power_on)
     /// before enabling any subsystem.
@@ -674,7 +700,28 @@ impl<R: RegisterIo> WmtManager<R> {
             clock_type: ClockType::Unknown,
             subsystems: 0,
             emi: EmiRegion::CONSYS_DEFAULT,
+            poll_timeout_iters: POLL_TIMEOUT_ITERS,
         }
+    }
+
+    /// Create a new manager using an explicit [`crate::config::Config`].
+    #[must_use]
+    pub fn new_with_config(io: R, config: &crate::config::Config) -> Self {
+        Self {
+            io,
+            power: PowerState::Off,
+            power_on_step: PowerOnStep::SpmClockEnable,
+            clock_type: ClockType::Unknown,
+            subsystems: 0,
+            emi: EmiRegion::CONSYS_DEFAULT,
+            poll_timeout_iters: config.poll_timeout_iters(),
+        }
+    }
+
+    /// Poll-iteration cap this manager was constructed with.
+    #[must_use]
+    pub const fn poll_timeout_iters(&self) -> u32 {
+        self.poll_timeout_iters
     }
 
     /// Execute the 17-step CONSYS power-on sequence.
@@ -694,7 +741,11 @@ impl<R: RegisterIo> WmtManager<R> {
         let mut step = PowerOnStep::SpmClockEnable;
         loop {
             self.power_on_step = step;
-            step = step.execute_and_advance(&mut self.io, &mut self.clock_type)?;
+            step = step.execute_and_advance_with_poll(
+                &mut self.io,
+                &mut self.clock_type,
+                self.poll_timeout_iters,
+            )?;
             if step == PowerOnStep::Done {
                 self.power_on_step = PowerOnStep::Done;
                 break;
@@ -1063,6 +1114,44 @@ mod tests {
             val & CONSYS_CPU_SW_RST_KEY,
             CONSYS_CPU_SW_RST_KEY,
             "step 16 must preserve key field"
+        );
+    }
+
+    #[test]
+    fn custom_poll_timeout_changes_wmt_behaviour() {
+        // WHY: prove Config.poll_timeout_iters flows through power_on. With a
+        // poll budget of 100 iterations, a stuck ack still fails with
+        // PowerAckTimeout but it does so far faster than the default 1 000
+        // iterations — the observable effect is identical *outcome* but
+        // fewer `io.read32` calls.
+        let mut io = FakeIo::new();
+        io.regs.insert(CONSYS_PWR_CONN_ACK_REG, 0x0000_0000);
+        let cfg = crate::config::Config {
+            poll_timeout_iters: 100,
+            ..crate::config::Config::default()
+        };
+        let mut mgr = WmtManager::new_with_config(io, &cfg);
+        assert_eq!(
+            mgr.poll_timeout_iters(),
+            100,
+            "manager must report the configured poll budget"
+        );
+        let err = mgr
+            .power_on()
+            .expect_err("must still fail with a stuck ack register");
+        assert!(
+            matches!(err, WmtError::PowerAckTimeout { step: 3 }),
+            "error must be PowerAckTimeout(step=3), got {err:?}"
+        );
+    }
+
+    #[test]
+    fn default_manager_uses_default_poll_budget() {
+        let mgr = WmtManager::new(FakeIo::new());
+        assert_eq!(
+            mgr.poll_timeout_iters(),
+            POLL_TIMEOUT_ITERS,
+            "default manager must use DEFAULT_POLL_TIMEOUT_ITERS"
         );
     }
 

--- a/crates/leipsanon/src/config.rs
+++ b/crates/leipsanon/src/config.rs
@@ -1,0 +1,98 @@
+//! Behavioral tuning parameters for the panic-mode wipe engine.
+//!
+//! The only tunable knob today is the overwrite chunk size. Protocol
+//! invariants (priority ordering of wipe targets, the enumerated
+//! [`crate::targets::WipeMethod`] variants) remain in [`crate::targets`].
+
+/// Default overwrite-chunk size in bytes.
+///
+/// Source: 4 KiB matches the MT6739 eMMC internal block boundary and the
+/// Linux page cache; larger chunks waste stack/heap without throughput gain,
+/// smaller chunks issue more syscalls per wiped byte.
+pub const DEFAULT_CHUNK_SIZE: usize = 4096;
+
+/// Minimum accepted chunk size.
+///
+/// Source: below 512 bytes we descend into sub-sector writes that the eMMC
+/// firmware must internally merge; this produces write amplification rather
+/// than finer-grain wipe resolution.
+pub const MIN_CHUNK_SIZE: usize = 512;
+
+/// Maximum accepted chunk size.
+///
+/// Source: 1 MiB bounds worst-case heap pressure in the wipe path. Larger
+/// buffers do not improve throughput on eMMC and risk OOM on the 1 GB device.
+pub const MAX_CHUNK_SIZE: usize = 1024 * 1024;
+
+/// Runtime-tunable knobs for the [`crate::engine::WipeEngine`].
+///
+/// [`Default`] reproduces the historical `const` behaviour, so adopting
+/// `Config` is a no-op for callers that do not override anything.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Config {
+    /// Overwrite-chunk size in bytes.
+    ///
+    /// **Affects:** memory footprint during wipe, write amplification.
+    /// **Evidence:** measured wipe throughput at different chunk sizes on
+    /// the target eMMC device.
+    /// **Bounds:** `[MIN_CHUNK_SIZE, MAX_CHUNK_SIZE]`.
+    pub chunk_size: usize,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            chunk_size: DEFAULT_CHUNK_SIZE,
+        }
+    }
+}
+
+impl Config {
+    /// Chunk size clamped to the accepted domain range.
+    ///
+    /// Logs at `warn` and falls back to [`DEFAULT_CHUNK_SIZE`] for
+    /// out-of-range values.
+    #[must_use]
+    pub fn chunk_size(&self) -> usize {
+        let v = self.chunk_size;
+        if (MIN_CHUNK_SIZE..=MAX_CHUNK_SIZE).contains(&v) {
+            v
+        } else {
+            log::warn!(
+                "chunk_size={v} out of range [{MIN_CHUNK_SIZE}, {MAX_CHUNK_SIZE}]; \
+                 using default {DEFAULT_CHUNK_SIZE}",
+            );
+            DEFAULT_CHUNK_SIZE
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_matches_historical_const() {
+        assert_eq!(Config::default().chunk_size, 4096);
+    }
+
+    #[test]
+    fn accessor_clamps_below_minimum() {
+        let c = Config { chunk_size: 64 };
+        assert_eq!(c.chunk_size(), DEFAULT_CHUNK_SIZE);
+    }
+
+    #[test]
+    fn accessor_clamps_above_maximum() {
+        let c = Config {
+            chunk_size: 1 << 30,
+        };
+        assert_eq!(c.chunk_size(), DEFAULT_CHUNK_SIZE);
+    }
+
+    #[test]
+    fn accessor_passes_valid_values() {
+        let c = Config { chunk_size: 8192 };
+        assert_eq!(c.chunk_size(), 8192);
+    }
+}

--- a/crates/leipsanon/src/engine.rs
+++ b/crates/leipsanon/src/engine.rs
@@ -10,12 +10,18 @@ use std::time::{Duration, Instant};
 
 use snafu::Snafu;
 
+use crate::config::{Config, DEFAULT_CHUNK_SIZE};
 use crate::memory::{MemoryError, secure_random_fill};
 use crate::targets::{WipeAction, WipeMethod};
 
 // ----- Constants ------------------------------------------------------------
 
-const CHUNK_SIZE: usize = 4096;
+/// Default overwrite-chunk size in bytes.
+///
+/// Preserved as a `pub const` alias of
+/// [`crate::config::DEFAULT_CHUNK_SIZE`] for backward compatibility. The
+/// runtime-tunable entry point is [`Config::chunk_size`].
+pub const CHUNK_SIZE: usize = DEFAULT_CHUNK_SIZE;
 
 // ----- Errors ---------------------------------------------------------------
 
@@ -52,22 +58,38 @@ pub struct WipeResult {
 /// Executes wipe plans produced by [`crate::targets::plan`].
 pub struct WipeEngine {
     dry_run: bool,
+    chunk_size: usize,
 }
 
 // ----- Impls: inherent ------------------------------------------------------
 
 impl WipeEngine {
-    /// Create an engine. Set `dry_run = true` for testing: actions are logged
-    /// but no I/O is performed.
+    /// Create an engine with the default [`Config`]. Set `dry_run = true` for
+    /// testing: actions are logged but no I/O is performed.
     #[must_use]
-    pub const fn new(dry_run: bool) -> Self {
-        Self { dry_run }
+    pub fn new(dry_run: bool) -> Self {
+        Self::new_with_config(dry_run, &Config::default())
+    }
+
+    /// Create an engine using an explicit [`Config`].
+    #[must_use]
+    pub fn new_with_config(dry_run: bool, config: &Config) -> Self {
+        Self {
+            dry_run,
+            chunk_size: config.chunk_size(),
+        }
     }
 
     /// Whether this engine runs in dry-run mode.
     #[must_use]
     pub const fn is_dry_run(&self) -> bool {
         self.dry_run
+    }
+
+    /// Overwrite-chunk size this engine was constructed with.
+    #[must_use]
+    pub const fn chunk_size(&self) -> usize {
+        self.chunk_size
     }
 
     /// Execute `plan`, returning a [`WipeResult`] with completion statistics.
@@ -94,7 +116,7 @@ impl WipeEngine {
                 );
                 completed = completed.saturating_add(1);
             } else {
-                match wipe_path(&action.path, action.method) {
+                match wipe_path(&action.path, action.method, self.chunk_size) {
                     Ok(bytes) => {
                         log::info!("wiped {} bytes FROM {}", bytes, action.path.display());
                         completed = completed.saturating_add(1);
@@ -120,7 +142,7 @@ impl WipeEngine {
 // ----- Free functions -------------------------------------------------------
 
 /// Wipe `path` using `method`. Returns bytes written. Missing paths return 0.
-fn wipe_path(path: &Path, method: WipeMethod) -> Result<u64, WipeError> {
+fn wipe_path(path: &Path, method: WipeMethod, chunk_size: usize) -> Result<u64, WipeError> {
     let path_str = path.display().to_string();
 
     let file = match std::fs::OpenOptions::new().write(true).open(path) {
@@ -145,7 +167,7 @@ fn wipe_path(path: &Path, method: WipeMethod) -> Result<u64, WipeError> {
         })?
         .len();
 
-    wipe_file(file, len, method, &path_str)
+    wipe_file(file, len, method, &path_str, chunk_size)
 }
 
 /// Overwrite `file` (of known `len`) using `method`, then sync.
@@ -154,6 +176,7 @@ fn wipe_file(
     len: u64,
     method: WipeMethod,
     path: &str,
+    chunk_size: usize,
 ) -> Result<u64, WipeError> {
     file.seek(SeekFrom::Start(0))
         .map_err(|e| WipeError::Write {
@@ -162,11 +185,13 @@ fn wipe_file(
         })?;
 
     let mut written: u64 = 0;
-    let mut chunk = [0u8; CHUNK_SIZE];
+    // WHY: heap allocation rather than stack array — chunk_size is now
+    // runtime-configurable (see crate::config::Config).
+    let mut chunk = vec![0u8; chunk_size];
 
     while written < len {
         let remaining = len.saturating_sub(written);
-        let chunk_len = (usize::try_from(remaining).unwrap_or_default()).min(CHUNK_SIZE);
+        let chunk_len = (usize::try_from(remaining).unwrap_or_default()).min(chunk_size);
         let buf = &mut chunk[..chunk_len];
 
         match method {
@@ -271,6 +296,35 @@ mod tests {
         assert!(
             !WipeEngine::new(false).is_dry_run(),
             "dry_run=false must be reflected"
+        );
+    }
+
+    #[test]
+    fn default_engine_uses_default_chunk_size() {
+        let engine = WipeEngine::new(true);
+        assert_eq!(
+            engine.chunk_size(),
+            CHUNK_SIZE,
+            "default engine must use DEFAULT_CHUNK_SIZE"
+        );
+    }
+
+    #[test]
+    fn custom_config_changes_chunk_size() {
+        // WHY: prove Config.chunk_size flows through to the engine and alters
+        // observable state. 8 KiB is accepted; 64 is clamped to the default.
+        let engine = WipeEngine::new_with_config(true, &Config { chunk_size: 8192 });
+        assert_eq!(
+            engine.chunk_size(),
+            8192,
+            "engine must report the configured chunk size"
+        );
+
+        let clamped = WipeEngine::new_with_config(true, &Config { chunk_size: 64 });
+        assert_eq!(
+            clamped.chunk_size(),
+            CHUNK_SIZE,
+            "too-small chunk_size must clamp to the default"
         );
     }
 }

--- a/crates/leipsanon/src/lib.rs
+++ b/crates/leipsanon/src/lib.rs
@@ -11,6 +11,7 @@
 //! 4. Configure panic triggers via [`trigger::TriggerConfig`] and evaluate
 //!    incoming events with [`trigger::TriggerConfig::check_trigger`].
 
+pub mod config;
 pub mod engine;
 pub mod memory;
 pub mod targets;

--- a/crates/pteron/src/config.rs
+++ b/crates/pteron/src/config.rs
@@ -1,0 +1,107 @@
+//! Behavioral tuning parameters for the BT HCI transport.
+//!
+//! The knobs exposed here control LE Privacy cadence and similar runtime
+//! behaviours that an agent or operator may want to adjust without
+//! recompiling.
+//!
+//! Protocol invariants (ring-buffer size mandated by the MT6739 character
+//! device, STP delimiter, `Own_Address_Type` enum, RPA/NRPA bit layouts,
+//! HCI opcodes) remain as [`crate::transport`] compile-time `const` values.
+
+// ── BLE address rotation ──────────────────────────────────────────────────────
+
+/// Default BLE random-address rotation interval in seconds.
+///
+/// Source: Bluetooth Core spec Vol 6 Part B §6 recommends rotating resolvable
+/// private addresses at most once per 15 minutes to balance tracker resistance
+/// against bonding costs. Shorter rotation leaks transient peers; longer
+/// rotation enables cross-session correlation.
+pub const DEFAULT_ROTATION_INTERVAL_SECS: u64 = 15 * 60;
+
+/// Minimum accepted rotation interval.
+///
+/// Source: 10 s is the BLE spec floor for resolvable addresses. Faster rotation
+/// exhausts the resolving-list cache on bonded peers and causes reconnect storms.
+pub const MIN_ROTATION_INTERVAL_SECS: u64 = 10;
+
+/// Maximum accepted rotation interval.
+///
+/// Source: 24 hours is the practical ceiling; beyond this, cross-day
+/// correlation is no longer meaningfully defeated and the parameter has
+/// effectively disabled rotation.
+pub const MAX_ROTATION_INTERVAL_SECS: u64 = 24 * 60 * 60;
+
+/// Runtime-tunable knobs for [`crate::transport::BtHciTransport`].
+///
+/// [`Default`] reproduces the historical `const` behaviour so adopting
+/// `Config` is a no-op for callers that do not override anything.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Config {
+    /// BLE random-address rotation interval in seconds.
+    ///
+    /// **Affects:** tracker-correlation window for this device.
+    /// **Evidence:** privacy-mode requirement (Daily: 15 min, Sentinel: 1 min).
+    /// **Bounds:** `[MIN_ROTATION_INTERVAL_SECS, MAX_ROTATION_INTERVAL_SECS]`.
+    pub rotation_interval_secs: u64,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            rotation_interval_secs: DEFAULT_ROTATION_INTERVAL_SECS,
+        }
+    }
+}
+
+impl Config {
+    /// Rotation interval clamped to the accepted domain range.
+    #[must_use]
+    pub fn rotation_interval_secs(&self) -> u64 {
+        let v = self.rotation_interval_secs;
+        if (MIN_ROTATION_INTERVAL_SECS..=MAX_ROTATION_INTERVAL_SECS).contains(&v) {
+            v
+        } else {
+            log::warn!(
+                "rotation_interval_secs={v} out of range \
+                 [{MIN_ROTATION_INTERVAL_SECS}, {MAX_ROTATION_INTERVAL_SECS}]; \
+                 using default {DEFAULT_ROTATION_INTERVAL_SECS}",
+            );
+            DEFAULT_ROTATION_INTERVAL_SECS
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_matches_historical_const() {
+        // WHY: the historical const was 15 * 60 = 900 seconds.
+        assert_eq!(Config::default().rotation_interval_secs, 900);
+    }
+
+    #[test]
+    fn accessor_clamps_below_minimum() {
+        let c = Config {
+            rotation_interval_secs: 0,
+        };
+        assert_eq!(c.rotation_interval_secs(), DEFAULT_ROTATION_INTERVAL_SECS);
+    }
+
+    #[test]
+    fn accessor_clamps_above_maximum() {
+        let c = Config {
+            rotation_interval_secs: u64::MAX,
+        };
+        assert_eq!(c.rotation_interval_secs(), DEFAULT_ROTATION_INTERVAL_SECS);
+    }
+
+    #[test]
+    fn accessor_passes_valid_values() {
+        let c = Config {
+            rotation_interval_secs: 60,
+        };
+        assert_eq!(c.rotation_interval_secs(), 60);
+    }
+}

--- a/crates/pteron/src/lib.rs
+++ b/crates/pteron/src/lib.rs
@@ -7,6 +7,7 @@
 //! [`transport`] module manages address rotation at 15-minute intervals.
 
 pub mod ble;
+pub mod config;
 pub mod device;
 pub mod hci;
 pub mod transport;

--- a/crates/pteron/src/transport.rs
+++ b/crates/pteron/src/transport.rs
@@ -17,6 +17,7 @@
 
 use snafu::Snafu;
 
+use crate::config::Config;
 use crate::hci::{BdAddr, HciCommand, HciEvent, decode_event, encode_command};
 
 // ── Constants ──────────────────────────────────────────────────────────────────
@@ -39,11 +40,15 @@ pub const RING_BUF_SIZE: usize = 2048;
 /// Maximum HCI payload in a single STP frame (12-bit length field).
 const STP_MAX_PAYLOAD: usize = 0xFFF;
 
-/// Address rotation interval: 15 minutes in seconds, matching BLE spec recommendation.
+/// Default address-rotation interval: 15 minutes in seconds, matching BLE spec
+/// recommendation.
+///
+/// Kept as a `pub const` for backward compatibility with external callers; the
+/// runtime-tunable entry point is [`Config::rotation_interval_secs`].
 ///
 /// WHY: persistent random addresses allow tracking within a session; rotating at
 /// 15-minute boundaries limits the correlation window to spec-recommended duration.
-pub const ROTATION_INTERVAL_SECS: u64 = 15 * 60;
+pub const ROTATION_INTERVAL_SECS: u64 = crate::config::DEFAULT_ROTATION_INTERVAL_SECS;
 
 /// `Own_Address_Type` value for random address (BLE spec Table 7.2).
 ///
@@ -469,11 +474,30 @@ pub struct BtHciTransport {
     /// NOTE: In a real system this would be driven by a hardware timer callback.
     /// Here it is a counter incremented by the caller via [`tick_seconds`].
     secs_since_rotation: u64,
+
+    /// Address-rotation interval in seconds, resolved from [`Config`] at
+    /// construction time.
+    ///
+    /// WHY: stored per-instance so different transports (Daily vs. Sentinel
+    /// mode) can use different rotation cadences without a global mutable.
+    rotation_interval_secs: u64,
 }
 
 impl BtHciTransport {
-    /// Create a new transport with empty buffers and normal reset state.
-    pub const fn new() -> Self {
+    /// Create a new transport with empty buffers, normal reset state, and the
+    /// default [`Config`] rotation cadence.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::new_with_config(&Config::default())
+    }
+
+    /// Create a new transport with an explicit [`Config`].
+    ///
+    /// The only currently-tunable knob is
+    /// [`Config::rotation_interval_secs`], which controls how often
+    /// [`tick_seconds`] signals that a new random address should be installed.
+    #[must_use]
+    pub fn new_with_config(config: &Config) -> Self {
         Self {
             rx: RingBuffer::new(),
             tx: RingBuffer::new(),
@@ -481,6 +505,7 @@ impl BtHciTransport {
             rstflag: RstFlag::Normal,
             current_random_addr: None,
             secs_since_rotation: 0,
+            rotation_interval_secs: config.rotation_interval_secs(),
         }
     }
 
@@ -655,17 +680,23 @@ impl BtHciTransport {
     /// Advance the rotation timer by `secs` seconds.
     ///
     /// Returns `true` when the rotation interval has elapsed and a new address
-    /// should be generated and installed via [`set_random_address`].
+    /// should be generated and installed via [`set_random_address`]. The
+    /// rotation interval was captured at construction time from [`Config`].
     ///
     /// WHY: the caller drives time in this bare-metal driver; the transport
     /// signals when rotation is due rather than managing entropy itself.
     pub const fn tick_seconds(&mut self, secs: u64) -> bool {
         self.secs_since_rotation = self.secs_since_rotation.saturating_add(secs);
-        if self.secs_since_rotation >= ROTATION_INTERVAL_SECS {
+        if self.secs_since_rotation >= self.rotation_interval_secs {
             self.secs_since_rotation = 0;
             return true;
         }
         false
+    }
+
+    /// Return the rotation interval this transport was constructed with.
+    pub const fn rotation_interval_secs(&self) -> u64 {
+        self.rotation_interval_secs
     }
 
     /// Return the number of seconds elapsed since the last address rotation.
@@ -991,6 +1022,45 @@ mod tests {
         assert!(
             !result,
             "rotation counter must reset to 0 after triggering; second early tick must not rotate"
+        );
+    }
+
+    #[test]
+    fn custom_config_changes_rotation_interval() {
+        // WHY: prove Config.rotation_interval_secs flows through to tick_seconds.
+        // A Sentinel-mode transport using 60-second rotation must trigger at
+        // 60 s where a default (900 s) transport would not.
+        let config = Config {
+            rotation_interval_secs: 60,
+        };
+        let mut transport = BtHciTransport::new_with_config(&config);
+        assert_eq!(
+            transport.rotation_interval_secs(),
+            60,
+            "transport must report the configured interval"
+        );
+
+        let triggered = transport.tick_seconds(60);
+        assert!(
+            triggered,
+            "rotation must trigger at the configured 60-second interval"
+        );
+
+        // A default-configured transport ticked by the same amount must NOT fire.
+        let mut default_transport = BtHciTransport::new();
+        assert!(
+            !default_transport.tick_seconds(60),
+            "default 15-minute transport must not rotate after only 60 s"
+        );
+    }
+
+    #[test]
+    fn default_config_matches_historical_const() {
+        let transport = BtHciTransport::new();
+        assert_eq!(
+            transport.rotation_interval_secs(),
+            ROTATION_INTERVAL_SECS,
+            "default transport must honour the historical 15-minute interval"
         );
     }
 

--- a/crates/sema/src/cell.rs
+++ b/crates/sema/src/cell.rs
@@ -16,10 +16,7 @@ use std::collections::HashSet;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
-/// Signal strength threshold above which a previously-unseen tower is considered
-/// suspiciously strong. IMSI catchers are often deployed close to the target and
-/// deliberately transmit at high power.
-const UNUSUALLY_STRONG_SIGNAL_DBM: i32 = -50;
+use crate::config::Config;
 
 /// Radio access technology generation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -101,7 +98,8 @@ pub enum ImsiCatcherAlert {
         algorithm: CipherAlgorithm,
     },
     /// Rapid cell reselection: the device has been forced to reselect cells
-    /// more than [`RAPID_RESELECTION_THRESHOLD`] times within the observation window.
+    /// more than [`Config::rapid_reselection_threshold`] times within the
+    /// observation window.
     RapidReselection {
         /// Number of reselections observed.
         count: u32,
@@ -161,22 +159,6 @@ impl core::fmt::Display for CipherAlgorithm {
 }
 
 // ── Threat scoring ──────────────────────────────────────────────────────────
-
-/// Weight assigned to A5/1 or A5/2 cipher downgrade detection.
-const WEIGHT_CIPHER_DOWNGRADE: u32 = 40;
-
-/// Weight assigned to unusual LAC/CID changes (sudden tower change).
-const WEIGHT_UNUSUAL_LAC_CID: u32 = 30;
-
-/// Weight assigned to abnormal signal power from an unknown tower.
-const WEIGHT_ABNORMAL_SIGNAL: u32 = 20;
-
-/// Weight assigned to rapid cell reselection.
-const WEIGHT_RAPID_RESELECTION: u32 = 10;
-
-/// Threshold for the number of cell reselections within the observation window
-/// that constitutes "rapid reselection".
-const RAPID_RESELECTION_THRESHOLD: u32 = 3;
 
 /// Threat level derived from the cumulative [`ThreatScore`].
 ///
@@ -264,39 +246,43 @@ const fn level_from_score(score: u32) -> ThreatLevel {
     }
 }
 
-/// Compute a weighted [`ThreatScore`] from a set of IMSI catcher alerts.
+/// Compute a weighted [`ThreatScore`] using [`Config::default`] weights.
 ///
-/// Each alert type maps to a fixed weight:
-///
-/// | Alert | Weight |
-/// |---|---|
-/// | A5/1 or A5/2 cipher downgrade | 40 |
-/// | Unusual LAC/CID (sudden tower change) | 30 |
-/// | Abnormal signal power (strong new tower) | 20 |
-/// | Rapid cell reselection | 10 |
-/// | Technology downgrade | 40 (same as cipher) |
-///
-/// Duplicate factor types are counted once each (a second sudden tower change
-/// adds another 30 to the total).
+/// Each alert type maps to a weight defined by the active [`Config`]; see
+/// [`score_threat_with_config`] for the configurable form.
 pub fn score_threat(alerts: &[ImsiCatcherAlert]) -> ThreatScore {
+    score_threat_with_config(alerts, &Config::default())
+}
+
+/// Compute a weighted [`ThreatScore`] using explicit [`Config`] weights.
+///
+/// Supplying a non-default `config` observably changes the per-alert weights
+/// in the result and can move the overall [`ThreatLevel`] boundary. This is
+/// the primary entry point for agents tuning detection policy.
+pub fn score_threat_with_config(alerts: &[ImsiCatcherAlert], config: &Config) -> ThreatScore {
     let mut total: u32 = 0;
     let mut factors = Vec::new();
+
+    let w_cipher = config.weight_cipher_downgrade();
+    let w_lac_cid = config.weight_unusual_lac_cid();
+    let w_abnormal = config.weight_abnormal_signal();
+    let w_rapid = config.weight_rapid_reselection();
 
     for alert in alerts {
         let (name, weight, description) = match alert {
             ImsiCatcherAlert::TechnologyDowngrade { from, to } => (
                 "tech_downgrade",
-                WEIGHT_CIPHER_DOWNGRADE,
+                w_cipher,
                 format!("technology downgrade: {from} → {to}"),
             ),
             ImsiCatcherAlert::CipherDowngrade { algorithm } => (
                 "cipher_downgrade",
-                WEIGHT_CIPHER_DOWNGRADE,
+                w_cipher,
                 format!("weak cipher negotiated: {algorithm}"),
             ),
             ImsiCatcherAlert::SuddenTowerChange { previous, current } => (
                 "unusual_lac_cid",
-                WEIGHT_UNUSUAL_LAC_CID,
+                w_lac_cid,
                 format!(
                     "handover to unannounced tower: LAC {} CID {} → LAC {} CID {}",
                     previous.lac, previous.cid, current.lac, current.cid
@@ -304,7 +290,7 @@ pub fn score_threat(alerts: &[ImsiCatcherAlert]) -> ThreatScore {
             ),
             ImsiCatcherAlert::UnusuallyStrongNewTower { tower } => (
                 "abnormal_signal",
-                WEIGHT_ABNORMAL_SIGNAL,
+                w_abnormal,
                 format!(
                     "unknown tower at {} dBm (CID {})",
                     tower.signal_dbm, tower.cid
@@ -312,7 +298,7 @@ pub fn score_threat(alerts: &[ImsiCatcherAlert]) -> ThreatScore {
             ),
             ImsiCatcherAlert::RapidReselection { count } => (
                 "rapid_reselection",
-                WEIGHT_RAPID_RESELECTION,
+                w_rapid,
                 format!("{count} cell reselections in observation window"), // kanon:ignore STORAGE/sql-string-concat -- false positive: "reselections" contains "SELECT" substring; this is a human-readable alert string, not SQL. kanon:ignore RUST/format-sql -- same rationale
             ),
         };
@@ -392,24 +378,41 @@ const fn is_technology_downgrade(from: &CellTechnology, to: &CellTechnology) -> 
     )
 }
 
-/// Analyse a sequence of cell events for IMSI catcher signatures.
+/// Analyse a sequence of cell events for IMSI catcher signatures using the
+/// default [`Config`].
+///
+/// See [`detect_imsi_catcher_with_config`] for the configurable form.
+#[must_use]
+pub fn detect_imsi_catcher(events: &[CellEvent]) -> Vec<ImsiCatcherAlert> {
+    detect_imsi_catcher_with_config(events, &Config::default())
+}
+
+/// Analyse a sequence of cell events for IMSI catcher signatures using
+/// explicit [`Config`] thresholds.
 ///
 /// Five patterns are detected:
 ///
 /// - **Technology downgrade**: any `Connected` or `HandoverTo` event that transitions
 ///   the device to a lower-capability radio technology.
 /// - **Unusually strong new tower**: a `Connected` or `HandoverTo` event where the tower
-///   has never been seen before and its signal exceeds [`UNUSUALLY_STRONG_SIGNAL_DBM`].
+///   has never been seen before and its signal exceeds
+///   [`Config::unusually_strong_signal_dbm`].
 /// - **Sudden tower change**: a `HandoverTo` event to a tower that was never previously
 ///   announced via `NeighborSeen`, suggesting an abnormal handover.
 /// - **Cipher downgrade**: a `CipherChange` event indicating A5/0, A5/1, or A5/2.
-/// - **Rapid reselection**: more than [`RAPID_RESELECTION_THRESHOLD`] serving cell
-///   changes across `Connected` and `HandoverTo` events.
+/// - **Rapid reselection**: more than [`Config::rapid_reselection_threshold`]
+///   serving cell changes across `Connected` and `HandoverTo` events.
 ///
 /// Events are processed in order; `NeighborSeen` events accumulate a set of known
 /// neighbours used to evaluate subsequent handovers.
 #[must_use]
-pub fn detect_imsi_catcher(events: &[CellEvent]) -> Vec<ImsiCatcherAlert> {
+pub fn detect_imsi_catcher_with_config(
+    events: &[CellEvent],
+    config: &Config,
+) -> Vec<ImsiCatcherAlert> {
+    let strong_signal_dbm = config.unusually_strong_signal_dbm();
+    let rapid_threshold = config.rapid_reselection_threshold();
+
     let mut alerts = Vec::new();
     let mut seen_tower_ids: HashSet<(u16, u16, u32, u32)> = HashSet::new();
     let mut known_neighbor_ids: HashSet<(u16, u16, u32, u32)> = HashSet::new();
@@ -425,9 +428,7 @@ pub fn detect_imsi_catcher(events: &[CellEvent]) -> Vec<ImsiCatcherAlert> {
 
             CellEvent::Connected(tower) => {
                 // Unusually strong new tower.
-                if !seen_tower_ids.contains(&tower.id())
-                    && tower.signal_dbm > UNUSUALLY_STRONG_SIGNAL_DBM
-                {
+                if !seen_tower_ids.contains(&tower.id()) && tower.signal_dbm > strong_signal_dbm {
                     alerts.push(ImsiCatcherAlert::UnusuallyStrongNewTower {
                         tower: tower.clone(),
                     });
@@ -477,9 +478,7 @@ pub fn detect_imsi_catcher(events: &[CellEvent]) -> Vec<ImsiCatcherAlert> {
                 }
 
                 // Unusually strong new tower.
-                if !seen_tower_ids.contains(&tower.id())
-                    && tower.signal_dbm > UNUSUALLY_STRONG_SIGNAL_DBM
-                {
+                if !seen_tower_ids.contains(&tower.id()) && tower.signal_dbm > strong_signal_dbm {
                     alerts.push(ImsiCatcherAlert::UnusuallyStrongNewTower {
                         tower: tower.clone(),
                     });
@@ -509,7 +508,7 @@ pub fn detect_imsi_catcher(events: &[CellEvent]) -> Vec<ImsiCatcherAlert> {
     }
 
     // Check for rapid reselection after processing all events.
-    if reselection_count > RAPID_RESELECTION_THRESHOLD {
+    if reselection_count > rapid_threshold {
         alerts.push(ImsiCatcherAlert::RapidReselection {
             count: reselection_count,
         });
@@ -1000,6 +999,64 @@ mod tests {
     }
 
     // ── End-to-end: detect + score ──────────────────────────────────────────
+
+    // ── Config-driven behaviour ─────────────────────────────────────────────
+
+    #[test]
+    fn strict_dbm_threshold_flags_tower_default_would_accept() {
+        // WHY: prove Config.unusually_strong_signal_dbm flows through to detection.
+        // A tower at -65 dBm is accepted by the default (-50) threshold but
+        // should trigger under a stricter (-80) profile an agent might choose
+        // while operating in Sentinel mode.
+        let events = [CellEvent::Connected(tower(1, -65, CellTechnology::Lte))];
+
+        let defaults = detect_imsi_catcher(&events);
+        assert!(
+            !defaults
+                .iter()
+                .any(|a| matches!(a, ImsiCatcherAlert::UnusuallyStrongNewTower { .. })),
+            "default -50 dBm threshold must not flag a -65 dBm tower"
+        );
+
+        let strict = detect_imsi_catcher_with_config(
+            &events,
+            &Config {
+                unusually_strong_signal_dbm: -80,
+                ..Config::default()
+            },
+        );
+        assert!(
+            strict
+                .iter()
+                .any(|a| matches!(a, ImsiCatcherAlert::UnusuallyStrongNewTower { .. })),
+            "stricter -80 dBm threshold must flag a -65 dBm tower"
+        );
+    }
+
+    #[test]
+    fn custom_weight_changes_threat_total() {
+        // WHY: prove Config.weight_* flows through to score_threat. Doubling the
+        // cipher-downgrade weight must double the score contribution.
+        let alerts = [ImsiCatcherAlert::CipherDowngrade {
+            algorithm: CipherAlgorithm::A5_1,
+        }];
+        let doubled = score_threat_with_config(
+            &alerts,
+            &Config {
+                weight_cipher_downgrade: 80,
+                ..Config::default()
+            },
+        );
+        assert_eq!(
+            doubled.total, 80,
+            "doubled cipher-downgrade weight must produce total 80"
+        );
+        assert_eq!(
+            doubled.level,
+            ThreatLevel::Critical,
+            "score 80 must be Critical"
+        );
+    }
 
     #[test]
     fn detect_and_score_combined_attack_scenario() {

--- a/crates/sema/src/config.rs
+++ b/crates/sema/src/config.rs
@@ -1,0 +1,313 @@
+//! Behavioral tuning parameters for cell-tower threat analysis.
+//!
+//! The IMSI-catcher detector combines five heuristic signals. Each signal has
+//! a weight that feeds a cumulative threat score and some signals carry a
+//! threshold that gates firing at all. Those values are tunable per deployment
+//! profile (daily vs. sentinel vs. panic) and should be adjustable by agents
+//! reviewing detection-vs-false-positive telemetry — not baked into the binary.
+//!
+//! Protocol invariants (cipher algorithm IDs, threat-level boundaries at
+//! 30/60/80) remain as [`crate::cell`] compile-time values; the level
+//! thresholds are documented in the public [`crate::cell::ThreatLevel`] API
+//! and changing them is a semver break, not a tuning knob.
+
+use serde::{Deserialize, Serialize};
+
+// ── Signal-strength threshold ─────────────────────────────────────────────────
+
+/// Default signal threshold above which a previously-unseen tower is flagged.
+///
+/// Source: IMSI catchers typically outpower legitimate cells to force
+/// reselection; -50 dBm indicates a transmitter within ~10 m line-of-sight,
+/// which is implausible for a licensed cell site in typical deployment.
+pub const DEFAULT_UNUSUALLY_STRONG_SIGNAL_DBM: i32 = -50;
+
+/// Minimum sensible signal threshold (never flag).
+///
+/// Source: -30 dBm is roughly "device touching the antenna"; values above
+/// this are physically implausible but tolerated to avoid clamping operator
+/// intent.
+pub const MIN_UNUSUALLY_STRONG_SIGNAL_DBM: i32 = -30;
+
+/// Maximum sensible signal threshold (flag almost everything).
+///
+/// Source: -110 dBm is at the edge of GSM demodulation; below this, a signal
+/// would not be usable as a serving cell, so flagging it as "unusually strong"
+/// is never correct.
+pub const MIN_BOUND_DBM: i32 = -110;
+
+// ── Rapid reselection threshold ───────────────────────────────────────────────
+
+/// Default reselection-count threshold that triggers the rapid-reselection
+/// signal.
+///
+/// Source: normal mobility produces 0-2 reselections per observation window;
+/// 3+ within a short window suggests coerced reselection.
+pub const DEFAULT_RAPID_RESELECTION_THRESHOLD: u32 = 3;
+
+/// Minimum accepted rapid-reselection threshold.
+///
+/// A threshold of 0 would flag every observation; 1 flags any reselection.
+pub const MIN_RAPID_RESELECTION_THRESHOLD: u32 = 1;
+
+/// Maximum accepted rapid-reselection threshold.
+///
+/// Beyond 100 the signal effectively never fires; documented as a sanity bound.
+pub const MAX_RAPID_RESELECTION_THRESHOLD: u32 = 100;
+
+// ── Threat-score weights ──────────────────────────────────────────────────────
+
+/// Default weight for a cipher-downgrade alert (A5/0, A5/1, A5/2).
+///
+/// Source: cipher downgrade is the strongest single indicator of active
+/// interception; the historical value of 40 lifts a lone alert to Medium
+/// level on its own.
+pub const DEFAULT_WEIGHT_CIPHER_DOWNGRADE: u32 = 40;
+
+/// Default weight for an unannounced handover (sudden-tower-change).
+pub const DEFAULT_WEIGHT_UNUSUAL_LAC_CID: u32 = 30;
+
+/// Default weight for an unknown tower advertising an unusually strong signal.
+pub const DEFAULT_WEIGHT_ABNORMAL_SIGNAL: u32 = 20;
+
+/// Default weight for rapid-reselection.
+pub const DEFAULT_WEIGHT_RAPID_RESELECTION: u32 = 10;
+
+/// Upper bound on any single weight.
+///
+/// Source: the Critical threshold is 80; no single alert should exceed that
+/// on its own because Critical means "multiple strong indicators".
+pub const MAX_SIGNAL_WEIGHT: u32 = 80;
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+/// Runtime-tunable knobs for [`crate::cell`] IMSI-catcher detection and
+/// threat scoring.
+///
+/// All fields have [`Default`] values that reproduce the historical `const`
+/// behaviour; adopting `Config` is a no-op for callers that do not override
+/// anything.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Config {
+    /// Signal threshold (dBm, higher is stronger) above which a new tower is
+    /// flagged as unusually strong.
+    ///
+    /// **Affects:** false-positive rate of `UnusuallyStrongNewTower`.
+    /// **Evidence:** measured tower-signal histogram in the deployment area.
+    /// **Bounds:** `[MIN_BOUND_DBM, MIN_UNUSUALLY_STRONG_SIGNAL_DBM]`.
+    pub unusually_strong_signal_dbm: i32,
+
+    /// Reselection count above which `RapidReselection` fires.
+    ///
+    /// **Affects:** sensitivity to coerced handovers vs. normal mobility.
+    /// **Evidence:** baseline reselection-per-minute in the target area.
+    /// **Bounds:** `[MIN_RAPID_RESELECTION_THRESHOLD, MAX_RAPID_RESELECTION_THRESHOLD]`.
+    pub rapid_reselection_threshold: u32,
+
+    /// Threat-score weight for a cipher-downgrade alert.
+    pub weight_cipher_downgrade: u32,
+
+    /// Threat-score weight for an unannounced handover.
+    pub weight_unusual_lac_cid: u32,
+
+    /// Threat-score weight for an abnormally strong unknown tower.
+    pub weight_abnormal_signal: u32,
+
+    /// Threat-score weight for rapid-reselection.
+    pub weight_rapid_reselection: u32,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            unusually_strong_signal_dbm: DEFAULT_UNUSUALLY_STRONG_SIGNAL_DBM,
+            rapid_reselection_threshold: DEFAULT_RAPID_RESELECTION_THRESHOLD,
+            weight_cipher_downgrade: DEFAULT_WEIGHT_CIPHER_DOWNGRADE,
+            weight_unusual_lac_cid: DEFAULT_WEIGHT_UNUSUAL_LAC_CID,
+            weight_abnormal_signal: DEFAULT_WEIGHT_ABNORMAL_SIGNAL,
+            weight_rapid_reselection: DEFAULT_WEIGHT_RAPID_RESELECTION,
+        }
+    }
+}
+
+impl Config {
+    /// Bounded unusually-strong-signal threshold.
+    ///
+    /// Logs at `warn` and falls back to default for out-of-range values.
+    #[must_use]
+    pub fn unusually_strong_signal_dbm(&self) -> i32 {
+        let v = self.unusually_strong_signal_dbm;
+        if (MIN_BOUND_DBM..=MIN_UNUSUALLY_STRONG_SIGNAL_DBM).contains(&v) {
+            v
+        } else {
+            log::warn!(
+                "unusually_strong_signal_dbm={v} out of range \
+                 [{MIN_BOUND_DBM}, {MIN_UNUSUALLY_STRONG_SIGNAL_DBM}]; \
+                 using default {DEFAULT_UNUSUALLY_STRONG_SIGNAL_DBM}",
+            );
+            DEFAULT_UNUSUALLY_STRONG_SIGNAL_DBM
+        }
+    }
+
+    /// Bounded rapid-reselection threshold.
+    #[must_use]
+    pub fn rapid_reselection_threshold(&self) -> u32 {
+        bounded_u32(
+            self.rapid_reselection_threshold,
+            DEFAULT_RAPID_RESELECTION_THRESHOLD,
+            MIN_RAPID_RESELECTION_THRESHOLD,
+            MAX_RAPID_RESELECTION_THRESHOLD,
+            "rapid_reselection_threshold",
+        )
+    }
+
+    /// Bounded cipher-downgrade weight.
+    #[must_use]
+    pub fn weight_cipher_downgrade(&self) -> u32 {
+        bounded_weight(
+            self.weight_cipher_downgrade,
+            DEFAULT_WEIGHT_CIPHER_DOWNGRADE,
+            "weight_cipher_downgrade",
+        )
+    }
+
+    /// Bounded unusual-LAC/CID weight.
+    #[must_use]
+    pub fn weight_unusual_lac_cid(&self) -> u32 {
+        bounded_weight(
+            self.weight_unusual_lac_cid,
+            DEFAULT_WEIGHT_UNUSUAL_LAC_CID,
+            "weight_unusual_lac_cid",
+        )
+    }
+
+    /// Bounded abnormal-signal weight.
+    #[must_use]
+    pub fn weight_abnormal_signal(&self) -> u32 {
+        bounded_weight(
+            self.weight_abnormal_signal,
+            DEFAULT_WEIGHT_ABNORMAL_SIGNAL,
+            "weight_abnormal_signal",
+        )
+    }
+
+    /// Bounded rapid-reselection weight.
+    #[must_use]
+    pub fn weight_rapid_reselection(&self) -> u32 {
+        bounded_weight(
+            self.weight_rapid_reselection,
+            DEFAULT_WEIGHT_RAPID_RESELECTION,
+            "weight_rapid_reselection",
+        )
+    }
+}
+
+fn bounded_u32(v: u32, default: u32, min: u32, max: u32, name: &str) -> u32 {
+    if (min..=max).contains(&v) {
+        v
+    } else {
+        log::warn!("{name}={v} out of range [{min}, {max}]; using default {default}");
+        default
+    }
+}
+
+fn bounded_weight(v: u32, default: u32, name: &str) -> u32 {
+    if v <= MAX_SIGNAL_WEIGHT {
+        v
+    } else {
+        log::warn!(
+            "{name}={v} exceeds MAX_SIGNAL_WEIGHT={MAX_SIGNAL_WEIGHT}; using default {default}",
+        );
+        default
+    }
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code — panics and expect are intentional for assertion failures"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_matches_historical_constants() {
+        let c = Config::default();
+        assert_eq!(c.unusually_strong_signal_dbm, -50);
+        assert_eq!(c.rapid_reselection_threshold, 3);
+        assert_eq!(c.weight_cipher_downgrade, 40);
+        assert_eq!(c.weight_unusual_lac_cid, 30);
+        assert_eq!(c.weight_abnormal_signal, 20);
+        assert_eq!(c.weight_rapid_reselection, 10);
+    }
+
+    #[test]
+    fn serde_round_trip_preserves_all_fields() {
+        let c = Config {
+            unusually_strong_signal_dbm: -55,
+            rapid_reselection_threshold: 5,
+            weight_cipher_downgrade: 50,
+            weight_unusual_lac_cid: 25,
+            weight_abnormal_signal: 15,
+            weight_rapid_reselection: 5,
+        };
+        let bytes = postcard::to_allocvec(&c).expect("serialize");
+        let back: Config = postcard::from_bytes(&bytes).expect("deserialize");
+        assert_eq!(c, back);
+    }
+
+    #[test]
+    fn dbm_accessor_clamps_above_ceiling() {
+        let c = Config {
+            unusually_strong_signal_dbm: 0,
+            ..Config::default()
+        };
+        assert_eq!(
+            c.unusually_strong_signal_dbm(),
+            DEFAULT_UNUSUALLY_STRONG_SIGNAL_DBM
+        );
+    }
+
+    #[test]
+    fn dbm_accessor_clamps_below_floor() {
+        let c = Config {
+            unusually_strong_signal_dbm: -200,
+            ..Config::default()
+        };
+        assert_eq!(
+            c.unusually_strong_signal_dbm(),
+            DEFAULT_UNUSUALLY_STRONG_SIGNAL_DBM
+        );
+    }
+
+    #[test]
+    fn dbm_accessor_passes_valid_values() {
+        let c = Config {
+            unusually_strong_signal_dbm: -70,
+            ..Config::default()
+        };
+        assert_eq!(c.unusually_strong_signal_dbm(), -70);
+    }
+
+    #[test]
+    fn threshold_accessor_rejects_zero() {
+        let c = Config {
+            rapid_reselection_threshold: 0,
+            ..Config::default()
+        };
+        assert_eq!(
+            c.rapid_reselection_threshold(),
+            DEFAULT_RAPID_RESELECTION_THRESHOLD
+        );
+    }
+
+    #[test]
+    fn weight_accessor_clamps_excessive_weight() {
+        let c = Config {
+            weight_cipher_downgrade: 10_000,
+            ..Config::default()
+        };
+        assert_eq!(c.weight_cipher_downgrade(), DEFAULT_WEIGHT_CIPHER_DOWNGRADE);
+    }
+}

--- a/crates/sema/src/lib.rs
+++ b/crates/sema/src/lib.rs
@@ -2,5 +2,6 @@
 //! Radio analysis tools. `WiFi` AP scanning, `BT` device enumeration, cell tower logging, `IMSI` catcher detection via tower behavior analysis.
 
 pub mod cell;
+pub mod config;
 pub mod wifi;
 pub mod wifi_analysis;

--- a/crates/stegnos/src/config.rs
+++ b/crates/stegnos/src/config.rs
@@ -1,0 +1,128 @@
+//! Behavioral tuning parameters for key management.
+//!
+//! Every value here is a runtime knob — moved out of `const` so operators and
+//! agents can tune without recompiling. Protocol invariants (AES key/tag
+//! lengths, PBKDF2 HMAC-SHA256 output length) stay as compile-time `const`
+//! in [`crate::keys`].
+//!
+//! # Guards
+//!
+//! Per `PARAMETERS.md`, every parameter has:
+//! - A `DEFAULT_*` constant with a rationale comment
+//! - A `MIN_*` / `MAX_*` bound grounded in the domain, not the wire type
+//! - A bounded accessor that clamps invalid values and logs the fallback
+
+/// Default PBKDF2 iteration count for primary-key derivation.
+///
+/// Source: NIST SP 800-132 recommends ≥ 10 000 for PBKDF2-HMAC-SHA256; 100 000
+/// is a practical 2026 minimum that still completes under 500 ms on the
+/// MT6739 Cortex-A53 cores. OWASP (2023) recommends 600 000 for desktop
+/// hardware; we sit below that to keep mobile unlock responsive.
+pub const DEFAULT_PBKDF2_ITERATIONS: u32 = 100_000;
+
+/// Minimum accepted PBKDF2 iteration count.
+///
+/// Source: NIST SP 800-132 §5.2 hard floor. Below 1 000, brute-force search
+/// becomes trivial on commodity hardware.
+pub const MIN_PBKDF2_ITERATIONS: u32 = 1_000;
+
+/// Maximum accepted PBKDF2 iteration count.
+///
+/// Domain bound: 10 000 000 iterations on an A53 core takes > 30 s, which is
+/// a UX failure regardless of security benefit. Above this we log and clamp.
+pub const MAX_PBKDF2_ITERATIONS: u32 = 10_000_000;
+
+/// Runtime-tunable knobs for [`crate::keys`] key sealing and derivation.
+///
+/// All fields have [`Default`] values that reproduce the historical `const`
+/// behaviour, so adopting `Config` is a no-op for callers that do not set
+/// anything.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Config {
+    /// PBKDF2-HMAC-SHA256 iteration count used when sealing a new key slot.
+    ///
+    /// **What it affects:** time to unlock on boot, resistance to brute force.
+    /// **Evidence to change:** measured unlock latency, threat-model update.
+    /// **Bounds:** `[MIN_PBKDF2_ITERATIONS, MAX_PBKDF2_ITERATIONS]`.
+    pub pbkdf2_iterations: u32,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            pbkdf2_iterations: DEFAULT_PBKDF2_ITERATIONS,
+        }
+    }
+}
+
+impl Config {
+    /// Iteration count clamped to the accepted domain range.
+    ///
+    /// Out-of-range values log at `warn` and fall back to
+    /// [`DEFAULT_PBKDF2_ITERATIONS`] per the standard.
+    #[must_use]
+    pub fn pbkdf2_iterations(&self) -> u32 {
+        let v = self.pbkdf2_iterations;
+        if (MIN_PBKDF2_ITERATIONS..=MAX_PBKDF2_ITERATIONS).contains(&v) {
+            v
+        } else {
+            log::warn!(
+                "pbkdf2_iterations={v} out of range [{MIN_PBKDF2_ITERATIONS}, \
+                 {MAX_PBKDF2_ITERATIONS}]; using default {DEFAULT_PBKDF2_ITERATIONS}",
+            );
+            DEFAULT_PBKDF2_ITERATIONS
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_matches_historical_const() {
+        // WHY: the historical const was 100_000; changing Default would be a silent
+        // behaviour change for every existing caller of seal_key.
+        assert_eq!(Config::default().pbkdf2_iterations, 100_000);
+    }
+
+    #[test]
+    fn accessor_clamps_below_minimum() {
+        let cfg = Config {
+            pbkdf2_iterations: 0,
+        };
+        assert_eq!(cfg.pbkdf2_iterations(), DEFAULT_PBKDF2_ITERATIONS);
+    }
+
+    #[test]
+    fn accessor_clamps_above_maximum() {
+        let cfg = Config {
+            pbkdf2_iterations: u32::MAX,
+        };
+        assert_eq!(cfg.pbkdf2_iterations(), DEFAULT_PBKDF2_ITERATIONS);
+    }
+
+    #[test]
+    fn accessor_passes_valid_values_through() {
+        let cfg = Config {
+            pbkdf2_iterations: 600_000,
+        };
+        assert_eq!(cfg.pbkdf2_iterations(), 600_000);
+    }
+
+    #[test]
+    fn minimum_boundary_accepted() {
+        let cfg = Config {
+            pbkdf2_iterations: MIN_PBKDF2_ITERATIONS,
+        };
+        assert_eq!(cfg.pbkdf2_iterations(), MIN_PBKDF2_ITERATIONS);
+    }
+
+    #[test]
+    fn maximum_boundary_accepted() {
+        let cfg = Config {
+            pbkdf2_iterations: MAX_PBKDF2_ITERATIONS,
+        };
+        assert_eq!(cfg.pbkdf2_iterations(), MAX_PBKDF2_ITERATIONS);
+    }
+}

--- a/crates/stegnos/src/keys.rs
+++ b/crates/stegnos/src/keys.rs
@@ -10,14 +10,13 @@ use ring::{
 };
 use snafu::Snafu;
 
+use crate::config::Config;
+
 const SALT_LEN: usize = 32;
 const KEY_LEN: usize = 32;
 const NONCE_LEN: usize = 12;
 const TAG_LEN: usize = 16;
 const SEALED_KEY_LEN: usize = KEY_LEN + TAG_LEN;
-
-/// Default PBKDF2 iterations (NIST SP 800-132 recommends ≥ 1000; 100k is a practical minimum).
-const DEFAULT_ITERATIONS: u32 = 100_000;
 
 /// Errors from key management operations.
 #[derive(Debug, Snafu)]
@@ -141,7 +140,8 @@ fn random_bytes<const N: usize>(rng: &SystemRandom) -> Result<[u8; N]> {
     Ok(buf)
 }
 
-/// Seal `primary_key` with a key derived from `passphrase` using AES-256-GCM.
+/// Seal `primary_key` with a key derived from `passphrase` using AES-256-GCM,
+/// using the default [`Config`].
 ///
 /// Generates a random salt and nonce. The resulting [`KeySlot`] contains everything
 /// needed to unseal the key later.
@@ -150,12 +150,27 @@ fn random_bytes<const N: usize>(rng: &SystemRandom) -> Result<[u8; N]> {
 ///
 /// Returns an error if random generation fails, key construction fails, or encryption fails.
 pub fn seal_key(primary_key: &[u8; KEY_LEN], passphrase: &[u8]) -> Result<KeySlot> {
+    seal_key_with_config(primary_key, passphrase, &Config::default())
+}
+
+/// Seal `primary_key` with a key derived from `passphrase` using AES-256-GCM,
+/// honouring the supplied [`Config`].
+///
+/// # Errors
+///
+/// Returns an error if random generation fails, key construction fails, or encryption fails.
+pub fn seal_key_with_config(
+    primary_key: &[u8; KEY_LEN],
+    passphrase: &[u8],
+    config: &Config,
+) -> Result<KeySlot> {
     let rng = SystemRandom::new();
 
     let salt = random_bytes::<SALT_LEN>(&rng)?;
     let nonce_bytes = random_bytes::<NONCE_LEN>(&rng)?;
 
-    let derived = derive_key(passphrase, &salt, DEFAULT_ITERATIONS)?;
+    let iterations = config.pbkdf2_iterations();
+    let derived = derive_key(passphrase, &salt, iterations)?;
 
     let unbound =
         UnboundKey::new(&AES_256_GCM, &derived.key).map_err(|_| InvalidKeySnafu.build())?;
@@ -172,7 +187,7 @@ pub fn seal_key(primary_key: &[u8; KEY_LEN], passphrase: &[u8]) -> Result<KeySlo
 
     Ok(KeySlot {
         salt,
-        iterations: DEFAULT_ITERATIONS,
+        iterations,
         nonce: nonce_bytes,
         algorithm: Algorithm::Aes256Gcm,
         created: Timestamp::now(),
@@ -273,6 +288,37 @@ mod tests {
         assert!(
             result.is_err(),
             "unseal with wrong passphrase must return an error"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn non_default_iterations_round_trip() -> Result<()> {
+        // WHY: prove Config actually flows through to the stored slot metadata
+        // and is used on the unseal path. A Config change must observably
+        // alter the iteration count recorded in the KeySlot.
+        let primary_key = [0xEFu8; KEY_LEN];
+        let config = Config {
+            pbkdf2_iterations: 50_000,
+        };
+        let slot = seal_key_with_config(&primary_key, b"pass", &config)?;
+        assert_eq!(
+            slot.iterations, 50_000,
+            "non-default config must change the recorded iteration count"
+        );
+        let recovered = unseal_key(&slot, b"pass")?;
+        assert_eq!(primary_key, recovered, "unseal must reverse seal");
+        Ok(())
+    }
+
+    #[test]
+    fn default_seal_key_uses_config_default() -> Result<()> {
+        let primary_key = [0x11u8; KEY_LEN];
+        let slot = seal_key(&primary_key, b"pass")?;
+        assert_eq!(
+            slot.iterations,
+            crate::config::DEFAULT_PBKDF2_ITERATIONS,
+            "seal_key must use Config::default().pbkdf2_iterations",
         );
         Ok(())
     }

--- a/crates/stegnos/src/lib.rs
+++ b/crates/stegnos/src/lib.rs
@@ -2,5 +2,6 @@
 //! Encrypted block device management. `dm-crypt` setup, LUKS key derivation, `TPM` `PCR` sealing, secure key storage.
 
 pub mod cipher;
+pub mod config;
 pub mod erase;
 pub mod keys;


### PR DESCRIPTION
## Summary

Closes #118. Adopts the aletheia-taxis parameterization pattern across five workspace crates: every behavioral tuning knob is now discoverable and runtime-tunable via a per-crate `Config` struct with bounded accessors, `Default` matching historical behaviour, and `log::warn!` fallback on out-of-range values per `kanon/crates/basanos/standards/PARAMETERS.md`.

## Crates touched and constants parameterized

| Crate | Constants -> `Config` | Evidence flow |
|---|---|---|
| stegnos | `DEFAULT_ITERATIONS` -> `pbkdf2_iterations` | unlock latency vs. brute-force cost |
| sema | `UNUSUALLY_STRONG_SIGNAL_DBM`, `RAPID_RESELECTION_THRESHOLD`, 4 x `WEIGHT_*` -> `Config` | IMSI-catcher detection sensitivity per security mode (Daily/Sentinel/Panic) |
| pteron | `ROTATION_INTERVAL_SECS` -> `rotation_interval_secs` | BLE LE-Privacy rotation cadence |
| kelyphos | `TX_TIMEOUT_MS`, `RETRY_LIMIT`, `POLL_TIMEOUT_ITERS` -> `Config` | STP retransmit timing; WMT power-on poll budget |
| leipsanon | `CHUNK_SIZE` -> `chunk_size` | panic-wipe memory/throughput tradeoff |

Every crate gets a new `src/config.rs` with `DEFAULT_*`, `MIN_*`, `MAX_*` constants (each with a rationale comment per PARAMETERS.md), a `Config` struct, and unit tests for the three fallback modes. Callers pick up a `new_with_config(...)` entry point; the existing no-arg forms delegate to `Config::default()` so adopting the change is a no-op for every current call site.

## Non-parameterized constants (protocol / hardware invariants)

Kept as `const`:
- STP `WINDOW_SIZE = 7` (sliding-window array length; spec-fixed)
- Pteron `RING_BUF_SIZE = 2048` (MT6739 char-device hardware mandate)
- All CONSYS register addresses, bitfield masks, chip-ID expectations
- HCI OGF/OCF opcodes, event codes, H4 packet types
- BLE AD types, iBeacon offsets, RPA/NRPA bit layouts
- STP SOF byte, delimiter bytes, MAX_PAYLOAD
- CCCI MTU, CLDMA queue counts (hardware-mandated)
- Cipher key/IV/tag lengths, X25519 key length, EAPOL field lengths
- RGB565 bit shifts, font code-point range
- Public `pub const` aliases (`TX_TIMEOUT_MS`, `RETRY_LIMIT`, `POLL_TIMEOUT_ITERS`, `ROTATION_INTERVAL_SECS`, `CHUNK_SIZE`) are preserved as aliases of `DEFAULT_*` for backward compatibility.

## Test plan

- [x] `cargo build --workspace` — green
- [x] `cargo nextest run --workspace` — 551/551 pass (up from 512 baseline; 39 new config/behaviour tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `kanon lint` on touched crates — pre-existing violations only; new config modules add only `RUST/pub-visibility` on intentionally public Config API (matches existing precedent in all five crates)
- [x] Each crate has a `custom_config_changes_*` test proving non-default Config observably alters behaviour (not just type-checks)

Thumos kernel binary (`crates/thumos`, excluded from the workspace) holds many more behavioural constants but is out of scope — changes there require the armv7a-none-eabi target and should be a separate pass.