### PR TITLE
fix(aither): replace ring crypto helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,9 +17,12 @@ dependencies = [
 name = "aither"
 version = "0.1.5"
 dependencies = [
+ "getrandom 0.4.2",
+ "hmac",
  "log",
  "nom",
- "ring",
+ "pbkdf2",
+ "sha1",
  "smoltcp",
  "snafu",
 ]
@@ -88,6 +91,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +163,17 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -360,6 +383,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,6 +579,16 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -818,6 +860,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,6 +938,12 @@ dependencies = [
  "xts-mode",
  "zeroize",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,10 @@ rustix = { version = "1", features = [
 
 # Crypto
 getrandom = "0.4"
+hmac = "0.12"
+pbkdf2 = "0.12"
 ring = "0.17"
+sha1 = "0.10"
 
 # Networking
 smoltcp = { version = "0.12", default-features = false, features = [

--- a/crates/aither/Cargo.toml
+++ b/crates/aither/Cargo.toml
@@ -8,8 +8,11 @@ publish.workspace = true
 repository.workspace = true
 
 [dependencies]
-ring = { workspace = true }
+getrandom = { workspace = true }
+hmac = { workspace = true }
 nom = { workspace = true }
+pbkdf2 = { workspace = true }
+sha1 = { workspace = true }
 smoltcp = { workspace = true }
 snafu = { workspace = true }
 log = { workspace = true }

--- a/crates/aither/src/mac.rs
+++ b/crates/aither/src/mac.rs
@@ -2,7 +2,7 @@
 //!
 //! Implements HIF MCR register constants, TX/RX descriptors, command/event
 //! protocol, passive-default scanning, association state machine, and
-//! per-connection MAC randomization via ring CSPRNG.
+//! per-connection MAC randomization via the OS CSPRNG.
 
 // WHY: All items are hardware API surface wired to lower layers. Upper-layer
 // callers (supplicant, netif) will be added in subsequent phases.
@@ -15,7 +15,6 @@
     reason = "private module; pub(crate) is consistent with project visibility convention"
 )]
 
-use ring::rand::{SecureRandom, SystemRandom};
 use snafu::{Snafu, ensure};
 
 use crate::wpa::{self, PMK_LEN};
@@ -660,11 +659,9 @@ impl MacAddress {
     /// # Errors
     ///
     /// Returns [`Error::Rng`] if the system CSPRNG fails.
-    pub(crate) fn generate_random(rng: &SystemRandom) -> Result<Self, Error> {
+    pub(crate) fn generate_random() -> Result<Self, Error> {
         let mut bytes = [0u8; 6];
-        // WHY: ring::error::Unspecified does not implement std::error::Error,
-        // so snafu .context() cannot be used; map manually instead.
-        rng.fill(&mut bytes).map_err(|_| Error::Rng)?;
+        getrandom::fill(&mut bytes).map_err(|_| Error::Rng)?;
         // INVARIANT: bit 0 clear = unicast, bit 1 SET = locally administered
         let [mut b0, b1, b2, b3, b4, b5] = bytes;
         b0 &= 0xfe; // clear multicast bit
@@ -759,9 +756,6 @@ pub(crate) enum Error {
     },
 
     /// CSPRNG failure during MAC generation.
-    ///
-    /// `ring::error::Unspecified` carries no additional information beyond the
-    /// fact that entropy collection failed.
     #[snafu(display("MAC randomization RNG failure"))]
     Rng,
 }
@@ -772,10 +766,8 @@ pub(crate) enum Error {
 
 /// MAC driver state for a single `WiFi` HIF interface instance.
 ///
-/// Owns the CSPRNG, the active randomized MAC address, and the association FSM.
+/// Owns the active randomized MAC address and the association FSM.
 pub(crate) struct WiFiMacDriver {
-    /// System CSPRNG for MAC randomization.
-    rng: SystemRandom,
     /// Current locally-administered MAC address for this connection.
     current_mac: MacAddress,
     /// Hardware AHB base address (FROM device tree).
@@ -791,10 +783,8 @@ impl WiFiMacDriver {
     ///
     /// Returns [`Error::Rng`] if initial MAC generation fails.
     pub(crate) fn new(hif_base: u32) -> Result<Self, Error> {
-        let rng = SystemRandom::new();
-        let current_mac = MacAddress::generate_random(&rng)?;
+        let current_mac = MacAddress::generate_random()?;
         Ok(Self {
-            rng,
             current_mac,
             hif_base,
             assoc_state: AssocState::Idle,
@@ -814,7 +804,7 @@ impl WiFiMacDriver {
     ///
     /// Returns [`Error::Rng`] if MAC generation fails.
     pub(crate) fn set_mac_address(&mut self, seq_num: u8) -> Result<WifiCommand, Error> {
-        self.current_mac = MacAddress::generate_random(&self.rng)?;
+        self.current_mac = MacAddress::generate_random()?;
         // WHY: MAC bytes are packed INTO two 32-bit registers: low 4 bytes and
         // high 2 bytes. We write the low word here via ACCESS_REG. Callers must
         // issue a follow-up ACCESS_REG write for the high 2 bytes (seq_num+1).
@@ -903,7 +893,6 @@ impl Default for WiFiMacDriver {
     /// this default in a working environment.
     fn default() -> Self {
         Self {
-            rng: SystemRandom::new(),
             current_mac: MacAddress([0u8; 6]),
             hif_base: 0,
             assoc_state: AssocState::Idle,
@@ -1110,9 +1099,8 @@ mod tests {
 
     #[test]
     fn generated_mac_always_has_locally_administered_bit_set() {
-        let rng = SystemRandom::new();
         for _ in 0..20 {
-            let mac = MacAddress::generate_random(&rng).unwrap_or_default();
+            let mac = MacAddress::generate_random().unwrap_or_default();
             assert!(
                 mac.is_locally_administered(),
                 "locally-administered bit must be SET in generated MAC"
@@ -1122,9 +1110,8 @@ mod tests {
 
     #[test]
     fn generated_mac_always_has_multicast_bit_clear() {
-        let rng = SystemRandom::new();
         for _ in 0..20 {
-            let mac = MacAddress::generate_random(&rng).unwrap_or_default();
+            let mac = MacAddress::generate_random().unwrap_or_default();
             assert!(
                 mac.is_unicast(),
                 "multicast bit must be clear in generated MAC"
@@ -1135,9 +1122,8 @@ mod tests {
     #[test]
     fn generated_macs_are_independently_valid() {
         // NOTE: Probability of collision is 2^{-46}  -  negligible.
-        let rng = SystemRandom::new();
-        let mac_a = MacAddress::generate_random(&rng).unwrap_or_default();
-        let mac_b = MacAddress::generate_random(&rng).unwrap_or_default();
+        let mac_a = MacAddress::generate_random().unwrap_or_default();
+        let mac_b = MacAddress::generate_random().unwrap_or_default();
         // We verify both are valid rather than asserting inequality
         // (collision is theoretically possible but negligibly unlikely).
         assert!(

--- a/crates/aither/src/wpa.rs
+++ b/crates/aither/src/wpa.rs
@@ -7,7 +7,11 @@
 
 use std::num::NonZeroU32;
 
-use ring::{hmac, pbkdf2};
+use hmac::{Hmac, Mac};
+use pbkdf2::pbkdf2_hmac;
+use sha1::Sha1;
+
+type HmacSha1 = Hmac<Sha1>;
 
 /// PBKDF2 iteration count for PSK derivation (IEEE 802.11-2020 fixed value).
 ///
@@ -91,13 +95,7 @@ impl Drop for Ptk {
 #[must_use]
 pub(crate) fn derive_pmk(passphrase: &[u8], ssid: &[u8]) -> [u8; PMK_LEN] {
     let mut pmk = [0u8; PMK_LEN];
-    pbkdf2::derive(
-        pbkdf2::PBKDF2_HMAC_SHA1,
-        PBKDF2_ITERS,
-        ssid,       // salt
-        passphrase, // secret
-        &mut pmk,
-    );
+    pbkdf2_hmac::<Sha1>(passphrase, ssid, PBKDF2_ITERS.get(), &mut pmk);
     pmk
 }
 
@@ -163,9 +161,11 @@ pub(crate) fn derive_ptk(
 /// passing `data` to this function.
 #[must_use]
 pub(crate) fn compute_mic(kck: &[u8; KCK_LEN], data: &[u8]) -> [u8; MIC_LEN] {
-    let key = hmac::Key::new(hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY, kck);
-    let tag = hmac::sign(&key, data);
-    let bytes = tag.as_ref();
+    let Ok(mut mac) = HmacSha1::new_from_slice(kck) else {
+        return [0u8; MIC_LEN];
+    };
+    mac.update(data);
+    let bytes = mac.finalize().into_bytes();
     let mut mic = [0u8; MIC_LEN];
     // HMAC-SHA1 produces 20 bytes; we take the first 16 (128 bits).
     mic.copy_from_slice(&bytes[..MIC_LEN]);
@@ -207,7 +207,6 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 /// `input` must already be the concatenation `A || 0x00 || B`; the counter
 /// byte `i` is appended per iteration.
 fn prf(key: &[u8], input: &[u8], output: &mut [u8]) {
-    let hmac_key = hmac::Key::new(hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY, key);
     let out_len = output.len();
     let mut pos = 0usize;
     let mut counter = 0u8;
@@ -217,8 +216,11 @@ fn prf(key: &[u8], input: &[u8], output: &mut [u8]) {
         msg.extend_from_slice(input);
         msg.push(counter);
 
-        let tag = hmac::sign(&hmac_key, &msg);
-        let tag_bytes = tag.as_ref();
+        let Ok(mut mac) = HmacSha1::new_from_slice(key) else {
+            return;
+        };
+        mac.update(&msg);
+        let tag_bytes = mac.finalize().into_bytes();
         let copy_len = (out_len - pos).min(tag_bytes.len());
         output[pos..pos + copy_len].copy_from_slice(&tag_bytes[..copy_len]);
         pos += copy_len;

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -4,14 +4,23 @@ version = 4
 
 [[package]]
 name = "aither"
-version = "0.1.3"
+version = "0.1.5"
 dependencies = [
+ "getrandom 0.4.2",
+ "hmac",
  "log",
  "nom",
- "ring",
+ "pbkdf2",
+ "sha1",
  "smoltcp",
  "snafu",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arbitrary"
@@ -21,7 +30,7 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "asphaleia"
-version = "0.1.3"
+version = "0.1.5"
 dependencies = [
  "log",
  "rustix",
@@ -39,6 +48,15 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "byteorder"
@@ -65,13 +83,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -81,14 +135,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
-name = "getrandom"
-version = "0.2.17"
+name = "foldhash"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
- "cfg-if",
- "libc",
- "wasi",
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -99,8 +158,21 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -111,6 +183,21 @@ checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heapless"
@@ -129,6 +216,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,13 +260,19 @@ dependencies = [
 
 [[package]]
 name = "klesis"
-version = "0.1.3"
+version = "0.1.5"
 dependencies = [
  "log",
  "nom",
  "rustix",
  "snafu",
 ]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -198,6 +324,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,18 +368,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "ring"
-version = "0.17.14"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.17",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rustix"
@@ -245,7 +383,66 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -295,6 +492,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,22 +519,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "untrusted"
-version = "0.9.0"
+name = "unicode-xid"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
+name = "version_check"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasip2"
@@ -343,19 +552,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-sys"
@@ -367,71 +610,95 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"


### PR DESCRIPTION
## Summary
- replace aither MAC randomization with `getrandom::fill`
- replace WPA PBKDF2/HMAC-SHA1 helpers with RustCrypto `pbkdf2`, `hmac`, and `sha1`
- update root and fuzz lockfiles so aither no longer pulls `ring`; `krypta` and `stegnos` remain staged separately

## Scope
Narrow #146 slice only. This does not touch `krypta` protocol crypto or `stegnos` persisted key sealing.

## Gates
- Gate-Passed: `git diff --check`
- Gate-Passed: `cargo fmt --all --check`
- Gate-Passed: `cargo check --locked -p aither --all-targets`
- Gate-Passed: `cargo clippy --locked -p aither --all-targets -- -D warnings`
- Gate-Passed: `cargo test --locked -p aither`
- Gate-Passed: `cargo check --locked --workspace --all-targets`
- Gate-Blocked: `cargo check --manifest-path fuzz/Cargo.toml --locked` (existing fuzz targets use private crate APIs outside this change)

Refs #146