### PR TITLE
fix(eidolon): replace unwrap_or_default with explicit handling; add test assertions

### DIFF
--- a/crates/eidolon/src/font.rs
+++ b/crates/eidolon/src/font.rs
@@ -231,9 +231,10 @@ pub fn draw_char(fb: &mut Framebuffer, x: u32, y: u32, ch: char, fg: Rgb565, bg:
         for col in 0u8..8 {
             let bit = (byte >> (7 - col)) & 1;
             let color = if bit != 0 { fg } else { bg };
+            // SAFETY: glyph has exactly 16 rows, so row is 0..16, always fits in u32.
             fb.set_pixel(
                 x + u32::from(col),
-                y + u32::try_from(row).unwrap_or_default(),
+                y + row as u32,
                 color,
             );
         }
@@ -246,7 +247,9 @@ pub fn draw_char(fb: &mut Framebuffer, x: u32, y: u32, ch: char, fg: Rgb565, bg:
 /// outside the framebuffer boundary are clipped.
 pub fn draw_str(fb: &mut Framebuffer, x: u32, y: u32, s: &str, fg: Rgb565, bg: Rgb565) {
     for (i, ch) in s.chars().enumerate() {
-        let cx = x.saturating_add(u32::try_from(i).unwrap_or_default() * CHAR_WIDTH);
+        // WHY: i exceeds u32 only for >4 GiB strings, impossible on this device;
+        // saturating_add handles u32::MAX gracefully.
+        let cx = x.saturating_add(u32::try_from(i).unwrap_or(u32::MAX) * CHAR_WIDTH);
         draw_char(fb, cx, y, ch, fg, bg);
     }
 }

--- a/crates/eidolon/src/framebuffer.rs
+++ b/crates/eidolon/src/framebuffer.rs
@@ -21,9 +21,8 @@ pub struct Framebuffer {
 impl Framebuffer {
     /// Allocate a new framebuffer filled with black.
     pub(crate) fn new(width: u32, height: u32) -> Self {
-        let size = usize::try_from(width).unwrap_or_default()
-            * usize::try_from(height).unwrap_or_default()
-            * BYTES_PER_PIXEL;
+        // SAFETY: u32 always fits in usize.
+        let size = width as usize * height as usize * BYTES_PER_PIXEL;
         Self {
             buf: vec![0u8; size],
             width,
@@ -36,10 +35,8 @@ impl Framebuffer {
         if x >= self.width || y >= self.height {
             return;
         }
-        let idx = (usize::try_from(y).unwrap_or_default()
-            * usize::try_from(self.width).unwrap_or_default()
-            + usize::try_from(x).unwrap_or_default())
-            * BYTES_PER_PIXEL;
+        // SAFETY: coordinates are bounds-checked and buffer dimensions fit in usize.
+        let idx = (y as usize * self.width as usize + x as usize) * BYTES_PER_PIXEL;
         let bytes = color.0.to_le_bytes();
         if let Some(slot) = self
             .buf
@@ -57,10 +54,8 @@ impl Framebuffer {
         let x_end = x.saturating_add(w).min(self.width);
         for row in y..y_end {
             for col in x..x_end {
-                let idx = (usize::try_from(row).unwrap_or_default()
-                    * usize::try_from(self.width).unwrap_or_default()
-                    + usize::try_from(col).unwrap_or_default())
-                    * BYTES_PER_PIXEL;
+                // SAFETY: coordinates are bounds-checked and buffer dimensions fit in usize.
+                let idx = (row as usize * self.width as usize + col as usize) * BYTES_PER_PIXEL;
                 if let Some(slot) = self
                     .buf
                     .get_mut(idx..idx + BYTES_PER_PIXEL)

--- a/crates/eidolon/src/status_bar.rs
+++ b/crates/eidolon/src/status_bar.rs
@@ -100,19 +100,34 @@ mod tests {
     #[test]
     fn draw_does_not_panic_at_nominal_values() {
         let mut fb = Framebuffer::new(240, 320);
+        fb.clear(Rgb565::WHITE);
         StatusBar::draw(&mut fb, 3, 75, "12:34");
+        assert!(
+            fb.as_bytes().iter().any(|&b| b != 0xFF),
+            "status bar must write at least one pixel"
+        );
     }
 
     #[test]
     fn draw_does_not_panic_at_zero_values() {
         let mut fb = Framebuffer::new(240, 320);
+        fb.clear(Rgb565::WHITE);
         StatusBar::draw(&mut fb, 0, 0, "");
+        assert!(
+            fb.as_bytes().iter().any(|&b| b != 0xFF),
+            "status bar must write at least one pixel even at zero values"
+        );
     }
 
     #[test]
     fn draw_does_not_panic_at_max_values() {
         let mut fb = Framebuffer::new(240, 320);
+        fb.clear(Rgb565::WHITE);
         StatusBar::draw(&mut fb, 255, 255, "00:00");
+        assert!(
+            fb.as_bytes().iter().any(|&b| b != 0xFF),
+            "status bar must write at least one pixel even at max values"
+        );
     }
 
     #[test]
@@ -162,6 +177,11 @@ mod tests {
     fn signal_bars_clamped_above_4() {
         // Should not panic with more than 4 bars
         let mut fb = Framebuffer::new(240, 320);
+        fb.clear(Rgb565::WHITE);
         StatusBar::draw(&mut fb, 10, 80, "09:00");
+        assert!(
+            fb.as_bytes().iter().any(|&b| b != 0xFF),
+            "status bar must write at least one pixel when signal bars are clamped"
+        );
     }
 }

--- a/crates/eidolon/src/widgets/dialer.rs
+++ b/crates/eidolon/src/widgets/dialer.rs
@@ -426,8 +426,12 @@ mod tests {
         d.on_key(Key::Num1);
         d.on_key(Key::Num2);
         let mut fb = Framebuffer::new(240, 320);
-        // NOTE: should complete without panic
+        fb.clear(Rgb565::WHITE);
         d.draw(&mut fb, 0, 0);
+        assert!(
+            fb.as_bytes().iter().any(|&b| b != 0xFF),
+            "dialer must write at least one pixel"
+        );
     }
 
     #[test]

--- a/crates/eidolon/src/widgets/dialog.rs
+++ b/crates/eidolon/src/widgets/dialog.rs
@@ -325,7 +325,11 @@ mod tests {
     fn draw_does_not_panic() {
         let d = Dialog::confirm("Alert", "Delete everything?");
         let mut fb = Framebuffer::new(240, 320);
-        // NOTE: should not panic
+        fb.clear(Rgb565::WHITE);
         d.draw(&mut fb, 20, 100);
+        assert!(
+            fb.as_bytes().iter().any(|&b| b != 0xFF),
+            "dialog must write at least one pixel"
+        );
     }
 }

--- a/crates/eidolon/src/widgets/list.rs
+++ b/crates/eidolon/src/widgets/list.rs
@@ -397,7 +397,11 @@ mod tests {
     fn draw_does_not_panic_on_empty_list() {
         let list = TextList::with_width(240);
         let mut fb = Framebuffer::new(240, 320);
-        // NOTE: should complete without panic or index error
+        fb.clear(Rgb565::WHITE);
         list.draw(&mut fb, 0, 0);
+        assert!(
+            fb.as_bytes().iter().any(|&b| b != 0xFF),
+            "empty list must still write row backgrounds"
+        );
     }
 }


### PR DESCRIPTION
- `font.rs`: replace `unwrap_or_default` on numeric conversions with `as`-cast + `SAFETY` comments where the conversion is unconditional (glyph row 0..16), and `unwrap_or(u32::MAX)` + `WHY` for string index where overflow is architecturally impossible.
- `framebuffer.rs`: replace `unwrap_or_default` on `usize` conversions with `as`-cast + `SAFETY` comments because coordinates are bounds-checked and `u32` always fits in `usize`.
- `status_bar.rs`, `widgets/dialer.rs`, `widgets/dialog.rs`, `widgets/list.rs`: convert tautological draw-does-not-panic tests into assertions that verify at least one pixel is written (pre-fill framebuffer white, assert not all white after draw).

Gate-Passed: `cargo test -p eidolon` (69 passed), kanon lint clean on `RUST/no-result-unwrap-or-default` and `TESTING/tautological-test`.