### PR TITLE
refactor(eidolon): slice-as-array in framebuffer (progresses #130)

### DIFF
--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -48,7 +48,6 @@ RUST/indexing-slicing:crates/klesis/src/pdu.rs
 RUST/indexing-slicing:crates/klesis/src/ccci.rs
 RUST/indexing-slicing:crates/klesis/src/gsm7.rs
 RUST/indexing-slicing:crates/klesis/src/transport.rs
-RUST/indexing-slicing:crates/eidolon/src/framebuffer.rs
 RUST/indexing-slicing:crates/haphe/src/gpio.rs
 RUST/indexing-slicing:crates/haphe/src/input.rs
 RUST/indexing-slicing:crates/haphe/src/touch.rs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,7 @@ dependencies = [
 name = "kelyphos"
 version = "0.1.4"
 dependencies = [
+ "log",
  "snafu",
 ]
 

--- a/crates/eidolon/src/framebuffer.rs
+++ b/crates/eidolon/src/framebuffer.rs
@@ -40,14 +40,19 @@ impl Framebuffer {
             * usize::try_from(self.width).unwrap_or_default()
             + usize::try_from(x).unwrap_or_default())
             * BYTES_PER_PIXEL;
-        let [lo, hi] = color.0.to_le_bytes();
-        self.buf[idx] = lo;
-        self.buf[idx + 1] = hi;
+        let bytes = color.0.to_le_bytes();
+        if let Some(slot) = self
+            .buf
+            .get_mut(idx..idx + BYTES_PER_PIXEL)
+            .and_then(|s| <&mut [u8; BYTES_PER_PIXEL]>::try_from(s).ok())
+        {
+            *slot = bytes;
+        }
     }
 
     /// Fill a rectangular region with `color`. Clips to the framebuffer boundary.
     pub fn fill_rect(&mut self, x: u32, y: u32, w: u32, h: u32, color: Rgb565) {
-        let [lo, hi] = color.0.to_le_bytes();
+        let bytes = color.0.to_le_bytes();
         let y_end = y.saturating_add(h).min(self.height);
         let x_end = x.saturating_add(w).min(self.width);
         for row in y..y_end {
@@ -56,8 +61,13 @@ impl Framebuffer {
                     * usize::try_from(self.width).unwrap_or_default()
                     + usize::try_from(col).unwrap_or_default())
                     * BYTES_PER_PIXEL;
-                self.buf[idx] = lo;
-                self.buf[idx + 1] = hi;
+                if let Some(slot) = self
+                    .buf
+                    .get_mut(idx..idx + BYTES_PER_PIXEL)
+                    .and_then(|s| <&mut [u8; BYTES_PER_PIXEL]>::try_from(s).ok())
+                {
+                    *slot = bytes;
+                }
             }
         }
     }
@@ -66,8 +76,9 @@ impl Framebuffer {
     pub fn clear(&mut self, color: Rgb565) {
         let bytes = color.0.to_le_bytes();
         for chunk in self.buf.chunks_exact_mut(BYTES_PER_PIXEL) {
-            chunk[0] = bytes[0];
-            chunk[1] = bytes[1];
+            if let Ok(slot) = <&mut [u8; BYTES_PER_PIXEL]>::try_from(chunk) {
+                *slot = bytes;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Rewrite `set_pixel`, `fill_rect`, `clear` in `crates/eidolon/src/framebuffer.rs` to use `get_mut(idx..idx + 2).and_then(try_into::<&mut [u8; 2]>)` instead of pair-indexing (`buf[idx]`, `buf[idx + 1]`).
- Remove `RUST/indexing-slicing:crates/eidolon/src/framebuffer.rs` from `.kanon-lint-ignore`.

## Why
The umbrella tracker #130 calls for replacing direct slice/array indexing with bounds-safe patterns. Framebuffer was the smallest (4 violations, 208 LOC), minimal-risk starting point. The new form is provably safe without runtime cost and lifts one file out of the suppression list.

## Test plan
- [x] `cargo check -p eidolon` clean
- [x] `cargo nextest run -p eidolon` — 69/69 pass
- [x] `kanon lint . --summary` — no open violations

Progresses #130 (not `Closes` — 18 other files still on the tracker).