### PR TITLE
chore(repo): align thumos with FLEET-REPO-SETUP

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.md whitespace=-trailing-space,-blank-at-eol

--- a/.github/workflows/gate-attestation.yml
+++ b/.github/workflows/gate-attestation.yml
@@ -1,0 +1,47 @@
+name: Gate Attestation
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gate-attestation:
+    name: gate-attestation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify Gate-Passed trailer
+        run: |
+          commits=$(git log --format="%H" "origin/${{ github.base_ref }}..HEAD")
+          if [ -z "$commits" ]; then
+            echo "ERROR: No commits found in PR"
+            exit 1
+          fi
+
+          found=false
+          for sha in $commits; do
+            body=$(git log -1 --format="%b" "$sha")
+            if echo "$body" | grep -q "^Gate-Passed:"; then
+              version=$(echo "$body" | grep "^Gate-Passed:" | head -1)
+              echo "Found gate attestation: $version"
+              found=true
+              break
+            fi
+          done
+
+          if [ "$found" = false ]; then
+            echo "ERROR: No Gate-Passed trailer found in any PR commit."
+            echo "Run the local gate and commit with the trailer."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Apply the fleet standard codified in [kanon FLEET-REPO-SETUP.md](https://github.com/forkwright/kanon/tree/main/crates/basanos/standards/FLEET-REPO-SETUP.md) (canary: harmonia#275). Thumos is Tier U (private kernel; release-please discipline).

## In-tree changes

| Item | Before | After |
|------|--------|-------|
| `.gitattributes` | absent | adds `*.md whitespace=-trailing-space,-blank-at-eol` (D-055) |
| `.github/workflows/gate-attestation.yml` | absent | adds the standard gate-attestation check |

## Out-of-tree changes (applied via gh api before opening this PR)

| Setting | Before | After |
|---------|--------|-------|
| `allow_auto_merge` | false | true |
| `delete_branch_on_merge` | false | true |
| `allow_merge_commit` | true | false |
| `allow_rebase_merge` | true | false |

## Requires operator manual action

1. **Branch protection on `main`** per FLEET-REPO-SETUP §2. Not auto-applied (lockout risk).

## Related

- [kanon FLEET-REPO-SETUP.md](https://github.com/forkwright/kanon/tree/main/crates/basanos/standards/FLEET-REPO-SETUP.md)
- [harmonia#275](https://github.com/forkwright/harmonia/pull/275) — canary

Gate-Passed: kanon 0.1.0