### PR TITLE
fix(kernel): wire firewall into network device path

### DIFF
--- a/crates/thumos/src/firewall.rs
+++ b/crates/thumos/src/firewall.rs
@@ -18,16 +18,10 @@
 //!
 //! # Integration
 //!
-//! This module is standalone — it does not modify `net.rs`. The wiring into
-//! the smoltcp poll loop will happen in a future integration pass. Callers
-//! can use [`Firewall::evaluate_rx`] and [`Firewall::evaluate_tx`] at any
-//! packet interception point.
-
-// WHY: firewall API not yet wired into the network poll path (future integration).
-#![expect(
-    dead_code,
-    reason = "Firewall API not yet wired to net.rs poll loop (future integration pass)"
-)]
+//! `net.rs` wires this filter through a device wrapper that evaluates RX
+//! packets before smoltcp sees them and TX packets before the driver sends
+//! them. Callers can still use [`Firewall::evaluate_rx`] and
+//! [`Firewall::evaluate_tx`] at other packet interception points.
 
 extern crate alloc;
 
@@ -107,6 +101,7 @@ pub enum Action {
     /// Drop the packet.
     Deny,
     /// Forward the packet and log the event.
+    #[expect(dead_code, reason = "log action reserved for audit-policy rules")]
     Log,
 }
 
