### PR TITLE
docs(kernel): audit unwired feature status

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Sovereign mobile OS for the AGM M7. Privacy-first, counter-surveillance, hardwar
 
 A custom Rust OS for the AGM M7 (MT6739, 1GB RAM, 240x320 QVGA, IP68) that gives the user complete sovereignty over their device. Full Rust from kernel to UI. Secure communication, counter-surveillance, proactive defense. No backdoors, no telemetry, no trust in infrastructure you don't control.
 
-> **Current status:** Active phase tracking, blockers, and hardware-validation status are maintained in the internal planning record.
+> **Current status:** The repository contains a broad compiled and tested software surface, but hardware validation and several boot/userspace wiring paths remain open.
 
 ## Name
 
@@ -39,21 +39,21 @@ MT6739 hardware (modem on separate core, firewalled at CCCI driver level)
 
 ## Status
 
-**Phase 11: System Qualification** (canonical tracker last updated 2026-04-20; phase status updated 2026-04-12). Hardware validation is pending on an AGM M7 factory firmware flash; software milestones through Phase 10 cover the compiled/tested surface, with end-to-end hardware, boot, and userspace wiring gaps tracked below.
+**Phase 11: System Qualification** (canonical tracker last updated 2026-04-20; phase status updated 2026-04-12). Hardware validation is pending on an AGM M7 factory firmware flash. Phase 10 names a compiled/tested code catalog, not a claim that every named capability is boot-wired, reachable from userspace, or hardware-ready.
 
-13 crates (12 userspace workspace members plus the `thumos` kernel binary, excluded from the main workspace for bare-metal builds), 2,313 tests (1,618 kernel + 695 workspace), ~102K LOC (81K kernel, 21K userspace), 107 kernel modules. Kernel implements 45 syscalls including fork/exec/waitpid, mmap/brk/mprotect, pipe/futex IPC, POSIX signals (sigaction/kill/sigreturn), clock_gettime/nanosleep, network sockets (TCP/UDP/bind/listen/accept/connect/sendto/recvfrom). Slab allocator (7 size classes), ChaCha20 CSPRNG, capability-based access control, DVFS power management, watchdog timer, VFS with LFS/ramfs/devfs, firewall with DNS blocklist, DHCP client, DNS resolver, 3-zone UI framework (240x320), telephony (AT modem, voice calls, SMS), audio session manager (MT6357 codec, priority preemption), battery monitor, T9 input, contacts, FM radio, BT A2DP, calendar/alarm/timer/stopwatch (heorte), mic audit log, measured boot (Ed25519), encrypted block device (AES-256-XTS), key hierarchy (PBKDF2+HKDF), lock screen (passphrase/PIN/duress), security modes (Daily/Sentinel/Panic/Covert Lock), HMAC-chain audit log, BFU auto-reboot timer, panic wipe, privacy dashboard, DNS-over-TLS, HTTP client, JSON parser, Matrix CS API (sync/rooms/send), Matrix E2E encryption (Olm/Megolm), USB credential provisioning, unified inbox (SMS + Matrix + Briar + Meshtastic with bridge support), voice-to-text (ekphrasis via aletheia STT), action proposals, Briar P2P messaging, Meshtastic LoRa mesh, nous AI entity management (capability presets, chat screen with action proposal cards), IMSI catcher scoring, Silent SMS detection, 2G refusal, CCCI traffic logger, modem baseline analysis, CCCI modem firewall, modem PMIC power cut, threat monitor screen. Hardware drivers: eMMC (MSDC), display (DDP + GC9306), WiFi MAC (randomization), BT HCI (LE Privacy), WMT, CCCI modem containment, USB ACM, GPIO keypad, touchscreen, GPS (NMEA), Bluetooth (STP/HCI).
+13 crates (12 userspace workspace members plus the `thumos` kernel binary, excluded from the main workspace for bare-metal builds), 2,313 tests (1,618 kernel + 695 workspace), ~102K LOC (81K kernel, 21K userspace), 107 kernel modules. The kernel has implemented and tested core surfaces including MMU, allocator, GIC/timer, scheduler, IPC, signals, 45 syscalls, VFS with LFS/ramfs/devfs, block cache, CSPRNG, capabilities, DVFS, watchdog, telephony parsing/containment, security modes, lock screen, audit log, panic wipe, measured boot primitives, encryption primitives, and several UI/radio/messaging modules. Named higher-level capabilities such as multi-screen UI routing, calendar/alarm runtime ownership, wall-clock trust selection, Bluetooth/GPS userspace control, BT audio, Matrix/voice assistant flows, and mesh/inbox integrations remain compiled surfaces unless a boot or userspace call path is listed in the wiring audit.
 
 _Phase, test split, LOC, and module totals are aligned to the internal project state record. Crate count was verified with `ls -d crates/*/ | wc -l` on 2026-05-04. A cheap source grep (`rg "#\[test\]" crates/ | wc -l`) reports 2,187 annotated test functions, so the canonical test inventory remains the source of truth without a full cargo listing._
 
 ### Known gaps
 
