### PR TITLE
docs(agents): add preamble to AGENTS.md; fix defers_to paths in CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,9 @@
+<!--
+scope: thumos repo build/lint rules and agent conventions (cross-tool reference for AI coding assistants)
+defers_to: CLAUDE.md for architecture decisions and operator principles; kanon standards for universal engineering policy
+tightens: build commands, lint invariants, and non-obvious Rust/kernel constraints specific to this repo
+-->
+
 # AGENTS.md - Thumos
 
 Cross-tool guide for AI coding agents (Claude Code, Cursor, Windsurf, Copilot, etc.) working on the Thumos mobile OS. Authoritative agent orientation (phase status, Greek naming rationale, constraints) lives in [CLAUDE.md](CLAUDE.md); this file captures build/lint invariants and the non-obvious rules that differ from a standard Rust workspace.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 <!--
 scope: thumos repo conventions (bare-metal Rust kernel + userspace for AGM M7 / MT6739)
-defers_to: ~/menos-ops/CLAUDE.md for machine topology; ~/.claude/CLAUDE.md for operator principles; kanon standards for universal engineering policy
+defers_to: operator CLAUDE.md (menos-ops) for machine topology; operator global CLAUDE.md for principles; kanon standards for universal engineering policy
 tightens: MT6739-specific constraints and device-identity protection discipline that do not apply outside this repo
 -->
 


### PR DESCRIPTION
Fixes two `kanon lint` violations:

1. **CONTEXT/preamble-required** on `AGENTS.md`: added HTML comment preamble with `scope`, `defers_to`, and `tightens`.

2. **WORKFLOW/defers-to** on `CLAUDE.md`: replaced non-resolving `~/menos-ops/CLAUDE.md` and `~/.claude/CLAUDE.md` paths with abstract operator-side references.

Verification: `kanon lint --writing .` passes with zero `CONTEXT/preamble-required` and `WORKFLOW/defers-to` violations.

Gate-Passed: kanon lint --writing . passes with zero CONTEXT/preamble-required and WORKFLOW/defers-to violations.