### PR TITLE
fix(stegnos): replace ring key sealing helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11,6 +21,20 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -162,7 +186,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -313,6 +347,16 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -581,6 +625,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,6 +638,18 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -708,7 +770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -718,7 +780,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -736,7 +807,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -871,6 +942,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,10 +1012,13 @@ name = "stegnos"
 version = "0.1.5"
 dependencies = [
  "aes",
+ "aes-gcm",
+ "getrandom 0.4.2",
  "jiff",
  "log",
- "ring",
+ "pbkdf2",
  "rustix",
+ "sha2",
  "snafu",
  "xts-mode",
  "zeroize",
@@ -1023,6 +1108,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,11 +71,13 @@ rustix = { version = "1", features = [
 ] }
 
 # Crypto
+aes-gcm = "0.10"
 getrandom = "0.4"
 hmac = "0.12"
 pbkdf2 = "0.12"
 ring = "0.17"
 sha1 = "0.10"
+sha2 = "0.10"
 
 # Networking
 smoltcp = { version = "0.12", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The Phase 10 / Phase 11 status above describes the kernel's compiled and tested 
 - [#143](https://github.com/forkwright/thumos/issues/143) — network stack still boots on a firewall-backed loopback path; WiFi driver remains unwired
 - [#144](https://github.com/forkwright/thumos/issues/144) — userspace process spawn falls back to wfe idle loop (no /init or /shell ELF)
 - [#145](https://github.com/forkwright/thumos/issues/145) — advertised kernel features compiled but unwired: 46 crate-level expectation blocks, plus 43 item-level low-level dead-code suppressions tracked separately
-- [#146](https://github.com/forkwright/thumos/issues/146) — `ring` dependency violates pure-Rust sovereignty policy in 4 crates
+- [#146](https://github.com/forkwright/thumos/issues/146) — remaining direct `ring` dependency is isolated to `krypta` protocol crypto
 
 ## Related
 

--- a/crates/stegnos/Cargo.toml
+++ b/crates/stegnos/Cargo.toml
@@ -9,9 +9,12 @@ repository.workspace = true
 
 [dependencies]
 aes = "0.8"
+aes-gcm = { workspace = true }
+getrandom = { workspace = true }
 jiff = { workspace = true }
-ring = { workspace = true }
+pbkdf2 = { workspace = true }
 rustix = { workspace = true }
+sha2 = { workspace = true }
 snafu = { workspace = true }
 log = { workspace = true }
 xts-mode = "0.5"

--- a/crates/stegnos/src/keys.rs
+++ b/crates/stegnos/src/keys.rs
@@ -1,13 +1,12 @@
 //! Key management: PBKDF2 key derivation, AES-256-GCM primary key seal/unseal.
 
-use std::num::NonZeroU32;
-
-use jiff::Timestamp;
-use ring::{
-    aead::{self, AES_256_GCM, LessSafeKey, Nonce, UnboundKey},
-    pbkdf2,
-    rand::{SecureRandom, SystemRandom},
+use aes_gcm::{
+    Aes256Gcm, Nonce,
+    aead::{AeadInPlace, KeyInit},
 };
+use jiff::Timestamp;
+use pbkdf2::pbkdf2_hmac;
+use sha2::Sha256;
 use snafu::Snafu;
 
 use crate::config::Config;
@@ -120,15 +119,12 @@ pub(crate) fn derive_key(
     salt: &[u8; SALT_LEN],
     iterations: u32,
 ) -> Result<DerivedKey> {
-    let iters = NonZeroU32::new(iterations).ok_or_else(|| ZeroIterationsSnafu.build())?;
+    if iterations == 0 {
+        return ZeroIterationsSnafu.fail();
+    }
+
     let mut key = [0u8; KEY_LEN];
-    pbkdf2::derive(
-        pbkdf2::PBKDF2_HMAC_SHA256,
-        iters,
-        salt,
-        passphrase,
-        &mut key,
-    );
+    pbkdf2_hmac::<Sha256>(passphrase, salt, iterations, &mut key);
     Ok(DerivedKey {
         key,
         salt: *salt,
@@ -137,10 +133,9 @@ pub(crate) fn derive_key(
 }
 
 /// Generate `N` cryptographically random bytes.
-fn random_bytes<const N: usize>(rng: &SystemRandom) -> Result<[u8; N]> {
+fn random_bytes<const N: usize>() -> Result<[u8; N]> {
     let mut buf = [0u8; N];
-    rng.fill(&mut buf)
-        .map_err(|_| RandomGenerationSnafu.build())?;
+    getrandom::fill(&mut buf).map_err(|_| RandomGenerationSnafu.build())?;
     Ok(buf)
 }
 
@@ -168,22 +163,19 @@ pub(crate) fn seal_key_with_config(
     passphrase: &[u8],
     config: Config,
 ) -> Result<KeySlot> {
-    let rng = SystemRandom::new();
-
-    let salt = random_bytes::<SALT_LEN>(&rng)?;
-    let nonce_bytes = random_bytes::<NONCE_LEN>(&rng)?;
+    let salt = random_bytes::<SALT_LEN>()?;
+    let nonce_bytes = random_bytes::<NONCE_LEN>()?;
 
     let iterations = config.pbkdf2_iterations();
     let derived = derive_key(passphrase, &salt, iterations)?;
 
-    let unbound =
-        UnboundKey::new(&AES_256_GCM, &derived.key).map_err(|_| InvalidKeySnafu.build())?;
-    let sealing_key = LessSafeKey::new(unbound);
-    let nonce = Nonce::assume_unique_for_key(nonce_bytes);
+    let sealing_key =
+        Aes256Gcm::new_from_slice(&derived.key).map_err(|_| InvalidKeySnafu.build())?;
+    let nonce = Nonce::from_slice(&nonce_bytes);
 
     let mut buf = primary_key.to_vec();
     sealing_key
-        .seal_in_place_append_tag(nonce, aead::Aad::empty(), &mut buf)
+        .encrypt_in_place(nonce, b"", &mut buf)
         .map_err(|_| KeySealSnafu.build())?;
 
     let mut ciphertext = [0u8; SEALED_KEY_LEN];
@@ -212,17 +204,16 @@ pub(crate) fn seal_key_with_config(
 pub(crate) fn unseal_key(slot: &KeySlot, passphrase: &[u8]) -> Result<[u8; KEY_LEN]> {
     let derived = derive_key(passphrase, &slot.salt, slot.iterations)?;
 
-    let unbound =
-        UnboundKey::new(&AES_256_GCM, &derived.key).map_err(|_| InvalidKeySnafu.build())?;
-    let opening_key = LessSafeKey::new(unbound);
-    let nonce = Nonce::assume_unique_for_key(slot.nonce);
+    let opening_key =
+        Aes256Gcm::new_from_slice(&derived.key).map_err(|_| InvalidKeySnafu.build())?;
+    let nonce = Nonce::from_slice(&slot.nonce);
 
     let mut buf = slot.ciphertext.to_vec();
-    let plaintext = opening_key
-        .open_in_place(nonce, aead::Aad::empty(), &mut buf)
+    opening_key
+        .decrypt_in_place(nonce, b"", &mut buf)
         .map_err(|_| KeyUnsealSnafu.build())?;
 
-    let slice = plaintext
+    let slice = buf
         .get(..KEY_LEN)
         .ok_or_else(|| BadPlaintextLengthSnafu.build())?;
     let mut primary_key = [0u8; KEY_LEN];
@@ -244,6 +235,26 @@ mod tests {
         assert_eq!(
             a.key, b.key,
             "PBKDF2 must be deterministic for same passphrase and salt"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn derive_key_matches_pbkdf2_sha256_known_answer() -> Result<()> {
+        // PBKDF2-HMAC-SHA256 vector from common RFC 6070-style test suites.
+        let mut salt = [0u8; SALT_LEN];
+        salt[..4].copy_from_slice(b"salt");
+
+        let derived = derive_key(b"password", &salt, 1)?;
+
+        assert_eq!(
+            derived.key,
+            [
+                0x1f, 0x0b, 0x0d, 0x29, 0x78, 0x96, 0x2e, 0xb0, 0xa4, 0x14, 0x6d, 0xdc, 0x02, 0xe2,
+                0x2c, 0x04, 0x5e, 0x42, 0xe4, 0x99, 0xf4, 0x0f, 0xf2, 0x84, 0x15, 0x3f, 0xa8, 0x45,
+                0x68, 0xbf, 0xbf, 0xff,
+            ],
+            "PBKDF2-HMAC-SHA256 output must match known answer"
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary

Part of #146. This removes `ring` from `stegnos` key-slot sealing and keeps the staged crypto migration focused away from `krypta` protocol code.

- replace `ring` PBKDF2-HMAC-SHA256 with the RustCrypto `pbkdf2` + `sha2` path
- replace `ring` AES-256-GCM sealing/unsealing with `aes-gcm`
- replace `ring::SystemRandom` with `getrandom`
- add a PBKDF2-HMAC-SHA256 known-answer regression for the crate
- refresh README #146 accounting so the remaining direct `ring` use is scoped to `krypta`

## Gates

- `cargo fmt --all --check`
- `cargo check --locked -p stegnos --all-targets`
- `cargo clippy --locked -p stegnos --all-targets -- -D warnings`
- `cargo test --locked -p stegnos`
- `cargo check --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo test --locked --workspace`
- `git diff --check`