### PR TITLE
fix(toolchain): align Rust pin to 1.94 (#155)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "aither"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "log",
  "nom",
@@ -32,7 +32,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "asphaleia"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "log",
  "rustix",
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "eidolon"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "embedded-graphics",
  "embedded-graphics-core",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "haphe"
-version = "0.1.4"
+version = "0.1.5"
 
 [[package]]
 name = "hash32"
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "kelyphos"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "log",
  "snafu",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "klesis"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "log",
  "nom",
@@ -453,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "krypta"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "log",
  "postcard",
@@ -470,7 +470,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "leipsanon"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "log",
  "ring",
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "pteron"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "jiff",
  "log",
@@ -759,7 +759,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sema"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "jiff",
  "log",
@@ -874,7 +874,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stegnos"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "aes",
  "jiff",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "topos"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "jiff",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = ["crates/thumos"]
 version = "0.1.5"
 edition = "2024"
 # WHY: match the toolchain we actually build and test against.
-rust-version = "1.85"
+rust-version = "1.94"
 license = "LicenseRef-PolyForm-Shield-1.0.0"
 repository = "https://github.com/forkwright/thumos"
 publish = false

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85"
+channel = "1.94"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary
Closes #155.

- `rust-toolchain.toml`: `channel = "1.85"` → `"1.94"`
- `Cargo.toml` workspace: `rust-version = "1.85"` → `"1.94"`
- `Cargo.lock`: refreshed after cargo gate

## Test plan
Local gate run on this commit (`c6ac505`):
- [x] `cargo fmt --all --check`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo build --workspace`
- [x] `cargo test --workspace`

## Context
Built by codex-thumos-audits-mm dispatch (T2 middle-manager under CC orchestrator). Push retry-succeeded after transient GitHub 5xx (3 prior request IDs in escalations log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)