### PR TITLE
fix(ramfs): normalize dot-prefixed cpio paths

### DIFF
--- a/crates/thumos/src/ramfs.rs
+++ b/crates/thumos/src/ramfs.rs
@@ -228,11 +228,8 @@ impl RamFs {
 
             if !name.is_empty() && name != "." {
                 // Strip leading "./" if present (common in CPIO archives)
-                let clean_name = name
-                    .strip_prefix("./")
-                    .unwrap_or(name)
-                    .strip_prefix('/')
-                    .unwrap_or(name);
+                let clean_name = name.strip_prefix("./").unwrap_or(name);
+                let clean_name = clean_name.strip_prefix('/').unwrap_or(clean_name);
 
                 if !clean_name.is_empty() {
                     if is_dir {
@@ -1028,6 +1025,20 @@ mod tests {
         let mut buf = [0u8; 32];
         let read = fs.read(init_id, 0, &mut buf).expect("read init");
         assert_eq!(&buf[..read], b"#!/bin/sh");
+    }
+
+    #[test]
+    fn parse_cpio_strips_dot_slash_prefixes() {
+        let mut archive = Vec::new();
+        archive.extend(build_cpio_entry("./init", b"#!/bin/sh", 0o100755));
+        archive.extend(build_cpio_entry("./etc/hostname", b"thumos", 0o100644));
+        archive.extend(build_cpio_trailer());
+
+        let fs = RamFs::from_cpio(&archive);
+
+        assert_eq!(fs.find("init"), Some(b"#!/bin/sh".as_slice()));
+        assert_eq!(fs.find("etc/hostname"), Some(b"thumos".as_slice()));
+        assert_eq!(fs.find("./init"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- normalize CPIO names like `./init` to `init` after stripping the documented archive prefix
- add a regression test covering `./init` and `./etc/hostname` entries

## Scope
This is a parser correctness slice for #144. It does not embed real `/init` or `/shell` ELF artifacts and does not change the idle fallback behavior.

## Gates
- Gate-Passed: `git diff --check`
- Gate-Passed: `cargo fmt --all --check`
- Gate-Passed: `cargo +nightly check -Z build-std=core,alloc --target armv7a-none-eabi`
- Gate-Blocked: `cargo test --manifest-path crates/thumos/Cargo.toml ramfs::tests::parse_cpio_strips_dot_slash_prefixes` (existing kernel test compile failures outside this change: missing `ToString` imports and `ModePolicy::contains` mismatch)

Refs #144