### PR TITLE
docs(metaxu): record aletheia bridge decision

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@ Thumos is a full-Rust mobile OS targeting the AGM M7 (MT6739). No C authored, no
 
 ## Crate map
 
-13 crates total: 1 bare-metal kernel binary + 12 workspace library crates.
+14 crates total: 1 bare-metal kernel binary + 13 workspace library crates.
 
 ### Kernel binary (excluded from workspace)
 
@@ -56,6 +56,12 @@ Thumos is a full-Rust mobile OS targeting the AGM M7 (MT6739). No C authored, no
 | `asphaleia` | Packet filter firewall, DNS blocklist, capability enforcement |
 | `leipsanon` | Panic mode: priority-ordered wipe, trigger system, memory scrubbing |
 
+**Cognition bridge**
+
+| Crate | Description |
+|-------|-------------|
+| `metaxu` | Aletheia/Thumos thin-client bridge protocol: typed tasks, capability grant claims, opaque identity references |
+
 ## Dependency direction
 
 The kernel (`thumos`) is a standalone `no_std` binary with no workspace dependencies. Workspace crates depend on each other as follows:
@@ -64,7 +70,7 @@ The kernel (`thumos`) is a standalone `no_std` binary with no workspace dependen
 eidolon --> haphe    (UI reads input events)
 ```
 
-All other workspace crates are independent of each other. External dependencies flow downward: crates use `ring`, `nom`, `smoltcp`, `snafu`, etc. but never import from higher layers.
+All other workspace crates are independent of each other. External dependencies flow downward: crates use RustCrypto, `nom`, `smoltcp`, `snafu`, etc. but never import from higher layers. `metaxu` is a protocol boundary only; it does not embed the Aletheia runtime or wire a live network transport.
 
 **Rule**: lower layers do not import from higher layers. `haphe` does not depend on `eidolon`. Radio crates do not depend on security crates. The kernel depends on nothing in the workspace.
 
@@ -83,6 +89,8 @@ All other workspace crates are independent of each other. External dependencies 
 |  asphaleia (firewall) | leipsanon (panic mode)|
 |  stegnos (encrypted storage)                  |
 +-----------------------------------------------+
+|  metaxu (Aletheia/Thumos thin-client bridge)  |
++-----------------------------------------------+
 |              haphe (input)                     |
 +-----------------------------------------------+
 |          thumos (kernel, bare-metal)           |
@@ -96,6 +104,7 @@ All other workspace crates are independent of each other. External dependencies 
 - **New kernel subsystem**: add a module inside `crates/thumos/src/`. The kernel is monolithic; subsystems are modules, not separate crates.
 - **New userspace domain**: add a new workspace crate in `crates/`. Register it in `Cargo.toml` workspace members. Follow naming convention (Greek, per `gnomon.md`).
 - **New driver**: implement in the kernel crate if it touches hardware registers. Implement as a workspace crate if it operates at a higher abstraction (like `aither` or `pteron` which define protocol logic).
+- **Aletheia bridge task**: extend `metaxu` protocol types first. Wire live transports separately through existing network and policy layers; do not bypass firewall boot sequencing or userspace spawn work.
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ MT6739 hardware (modem on separate core, firewalled at CCCI driver level)
 
 **Phase 11: System Qualification** (canonical tracker last updated 2026-04-20; phase status updated 2026-04-12). Hardware validation is pending on an AGM M7 factory firmware flash. Phase 10 names a compiled/tested code catalog, not a claim that every named capability is boot-wired, reachable from userspace, or hardware-ready.
 
-13 crates (12 userspace workspace members plus the `thumos` kernel binary, excluded from the main workspace for bare-metal builds), 2,313 tests (1,618 kernel + 695 workspace), ~102K LOC (81K kernel, 21K userspace), 107 kernel modules. The kernel has implemented and tested core surfaces including MMU, allocator, GIC/timer, scheduler, IPC, signals, 45 syscalls, VFS with LFS/ramfs/devfs, block cache, CSPRNG, capabilities, DVFS, watchdog, telephony parsing/containment, security modes, lock screen, audit log, panic wipe, measured boot primitives, encryption primitives, and several UI/radio/messaging modules. Named higher-level capabilities such as multi-screen UI routing, calendar/alarm runtime ownership, wall-clock trust selection, Bluetooth/GPS userspace control, BT audio, Matrix/voice assistant flows, and mesh/inbox integrations remain compiled surfaces unless a boot or userspace call path is listed in the wiring audit.
+14 crates (13 userspace workspace members plus the `thumos` kernel binary, excluded from the main workspace for bare-metal builds), 2,313 tests (1,618 kernel + 695 workspace), ~102K LOC (81K kernel, 21K userspace), 107 kernel modules. The kernel has implemented and tested core surfaces including MMU, allocator, GIC/timer, scheduler, IPC, signals, 45 syscalls, VFS with LFS/ramfs/devfs, block cache, CSPRNG, capabilities, DVFS, watchdog, telephony parsing/containment, security modes, lock screen, audit log, panic wipe, measured boot primitives, encryption primitives, and several UI/radio/messaging modules. Named higher-level capabilities such as multi-screen UI routing, calendar/alarm runtime ownership, wall-clock trust selection, Bluetooth/GPS userspace control, BT audio, Matrix/voice assistant flows, and mesh/inbox integrations remain compiled surfaces unless a boot or userspace call path is listed in the wiring audit. The userspace workspace also includes `metaxu`, the thin-client protocol surface for Aletheia bridge tasks; it does not embed a live Aletheia runtime.
 
-_Phase, test split, LOC, and module totals are aligned to the internal project state record. Crate count was verified with `ls -d crates/*/ | wc -l` on 2026-05-04. A cheap source grep (`rg "#\[test\]" crates/ | wc -l`) reports 2,187 annotated test functions, so the canonical test inventory remains the source of truth without a full cargo listing._
+_Phase, test split, LOC, and module totals are aligned to the internal project state record. Crate count was verified with `ls -d crates/*/ | wc -l` on 2026-05-26. A cheap source grep (`rg "#\[test\]" crates/ | wc -l`) reports 2,208 annotated test functions, so the canonical test inventory remains the source of truth without a full cargo listing._
 
 ### Known gaps
 
@@ -55,7 +55,7 @@ MT6739 data path is absent, and keeps DHCP/DNS/socket smoke coverage on a
 firewall-backed loopback path. Real WiFi packet I/O is not boot-ready until
 WMT/STP frame TX/RX, scan, and association are implemented on hardware.
 
-- [#141](https://github.com/forkwright/thumos/issues/141) — aletheia agent runtime bridge is not yet designed or wired
+- Aletheia live runtime integration — phase-1 decision recorded in [docs/ALETHEIA-BRIDGE.md](docs/ALETHEIA-BRIDGE.md) and `metaxu`; live transport, grant verification, and UI wiring remain future work
 - [#142](https://github.com/forkwright/thumos/issues/142) — boot-time security subsystems are success-without-work placeholders
 - Userspace image packaging remains incomplete: boot reports missing `/init` or `/shell` entries instead of spawning kernel-owned idle placeholders.
 - [#145](https://github.com/forkwright/thumos/issues/145) — advertised kernel features compiled but unwired: current baseline is 8 crate-level `dead_code` expectations plus 48 item-level suppressions; see [kernel wiring audit](docs/KERNEL-WIRING-AUDIT.md)
@@ -64,7 +64,7 @@ WMT/STP frame TX/RX, scan, and association are implemented on hardware.
 ## Related
 
 - [akroasis](https://github.com/forkwright/akroasis): signals intelligence toolkit (thumos as field node)
-- [aletheia](https://github.com/forkwright/aletheia): epistemology runtime (philosophical sibling)
+- [aletheia](https://github.com/forkwright/aletheia): epistemology runtime (remote runtime for the `metaxu` thin-client bridge)
 
 ## Disclaimer
 

--- a/docs/ALETHEIA-BRIDGE.md
+++ b/docs/ALETHEIA-BRIDGE.md
@@ -1,0 +1,62 @@
+# Aletheia Bridge Decision
+
+Status: accepted
+
+Date: 2026-05-26
+
+Issue: [#141](https://github.com/forkwright/thumos/issues/141)
+
+## Decision
+
+Thumos uses a thin-client bridge to a menos-resident Aletheia runtime. The
+runtime does not run in-process on the device in phase 1.
+
+The device-side integration surface is the `metaxu` workspace crate. `metaxu`
+defines typed task requests, task responses, opaque device identity references,
+capability grant claims, and a synchronous byte transport trait. It is a wire
+boundary for constrained Thumos clients, not an embedded cognition runtime.
+
+## Rationale
+
+Thumos targets constrained mobile hardware and already has separate local
+surfaces for voice transcription (`ekphrasis`) and nous action proposals. The
+Aletheia runtime is expected to be heavier than the device boundary should own:
+it may need model orchestration, tool scheduling, long-lived memory, and
+fleet-level context. Keeping that runtime off-device preserves the Thumos
+resource budget and keeps the device boundary focused on typed, auditable
+actions.
+
+The thin-client design also keeps capability enforcement local to Thumos. A
+runtime request can carry grant claims, but the device side remains responsible
+for verifying policy before sending SMS, placing calls, reading contacts, or
+opening audio sessions. Device identity is represented by opaque handles and
+attestation digests; raw IMEI, IMSI, WiFi MAC, Bluetooth address, and similar
+hardware identifiers must not cross this bridge.
+
+## Current Surface
+
+- `crates/metaxu` is registered as a workspace crate.
+- Requests and responses serialize with `postcard`.
+- `BridgeClient` exchanges one request frame for one response frame through a
+  caller-provided transport.
+- The crate has an in-memory round-trip test for device -> runtime -> device.
+- The local preflight only checks that a request carries a grant for the needed
+  capability. It does not authenticate grants, check expiration, or prove remote
+  runtime identity.
+
+## Non-Goals
+
+- No Aletheia runtime is embedded in Thumos.
+- No live LTE, mesh, SMS, Matrix, or socket transport is wired by this decision.
+- No network or firewall boot path changes are part of this bridge decision.
+- No userspace spawn or init path changes are part of this bridge decision.
+- No dependency on a C toolchain or heavyweight runtime library is introduced.
+
+## Follow-Up Work
+
+- Bind `metaxu` to the selected live transport without bypassing firewall policy.
+- Connect nous capability presets to concrete `metaxu` grant verification.
+- Add runtime peer authentication and grant expiration checks.
+- Route accepted device actions through the existing confirmation UI and local
+  service APIs.
+- Cross-link the corresponding Aletheia-side runtime endpoint when it exists.


### PR DESCRIPTION
## Summary
- Record the #141 architecture decision: Thumos uses a thin-client bridge to a menos-resident Aletheia runtime, not an embedded phase-1 runtime.
- Document the current `metaxu` integration surface and its non-goals: no live transport, no runtime dependency, no network/firewall boot-path changes, and no userspace spawn-path changes.
- Align README and architecture docs with the registered `metaxu` crate and verified crate/workspace test-list counts.

Closes #141

## Gates
- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`
- `git diff --check`
- Forbidden-marker scan against `origin/main...HEAD`: no matches

Kernel files were not changed. A kernel host `cargo test -- --list` probe was not claimed because it fails on the current baseline before listing tests.

Gate-Passed: cargo fmt --check; cargo check --workspace; cargo test --workspace; cargo clippy --workspace -- -D warnings; git diff --check; forbidden-marker scan