### PR TITLE
fix(krypta): replace ring with rustcrypto primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,15 +77,21 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "az"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bit-set"
@@ -110,9 +116,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -142,16 +148,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
-]
-
-[[package]]
-name = "cc"
-version = "1.2.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
-dependencies = [
- "find-msvc-tools",
- "shlex",
 ]
 
 [[package]]
@@ -195,6 +191,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +232,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +277,30 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -297,7 +360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -307,10 +370,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
-name = "find-msvc-tools"
-version = "0.1.9"
+name = "fiat-crypto"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "float-cmp"
@@ -446,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heapless"
@@ -481,6 +544,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,7 +574,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -524,9 +596,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "392c70591e8749fe235ddaf513e6f58b26bce3dcc16524cecc8936f75afa161e"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -534,14 +606,14 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-link",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "47b605b0c050d845fc355bb11eb3f9a8deddc218ea60c76e61aa1f2adfb2c96a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -597,11 +669,17 @@ dependencies = [
 name = "krypta"
 version = "0.1.5"
 dependencies = [
+ "aes-gcm",
+ "ed25519-dalek",
+ "getrandom 0.4.2",
+ "hkdf",
+ "hmac",
  "log",
  "postcard",
- "ring",
  "serde",
+ "sha2",
  "snafu",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -623,9 +701,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
@@ -644,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "managed"
@@ -725,6 +803,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,9 +832,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -800,7 +888,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "num-traits",
  "rand",
  "rand_chacha",
@@ -849,9 +937,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -901,20 +989,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.17",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,11 +1003,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -979,9 +1053,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1015,9 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -1049,10 +1123,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "shlex"
-version = "1.3.0"
+name = "signature"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
 
 [[package]]
 name = "slab"
@@ -1101,6 +1178,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -1159,7 +1246,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1195,9 +1282,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ulid"
@@ -1237,12 +1324,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1265,11 +1346,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -1278,7 +1359,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -1354,7 +1435,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -1378,85 +1459,12 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -1466,6 +1474,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -1516,7 +1530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",
@@ -1544,6 +1558,18 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
 ]
 
 [[package]]
@@ -1581,6 +1607,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,12 +73,14 @@ rustix = { version = "1", features = [
 
 # Crypto
 aes-gcm = "0.10"
+ed25519-dalek = "2"
 getrandom = "0.4"
+hkdf = "0.12"
 hmac = "0.12"
 pbkdf2 = "0.12"
-ring = "0.17"
 sha1 = "0.10"
 sha2 = "0.10"
+x25519-dalek = { version = "2", features = ["static_secrets", "zeroize"] }
 
 # Networking
 smoltcp = { version = "0.12", default-features = false, features = [

--- a/crates/krypta/Cargo.toml
+++ b/crates/krypta/Cargo.toml
@@ -8,11 +8,17 @@ publish.workspace = true
 repository.workspace = true
 
 [dependencies]
-ring = { workspace = true }
+aes-gcm = { workspace = true }
+ed25519-dalek = { workspace = true }
+getrandom = { workspace = true }
+hkdf = { workspace = true }
+hmac = { workspace = true }
+sha2 = { workspace = true }
 snafu = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
 postcard = { workspace = true }
+x25519-dalek = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/krypta/src/identity.rs
+++ b/crates/krypta/src/identity.rs
@@ -1,11 +1,11 @@
 //! Ed25519 identity key pairs for signing and authentication.
 
-use ring::rand::SystemRandom;
-use ring::signature::{ED25519, Ed25519KeyPair, KeyPair, UnparsedPublicKey};
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
 
 use crate::error::{InvalidKeySnafu, InvalidSignatureSnafu, KeyGenerationSnafu, Result};
 
 const PUBLIC_KEY_LEN: usize = 32;
+const PRIVATE_KEY_LEN: usize = 32;
 
 /// Ed25519 public identity key (32 bytes).
 #[derive(Clone, PartialEq, Eq)]
@@ -25,7 +25,11 @@ impl PublicIdentityKey {
 
 impl std::fmt::Debug for PublicIdentityKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "PublicIdentityKey({:02x}{:02x}..)", self.0[0], self.0[1])
+        write!(f, "PublicIdentityKey(")?;
+        for byte in self.0.iter().take(2) {
+            write!(f, "{byte:02x}")?;
+        }
+        write!(f, "..)")
     }
 }
 
@@ -40,8 +44,8 @@ impl std::fmt::Display for PublicIdentityKey {
 
 /// Ed25519 identity key pair. Holds private key material; never logged.
 pub(crate) struct IdentityKeyPair {
-    /// PKCS#8-encoded Ed25519 private key.
-    pkcs8_bytes: Vec<u8>,
+    /// Raw Ed25519 signing seed.
+    private_key_bytes: [u8; PRIVATE_KEY_LEN],
     /// Cached public key bytes (32 bytes).
     public_key_bytes: [u8; PUBLIC_KEY_LEN],
 }
@@ -61,16 +65,12 @@ impl IdentityKeyPair {
     ///
     /// Returns [`Error::KeyGeneration`] if key generation or parsing fails.
     pub(crate) fn generate() -> Result<Self> {
-        let rng = SystemRandom::new();
-        let pkcs8_doc =
-            Ed25519KeyPair::generate_pkcs8(&rng).map_err(|_| KeyGenerationSnafu.build())?;
-        let key_pair = Ed25519KeyPair::from_pkcs8(pkcs8_doc.as_ref())
-            .map_err(|_| KeyGenerationSnafu.build())?;
-        let pub_bytes = key_pair.public_key().as_ref();
-        let mut public_key_bytes = [0u8; PUBLIC_KEY_LEN];
-        public_key_bytes.copy_from_slice(pub_bytes);
+        let mut private_key_bytes = [0u8; PRIVATE_KEY_LEN];
+        getrandom::fill(&mut private_key_bytes).map_err(|_| KeyGenerationSnafu.build())?;
+        let key_pair = SigningKey::from_bytes(&private_key_bytes);
+        let public_key_bytes = key_pair.verifying_key().to_bytes();
         Ok(Self {
-            pkcs8_bytes: pkcs8_doc.as_ref().to_vec(),
+            private_key_bytes,
             public_key_bytes,
         })
     }
@@ -86,9 +86,8 @@ impl IdentityKeyPair {
     ///
     /// Returns [`Error::InvalidKey`] if the stored key bytes are malformed.
     pub(crate) fn sign(&self, data: &[u8]) -> Result<Vec<u8>> {
-        let key_pair =
-            Ed25519KeyPair::from_pkcs8(&self.pkcs8_bytes).map_err(|_| InvalidKeySnafu.build())?;
-        Ok(key_pair.sign(data).as_ref().to_vec())
+        let key_pair = SigningKey::from_bytes(&self.private_key_bytes);
+        Ok(key_pair.sign(data).to_bytes().to_vec())
     }
 
     /// Verifies an Ed25519 `signature` over `data` against `public_key`.
@@ -101,9 +100,11 @@ impl IdentityKeyPair {
         data: &[u8],
         signature: &[u8],
     ) -> Result<()> {
-        let pub_key = UnparsedPublicKey::new(&ED25519, public_key.as_bytes().as_ref());
+        let pub_key =
+            VerifyingKey::from_bytes(public_key.as_bytes()).map_err(|_| InvalidKeySnafu.build())?;
+        let sig = Signature::from_slice(signature).map_err(|_| InvalidSignatureSnafu.build())?;
         pub_key
-            .verify(data, signature)
+            .verify_strict(data, &sig)
             .map_err(|_| InvalidSignatureSnafu.build())
     }
 }
@@ -114,7 +115,13 @@ mod tests {
 
     #[test]
     fn generates_key_pair_without_error() -> Result<()> {
-        IdentityKeyPair::generate()?;
+        let key = IdentityKeyPair::generate()?;
+
+        assert_ne!(
+            key.public_key().as_bytes(),
+            &[0u8; PUBLIC_KEY_LEN],
+            "generated public key must not be all zeroes"
+        );
         Ok(())
     }
 
@@ -176,5 +183,37 @@ mod tests {
             "Ed25519 public key must be 32 bytes"
         );
         Ok(())
+    }
+
+    #[test]
+    fn ed25519_rfc8032_test_vector_1_signs_and_verifies() -> Result<()> {
+        let private_key_bytes = [
+            0x9d, 0x61, 0xb1, 0x9d, 0xef, 0xfd, 0x5a, 0x60, 0xba, 0x84, 0x4a, 0xf4, 0x92, 0xec,
+            0x2c, 0xc4, 0x44, 0x49, 0xc5, 0x69, 0x7b, 0x32, 0x69, 0x19, 0x70, 0x3b, 0xac, 0x03,
+            0x1c, 0xae, 0x7f, 0x60,
+        ];
+        let public_key_bytes = [
+            0xd7, 0x5a, 0x98, 0x01, 0x82, 0xb1, 0x0a, 0xb7, 0xd5, 0x4b, 0xfe, 0xd3, 0xc9, 0x64,
+            0x07, 0x3a, 0x0e, 0xe1, 0x72, 0xf3, 0xda, 0xa6, 0x23, 0x25, 0xaf, 0x02, 0x1a, 0x68,
+            0xf7, 0x07, 0x51, 0x1a,
+        ];
+        let expected_signature = [
+            0xe5, 0x56, 0x43, 0x00, 0xc3, 0x60, 0xac, 0x72, 0x90, 0x86, 0xe2, 0xcc, 0x80, 0x6e,
+            0x82, 0x8a, 0x84, 0x87, 0x7f, 0x1e, 0xb8, 0xe5, 0xd9, 0x74, 0xd8, 0x73, 0xe0, 0x65,
+            0x22, 0x49, 0x01, 0x55, 0x5f, 0xb8, 0x82, 0x15, 0x90, 0xa3, 0x3b, 0xac, 0xc6, 0x1e,
+            0x39, 0x70, 0x1c, 0xf9, 0xb4, 0x6b, 0xd2, 0x5b, 0xf5, 0xf0, 0x59, 0x5b, 0xbe, 0x24,
+            0x65, 0x51, 0x41, 0x43, 0x8e, 0x7a, 0x10, 0x0b,
+        ];
+        let key = IdentityKeyPair {
+            private_key_bytes,
+            public_key_bytes,
+        };
+        let signature = key.sign(b"")?;
+
+        assert_eq!(
+            signature, expected_signature,
+            "RFC 8032 Ed25519 test vector 1 signature must match"
+        );
+        IdentityKeyPair::verify(&key.public_key(), b"", &signature)
     }
 }

--- a/crates/krypta/src/ratchet.rs
+++ b/crates/krypta/src/ratchet.rs
@@ -1,9 +1,15 @@
 //! Symmetric ratchet: HMAC-SHA256 chain key advancement, AES-256-GCM message encryption.
 
-use ring::aead::{AES_256_GCM, Aad, LessSafeKey, NONCE_LEN, Nonce, UnboundKey};
-use ring::hmac::{self, HMAC_SHA256};
+use aes_gcm::aead::{AeadInPlace, KeyInit};
+use aes_gcm::{Aes256Gcm, Nonce};
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
 
 use crate::error::{DecryptionSnafu, EncryptionSnafu, InvalidKeySnafu, Result};
+
+const NONCE_LEN: usize = 12;
+
+type HmacSha256 = Hmac<Sha256>;
 
 /// Byte appended to chain key for message key derivation: HMAC(CK, 0x01).
 const MK_LABEL: &[u8] = &[0x01];
@@ -58,14 +64,15 @@ impl std::fmt::Debug for RatchetState {
 /// Returns [`Error::InvalidKey`] if the derived message key is malformed.
 /// Returns [`Error::Encryption`] if AES-256-GCM sealing fails.
 pub(crate) fn encrypt(state: &mut RatchetState, plaintext: &[u8]) -> Result<CiphertextMessage> {
-    let message_key = derive_message_key(&state.chain_key);
-    let next_chain_key = derive_next_chain_key(&state.chain_key);
+    let message_key = derive_message_key(&state.chain_key)?;
+    let next_chain_key = derive_next_chain_key(&state.chain_key)?;
 
     let nonce = counter_nonce(state.counter);
-    let key = make_aes_key(&message_key)?;
+    let cipher = make_aes_cipher(&message_key)?;
 
     let mut in_out = plaintext.to_vec();
-    key.seal_in_place_append_tag(nonce, Aad::empty(), &mut in_out)
+    cipher
+        .encrypt_in_place(Nonce::from_slice(&nonce), b"", &mut in_out)
         .map_err(|_| EncryptionSnafu.build())?;
 
     let counter = state.counter;
@@ -85,49 +92,47 @@ pub(crate) fn encrypt(state: &mut RatchetState, plaintext: &[u8]) -> Result<Ciph
 /// Returns [`Error::InvalidKey`] if the derived message key is malformed.
 /// Returns [`Error::Decryption`] if AES-256-GCM authentication or decryption fails.
 pub(crate) fn decrypt(state: &mut RatchetState, msg: &CiphertextMessage) -> Result<Vec<u8>> {
-    let message_key = derive_message_key(&state.chain_key);
-    let next_chain_key = derive_next_chain_key(&state.chain_key);
+    let message_key = derive_message_key(&state.chain_key)?;
+    let next_chain_key = derive_next_chain_key(&state.chain_key)?;
 
     let nonce = counter_nonce(msg.counter);
-    let key = make_aes_key(&message_key)?;
+    let cipher = make_aes_cipher(&message_key)?;
 
     let mut in_out = msg.ciphertext.clone();
-    let plaintext_slice = key
-        .open_in_place(nonce, Aad::empty(), &mut in_out)
+    cipher
+        .decrypt_in_place(Nonce::from_slice(&nonce), b"", &mut in_out)
         .map_err(|_| DecryptionSnafu.build())?;
-    let plaintext = plaintext_slice.to_vec();
 
     state.chain_key = next_chain_key;
     state.counter = state.counter.wrapping_add(1);
 
-    Ok(plaintext)
+    Ok(in_out)
 }
 
-fn derive_message_key(chain_key: &[u8; 32]) -> [u8; 32] {
-    let key = hmac::Key::new(HMAC_SHA256, chain_key);
-    let tag = hmac::sign(&key, MK_LABEL);
+fn derive_message_key(chain_key: &[u8; 32]) -> Result<[u8; 32]> {
+    hmac_sha256(chain_key, MK_LABEL)
+}
+
+fn derive_next_chain_key(chain_key: &[u8; 32]) -> Result<[u8; 32]> {
+    hmac_sha256(chain_key, CK_LABEL)
+}
+
+fn hmac_sha256(key: &[u8; 32], data: &[u8]) -> Result<[u8; 32]> {
+    let mut mac = <HmacSha256 as Mac>::new_from_slice(key).map_err(|_| InvalidKeySnafu.build())?;
+    mac.update(data);
+    let tag = mac.finalize().into_bytes();
     let mut out = [0u8; 32];
-    out.copy_from_slice(tag.as_ref());
-    out
+    out.copy_from_slice(&tag);
+    Ok(out)
 }
 
-fn derive_next_chain_key(chain_key: &[u8; 32]) -> [u8; 32] {
-    let key = hmac::Key::new(HMAC_SHA256, chain_key);
-    let tag = hmac::sign(&key, CK_LABEL);
-    let mut out = [0u8; 32];
-    out.copy_from_slice(tag.as_ref());
-    out
+const fn counter_nonce(counter: u32) -> [u8; NONCE_LEN] {
+    let [b0, b1, b2, b3] = counter.to_le_bytes();
+    [b0, b1, b2, b3, 0, 0, 0, 0, 0, 0, 0, 0]
 }
 
-fn counter_nonce(counter: u32) -> Nonce {
-    let mut nonce_bytes = [0u8; NONCE_LEN];
-    nonce_bytes[..4].copy_from_slice(&counter.to_le_bytes());
-    Nonce::assume_unique_for_key(nonce_bytes)
-}
-
-fn make_aes_key(key_bytes: &[u8; 32]) -> Result<LessSafeKey> {
-    let unbound = UnboundKey::new(&AES_256_GCM, key_bytes).map_err(|_| InvalidKeySnafu.build())?;
-    Ok(LessSafeKey::new(unbound))
+fn make_aes_cipher(key_bytes: &[u8; 32]) -> Result<Aes256Gcm> {
+    Aes256Gcm::new_from_slice(key_bytes).map_err(|_| InvalidKeySnafu.build())
 }
 
 #[cfg(test)]

--- a/crates/krypta/src/x3dh.rs
+++ b/crates/krypta/src/x3dh.rs
@@ -1,7 +1,8 @@
 //! X3DH-style key agreement: pre-key bundles, X25519 ECDH, HKDF session key derivation.
 
-use ring::agreement::{EphemeralPrivateKey, UnparsedPublicKey, X25519};
-use ring::rand::SystemRandom;
+use hkdf::Hkdf;
+use sha2::Sha256;
+use x25519_dalek::{PublicKey, StaticSecret};
 
 use crate::error::{KeyAgreementSnafu, KeyDerivationSnafu, KeyGenerationSnafu, Result};
 use crate::identity::{IdentityKeyPair, PublicIdentityKey};
@@ -27,8 +28,8 @@ pub(crate) struct PreKeyBundle {
 pub(crate) struct OwnedBundle {
     /// Public side  -  share this with initiators.
     pub(crate) public_bundle: PreKeyBundle,
-    signed_prekey_private: EphemeralPrivateKey,
-    one_time_prekey_private: Option<EphemeralPrivateKey>,
+    signed_prekey_private: StaticSecret,
+    one_time_prekey_private: Option<StaticSecret>,
 }
 
 impl std::fmt::Debug for OwnedBundle {
@@ -94,11 +95,9 @@ pub(crate) struct InitiatorMessage {
 /// Returns [`Error::KeyGeneration`] if key generation fails.
 /// Returns [`Error::InvalidKey`] if the signing step fails.
 pub(crate) fn create_bundle(identity: &IdentityKeyPair) -> Result<OwnedBundle> {
-    let rng = SystemRandom::new();
-
-    let (spk_priv, spk_pub) = generate_x25519(&rng)?;
+    let (spk_priv, spk_pub) = generate_x25519()?;
     let prekey_signature = identity.sign(&spk_pub)?;
-    let (otpk_priv, otpk_pub) = generate_x25519(&rng)?;
+    let (otpk_priv, otpk_pub) = generate_x25519()?;
 
     Ok(OwnedBundle {
         public_bundle: PreKeyBundle {
@@ -127,24 +126,23 @@ pub(crate) fn initiate_session(
     our_identity: &IdentityKeyPair,
     their_bundle: &PreKeyBundle,
 ) -> Result<(SharedSecret, SessionKeys, InitiatorMessage)> {
-    let rng = SystemRandom::new();
-
     // Primary ephemeral key for DH with signed pre-key.
-    let (spk_eph_priv, spk_eph_pub) = generate_x25519(&rng)?;
-    let dh1 = agree(spk_eph_priv, &their_bundle.signed_prekey)?;
+    let (spk_eph_priv, spk_eph_pub) = generate_x25519()?;
+    let dh1 = agree(&spk_eph_priv, &their_bundle.signed_prekey)?;
 
     // Optional second ephemeral key for DH with one-time pre-key.
-    // Each DH uses a separate key because ring consumes EphemeralPrivateKey on use.
+    // Each DH uses separate initiator key material so every advertised public
+    // key maps to one X25519 operation.
     // The second ephemeral public key is included in InitiatorMessage so the
     // responder can compute the matching DH output.
     let (ikm, otp_eph_pub) = match their_bundle.one_time_prekey {
         Some(bundle_otp_pub) => {
-            let (otp_eph_priv, otp_pub) = generate_x25519(&rng)?;
-            let dh2 = agree(otp_eph_priv, &bundle_otp_pub)?;
-            let mut combined = [0u8; 64];
-            combined[..32].copy_from_slice(&dh1);
-            combined[32..].copy_from_slice(&dh2);
-            (combined.to_vec(), Some(otp_pub))
+            let (otp_eph_priv, otp_pub) = generate_x25519()?;
+            let dh2 = agree(&otp_eph_priv, &bundle_otp_pub)?;
+            let mut combined = Vec::with_capacity(64);
+            combined.extend_from_slice(&dh1);
+            combined.extend_from_slice(&dh2);
+            (combined, Some(otp_pub))
         }
         None => (dh1.to_vec(), None),
     };
@@ -173,16 +171,16 @@ pub(crate) fn respond_session(
     msg: &InitiatorMessage,
 ) -> Result<(SharedSecret, SessionKeys)> {
     // DH1: SPK_B_priv × EK_A_pub  -  mirrors initiate's EK_A × SPK_B.
-    let dh1 = agree(bundle.signed_prekey_private, &msg.ephemeral_key)?;
+    let dh1 = agree(&bundle.signed_prekey_private, &msg.ephemeral_key)?;
 
     let ikm = match (bundle.one_time_prekey_private, msg.one_time_ephemeral_key) {
         (Some(otpk_priv), Some(ek2_pub)) => {
             // DH2: OPK_B_priv × EK_A2_pub  -  mirrors initiate's EK_A2 × OPK_B.
-            let dh2 = agree(otpk_priv, &ek2_pub)?;
-            let mut combined = [0u8; 64];
-            combined[..32].copy_from_slice(&dh1);
-            combined[32..].copy_from_slice(&dh2);
-            combined.to_vec()
+            let dh2 = agree(&otpk_priv, &ek2_pub)?;
+            let mut combined = Vec::with_capacity(64);
+            combined.extend_from_slice(&dh1);
+            combined.extend_from_slice(&dh2);
+            combined
         }
         _ => dh1.to_vec(),
     };
@@ -191,30 +189,25 @@ pub(crate) fn respond_session(
 }
 
 /// Generates a fresh X25519 key pair, returning `(private_key, public_key_bytes)`.
-fn generate_x25519(rng: &SystemRandom) -> Result<(EphemeralPrivateKey, [u8; X25519_KEY_LEN])> {
-    let priv_key =
-        EphemeralPrivateKey::generate(&X25519, rng).map_err(|_| KeyGenerationSnafu.build())?;
-    let pub_ring = priv_key
-        .compute_public_key()
-        .map_err(|_| KeyGenerationSnafu.build())?;
-    let mut pub_bytes = [0u8; X25519_KEY_LEN];
-    pub_bytes.copy_from_slice(pub_ring.as_ref());
+fn generate_x25519() -> Result<(StaticSecret, [u8; X25519_KEY_LEN])> {
+    let mut private_bytes = [0u8; X25519_KEY_LEN];
+    getrandom::fill(&mut private_bytes).map_err(|_| KeyGenerationSnafu.build())?;
+    let priv_key = StaticSecret::from(private_bytes);
+    let pub_bytes = PublicKey::from(&priv_key).to_bytes();
     Ok((priv_key, pub_bytes))
 }
 
-fn agree(priv_key: EphemeralPrivateKey, peer_pub_bytes: &[u8]) -> Result<[u8; 32]> {
-    let peer = UnparsedPublicKey::new(&X25519, peer_pub_bytes);
-    ring::agreement::agree_ephemeral(priv_key, &peer, |key_material| {
-        let mut out = [0u8; 32];
-        out.copy_from_slice(key_material);
-        out
-    })
-    .map_err(|_| KeyAgreementSnafu.build())
+fn agree(priv_key: &StaticSecret, peer_pub_bytes: &[u8; X25519_KEY_LEN]) -> Result<[u8; 32]> {
+    let peer = PublicKey::from(*peer_pub_bytes);
+    let out = priv_key.diffie_hellman(&peer).to_bytes();
+    if out == [0u8; X25519_KEY_LEN] {
+        return Err(KeyAgreementSnafu.build());
+    }
+    Ok(out)
 }
 
 fn derive_keys(ikm: &[u8]) -> Result<(SharedSecret, SessionKeys)> {
-    let salt = ring::hkdf::Salt::new(ring::hkdf::HKDF_SHA256, &HKDF_SALT);
-    let prk = salt.extract(ikm);
+    let prk = Hkdf::<Sha256>::new(Some(&HKDF_SALT), ikm);
 
     let raw = hkdf_expand_32(&prk, b"X3DH shared secret")?;
     let i2r = hkdf_expand_32(&prk, b"initiator-to-responder")?;
@@ -229,19 +222,10 @@ fn derive_keys(ikm: &[u8]) -> Result<(SharedSecret, SessionKeys)> {
     ))
 }
 
-pub(crate) fn hkdf_expand_32(prk: &ring::hkdf::Prk, info: &[u8]) -> Result<[u8; 32]> {
-    struct Len32;
-    impl ring::hkdf::KeyType for Len32 {
-        fn len(&self) -> usize {
-            32
-        }
-    }
-    let info_slice = [info];
-    let okm = prk
-        .expand(&info_slice, Len32)
-        .map_err(|_| KeyDerivationSnafu.build())?;
+pub(crate) fn hkdf_expand_32(prk: &Hkdf<Sha256>, info: &[u8]) -> Result<[u8; 32]> {
     let mut out = [0u8; 32];
-    okm.fill(&mut out).map_err(|_| KeyDerivationSnafu.build())?;
+    prk.expand(info, &mut out)
+        .map_err(|_| KeyDerivationSnafu.build())?;
     Ok(out)
 }
 
@@ -253,7 +237,16 @@ mod tests {
     #[test]
     fn create_bundle_succeeds() -> Result<()> {
         let identity = IdentityKeyPair::generate()?;
-        create_bundle(&identity)?;
+        let bundle = create_bundle(&identity)?;
+
+        assert_ne!(
+            bundle.public_bundle.signed_prekey, [0u8; X25519_KEY_LEN],
+            "signed pre-key must not be all zeroes"
+        );
+        assert!(
+            bundle.public_bundle.one_time_prekey.is_some(),
+            "bundle must include an advertised one-time pre-key"
+        );
         Ok(())
     }
 
@@ -319,6 +312,74 @@ mod tests {
         assert_ne!(
             keys.initiator_to_responder, keys.responder_to_initiator,
             "send and receive keys must differ"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn x25519_rfc7748_known_answer() -> Result<()> {
+        let alice_private = [
+            0x77, 0x07, 0x6d, 0x0a, 0x73, 0x18, 0xa5, 0x7d, 0x3c, 0x16, 0xc1, 0x72, 0x51, 0xb2,
+            0x66, 0x45, 0xdf, 0x4c, 0x2f, 0x87, 0xeb, 0xc0, 0x99, 0x2a, 0xb1, 0x77, 0xfb, 0xa5,
+            0x1d, 0xb9, 0x2c, 0x2a,
+        ];
+        let alice_public = [
+            0x85, 0x20, 0xf0, 0x09, 0x89, 0x30, 0xa7, 0x54, 0x74, 0x8b, 0x7d, 0xdc, 0xb4, 0x3e,
+            0xf7, 0x5a, 0x0d, 0xbf, 0x3a, 0x0d, 0x26, 0x38, 0x1a, 0xf4, 0xeb, 0xa4, 0xa9, 0x8e,
+            0xaa, 0x9b, 0x4e, 0x6a,
+        ];
+        let bob_public = [
+            0xde, 0x9e, 0xdb, 0x7d, 0x7b, 0x7d, 0xc1, 0xb4, 0xd3, 0x5b, 0x61, 0xc2, 0xec, 0xe4,
+            0x35, 0x37, 0x3f, 0x83, 0x43, 0xc8, 0x5b, 0x78, 0x67, 0x4d, 0xad, 0xfc, 0x7e, 0x14,
+            0x6f, 0x88, 0x2b, 0x4f,
+        ];
+        let shared = [
+            0x4a, 0x5d, 0x9d, 0x5b, 0xa4, 0xce, 0x2d, 0xe1, 0x72, 0x8e, 0x3b, 0xf4, 0x80, 0x35,
+            0x0f, 0x25, 0xe0, 0x7e, 0x21, 0xc9, 0x47, 0xd1, 0x9e, 0x33, 0x76, 0xf0, 0x9b, 0x3c,
+            0x1e, 0x16, 0x17, 0x42,
+        ];
+        let alice_secret = StaticSecret::from(alice_private);
+
+        assert_eq!(
+            PublicKey::from(&alice_secret).to_bytes(),
+            alice_public,
+            "RFC 7748 Alice public key must match"
+        );
+        assert_eq!(
+            agree(&alice_secret, &bob_public)?,
+            shared,
+            "RFC 7748 X25519 shared secret must match"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn x25519_rejects_all_zero_shared_secret() {
+        let private_key = StaticSecret::from([0x11; X25519_KEY_LEN]);
+        assert!(
+            agree(&private_key, &[0u8; X25519_KEY_LEN]).is_err(),
+            "all-zero X25519 shared secret must be rejected"
+        );
+    }
+
+    #[test]
+    fn hkdf_rfc5869_sha256_test_case_1_first_32_bytes() -> Result<()> {
+        let salt = [
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+        ];
+        let info = [0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9];
+        let expected = [
+            0x3c, 0xb2, 0x5f, 0x25, 0xfa, 0xac, 0xd5, 0x7a, 0x90, 0x43, 0x4f, 0x64, 0xd0, 0x36,
+            0x2f, 0x2a, 0x2d, 0x2d, 0x0a, 0x90, 0xcf, 0x1a, 0x5a, 0x4c, 0x5d, 0xb0, 0x2d, 0x56,
+            0xec, 0xc4, 0xc5, 0xbf,
+        ];
+        let ikm = [0x0b; 22];
+        let prk = Hkdf::<Sha256>::new(Some(&salt), &ikm);
+
+        assert_eq!(
+            hkdf_expand_32(&prk, &info)?,
+            expected,
+            "RFC 5869 HKDF-SHA256 test case 1 prefix must match"
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary
- Replaces remaining `krypta` direct `ring` usage with RustCrypto/dalek primitives.
- Removes workspace `ring` and verifies no `ring`, `cc`, or `untrusted` packages remain in the workspace dependency tree.
- Adds Ed25519, X25519, HKDF, and all-zero shared-secret regression coverage.
- Rebases onto current `main` after PR #173 so `Cargo.lock` includes `metaxu` and remains conflict-free.

## Gates
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --jobs 8`
- `cargo test --workspace --jobs 8`
- `cargo clippy --workspace --all-targets --jobs 8 -- -D warnings`
- `kanon lint . --paths-from /tmp/thumos-146.paths --summary`
- `git diff --check`
- `cargo tree --workspace | rg "(^|[ ├└─])ring v|untrusted v|cc v"` returned no matches

Note: full-tree `kanon lint . --summary` is blocked by pre-existing baseline findings outside this PR scope.

Closes #146