### PR TITLE
feat(metaxu): add aletheia bridge client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,10 +124,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -162,6 +177,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
  "thiserror",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
 ]
 
 [[package]]
@@ -302,6 +332,30 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -510,6 +564,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "kelyphos"
 version = "0.1.5"
 dependencies = [
@@ -595,6 +661,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "metaxu"
+version = "0.1.5"
+dependencies = [
+ "compact_str",
+ "jiff",
+ "postcard",
+ "serde",
+ "snafu",
+ "ulid",
+]
+
+[[package]]
 name = "micromath"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +717,12 @@ dependencies = [
  "digest",
  "hmac",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "polyval"
@@ -853,6 +937,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,6 +953,12 @@ dependencies = [
  "tempfile",
  "wait-timeout",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "scopeguard"
@@ -959,6 +1055,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smoltcp"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,6 +1108,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stegnos"
@@ -1092,6 +1200,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "web-time",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,6 +1282,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1196,6 +1358,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/klesis",
     "crates/krypta",
     "crates/leipsanon",
+    "crates/metaxu",
     "crates/pteron",
     "crates/sema",
     "crates/stegnos",
@@ -108,6 +109,7 @@ log = "0.4"
 
 # Time
 jiff = "0.2"
+ulid = { version = "1", default-features = false }
 
 # Strings
 compact_str = "0.8"

--- a/crates/metaxu/Cargo.toml
+++ b/crates/metaxu/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "metaxu"
+description = "Aletheia/Thumos thin-client capability bridge"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+repository.workspace = true
+
+[dependencies]
+compact_str = { workspace = true, features = ["serde"] }
+jiff = { workspace = true, features = ["serde"] }
+postcard = { workspace = true }
+serde = { workspace = true }
+snafu = { workspace = true }
+ulid = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/metaxu/src/client.rs
+++ b/crates/metaxu/src/client.rs
@@ -1,0 +1,114 @@
+//! Thin bridge client storage.
+
+/// Thin client for sending typed Thumos task requests to the runtime boundary.
+pub struct BridgeClient<T> /* kanon:ignore RUST/pub-visibility -- public API */ {
+    pub(crate) transport: T,
+}
+
+#[cfg(test)]
+mod tests {
+    use compact_str::CompactString;
+    use ulid::Ulid;
+
+    use super::*;
+    use crate::{
+        BridgeTransport, Result,
+        protocol::{
+            Capability, CapabilityGrant, DeviceAction, DeviceIdentityRef, IdentityKind,
+            TaskRequest, TaskResponse, TaskStatus, decode_request, encode_response,
+        },
+    };
+
+    struct InMemoryRuntime {
+        seen_request: Option<TaskRequest>,
+    }
+
+    impl InMemoryRuntime {
+        fn new() -> Self {
+            Self { seen_request: None }
+        }
+    }
+
+    impl BridgeTransport for InMemoryRuntime {
+        fn exchange(&mut self, request_frame: &[u8]) -> Result<Vec<u8>> {
+            let request = decode_request(request_frame)?;
+            let response = match &request {
+                TaskRequest::SendSms { request_id, to, .. } => TaskResponse::accepted(
+                    *request_id,
+                    DeviceAction::SmsQueued {
+                        runtime_ref: CompactString::from(format!("runtime-sms:{to}")),
+                    },
+                ),
+                _ => TaskResponse::rejected(request.request_id(), "unsupported fake task"),
+            };
+
+            self.seen_request = Some(request);
+            encode_response(&response)
+        }
+    }
+
+    fn identity_ref() -> DeviceIdentityRef {
+        DeviceIdentityRef::new(IdentityKind::Session, "session-device-ref", [7; 32])
+    }
+
+    #[test]
+    fn sms_request_round_trips_through_in_memory_runtime() -> Result<()> {
+        let request_id = Ulid::from_bytes([1; 16]);
+        let request = TaskRequest::SendSms {
+            request_id,
+            identity: identity_ref(),
+            grants: vec![CapabilityGrant::new(
+                Capability::SmsSend,
+                "policy",
+                "grant-sms-1",
+            )],
+            to: "+15551234567".into(),
+            body: "bridge test".into(),
+        };
+
+        let mut client = BridgeClient::new(InMemoryRuntime::new());
+        let response = client.submit(&request)?;
+        let runtime = client.into_transport();
+
+        assert_eq!(runtime.seen_request, Some(request));
+        assert_eq!(
+            response,
+            TaskResponse {
+                request_id,
+                status: TaskStatus::Accepted {
+                    action: DeviceAction::SmsQueued {
+                        runtime_ref: "runtime-sms:+15551234567".into(),
+                    },
+                },
+            }
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn client_rejects_request_without_required_grant() {
+        let request = TaskRequest::SendSms {
+            request_id: Ulid::from_bytes([2; 16]),
+            identity: identity_ref(),
+            grants: vec![CapabilityGrant::new(
+                Capability::ContactsRead,
+                "policy",
+                "grant-contact-1",
+            )],
+            to: "+15551234567".into(),
+            body: "bridge test".into(),
+        };
+
+        let mut client = BridgeClient::new(InMemoryRuntime::new());
+        let result = client.submit(&request);
+
+        assert!(matches!(
+            result,
+            Err(crate::Error::MissingCapability {
+                capability: Capability::SmsSend,
+                ..
+            })
+        ));
+    }
+}

--- a/crates/metaxu/src/error.rs
+++ b/crates/metaxu/src/error.rs
@@ -1,0 +1,85 @@
+//! Error types for the Aletheia bridge.
+
+use compact_str::CompactString;
+use snafu::{GenerateImplicitData as _, Location, Snafu};
+use ulid::Ulid;
+
+use crate::protocol::Capability;
+
+/// Result type for bridge operations.
+pub type Result<T> = std::result::Result<T, Error>; // kanon:ignore RUST/pub-visibility -- public API
+
+/// Aletheia bridge errors.
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[non_exhaustive]
+pub enum Error {
+    /// Failed to serialize a bridge message.
+    #[snafu(display("failed to encode bridge message at {location}: {source}"))]
+    Encode {
+        /// Underlying serialization error.
+        source: postcard::Error,
+        /// Source location where the error was attached.
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    /// Failed to deserialize a bridge message.
+    #[snafu(display("failed to decode bridge message at {location}: {source}"))]
+    Decode {
+        /// Underlying deserialization error.
+        source: postcard::Error,
+        /// Source location where the error was attached.
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    /// A request was missing the capability grant required by its task.
+    #[snafu(display(
+        "request {request_id} is missing required capability grant {capability:?} at {location}"
+    ))]
+    MissingCapability {
+        /// Request identifier.
+        request_id: Ulid,
+        /// Capability required by the task.
+        capability: Capability,
+        /// Source location where the error was attached.
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    /// The runtime response did not correspond to the submitted request.
+    #[snafu(display(
+        "response request id {response_id} did not match submitted request {request_id} at {location}"
+    ))]
+    ResponseRequestMismatch {
+        /// Submitted request identifier.
+        request_id: Ulid,
+        /// Response request identifier.
+        response_id: Ulid,
+        /// Source location where the error was attached.
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    /// Transport-level failure.
+    #[snafu(display("bridge transport error at {location}: {message}"))]
+    Transport {
+        /// Transport-specific failure message.
+        message: CompactString,
+        /// Source location where the error was attached.
+        #[snafu(implicit)]
+        location: Location,
+    },
+}
+
+impl Error {
+    /// Build a transport error from an implementation-specific message.
+    #[must_use]
+    pub fn transport(message: impl Into<CompactString>) -> Self {
+        Self::Transport {
+            message: message.into(),
+            location: Location::generate(),
+        }
+    }
+}

--- a/crates/metaxu/src/lib.rs
+++ b/crates/metaxu/src/lib.rs
@@ -1,0 +1,142 @@
+#![deny(missing_docs)]
+//! Thin capability bridge between Thumos device services and an
+//! Aletheia/Menos-resident runtime.
+//!
+//! `metaxu` defines the typed wire boundary only: task requests, capability
+//! grant claims, device-identity references, responses, and a synchronous
+//! transport abstraction. It intentionally does not embed runtime logic,
+//! authenticate grants, or require live Menos connectivity.
+
+mod client;
+mod error;
+mod protocol;
+mod transport;
+
+use snafu::OptionExt as _;
+
+pub use client::BridgeClient; // kanon:ignore RUST/pub-visibility -- public API
+pub use error::{Error, Result};
+pub use protocol::{
+    AudioMode, Capability, CapabilityGrant, ContactSummary, DeviceAction, DeviceIdentityRef,
+    IdentityKind, TaskRequest, TaskResponse, TaskStatus,
+};
+pub use transport::BridgeTransport; // kanon:ignore RUST/pub-visibility -- public API
+
+impl<T> BridgeClient<T>
+where
+    T: BridgeTransport,
+{
+    /// Construct a bridge client around a transport implementation.
+    #[must_use]
+    pub const fn new(transport: T) -> Self {
+        Self { transport }
+    }
+
+    /// Return the underlying transport.
+    #[must_use]
+    pub fn into_transport(self) -> T {
+        self.transport
+    }
+
+    /// Serialize a request, exchange it with the runtime boundary, and parse
+    /// the response.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::MissingCapability`] when local preflight does not find
+    /// a grant claim for the required capability, [`Error::Transport`] for
+    /// transport failures,
+    /// [`Error::Decode`] for malformed responses, and
+    /// [`Error::ResponseRequestMismatch`] when the runtime answers another
+    /// request id.
+    pub fn submit(&mut self, request: &TaskRequest) -> Result<TaskResponse> {
+        request
+            .has_required_capability()
+            .then_some(())
+            .context(error::MissingCapabilitySnafu {
+                request_id: request.request_id(),
+                capability: request.required_capability(),
+            })?;
+
+        let request_id = request.request_id();
+        let request_frame = encode_request(request)?;
+        let response_frame = self.transport.exchange(&request_frame)?;
+        let response = decode_response(&response_frame)?;
+
+        (response.request_id == request_id).then_some(()).context(
+            error::ResponseRequestMismatchSnafu {
+                request_id,
+                response_id: response.request_id,
+            },
+        )?;
+
+        Ok(response)
+    }
+}
+
+/// Serialize a task request for transport.
+///
+/// # Errors
+///
+/// Returns [`Error::Encode`] if the request cannot be serialized.
+pub fn encode_request(request: &TaskRequest) -> Result<Vec<u8>> {
+    protocol::encode_request(request)
+}
+
+/// Deserialize a task request from transport bytes.
+///
+/// # Errors
+///
+/// Returns [`Error::Decode`] if the frame is malformed.
+pub fn decode_request(bytes: &[u8]) -> Result<TaskRequest> {
+    protocol::decode_request(bytes)
+}
+
+/// Serialize a task response for transport.
+///
+/// # Errors
+///
+/// Returns [`Error::Encode`] if the response cannot be serialized.
+pub fn encode_response(response: &TaskResponse) -> Result<Vec<u8>> {
+    protocol::encode_response(response)
+}
+
+/// Deserialize a task response from transport bytes.
+///
+/// # Errors
+///
+/// Returns [`Error::Decode`] if the frame is malformed.
+pub fn decode_response(bytes: &[u8]) -> Result<TaskResponse> {
+    protocol::decode_response(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use compact_str::CompactString;
+    use ulid::Ulid;
+
+    use super::{
+        Capability, CapabilityGrant, DeviceIdentityRef, Error, IdentityKind, TaskRequest,
+        decode_request, encode_request,
+    };
+
+    #[test]
+    fn crate_exports_encode_decode_round_trip() -> Result<(), Error> {
+        let request = TaskRequest::LookupContact {
+            request_id: Ulid::from_bytes([3; 16]),
+            identity: DeviceIdentityRef::new(IdentityKind::Device, "device-ref", [9; 32]),
+            grants: vec![CapabilityGrant::new(
+                Capability::ContactsRead,
+                "policy",
+                "grant-contact",
+            )],
+            query: CompactString::from("Ada"),
+        };
+
+        let encoded = encode_request(&request)?;
+        let decoded = decode_request(&encoded)?;
+
+        assert_eq!(decoded, request);
+        Ok(())
+    }
+}

--- a/crates/metaxu/src/protocol.rs
+++ b/crates/metaxu/src/protocol.rs
@@ -1,0 +1,377 @@
+//! Wire protocol types for the Aletheia/Thumos bridge.
+
+use compact_str::CompactString;
+use jiff::Timestamp;
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt as _;
+use ulid::Ulid;
+
+use crate::error::{EncodeSnafu, Result};
+
+mod ulid_bytes {
+    use serde::{Deserialize as _, Serialize as _, Serializer};
+    use ulid::Ulid;
+
+    pub(crate) fn serialize<S>(id: &Ulid, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        id.to_bytes().serialize(serializer)
+    }
+
+    pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<Ulid, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let bytes = <[u8; 16]>::deserialize(deserializer)?;
+        Ok(Ulid::from_bytes(bytes))
+    }
+}
+
+/// Capability classes that a runtime task may exercise through Thumos.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum Capability {
+    /// Send an SMS through the telephony stack.
+    SmsSend,
+    /// Place an outbound voice call.
+    CallDial,
+    /// Read contact records.
+    ContactsRead,
+    /// Capture microphone audio.
+    AudioCapture,
+    /// Play audio through the device speaker or receiver path.
+    AudioPlayback,
+    /// Reference the device identity handle without exposing raw identifiers.
+    DeviceIdentityReference,
+}
+
+/// Wire claim that a task was issued one bridge capability.
+///
+/// `metaxu` does not authenticate or authorize grants. Thumos policy or the
+/// Menos-facing runtime must validate issuer, grant id, expiration, and any
+/// cryptographic proof before performing a device action.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilityGrant {
+    /// Capability being granted.
+    pub capability: Capability,
+    /// Opaque issuer handle from Thumos policy.
+    pub issuer: CompactString,
+    /// Optional task-scoped grant identifier.
+    pub grant_id: CompactString,
+    /// Optional expiration timestamp for the external policy verifier.
+    pub expires_at: Option<Timestamp>,
+}
+
+impl CapabilityGrant {
+    /// Construct a non-expiring capability grant.
+    #[must_use]
+    pub fn new(
+        capability: Capability,
+        issuer: impl Into<CompactString>,
+        grant_id: impl Into<CompactString>,
+    ) -> Self {
+        Self {
+            capability,
+            issuer: issuer.into(),
+            grant_id: grant_id.into(),
+            expires_at: None,
+        }
+    }
+
+    /// Construct a capability grant with an absolute expiration.
+    #[must_use]
+    pub fn expiring(
+        capability: Capability,
+        issuer: impl Into<CompactString>,
+        grant_id: impl Into<CompactString>,
+        expires_at: Timestamp,
+    ) -> Self {
+        Self {
+            capability,
+            issuer: issuer.into(),
+            grant_id: grant_id.into(),
+            expires_at: Some(expires_at),
+        }
+    }
+}
+
+/// Kind of identity handle referenced by a task.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum IdentityKind {
+    /// Stable local device handle.
+    Device,
+    /// Per-session pseudonymous handle.
+    Session,
+    /// Per-capability pseudonymous handle.
+    Capability,
+}
+
+/// Opaque reference to device identity state.
+///
+/// This type deliberately carries a handle and attestation digest instead of
+/// raw IMEI, IMSI, MAC, Bluetooth address, or similar hardware identifiers.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeviceIdentityRef {
+    /// Identity reference class.
+    pub kind: IdentityKind,
+    /// Opaque handle generated inside Thumos.
+    pub handle: CompactString,
+    /// Digest binding this handle to local policy state.
+    pub attestation_digest: [u8; 32],
+}
+
+impl DeviceIdentityRef {
+    /// Construct an opaque device identity reference.
+    #[must_use]
+    pub fn new(
+        kind: IdentityKind,
+        handle: impl Into<CompactString>,
+        attestation_digest: [u8; 32],
+    ) -> Self {
+        Self {
+            kind,
+            handle: handle.into(),
+            attestation_digest,
+        }
+    }
+}
+
+/// Audio route requested by an audio task.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum AudioMode {
+    /// Microphone capture.
+    Capture,
+    /// Playback to the current policy-selected output.
+    Playback,
+}
+
+/// Typed task request sent from Thumos to the runtime boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum TaskRequest {
+    /// Send an SMS message.
+    SendSms {
+        /// Request identifier.
+        #[serde(with = "ulid_bytes")]
+        request_id: Ulid,
+        /// Opaque device identity reference.
+        identity: DeviceIdentityRef,
+        /// Capability grants attached to the task.
+        grants: Vec<CapabilityGrant>,
+        /// Destination address or contact-resolved route.
+        to: CompactString,
+        /// SMS body text.
+        body: CompactString,
+    },
+    /// Place an outbound call.
+    PlaceCall {
+        /// Request identifier.
+        #[serde(with = "ulid_bytes")]
+        request_id: Ulid,
+        /// Opaque device identity reference.
+        identity: DeviceIdentityRef,
+        /// Capability grants attached to the task.
+        grants: Vec<CapabilityGrant>,
+        /// Destination number or contact-resolved route.
+        to: CompactString,
+    },
+    /// Query local contacts through a capability-gated view.
+    LookupContact {
+        /// Request identifier.
+        #[serde(with = "ulid_bytes")]
+        request_id: Ulid,
+        /// Opaque device identity reference.
+        identity: DeviceIdentityRef,
+        /// Capability grants attached to the task.
+        grants: Vec<CapabilityGrant>,
+        /// Search query.
+        query: CompactString,
+    },
+    /// Request an audio capture or playback session.
+    AudioSession {
+        /// Request identifier.
+        #[serde(with = "ulid_bytes")]
+        request_id: Ulid,
+        /// Opaque device identity reference.
+        identity: DeviceIdentityRef,
+        /// Capability grants attached to the task.
+        grants: Vec<CapabilityGrant>,
+        /// Audio operation mode.
+        mode: AudioMode,
+        /// Maximum duration in milliseconds.
+        max_duration_ms: u32,
+    },
+}
+
+impl TaskRequest {
+    /// Return the task request identifier.
+    #[must_use]
+    pub const fn request_id(&self) -> Ulid {
+        match self {
+            Self::SendSms { request_id, .. }
+            | Self::PlaceCall { request_id, .. }
+            | Self::LookupContact { request_id, .. }
+            | Self::AudioSession { request_id, .. } => *request_id,
+        }
+    }
+
+    /// Return the identity reference carried by the task.
+    #[must_use]
+    pub const fn identity(&self) -> &DeviceIdentityRef {
+        match self {
+            Self::SendSms { identity, .. }
+            | Self::PlaceCall { identity, .. }
+            | Self::LookupContact { identity, .. }
+            | Self::AudioSession { identity, .. } => identity,
+        }
+    }
+
+    /// Return the capability grants carried by the task.
+    #[must_use]
+    pub fn grants(&self) -> &[CapabilityGrant] {
+        match self {
+            Self::SendSms { grants, .. }
+            | Self::PlaceCall { grants, .. }
+            | Self::LookupContact { grants, .. }
+            | Self::AudioSession { grants, .. } => grants,
+        }
+    }
+
+    /// Return the capability required by this task.
+    #[must_use]
+    pub const fn required_capability(&self) -> Capability {
+        match self {
+            Self::SendSms { .. } => Capability::SmsSend,
+            Self::PlaceCall { .. } => Capability::CallDial,
+            Self::LookupContact { .. } => Capability::ContactsRead,
+            Self::AudioSession { mode, .. } => match mode {
+                AudioMode::Capture => Capability::AudioCapture,
+                AudioMode::Playback => Capability::AudioPlayback,
+            },
+        }
+    }
+
+    /// Return whether a grant for the required capability is attached.
+    ///
+    /// This is a local preflight check only. It does not prove authorization or
+    /// enforce expiration; the runtime/policy verifier remains authoritative.
+    #[must_use]
+    pub fn has_required_capability(&self) -> bool {
+        let required = self.required_capability();
+        self.grants()
+            .iter()
+            .any(|grant| grant.capability == required)
+    }
+}
+
+/// Contact result returned from the runtime boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContactSummary {
+    /// Stable contact handle, not a raw storage key.
+    pub contact_ref: CompactString,
+    /// Display name.
+    pub display_name: CompactString,
+    /// Preferred dial or message route.
+    pub preferred_route: Option<CompactString>,
+}
+
+/// Device-side action accepted by the runtime boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum DeviceAction {
+    /// No device action is required.
+    None,
+    /// SMS may be queued locally.
+    SmsQueued {
+        /// Runtime correlation reference for the queued SMS.
+        runtime_ref: CompactString,
+    },
+    /// Call may be requested locally.
+    CallRequested {
+        /// Runtime correlation reference for the call.
+        runtime_ref: CompactString,
+    },
+    /// Contacts resolved by the runtime boundary.
+    Contacts {
+        /// Matching contacts.
+        contacts: Vec<ContactSummary>,
+    },
+    /// Audio session may be opened locally.
+    AudioSession {
+        /// Runtime correlation reference for the audio session.
+        runtime_ref: CompactString,
+        /// Audio operation mode.
+        mode: AudioMode,
+    },
+}
+
+/// Runtime response status.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum TaskStatus {
+    /// Request accepted with a device-side action.
+    Accepted {
+        /// Action for the device side.
+        action: DeviceAction,
+    },
+    /// Request rejected by bridge/runtime policy.
+    Rejected {
+        /// Human-readable policy reason.
+        reason: CompactString,
+    },
+}
+
+/// Response returned from the runtime boundary to Thumos.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskResponse {
+    /// Request identifier this response answers.
+    #[serde(with = "ulid_bytes")]
+    pub request_id: Ulid,
+    /// Response status.
+    pub status: TaskStatus,
+}
+
+impl TaskResponse {
+    /// Construct an accepted response.
+    #[must_use]
+    pub const fn accepted(request_id: Ulid, action: DeviceAction) -> Self {
+        Self {
+            request_id,
+            status: TaskStatus::Accepted { action },
+        }
+    }
+
+    /// Construct a rejected response.
+    #[must_use]
+    pub fn rejected(request_id: Ulid, reason: impl Into<CompactString>) -> Self {
+        Self {
+            request_id,
+            status: TaskStatus::Rejected {
+                reason: reason.into(),
+            },
+        }
+    }
+}
+
+/// Serialize a task request for transport.
+pub(crate) fn encode_request(request: &TaskRequest) -> Result<Vec<u8>> {
+    postcard::to_allocvec(request).context(EncodeSnafu)
+}
+
+/// Deserialize a task request from transport bytes.
+pub(crate) fn decode_request(bytes: &[u8]) -> Result<TaskRequest> {
+    postcard::from_bytes(bytes).context(crate::error::DecodeSnafu)
+}
+
+/// Serialize a task response for transport.
+pub(crate) fn encode_response(response: &TaskResponse) -> Result<Vec<u8>> {
+    postcard::to_allocvec(response).context(EncodeSnafu)
+}
+
+/// Deserialize a task response from transport bytes.
+pub(crate) fn decode_response(bytes: &[u8]) -> Result<TaskResponse> {
+    postcard::from_bytes(bytes).context(crate::error::DecodeSnafu)
+}

