### PR TITLE
fix(leipsanon): replace ring rng

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,8 +472,8 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 name = "leipsanon"
 version = "0.1.5"
 dependencies = [
+ "getrandom 0.4.2",
  "log",
- "ring",
  "rustix",
  "snafu",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ rustix = { version = "1", features = [
 ] }
 
 # Crypto
+getrandom = "0.4"
 ring = "0.17"
 
 # Networking

--- a/crates/leipsanon/Cargo.toml
+++ b/crates/leipsanon/Cargo.toml
@@ -8,8 +8,8 @@ publish.workspace = true
 repository.workspace = true
 
 [dependencies]
+getrandom = { workspace = true }
 log = { workspace = true }
-ring = { workspace = true }
 rustix = { workspace = true }
 snafu = { workspace = true }
 zeroize = "1"

--- a/crates/leipsanon/src/memory.rs
+++ b/crates/leipsanon/src/memory.rs
@@ -36,10 +36,7 @@ pub(crate) fn secure_zero(buf: &mut [u8]) {
 ///
 /// Returns [`MemoryError::RandomGeneration`] if the system RNG fails.
 pub(crate) fn secure_random_fill(buf: &mut [u8]) -> Result<(), MemoryError> {
-    use ring::rand::SecureRandom as _;
-
-    let rng = ring::rand::SystemRandom::new();
-    rng.fill(buf).map_err(|_| MemoryError::RandomGeneration)
+    getrandom::fill(buf).map_err(|_| MemoryError::RandomGeneration)
 }
 
 // ----- Types ----------------------------------------------------------------


### PR DESCRIPTION
## Summary
- replace leipsanon's RNG-only `ring::rand::SystemRandom` use with `getrandom::fill`
- remove the direct `ring` dependency from `crates/leipsanon` while leaving the remaining #146 crypto surfaces untouched

## Scope
This is the first staged #146 slice only. `ring` remains in `aither`, `krypta`, and `stegnos` for separate reviewed migrations.

## Gates
- Gate-Passed: `git diff --check`
- Gate-Passed: `cargo fmt --all --check`
- Gate-Passed: `cargo check --locked -p leipsanon --all-targets`
- Gate-Passed: `cargo clippy --locked -p leipsanon --all-targets -- -D warnings`
- Gate-Passed: `cargo test --locked -p leipsanon`
- Gate-Passed: `cargo check --locked --workspace --all-targets`

Refs #146