### PR TITLE
chore(security): allowlist HIGH (c) false-positives in .gitleaks.toml

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -20,4 +20,5 @@ paths = [
   '''vendor/''',
   '''\.gitleaks\.toml''',
   '''SECURITY\.md''',
+  '''crates/thumos/src/security\.rs''', # WHY: T1 - RFC 7914 test vector; see small-repo-security-triage-2026-05-21.md
 ]


### PR DESCRIPTION
## Summary
- Add a path allowlist entry for the HIGH class-(c) gitleaks false-positive from /home/ck/metis-ops/projects/_recovery/small-repo-security-triage-2026-05-21.md.
- Covered finding: T1.

## Validation
- gitleaks detect --source . --config .gitleaks.toml --no-banner --redact
- cargo +1.94-x86_64-unknown-linux-gnu check --workspace --no-default-features
- kanon lint --summary: n/a on verda per dispatcher footer