--- a/crates/metaxu/src/transport.rs
+++ b/crates/metaxu/src/transport.rs
@@ -1,0 +1,13 @@
+//! Transport abstraction for bridge frames.
+
+use crate::Result;
+
+/// Synchronous request/response transport for serialized bridge frames.
+///
+/// Implementations may be in-memory, IPC-backed, socket-backed, or any other
+/// Menos-facing mechanism. This trait is byte-oriented so tests can exercise
+/// serialization without requiring a live runtime connection.
+pub trait BridgeTransport /* kanon:ignore RUST/pub-visibility -- public API */ {
+    /// Exchange one serialized task request for one serialized task response.
+    fn exchange(&mut self, request_frame: &[u8]) -> Result<Vec<u8>>;
+}


### PR DESCRIPTION
## Summary
- Adds `metaxu`, a thin Aletheia/Thumos capability bridge crate.
- Defines typed task requests/responses, opaque device identity references, capability grant claims, and a synchronous byte transport.
- Documents that grant authentication/expiry enforcement belongs to Thumos policy or the Menos-facing runtime, not this wire crate.
- Adds in-memory round-trip coverage for SMS and crate export encode/decode coverage.

## Gates
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --jobs 8`
- `cargo test --workspace --jobs 8`
- `cargo clippy --workspace --all-targets --jobs 8 -- -D warnings`
- `kanon lint . --paths-from /tmp/thumos-141.paths --summary`
- `git diff --check`

Note: full-tree `kanon lint . --summary` is blocked by pre-existing baseline findings outside this PR scope.

QA: read-only DIFF-VERIFY completed; follow-up clarified capability grants as unauthenticated wire claims.

Refs #141