@@ -256,6 +251,7 @@ impl Firewall {
     ///
     /// Rules are evaluated in order and the first match wins, so prepending
     /// gives the new rule highest priority.
+    #[expect(dead_code, reason = "dynamic firewall rules await policy wiring")]
     pub(crate) fn add_rule(&mut self, rule: FilterRule) {
         self.rules.insert(0, rule);
     }
@@ -304,6 +300,7 @@ impl Firewall {
     }
 
     /// Return a reference to the firewall statistics.
+    #[cfg_attr(not(test), expect(dead_code, reason = "runtime firewall metrics UI pending"))]
     pub(crate) fn stats(&self) -> &FirewallStats {
         &self.stats
     }
@@ -391,6 +388,7 @@ impl Firewall {
 /// Called when [`Firewall::evaluate_rx`] or [`Firewall::evaluate_tx`]
 /// denies a packet. The `direction` indicates whether the packet was
 /// inbound or outbound.
+#[expect(dead_code, reason = "audit key plumbing is not available at net device hook yet")]
 pub(crate) fn log_packet_deny(
     direction: Direction,
     audit_log: &mut AuditLog,

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -27,7 +27,7 @@ use crate::heap;
 use crate::kconfig;
 use crate::mmio;
 use crate::mmu;
-use crate::net::{self, LoopbackDevice, NetworkStack};
+use crate::net::{self, FirewallDevice, LoopbackDevice, NetworkStack};
 use crate::page;
 use crate::power::PowerManager;
 use crate::process;
@@ -724,10 +724,11 @@ pub unsafe fn run() -> ! {
         // prove the DHCP+DNS integration path works end-to-end. Loopback
         // success is tracked separately and must not mark production
         // connectivity ready.
-        let device = LoopbackDevice::new();
+        let device = FirewallDevice::with_default_firewall(LoopbackDevice::new());
         let mac = smoltcp::wire::EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]);
         let now = net::instant_from_millis(crate::timer::elapsed_ms() as i64);
         let mut stack = NetworkStack::new(device, mac, now);
+        let _ = serial.write_str("       Firewall DNS blocklist active\r\n");
 
         // Start DHCP client.
         match DhcpClient::new(&mut stack) {

--- a/crates/thumos/src/net.rs
+++ b/crates/thumos/src/net.rs
@@ -26,8 +26,11 @@ use alloc::collections::VecDeque;
 use alloc::vec;
 use alloc::vec::Vec;
 
+use crate::firewall::{Action, Firewall};
 use smoltcp::iface::{Config, Interface, SocketHandle, SocketSet, SocketStorage};
-use smoltcp::phy::{self, ChecksumCapabilities, Device, DeviceCapabilities, Medium};
+use smoltcp::phy::{
+    self, ChecksumCapabilities, Device, DeviceCapabilities, Medium, RxToken as _,
+};
 use smoltcp::socket::{tcp, udp};
 use smoltcp::time::Instant;
 use smoltcp::wire::{EthernetAddress, HardwareAddress, IpCidr, Ipv4Address, Ipv4Cidr};
@@ -59,6 +62,12 @@ pub(crate) const UDP_TX_BUF_SIZE: usize = 4096;
 
 /// Default Ethernet MTU (standard 1514-byte frame: 14-byte header + 1500 payload).
 const DEFAULT_MTU: usize = 1514;
+
+/// Ethernet header length before the layer-3 payload.
+const ETHERNET_HEADER_LEN: usize = 14;
+
+/// EtherType for IPv4 frames.
+const ETHERTYPE_IPV4: u16 = 0x0800;
 
 // ---------------------------------------------------------------------------
 // Error types
@@ -172,6 +181,144 @@ impl Device for LoopbackDevice {
             queue: &mut self.queue,
         })
     }
+}
+
+// ---------------------------------------------------------------------------
+// Firewall device wrapper
+// ---------------------------------------------------------------------------
+
+/// Network device wrapper that filters IPv4 packets before/after smoltcp.
+///
+/// The firewall module evaluates raw IPv4 packets, while smoltcp devices move
+/// Ethernet frames. This wrapper strips the Ethernet header for IPv4 frames,
+/// leaves non-IPv4 traffic untouched, and preserves the existing `Device`
+/// contract for boot smoke tests and future WiFi-backed devices.
+pub(crate) struct FirewallDevice<D> {
+    device: D,
+    firewall: Firewall,
+}
+
+impl<D> FirewallDevice<D> {
+    /// Wrap a device with a firewall that has the default DNS blocklist loaded.
+    pub(crate) fn with_default_firewall(device: D) -> Self {
+        let mut firewall = Firewall::new();
+        firewall.load_default_blocklist();
+        Self { device, firewall }
+    }
+
+    /// Borrow the wrapped device immutably.
+    #[cfg(test)]
+    pub(crate) fn inner(&self) -> &D {
+        &self.device
+    }
+
+    /// Borrow the firewall immutably.
+    #[cfg(test)]
+    pub(crate) fn firewall(&self) -> &Firewall {
+        &self.firewall
+    }
+}
+
+/// Receive token for [`FirewallDevice`].
+pub(crate) struct FirewallRxToken {
+    buffer: Vec<u8>,
+}
+
+impl phy::RxToken for FirewallRxToken {
+    fn consume<R, F>(self, f: F) -> R
+    where
+        F: FnOnce(&[u8]) -> R,
+    {
+        f(&self.buffer)
+    }
+}
+
+/// Transmit token for [`FirewallDevice`].
+pub(crate) struct FirewallTxToken<'a, T: phy::TxToken> {
+    inner: T,
+    firewall: &'a mut Firewall,
+}
+
+impl<T: phy::TxToken> phy::TxToken for FirewallTxToken<'_, T> {
+    fn consume<R, F>(self, len: usize, f: F) -> R
+    where
+        F: FnOnce(&mut [u8]) -> R,
+    {
+        let mut buffer = vec![0u8; len];
+        let result = f(&mut buffer);
+
+        if frame_allowed_tx(self.firewall, &buffer) {
+            self.inner.consume(len, |out| {
+                out.copy_from_slice(&buffer);
+            });
+        }
+
+        result
+    }
+}
+
+impl<D: Device> Device for FirewallDevice<D> {
+    type RxToken<'a>
+        = FirewallRxToken
+    where
+        Self: 'a;
+    type TxToken<'a>
+        = FirewallTxToken<'a, D::TxToken<'a>>
+    where
+        Self: 'a;
+
+    fn capabilities(&self) -> DeviceCapabilities {
+        self.device.capabilities()
+    }
+
+    fn receive(&mut self, timestamp: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
+        let (rx, tx) = self.device.receive(timestamp)?;
+        let mut buffer = Vec::new();
+        rx.consume(|frame| buffer.extend_from_slice(frame));
+
+        if !frame_allowed_rx(&mut self.firewall, &buffer) {
+            return None;
+        }
+
+        Some((
+            FirewallRxToken { buffer },
+            FirewallTxToken {
+                inner: tx,
+                firewall: &mut self.firewall,
+            },
+        ))
+    }
+
+    fn transmit(&mut self, timestamp: Instant) -> Option<Self::TxToken<'_>> {
+        self.device.transmit(timestamp).map(|inner| FirewallTxToken {
+            inner,
+            firewall: &mut self.firewall,
+        })
+    }
+}
+
+fn ipv4_payload(frame: &[u8]) -> Option<&[u8]> {
+    let ethertype = u16::from_be_bytes([
+        *frame.get(12)?,
+        *frame.get(13)?,
+    ]);
+    if ethertype != ETHERTYPE_IPV4 {
+        return None;
+    }
+
+    frame.get(ETHERNET_HEADER_LEN..)
+}
+
+fn frame_allowed_rx(firewall: &mut Firewall, frame: &[u8]) -> bool {
+    ipv4_payload(frame).is_none_or(|packet| {
+        matches!(firewall.evaluate_rx(packet), Action::Allow | Action::Log)
+    })
+}
+
+fn frame_allowed_tx(firewall: &mut Firewall, frame: &[u8]) -> bool {
+    ipv4_payload(frame).is_none_or(|packet| {
+        matches!(firewall.evaluate_tx(packet), Action::Allow | Action::Log)
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -405,6 +552,59 @@ pub(crate) fn instant_from_millis(millis: i64) -> Instant {
 mod tests {
     use super::*;
 
+    fn make_ethernet_ipv4_frame(ipv4_packet: &[u8]) -> Vec<u8> {
+        let mut frame = Vec::with_capacity(ETHERNET_HEADER_LEN + ipv4_packet.len());
+        frame.extend_from_slice(&[0xff; 6]);
+        frame.extend_from_slice(&[0x02, 0x00, 0x00, 0x00, 0x00, 0x01]);
+        frame.extend_from_slice(&ETHERTYPE_IPV4.to_be_bytes());
+        frame.extend_from_slice(ipv4_packet);
+        frame
+    }
+
+    fn make_ipv4_tcp_packet(src: [u8; 4], dst: [u8; 4], src_port: u16, dst_port: u16) -> Vec<u8> {
+        let mut pkt = vec![0u8; 40];
+        pkt[0] = 0x45;
+        pkt[2..4].copy_from_slice(&40u16.to_be_bytes());
+        pkt[9] = 6;
+        pkt[12..16].copy_from_slice(&src);
+        pkt[16..20].copy_from_slice(&dst);
+        pkt[20..22].copy_from_slice(&src_port.to_be_bytes());
+        pkt[22..24].copy_from_slice(&dst_port.to_be_bytes());
+        pkt[32] = 0x50;
+        pkt
+    }
+
+    fn make_ipv4_udp_dns_query(domain: &str) -> Vec<u8> {
+        let mut dns = Vec::new();
+        dns.extend_from_slice(&[
+            0x00, 0x01, // ID
+            0x01, 0x00, // standard query, RD=1
+            0x00, 0x01, // QDCOUNT
+            0x00, 0x00, // ANCOUNT
+            0x00, 0x00, // NSCOUNT
+            0x00, 0x00, // ARCOUNT
+        ]);
+        for label in domain.split('.') {
+            dns.push(label.len() as u8);
+            dns.extend_from_slice(label.as_bytes());
+        }
+        dns.push(0);
+        dns.extend_from_slice(&[0x00, 0x01, 0x00, 0x01]);
+
+        let total = 20 + 8 + dns.len();
+        let mut pkt = vec![0u8; total];
+        pkt[0] = 0x45;
+        pkt[2..4].copy_from_slice(&(total as u16).to_be_bytes());
+        pkt[9] = 17;
+        pkt[12..16].copy_from_slice(&[127, 0, 0, 1]);
+        pkt[16..20].copy_from_slice(&[9, 9, 9, 9]);
+        pkt[20..22].copy_from_slice(&49152u16.to_be_bytes());
+        pkt[22..24].copy_from_slice(&53u16.to_be_bytes());
+        pkt[24..26].copy_from_slice(&((8 + dns.len()) as u16).to_be_bytes());
+        pkt[28..].copy_from_slice(&dns);
+        pkt
+    }
+
     /// Helper: build a `NetworkStack<LoopbackDevice>` with a stock IP config.
     fn make_stack() -> NetworkStack<LoopbackDevice> {
         let device = LoopbackDevice::new();
@@ -485,6 +685,61 @@ mod tests {
             });
         }
         assert_eq!(device.queued_frames(), 0);
+    }
+
+    #[test]
+    fn firewall_device_drops_blocklisted_dns_tx() {
+        let mut device = FirewallDevice::with_default_firewall(LoopbackDevice::new());
+        let frame = make_ethernet_ipv4_frame(&make_ipv4_udp_dns_query("app-measurement.com"));
+        let now = Instant::from_millis(0);
+
+        let tx = device.transmit(now);
+        assert!(tx.is_some(), "firewall device must expose tx token");
+        phy::TxToken::consume(tx.unwrap(), frame.len(), |buf| {
+            buf.copy_from_slice(&frame);
+        });
+
+        assert_eq!(
+            device.inner().queued_frames(),
+            0,
+            "blocked DNS query must not reach the wrapped device"
+        );
+        assert_eq!(
+            device.firewall().stats().dns_blocked,
+            1,
+            "firewall must account for blocklisted DNS"
+        );
+    }
+
+    #[test]
+    fn firewall_device_drops_default_denied_rx() {
+        let mut device = FirewallDevice::with_default_firewall(LoopbackDevice::new());
+        let frame = make_ethernet_ipv4_frame(&make_ipv4_tcp_packet(
+            [1, 2, 3, 4],
+            [127, 0, 0, 1],
+            443,
+            49152,
+        ));
+        let now = Instant::from_millis(0);
+
+        let tx = device.transmit(now).unwrap();
+        phy::TxToken::consume(tx, frame.len(), |buf| {
+            buf.copy_from_slice(&frame);
+        });
+        assert_eq!(device.inner().queued_frames(), 1);
+
+        let rx = device.receive(now);
+        assert!(rx.is_none(), "default inbound deny must suppress rx token");
+        assert_eq!(
+            device.firewall().stats().packets_denied,
+            1,
+            "firewall must account for denied inbound packet"
+        );
+        assert_eq!(
+            device.inner().queued_frames(),
+            0,
+            "denied rx packet must be consumed from the wrapped queue"
+        );
     }
 
     #[test]

--- a/crates/thumos/src/socket.rs
+++ b/crates/thumos/src/socket.rs
@@ -28,7 +28,7 @@ use smoltcp::socket::{tcp, udp};
 use smoltcp::wire::{IpEndpoint, IpAddress, Ipv4Address};
 
 use crate::fd::{self, FileDescriptor, MAX_FDS};
-use crate::net::{LoopbackDevice, NetworkStack};
+use crate::net::{FirewallDevice, LoopbackDevice, NetworkStack};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -168,7 +168,9 @@ static mut SOCKET_TABLE: [Option<SocketInfo>; MAX_FDS] = {
 ///
 /// WHY Option: NetworkStack::new() is not const. Initialized by
 /// `init_network_stack()` during kernel boot or test setup.
-static mut NETWORK_STACK: Option<NetworkStack<LoopbackDevice>> = None;
+type SocketNetworkStack = NetworkStack<FirewallDevice<LoopbackDevice>>;
+
+static mut NETWORK_STACK: Option<SocketNetworkStack> = None;
 
 // ---------------------------------------------------------------------------
 // Initialization
@@ -185,7 +187,7 @@ pub unsafe fn init_network_stack() {
     use smoltcp::wire::EthernetAddress;
 
     unsafe {
-        let device = LoopbackDevice::new();
+        let device = FirewallDevice::with_default_firewall(LoopbackDevice::new());
         let mac = EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]);
         let mut stack = NetworkStack::new(device, mac, Instant::from_millis(0));
         stack.set_ipv4_addr(Ipv4Address::new(127, 0, 0, 1), 8);
@@ -204,7 +206,7 @@ pub unsafe fn init_network_stack() {
 ///
 /// Caller must ensure `init_network_stack` has been called.
 /// Single-core cooperative kernel ensures exclusive access.
-unsafe fn get_network_stack() -> Option<&'static mut NetworkStack<LoopbackDevice>> {
+unsafe fn get_network_stack() -> Option<&'static mut SocketNetworkStack> {
     unsafe {
         let ns = &mut *core::ptr::addr_of_mut!(NETWORK_STACK);
         ns.as_mut()
@@ -561,7 +563,7 @@ pub(crate) fn sys_connect(fd: u32, addr_ptr: u32, addr_len: u32) -> u32 {
             let connect_result = unsafe {
                 let stack_ptr = &mut *core::ptr::addr_of_mut!(NETWORK_STACK);
                 let stack_ref = match stack_ptr.as_mut() {
-                    Some(s) => s as *mut NetworkStack<LoopbackDevice>,
+                    Some(s) => s as *mut SocketNetworkStack,
                     None => return fd::EBADF,
                 };
                 let cx = (*stack_ref).iface_mut().context();


### PR DESCRIPTION
## Summary
- add a firewall-backed smoltcp device wrapper that filters Ethernet IPv4 RX/TX before packets reach smoltcp or the wrapped driver
- use the wrapper for the kinit loopback DHCP/DNS smoke path and the global socket stack
- remove the old firewall module-wide dead-code expectation and leave only narrow residual expectations for policy/audit/metrics surfaces not wired in this slice

## Scope
Refs #143. This wires the packet filter into the current network path, but does not close #143 because WiFi hardware bring-up remains loopback-only.

## Gates
- cargo +nightly fmt --all --check
- git diff --check
- cargo test --workspace
- cargo clippy --workspace -- -D warnings
- cargo +nightly check -Z build-std=core,alloc --target armv7a-none-eabi
- cargo +nightly check --release -Z build-std=core,alloc --target armv7a-none-eabi

## Notes
- Direct kernel host tests via cargo +nightly test --bin thumos net::tests::firewall_device --target x86_64-unknown-linux-gnu are still blocked by unrelated existing test-build errors in other kernel modules.