### PR TITLE
fix(kernel): close wifi readiness truthfully

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,14 @@ _Phase, test split, LOC, and module totals are aligned to the internal project s
 
 The Phase 10 / Phase 11 status above describes compiled and tested surfaces, not end-to-end readiness. The following work is open and is not yet wired end-to-end on hardware:
 
+Network reality check: boot checks the WiFi hardware boundary through a
+fail-closed smoltcp adapter, reports production networking unavailable when the
+MT6739 data path is absent, and keeps DHCP/DNS/socket smoke coverage on a
+firewall-backed loopback path. Real WiFi packet I/O is not boot-ready until
+WMT/STP frame TX/RX, scan, and association are implemented on hardware.
+
 - [#141](https://github.com/forkwright/thumos/issues/141) — aletheia agent runtime bridge is not yet designed or wired
 - [#142](https://github.com/forkwright/thumos/issues/142) — boot-time security subsystems are success-without-work placeholders
-- [#143](https://github.com/forkwright/thumos/issues/143) — network stack still boots on a firewall-backed loopback path; WiFi driver remains unwired
 - Userspace image packaging remains incomplete: boot reports missing `/init` or `/shell` entries instead of spawning kernel-owned idle placeholders.
 - [#145](https://github.com/forkwright/thumos/issues/145) — advertised kernel features compiled but unwired: current baseline is 8 crate-level `dead_code` expectations plus 48 item-level suppressions; see [kernel wiring audit](docs/KERNEL-WIRING-AUDIT.md)
 - [#146](https://github.com/forkwright/thumos/issues/146) — remaining direct `ring` dependency is isolated to `krypta` protocol crypto

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -811,7 +811,7 @@ pub unsafe fn run() -> ! {
         // success is tracked separately and must not mark production
         // connectivity ready.
         let device = FirewallDevice::with_default_firewall(LoopbackDevice::new());
-        let mac = smoltcp::wire::EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]);
+        let mac = net::randomized_local_ethernet_address();
         let now = net::instant_from_millis(crate::timer::elapsed_ms() as i64);
         let mut stack = NetworkStack::new(device, mac, now);
         let _ = serial.write_str("       Firewall DNS blocklist active\r\n");

--- a/crates/thumos/src/net.rs
+++ b/crates/thumos/src/net.rs
@@ -27,7 +27,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use crate::firewall::{Action, Firewall};
-use crate::wifi::{WifiError, WifiHwOps};
+use crate::wifi::{WifiError, WifiHwOps, generate_random_mac};
 use smoltcp::iface::{Config, Interface, SocketHandle, SocketSet, SocketStorage};
 use smoltcp::phy::{
     self, ChecksumCapabilities, Device, DeviceCapabilities, Medium, RxToken as _,
@@ -69,6 +69,14 @@ const ETHERNET_HEADER_LEN: usize = 14;
 
 /// EtherType for IPv4 frames.
 const ETHERTYPE_IPV4: u16 = 0x0800;
+
+/// Generate a locally administered unicast Ethernet address for kernel stacks.
+///
+/// This is used even for host-only loopback smoke stacks so the production
+/// boot path never grows a fixed device address by accident.
+pub(crate) fn randomized_local_ethernet_address() -> EthernetAddress {
+    EthernetAddress(generate_random_mac())
+}
 
 // ---------------------------------------------------------------------------
 // Device readiness

--- a/crates/thumos/src/socket.rs
+++ b/crates/thumos/src/socket.rs
@@ -10,9 +10,9 @@
 //!
 //! - `SOCKET_TABLE`: fixed-size array of `Option<SocketInfo>`, indexed by fd
 //!   number (0..MAX_FDS). Populated on `sys_socket`, cleared on close.
-//! - `NETWORK_STACK`: global `NetworkStack<LoopbackDevice>` instance. Socket
-//!   creation and I/O go through this stack. Production WiFi integration
-//!   happens in a future boot-sequence wiring pass.
+//! - `NETWORK_STACK`: global firewall-backed loopback stack. Socket creation
+//!   and I/O go through this host-only smoke path until WiFi hardware frame
+//!   TX/RX is available; it must not be reported as production connectivity.
 //! - fd flags encode `FD_KIND_SOCKET` in the kind field so that close, read,
 //!   and write dispatch can identify socket fds without consulting the table.
 //!
@@ -28,7 +28,7 @@ use smoltcp::socket::{tcp, udp};
 use smoltcp::wire::{IpEndpoint, IpAddress, Ipv4Address};
 
 use crate::fd::{self, FileDescriptor, MAX_FDS};
-use crate::net::{FirewallDevice, LoopbackDevice, NetworkStack};
+use crate::net::{self, FirewallDevice, LoopbackDevice, NetworkStack};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -163,8 +163,9 @@ static mut SOCKET_TABLE: [Option<SocketInfo>; MAX_FDS] = {
 
 /// Global network stack for socket I/O.
 ///
-/// Uses LoopbackDevice for now; production WiFi integration will replace
-/// this with the WiFi driver's device in the boot sequence.
+/// Uses a firewall-backed LoopbackDevice for now. Production WiFi readiness is
+/// tracked separately during boot and remains false until hardware frame I/O is
+/// available.
 ///
 /// WHY Option: NetworkStack::new() is not const. Initialized by
 /// `init_network_stack()` during kernel boot or test setup.
@@ -176,7 +177,10 @@ static mut NETWORK_STACK: Option<SocketNetworkStack> = None;
 // Initialization
 // ---------------------------------------------------------------------------
 
-/// Initialize the global network stack with a loopback device.
+/// Initialize the global network stack with a firewall-backed loopback device.
+///
+/// This preserves socket syscall smoke coverage without claiming external
+/// network reachability.
 ///
 /// # Safety
 ///
@@ -184,11 +188,10 @@ static mut NETWORK_STACK: Option<SocketNetworkStack> = None;
 /// (cooperative kernel guarantee).
 pub unsafe fn init_network_stack() {
     use smoltcp::time::Instant;
-    use smoltcp::wire::EthernetAddress;
 
     unsafe {
         let device = FirewallDevice::with_default_firewall(LoopbackDevice::new());
-        let mac = EthernetAddress([0x02, 0x00, 0x00, 0x00, 0x00, 0x01]);
+        let mac = net::randomized_local_ethernet_address();
         let mut stack = NetworkStack::new(device, mac, Instant::from_millis(0));
         stack.set_ipv4_addr(Ipv4Address::new(127, 0, 0, 1), 8);
         let ns = &mut *core::ptr::addr_of_mut!(NETWORK_STACK);

--- a/crates/thumos/src/wifi.rs
+++ b/crates/thumos/src/wifi.rs
@@ -18,13 +18,15 @@
 //!
 //! ## Integration plan
 //!
-//! Wave 2 creates the module and tests. Wave 3 wires DHCP, smoltcp
-//! `phy::Device`, and boot integration via `kinit.rs`.
+//! The smoltcp adapter and boot readiness path are wired fail-closed: boot
+//! checks this backend, but it reports production networking unavailable until
+//! WMT/STP frame TX/RX, scan, and association are implemented on hardware.
 
-// WHY: hardware driver API not yet wired to upper layers (Wave 3 integration).
+// WHY: hardware data-path APIs are intentionally fail-closed until WMT/STP
+// frame TX/RX, scan, and association are implemented on the target.
 #![expect(
     dead_code,
-    reason = "WiFi driver API not yet wired to kinit (Wave 3)"
+    reason = "WiFi hardware data path not yet implemented on target"
 )]
 
 extern crate alloc;


### PR DESCRIPTION
## Summary
- Record the current network reality in README without leaving #143 as an old WiFi/firewall-unwired gap.
- Use the kernel WiFi MAC randomization helper for boot/socket loopback Ethernet addresses instead of a fixed address.
- Update socket and WiFi module docs to state that production WiFi remains fail-closed until MT6739 WMT/STP frame I/O is implemented.

Closes #143

## Gates
Passed:
- `cargo fmt --all --check`
- `git diff --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cd crates/thumos && cargo check --release --target armv7a-none-eabi`

Not passed:
- `cd crates/thumos && cargo test` fails on the existing kernel baseline: the crate config targets `armv7a-none-eabi`, so tests cannot find the `test` crate and then hit existing test-module errors.
- `cd crates/thumos && cargo test --target x86_64-unknown-linux-gnu` also fails on the existing kernel baseline: `examples/qemu_smoke.rs` reports no-std unwinding panic support, followed by existing test import/type errors.

Gate-Passed: cargo fmt --all --check; git diff --check; cargo check --workspace; cargo test --workspace; cargo clippy --workspace -- -D warnings; cd crates/thumos && cargo check --release --target armv7a-none-eabi