### PR TITLE
fix(kernel): render initial home status frame

### DIFF
--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -11,6 +11,7 @@
 extern crate alloc;
 
 use core::fmt::Write;
+use core::slice;
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use crate::ccci::CcciDriver;
@@ -36,7 +37,10 @@ use crate::power::PowerManager;
 use crate::process;
 #[cfg(test)]
 use crate::ramfs::RamFs;
+use crate::screen_home::{HomeScreen, HomeScreenState, OperatingMode};
+use crate::status_bar::{KernelStatusBar, StatusBarState};
 use crate::uart::Uart;
+use crate::ui::{self, UiManager};
 use crate::usb::UsbController;
 use crate::watchdog;
 
@@ -271,6 +275,9 @@ const MODEM_BOOT_TIMEOUT_MS: u64 = 10_000;
 )]
 const PANIC_RED_RGB565: u16 = 0xF800;
 
+/// Number of RGB565 pixels in the hardware framebuffer.
+const FRAMEBUFFER_PIXELS: usize = ui::SCREEN_WIDTH as usize * ui::SCREEN_HEIGHT as usize;
+
 // ---------------------------------------------------------------------------
 // Panic display helper
 // ---------------------------------------------------------------------------
@@ -293,6 +300,35 @@ pub(crate) unsafe fn fill_framebuffer(fb_addr: usize, width: u32, height: u32, c
             core::ptr::write_volatile(ptr.add(i), color);
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Initial UI frame
+// ---------------------------------------------------------------------------
+
+/// Render the first user-visible home frame after boot-time hardware init.
+fn render_initial_home_frame(fb: &mut [u16], state: &BootState) {
+    let mut home = HomeScreen::new();
+    home.update_state(HomeScreenState {
+        epoch_secs: 0,
+        carrier: "",
+        mode: OperatingMode::Daily,
+        unread_count: 0,
+    });
+
+    let status = StatusBarState {
+        battery_pct: 0,
+        mode_badge: Some("DAILY"),
+        mode_badge_color: Some(ui::color::WHITE),
+        threat_high: !state.modem_ok,
+        ..StatusBarState::default()
+    };
+
+    UiManager::new().render(
+        &home,
+        |status_fb| KernelStatusBar::draw(status_fb, &status),
+        fb,
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -938,7 +974,21 @@ pub unsafe fn run() -> ! {
     let _ = serial.write_str("\r\n");
 
     // -----------------------------------------------------------------------
-    // Step 13: Spawn userspace processes FROM mounted root ramfs
+    // Step 13d: Initial UI home frame
+    // -----------------------------------------------------------------------
+    if state.display_ok {
+        let _ = serial.write_str("[init] Rendering home UI\r\n");
+        // SAFETY: state.display_ok is only set after display.init(FB_BASE)
+        // succeeds. That maps FB_BASE as a writable RGB565 framebuffer of
+        // SCREEN_WIDTH * SCREEN_HEIGHT pixels for the GC9306 panel.
+        let fb =
+            unsafe { slice::from_raw_parts_mut(kconfig::FB_BASE as *mut u16, FRAMEBUFFER_PIXELS) };
+        render_initial_home_frame(fb, &state);
+        let _ = serial.write_str("       Home/status frame rendered\r\n");
+    }
+
+    // -----------------------------------------------------------------------
+    // Step 14: Spawn userspace processes FROM mounted root ramfs
     // -----------------------------------------------------------------------
     let _ = serial
         .write_str("[init] Spawning userspace processes\r\n");

--- a/crates/thumos/src/screen_home.rs
+++ b/crates/thumos/src/screen_home.rs
@@ -12,12 +12,9 @@
 //! accepts a snapshot of the current state to avoid holding references
 //! to kernel globals across the render boundary.
 
-// WHY: home screen is created in Phase 07 Wave 1, not yet wired to kinit.
-#![expect(dead_code, reason = "Home screen created in Phase 07 Wave 1, kinit wiring pending")]
-
 use crate::ui::{
     self, color, Key, Screen, ScreenAction, ScreenId,
-    CHAR_HEIGHT, CHAR_WIDTH, CONTENT_HEIGHT, SCREEN_WIDTH,
+    CHAR_HEIGHT, CONTENT_HEIGHT, SCREEN_WIDTH,
 };
 
 // ---------------------------------------------------------------------------
@@ -44,12 +41,6 @@ const UNREAD_Y: u16 = MODE_Y + CHAR_HEIGHT + 4;
 /// Time is rendered at 2x the base font size (16x32 pixels per character).
 const TIME_SCALE: u16 = 2;
 
-/// Width of a scaled character.
-const SCALED_CHAR_WIDTH: u16 = CHAR_WIDTH * TIME_SCALE;
-
-/// Height of a scaled character.
-const SCALED_CHAR_HEIGHT: u16 = CHAR_HEIGHT * TIME_SCALE;
-
 // ---------------------------------------------------------------------------
 // Operating mode
 // ---------------------------------------------------------------------------
@@ -62,8 +53,10 @@ pub enum OperatingMode {
     #[default]
     Daily,
     /// Heightened awareness mode.
+    #[expect(dead_code, reason = "requires security mode manager state wiring")]
     Sentinel,
     /// Emergency mode.
+    #[expect(dead_code, reason = "requires security mode manager state wiring")]
     Panic,
 }
 

--- a/crates/thumos/src/status_bar.rs
+++ b/crates/thumos/src/status_bar.rs
@@ -23,9 +23,6 @@
 //! - [`BtState::Ready`] or [`BtState::Scanning`] -> "BT"
 //! - [`GpsState::FixAcquired`] -> "GPS"
 
-// WHY: status bar created in Phase 07 Wave 1, not yet called from kinit.
-#![expect(dead_code, reason = "Status bar created in Phase 07 Wave 1, kinit wiring pending")]
-
 use crate::ui::{
     self, color,
     CHAR_HEIGHT, CHAR_WIDTH, SCREEN_WIDTH, STATUS_BAR_HEIGHT,
@@ -43,10 +40,13 @@ pub enum NetworkService {
     #[default]
     NoService,
     /// 2G (GSM/EDGE).
+    #[expect(dead_code, reason = "requires modem registration state wiring")]
     Edge,
     /// 3G (WCDMA/HSPA).
+    #[expect(dead_code, reason = "requires modem registration state wiring")]
     ThreeG,
     /// 4G LTE.
+    #[expect(dead_code, reason = "requires modem registration state wiring")]
     Lte,
 }
 


### PR DESCRIPTION
## Summary
- Renders an initial Home UI/status frame after hardware init when the display is available.
- Wires `UiManager`, `HomeScreen`, and `KernelStatusBar` into the kernel boot path.
- Narrows dead-code expects in home/status UI modules to not-yet-wired variants.

## Gates
- `cargo fmt --all -- --check`
- `cd crates/thumos && cargo check`
- `cd crates/thumos && cargo check --release`
- `git diff --check`

Note: path-scoped `kanon lint` reports existing whole-file baseline findings in touched kernel files.

Refs #145