### PR TITLE
fix(pteron,kelyphos): replace unwrap_or_default; annotate intentional result swallows

### DIFF
--- a/crates/kelyphos/src/stp.rs
+++ b/crates/kelyphos/src/stp.rs
@@ -106,7 +106,8 @@ impl StpFrame {
         frame.header.frame_type = FrameType::Data;
         frame.header.seq = seq & 0x07;
         let len = payload.len().min(MAX_PAYLOAD);
-        frame.header.length = u16::try_from(len).unwrap_or_default();
+        frame.header.length = u16::try_from(len)
+            .expect("invariant: len <= MAX_PAYLOAD (4095) fits in u16"); // kanon:ignore RUST/expect -- infallible: len <= MAX_PAYLOAD (4095) fits in u16
         frame.payload[..len].copy_from_slice(&payload[..len]);
         frame.payload_len = len;
         frame.header.checksum = compute_header_checksum(frame.header);

--- a/crates/kelyphos/src/wmt.rs
+++ b/crates/kelyphos/src/wmt.rs
@@ -634,7 +634,9 @@ impl RegisterIo for MmioRegisterIo {
     fn udelay(&mut self, micros: u32) {
         // WHY: busy-loop delay in kernel context WHERE sleep is unavailable.
         // Calibration assumes ~1000 cycles/µs at 1 GHz; acceptable for 1 µs steps.
-        let cycles = usize::try_from(micros).unwrap_or_default() * 1000;
+        let cycles = usize::try_from(micros)
+            .expect("invariant: u32 fits in usize on 32-bit target") // kanon:ignore RUST/expect -- infallible: u32 fits in usize on 32-bit target
+            * 1000;
         for _ in 0..cycles {
             core::hint::spin_loop();
         }

--- a/crates/pteron/src/hci.rs
+++ b/crates/pteron/src/hci.rs
@@ -331,7 +331,8 @@ pub(crate) fn encode_command(cmd: &HciCommand) -> Vec<u8> {
     let (opcode, params) = build_command_parts(cmd);
     let [op_lo, op_hi] = opcode.to_le_bytes();
     // INVARIANT: HCI parameter total is bounded by spec at 255 bytes; always fits in u8.
-    let param_len = u8::try_from(params.len()).unwrap_or_default();
+    let param_len = u8::try_from(params.len())
+        .expect("invariant: HCI parameter total is bounded by 255 bytes"); // kanon:ignore RUST/expect -- infallible by HCI spec; bounded at 255 bytes
 
     let mut packet = Vec::with_capacity(4 + params.len());
     packet.push(H4_COMMAND_TYPE);

--- a/crates/pteron/src/transport.rs
+++ b/crates/pteron/src/transport.rs
@@ -302,7 +302,8 @@ pub(crate) fn stp_encode(seq: u8, payload: &[u8], out: &mut [u8]) -> Result<usiz
     }
 
     // INVARIANT: payload.len() <= STP_MAX_PAYLOAD (0xFFF), checked above; fits in u16.
-    let plen = u16::try_from(payload.len()).unwrap_or_default();
+    let plen = u16::try_from(payload.len())
+        .expect("invariant: payload.len() <= STP_MAX_PAYLOAD (0xFFF), checked above"); // kanon:ignore RUST/expect -- infallible: checked against STP_MAX_PAYLOAD above
     let [plen_lo, plen_hi_raw] = plen.to_le_bytes();
     let seq4 = seq & 0x0F;
 
@@ -534,7 +535,7 @@ impl BtHciTransport {
                 // Inject HCI Hardware Error event INTO RX path per DRIVER-INTERFACES.md §4.4.
                 // Event: H4=0x04, code=0x10, param_len=0x01, hw_code=0x00
                 let hw_error_event: [u8; 4] = [0x04, 0x10, 0x01, 0x00];
-                let _ = self.rx.push(&hw_error_event);
+                let _ = self.rx.push(&hw_error_event); // WHY: best-effort RX injection; ring buffer may be full during reset storm.
                 RstFlag::ResetCompleteEventDelivered
             }
             RstFlag::ResetCompleteEventDelivered => RstFlag::Normal,


### PR DESCRIPTION
- Replace silent `.unwrap_or_default()` on `try_from` Results with `.expect("invariant: ...")` plus inline `kanon:ignore` annotations.
- Annotate best-effort RX ring-buffer injection with `// WHY:` rationale.

**Verification:**
- `cargo test -p pteron -p kelyphos` passes
- `kanon lint` zero violations for the touched files

Gate-Passed: cargo test -p pteron -p kelyphos && kanon lint