### PR TITLE
chore(hygiene): milestone audit sweep

### DIFF
--- a/crates/thumos/src/briar.rs
+++ b/crates/thumos/src/briar.rs
@@ -464,7 +464,7 @@ impl fmt::Display for BriarTransport {
 #[cfg(test)]
 mod tests {
     use alloc::string::ToString;
-    
+
     use super::*;
 
     // --- State tests ---

--- a/crates/thumos/src/cache.rs
+++ b/crates/thumos/src/cache.rs
@@ -274,7 +274,7 @@ impl Default for BlockCache {
 #[cfg(test)]
 mod tests {
     use alloc::vec;
-    
+
     use super::*;
     use crate::block::MemBlockDevice;
 

--- a/crates/thumos/src/capability.rs
+++ b/crates/thumos/src/capability.rs
@@ -113,7 +113,7 @@ pub(crate) fn check(required: u32) -> Result<(), u32> {
         // Log denial to UART.  A future phase will also append to the audit
         // ring buffer when CAP_AUDIT is available to the supervisor.
         use core::fmt::Write;
-        
+
         use crate::uart::Uart;
         let pid = crate::process::current_pid();
         let mut serial = Uart::new();

--- a/crates/thumos/src/ccci.rs
+++ b/crates/thumos/src/ccci.rs
@@ -1966,7 +1966,7 @@ impl CcciDriver {
 mod tests {
     use alloc::format;
     use alloc::vec::Vec;
-    
+
     use super::*;
 
     // -- Message header encode/decode --

--- a/crates/thumos/src/contacts.rs
+++ b/crates/thumos/src/contacts.rs
@@ -316,7 +316,7 @@ impl AsciiLowercase for str {
 #[cfg(test)]
 mod tests {
     use alloc::vec;
-    
+
     use super::*;
 
     #[test]

--- a/crates/thumos/src/dhcp.rs
+++ b/crates/thumos/src/dhcp.rs
@@ -220,7 +220,7 @@ impl DhcpClient {
 mod tests {
     use smoltcp::time::Instant;
     use smoltcp::wire::EthernetAddress;
-    
+
     use super::*;
     use crate::net::LoopbackDevice;
 

--- a/crates/thumos/src/dns.rs
+++ b/crates/thumos/src/dns.rs
@@ -570,7 +570,7 @@ impl DnsResolver {
 #[cfg(test)]
 mod tests {
     use alloc::vec;
-    
+
     use super::*;
 
     // -- Cache tests --

--- a/crates/thumos/src/dns_tls.rs
+++ b/crates/thumos/src/dns_tls.rs
@@ -496,7 +496,7 @@ impl core::fmt::Display for DotConfig {
 #[cfg(test)]
 mod tests {
     use alloc::vec;
-    
+
     use super::*;
 
     // -- Mock TLS transport ---------------------------------------------------

--- a/crates/thumos/src/ekphrasis.rs
+++ b/crates/thumos/src/ekphrasis.rs
@@ -1090,7 +1090,7 @@ fn parse_proposal_json(json_str: &str) -> Result<ActionProposal, EkphrasisError>
 #[cfg(test)]
 mod tests {
     use alloc::vec;
-    
+
     use super::*;
 
     // -----------------------------------------------------------------------

--- a/crates/thumos/src/encryption.rs
+++ b/crates/thumos/src/encryption.rs
@@ -291,7 +291,7 @@ impl From<SecurityError> for BlockError {
 #[cfg(test)]
 mod tests {
     use alloc::vec;
-    
+
     use super::*;
     use crate::block::MemBlockDevice;
 

--- a/crates/thumos/src/harmostes.rs
+++ b/crates/thumos/src/harmostes.rs
@@ -1174,7 +1174,7 @@ fn push_u32(s: &mut String, val: u32) {
 #[cfg(test)]
 mod tests {
     use alloc::string::ToString;
-    
+
     use super::*;
 
     /// Helper: build a minimal sync response JSON string.

--- a/crates/thumos/src/http_client.rs
+++ b/crates/thumos/src/http_client.rs
@@ -692,7 +692,7 @@ fn write_usize_to_buf(buf: &mut Vec<u8>, mut n: usize) {
 #[cfg(test)]
 mod tests {
     use alloc::string::ToString;
-    
+
     use super::*;
 
     // -- HttpMethod Display --

--- a/crates/thumos/src/json_mini.rs
+++ b/crates/thumos/src/json_mini.rs
@@ -818,7 +818,7 @@ fn decode_utf8_leading(byte: u8) -> Result<(u32, usize), JsonError> {
 #[cfg(test)]
 mod tests {
     use alloc::string::ToString;
-    
+
     use super::*;
 
     // ===== JsonWriter tests =====

--- a/crates/thumos/src/lfs_checkpoint.rs
+++ b/crates/thumos/src/lfs_checkpoint.rs
@@ -285,7 +285,7 @@ fn blocks_needed(byte_count: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use alloc::vec;
-    
+
     use super::*;
     use crate::block::MemBlockDevice;
 

--- a/crates/thumos/src/meshtastic.rs
+++ b/crates/thumos/src/meshtastic.rs
@@ -534,7 +534,7 @@ impl fmt::Display for MeshtasticTransport {
 #[cfg(test)]
 mod tests {
     use alloc::string::ToString;
-    
+
     use super::*;
 
     // --- State tests ---

--- a/crates/thumos/src/ramfs.rs
+++ b/crates/thumos/src/ramfs.rs
@@ -653,7 +653,7 @@ const fn align4(n: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use alloc::format;
-    
+
     use super::*;
 
     // -- Backward-compatibility tests (preserved from original) --

--- a/crates/thumos/src/screen_nous.rs
+++ b/crates/thumos/src/screen_nous.rs
@@ -790,7 +790,7 @@ fn format_msg_header(sender: &str) -> String {
 #[cfg(test)]
 mod tests {
     use alloc::string::String;
-    
+
     use super::*;
     use crate::ui::CONTENT_PIXELS;
 

--- a/crates/thumos/src/slab.rs
+++ b/crates/thumos/src/slab.rs
@@ -437,7 +437,7 @@ unsafe impl GlobalAlloc for KernelAllocator {
 #[cfg(test)]
 mod tests {
     use core::alloc::Layout;
-    
+
     use super::*;
 
     // -----------------------------------------------------------------------

--- a/crates/thumos/src/syscall.rs
+++ b/crates/thumos/src/syscall.rs
@@ -2055,7 +2055,7 @@ mod tests {
     #[test]
     fn slab_stress_no_leaks() {
         use core::alloc::Layout;
-        
+
         use crate::slab::SlabAllocator;
 
         // Local fake page pool backed by a static array.

--- a/crates/thumos/src/vfs.rs
+++ b/crates/thumos/src/vfs.rs
@@ -505,7 +505,7 @@ pub(crate) fn resolve_path(mounts: &MountTable, path: &str) -> Result<(usize, u3
 #[cfg(test)]
 mod tests {
     use alloc::vec;
-    
+
     use super::*;
 
     // -- TestFs: in-memory filesystem for testing --

--- a/crates/thumos/src/wifi.rs
+++ b/crates/thumos/src/wifi.rs
@@ -1175,7 +1175,7 @@ impl WifiHwOps for MockWifiHw {
 #[cfg(test)]
 mod tests {
     use alloc::vec;
-    
+
     use super::*;
 
     // Seed the kernel CSPRNG for deterministic test output.


### PR DESCRIPTION
## Summary

Milestone-level QA hygiene sweep for thumos. Stripped trailing whitespace from blank lines in 21 kernel source files (one blank line per file, all inside `cfg(test)` import groups or post-`use` separators).

## Changes

- 21 files, +21/-21 lines (whitespace-only on otherwise-blank lines)
- No semantic changes; no formatting changes beyond trailing whitespace
- Files: wifi, vfs, ccci, capability, cache, briar, syscall, slab, json_mini, http_client, harmostes, meshtastic, encryption, lfs_checkpoint, screen_nous, dns, dns_tls, contacts, ramfs, ekphrasis, dhcp

## Audit context

Part of milestone QA audit 2026-05-24. Full audit report in `metis-ops/projects/_recovery/repo-milestone-audit/thumos-2026-05-24.md`.

Other audit findings (no auto-fix; needs operator decision):
- README/AGENTS phase status claims vs known issues (#142-#146) — already documented in open issues
- llms.txt is present and aligned
- No AI indicators, no identity leakage, no secret/path leakage

## Test plan

- [ ] CI green (whitespace-only change; should be trivially safe)