### PR TITLE
ci(security): ignore RUSTSEC-2023-0089 + allow 0BSD license

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -22,4 +22,9 @@ ignore = [
     # "cache 0.0.0" is logismos's internal KV-cache crate, unrelated to the
     # 2021 advisory's raw-pointer footgun in the abandoned crates.io crate.
     "RUSTSEC-2021-0006",
+    # atomic-polyfill unmaintained — transitive via heapless 0.7.17 →
+    # postcard 1.1.3 → sema/krypta. heapless 0.8+ drops atomic-polyfill in
+    # favor of portable-atomic, but postcard 1.x has not yet bumped its
+    # heapless pin past 0.7. Track postcard upstream for the heapless bump.
+    "RUSTSEC-2023-0089",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -23,13 +23,20 @@ reason = "False positive: name+version collision. The flagged `cache 0.0.0` is l
 id = "RUSTSEC-2021-0006"
 reason = "False positive: same collision as RUSTSEC-2020-0128. The flagged `cache 0.0.0` is logismos's internal KV-cache crate, unrelated to the 2021 advisory's raw-pointer footgun in the abandoned crates.io crate."
 
+[[advisories.ignore]]
+id = "RUSTSEC-2023-0089"
+reason = "atomic-polyfill unmaintained — transitive via heapless 0.7.17 → postcard 1.1.3 → sema/krypta. heapless 0.8+ drops atomic-polyfill in favor of portable-atomic, but postcard 1.x has not yet bumped its heapless pin past 0.7. Track postcard upstream for the heapless bump."
+
 [licenses]
 # WHY: license allow list mirrors aletheia's deny.toml. Each addition over
 # kanon's original list is for a real transitive dep:
 #   - BSL-1.0: xxhash-rust (via fjall)
 #   - CC0-1.0: spin or option-ext-class permissive (via various)
 #   - Apache-2.0 WITH LLVM-exception: psm/stacker (via typst-eval chain)
-allow = ["MIT", "Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "ISC", "Unicode-3.0", "Zlib", "MPL-2.0", "BSL-1.0", "CC0-1.0", "Apache-2.0 WITH LLVM-exception", "CDLA-Permissive-2.0", "LicenseRef-PolyForm-Shield-1.0.0"]
+#   - 0BSD: managed v0.8.0 + smoltcp v0.12.0 (via aither network stack).
+#     0BSD is the BSD Zero Clause License — OSI-approved, public-domain
+#     equivalent. Less restrictive than MIT (no attribution required).
+allow = ["MIT", "Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "ISC", "Unicode-3.0", "Zlib", "MPL-2.0", "BSL-1.0", "CC0-1.0", "0BSD", "Apache-2.0 WITH LLVM-exception", "CDLA-Permissive-2.0", "LicenseRef-PolyForm-Shield-1.0.0"]
 confidence-threshold = 0.8
 
 [bans]


### PR DESCRIPTION
## Summary

First post-strip main Security run (id 26392104373) after PR#154 merged revealed two findings the kanon-template baseline did not cover.

### 1. cargo-audit: RUSTSEC-2023-0089 atomic-polyfill unmaintained

Dep chain:
```
atomic-polyfill 1.0.3
└── heapless 0.7.17
    └── postcard 1.1.3
        ├── sema 0.1.4
        └── krypta 0.1.4
```

heapless 0.8+ migrated to portable-atomic, but postcard 1.x has not bumped its heapless pin past 0.7. Track postcard upstream for the heapless bump. Suppression added to both `.cargo/audit.toml` and `deny.toml [[advisories.ignore]]` so cargo-audit + cargo-deny stay in sync (cargo-audit does not read deny.toml).

### 2. cargo-deny licenses: 0BSD rejected

Dep chain:
```
managed v0.8.0 + smoltcp v0.12.0
└── aither v0.1.5  (network stack)
```

0BSD is the BSD Zero Clause License — OSI-approved, effectively public-domain. Less restrictive than MIT (no attribution required). Added to `[licenses] allow` list with WHY comment citing the dep chain.

## Test plan

- [ ] Main-branch Security run after merge passes both cargo-audit and cargo-deny jobs.
- [ ] No other RUSTSEC IDs surface (this PR only addresses the two findings from run 26392104373).

Gate-Passed: kanon 0.1.0