-The Phase 10 / Phase 11 status above describes the kernel's compiled and tested surface. The following surface is tracked as open work and is not yet wired end-to-end on hardware:
+The Phase 10 / Phase 11 status above describes compiled and tested surfaces, not end-to-end readiness. The following work is open and is not yet wired end-to-end on hardware:
 
 - [#141](https://github.com/forkwright/thumos/issues/141) — aletheia agent runtime bridge is not yet designed or wired
 - [#142](https://github.com/forkwright/thumos/issues/142) — boot-time security subsystems are success-without-work placeholders
 - [#143](https://github.com/forkwright/thumos/issues/143) — network stack still boots on a firewall-backed loopback path; WiFi driver remains unwired
 - Userspace image packaging remains incomplete: boot reports missing `/init` or `/shell` entries instead of spawning kernel-owned idle placeholders.
-- [#145](https://github.com/forkwright/thumos/issues/145) — advertised kernel features compiled but unwired: 46 crate-level expectation blocks, plus 43 item-level low-level dead-code suppressions tracked separately
+- [#145](https://github.com/forkwright/thumos/issues/145) — advertised kernel features compiled but unwired: current baseline is 8 crate-level `dead_code` expectations plus 48 item-level suppressions; see [kernel wiring audit](docs/KERNEL-WIRING-AUDIT.md)
 - [#146](https://github.com/forkwright/thumos/issues/146) — remaining direct `ring` dependency is isolated to `krypta` protocol crypto
 
 ## Related

--- a/_llm/current_state.toml
+++ b/_llm/current_state.toml
@@ -8,13 +8,13 @@ source_docs = [
 ]
 
 [state]
-summary = "Thumos software milestones through Phase 10 are complete; Phase 11 hardware validation is blocked on restoring AGM M7 factory firmware."
+summary = "Thumos has a broad compiled/tested Phase 10 code catalog, but Phase 11 hardware validation and several boot/userspace wiring paths remain open."
 current_phase = "Phase 11: System Qualification."
 updated = "2026-04-20"
 
 [[recent]]
 date = "2026-04-12"
-item = "Software phases 03-10 complete; no software blockers remain."
+item = "Software phases 03-10 produced compiled/tested surfaces; end-to-end wiring gaps remain tracked in repo issues."
 
 [[recent]]
 date = "2026-04-12"

--- a/crates/thumos/src/clock.rs
+++ b/crates/thumos/src/clock.rs
@@ -20,8 +20,9 @@
 //! server, parses the response for server transmit timestamp, and computes
 //! the clock offset. Uses the socket syscall layer (Wave 4) for UDP.
 
-// WHY: clock module provides wall-clock time but is not yet called from userspace.
-#![expect(dead_code, reason = "Clock module wired in kinit but not yet called from userspace")]
+// WHY: clock module provides wall-clock policy, but kernel time and userspace
+// syscalls still use the lower-level timer/time paths.
+#![expect(dead_code, reason = "Clock trust manager is not wired into kernel time")]
 
 extern crate alloc;
 

--- a/crates/thumos/src/heorte.rs
+++ b/crates/thumos/src/heorte.rs
@@ -24,8 +24,9 @@
 //! - Tick-based timing: callers pass the current kernel tick count; the engine
 //!   computes elapsed time from deltas rather than polling a clock.
 
-// WHY: heorte module created in Phase 07 Wave 7, kinit wiring pending.
-#![expect(dead_code, reason = "Heorte created in Phase 07 Wave 7, kinit wiring pending")]
+// WHY: the engine is compiled and tested but no boot-time runtime manager
+// owns calendar/alarm/timer state yet.
+#![expect(dead_code, reason = "Heorte runtime manager is not wired into kinit")]
 
 extern crate alloc;
 use alloc::vec::Vec;

--- a/crates/thumos/src/heorte_timer.rs
+++ b/crates/thumos/src/heorte_timer.rs
@@ -4,8 +4,9 @@
 //! recording). Both use tick-based timing: callers pass the current kernel
 //! tick count and the engine computes elapsed time from deltas.
 
-// WHY: heorte module created in Phase 07 Wave 7, kinit wiring pending.
-#![expect(dead_code, reason = "Heorte created in Phase 07 Wave 7, kinit wiring pending")]
+// WHY: timers are compiled and tested through heorte but are not owned by a
+// boot-time runtime manager yet.
+#![expect(dead_code, reason = "Heorte timer runtime is not wired into kinit")]
 
 extern crate alloc;
 use alloc::vec::Vec;

--- a/crates/thumos/src/screen_alarm.rs
+++ b/crates/thumos/src/screen_alarm.rs
@@ -10,8 +10,9 @@
 //! large `HH:MM:SS.mmm`. Both use the kernel tick count passed via
 //! state updates.
 
-// WHY: alarm screen created in Phase 07 Wave 7, kinit wiring pending.
-#![expect(dead_code, reason = "Alarm screen created in Phase 07 Wave 7, kinit wiring pending")]
+// WHY: renderable screen exists, but kinit currently renders only the home
+// frame and has no alarm/timer route/input path.
+#![expect(dead_code, reason = "Alarm screen is not wired into the kinit UI route")]
 
 extern crate alloc;
 use alloc::vec::Vec;

--- a/crates/thumos/src/screen_calendar.rs
+++ b/crates/thumos/src/screen_calendar.rs
@@ -14,8 +14,9 @@
 //! before each render cycle, avoiding references to kernel globals across
 //! the render boundary.
 
-// WHY: calendar screen created in Phase 07 Wave 7, kinit wiring pending.
-#![expect(dead_code, reason = "Calendar screen created in Phase 07 Wave 7, kinit wiring pending")]
+// WHY: renderable screen exists, but kinit currently renders only the home
+// frame and has no calendar route/input path.
+#![expect(dead_code, reason = "Calendar screen is not wired into the kinit UI route")]
 
 extern crate alloc;
 use alloc::vec::Vec;

--- a/crates/thumos/src/ui.rs
+++ b/crates/thumos/src/ui.rs
@@ -21,8 +21,9 @@
 //! The font module is duplicated here because eidolon depends on `std` (via `Vec`)
 //! and cannot be linked into the `#![no_std]` kernel.
 
-// WHY: UI framework wired in Phase 07 but screens are not yet called from kinit.
-#![expect(dead_code, reason = "UI framework created in Phase 07 Wave 1, kinit wiring pending")]
+// WHY: kinit renders one initial home frame; full screen routing and input
+// dispatch through UiManager are still pending.
+#![expect(dead_code, reason = "UI framework has only initial home-frame kinit wiring")]
 
 extern crate alloc;
 use alloc::vec::Vec;

--- a/docs/KERNEL-WIRING-AUDIT.md
+++ b/docs/KERNEL-WIRING-AUDIT.md
@@ -1,0 +1,46 @@
+# Kernel Wiring Audit
+
+This is the issue #145 reality check for advertised kernel capabilities that compile but are not yet fully wired into boot, userspace, or hardware-backed runtime paths.
+
+The counts below are from `origin/main` as checked on 2026-05-26:
+
+```bash
+rg '^#!\[expect\(dead_code' crates/thumos/src | wc -l
+rg '^\s*#\[expect\(dead_code' crates/thumos/src | wc -l
+```
+
+Current result: 8 crate-level expectations and 48 item-level expectations.
+
+## Crate-Level Expectations
+
+| Module | Current reality |
+|---|---|
+| `ui.rs` | `kinit` renders an initial home/status frame, but full screen routing and input dispatch through `UiManager` are not wired. |
+| `heorte.rs` | Calendar/alarm/timer/stopwatch engine compiles and has tests, but no boot-time runtime manager owns the state. |
+| `heorte_timer.rs` | Timer/stopwatch logic compiles and has tests, but runtime ownership is pending with `heorte`. |
+| `screen_calendar.rs` | Renderable screen exists, but there is no `kinit` route/input path to show it. |
+| `screen_alarm.rs` | Renderable alarm/timer/stopwatch screen exists, but there is no `kinit` route/input path to show it. |
+| `clock.rs` | Wall-clock trust policy exists, but kernel time and userspace syscalls still use lower-level timer/time paths. |
+| `bluetooth.rs` | `kinit` attempts adapter initialization, but userspace control and higher-level audio/profile paths are not wired. |
+| `gps.rs` | `kinit` attempts receiver initialization, but userspace access and clock/topos integration are not wired. |
+
+## Item-Level Expectations
+
+These are lower-level dead-code suppressions, not proof that whole advertised features are production-ready.
+
+| File | Count | Meaning |
+|---|---:|---|
+| `audio_codec.rs` | 1 | Reserved register constant for future gain control. |
+| `device.rs` | 15 | Canonical address constants retained while drivers use local or `kconfig` constants. |
+| `emmc.rs` | 20 | Reserved register fields and commands for diagnostics, tuning, boot mode, CID/CSD readback, and storage-layer follow-up. |
+| `firewall.rs` | 3 | Dynamic policy and audit-key plumbing are not connected at the net device hook. |
+| `kinit.rs` | 2 | Boot progress types are tested but not yet emitted as runtime progress reporting. |
+| `power.rs` | 2 | Per-core power-down and DSI0 helper are reserved for follow-up hardware bring-up. |
+| `screen_home.rs` | 2 | Home screen modes await security-mode manager state wiring. |
+| `status_bar.rs` | 3 | Service-level badges await modem registration state wiring. |
+
+## Accounting Rules
+
+- A module being compiled and tested means the Rust surface exists; it does not imply boot reachability, userspace reachability, or hardware readiness.
+- Hardware/radio claims should be treated as ready only when the driver has a production call path and identity-protection behavior at the driver boundary.
+- Issue #143 owns the network path, issue #144 owns userspace spawn, and issue #141 owns the agent runtime bridge. This audit does not reclassify those paths as ready.


### PR DESCRIPTION
## Summary
- Demote README/current-state wording from complete readiness to compiled/tested surface accounting.
- Add docs/KERNEL-WIRING-AUDIT.md with current dead-code expectation counts and affected kernel modules.
- Update stale kernel suppression reasons where the actual call path has changed.

## Notes
- Kernel cargo test is not claimed as passed; the current baseline fails before this change with no-test/no-std configuration errors and pre-existing kernel test compile errors.
- Marker scan over git diff origin/main...HEAD found no matches for the requested AI indicator strings.

Closes #145

Gate-Passed: cargo fmt --check; cargo check --workspace; cargo test --workspace; cargo clippy --workspace -- -D warnings; cd crates/thumos && cargo check --release --target armv7a-none-eabi