### PR TITLE
test(kernel): add assertions to tautological screen render tests

### DIFF
--- a/crates/thumos/src/screen_call.rs
+++ b/crates/thumos/src/screen_call.rs
@@ -511,6 +511,8 @@ mod tests {
         let screen = make_active_screen(0, 5000);
         let mut fb = [0u16; SCREEN_WIDTH as usize * CONTENT_HEIGHT as usize];
         screen.draw(&mut fb);
+        let any_set = fb.iter().any(|&px| px != 0);
+        assert!(any_set, "active call screen must render visible content");
     }
 
     #[test]

--- a/crates/thumos/src/screen_contacts.rs
+++ b/crates/thumos/src/screen_contacts.rs
@@ -798,5 +798,7 @@ mod tests {
         screen.view = ContactView::Add;
         let mut fb = [0u16; CONTENT_PIXELS];
         screen.draw(&mut fb);
+        let any_set = fb.iter().any(|&px| px != 0);
+        assert!(any_set, "add contact view must render visible content");
     }
 }

--- a/crates/thumos/src/screen_dialer.rs
+++ b/crates/thumos/src/screen_dialer.rs
@@ -421,6 +421,7 @@ mod tests {
         let screen = DialerScreen::new();
         let mut fb = [0u16; SCREEN_WIDTH as usize * CONTENT_HEIGHT as usize];
         screen.draw(&mut fb);
-        // Must complete without panic.
+        let any_set = fb.iter().any(|&px| px != 0);
+        assert!(any_set, "dialer screen must render visible content");
     }
 }

--- a/crates/thumos/src/screen_messages.rs
+++ b/crates/thumos/src/screen_messages.rs
@@ -1103,6 +1103,8 @@ mod tests {
         screen.enter_compose();
         let mut fb = [0u16; CONTENT_PIXELS];
         screen.draw(&mut fb);
+        let any_set = fb.iter().any(|&px| px != 0);
+        assert!(any_set, "compose screen must render visible content");
     }
 
     // --- Wave 5: transport integration tests ---

--- a/crates/thumos/src/screen_nous.rs
+++ b/crates/thumos/src/screen_nous.rs
@@ -1033,7 +1033,8 @@ mod tests {
         let screen = NousChatScreen::new();
         let mut fb = [0u16; CONTENT_PIXELS];
         screen.draw(&mut fb);
-        // No panic = success.
+        let any_set = fb.iter().any(|&px| px != 0);
+        assert!(any_set, "empty nous chat must render visible content");
     }
 
     #[test]
@@ -1051,6 +1052,8 @@ mod tests {
 
         let mut fb = [0u16; CONTENT_PIXELS];
         screen.draw(&mut fb);
+        let any_set = fb.iter().any(|&px| px != 0);
+        assert!(any_set, "nous chat with messages must render visible content");
     }
 
     #[test]
@@ -1063,6 +1066,8 @@ mod tests {
 
         let mut fb = [0u16; CONTENT_PIXELS];
         screen.draw(&mut fb);
+        let any_set = fb.iter().any(|&px| px != 0);
+        assert!(any_set, "nous chat with proposal must render visible content");
     }
 
     #[test]

--- a/crates/thumos/src/screen_privacy.rs
+++ b/crates/thumos/src/screen_privacy.rs
@@ -1122,6 +1122,8 @@ mod tests {
         screen.view = PrivacyView::Detail;
         let mut fb = [0u16; SCREEN_WIDTH as usize * CONTENT_HEIGHT as usize];
         screen.draw(&mut fb);
+        let any_set = fb.iter().any(|&px| px != 0);
+        assert!(any_set, "privacy detail view must render visible content");
     }
 
     #[test]
@@ -1131,6 +1133,8 @@ mod tests {
         screen.purge_state = Some(PurgeConfirmState::new(1));
         let mut fb = [0u16; SCREEN_WIDTH as usize * CONTENT_HEIGHT as usize];
         screen.draw(&mut fb);
+        let any_set = fb.iter().any(|&px| px != 0);
+        assert!(any_set, "privacy purge confirm must render visible content");
     }
 
     #[test]

--- a/crates/thumos/src/screen_settings.rs
+++ b/crates/thumos/src/screen_settings.rs
@@ -641,7 +641,8 @@ mod tests {
         let screen = WifiSettingsScreen::new();
         let mut fb = [0u16; CONTENT_PIXELS];
         screen.draw(&mut fb);
-        // Should render without panic.
+        let any_set = fb.iter().any(|&px| px != 0);
+        assert!(any_set, "wifi disconnected screen must render visible content");
     }
 
     #[test]
@@ -659,7 +660,8 @@ mod tests {
         });
         let mut fb = [0u16; CONTENT_PIXELS];
         screen.draw(&mut fb);
-        // Should render without panic.
+        let any_set = fb.iter().any(|&px| px != 0);
+        assert!(any_set, "wifi connected screen must render visible content");
     }
 
     #[test]
@@ -667,6 +669,8 @@ mod tests {
         let screen = BtSettingsScreen::new();
         let mut fb = [0u16; CONTENT_PIXELS];
         screen.draw(&mut fb);
+        let any_set = fb.iter().any(|&px| px != 0);
+        assert!(any_set, "bluetooth disabled screen must render visible content");
     }
 
     #[test]
@@ -680,6 +684,8 @@ mod tests {
         });
         let mut fb = [0u16; CONTENT_PIXELS];
         screen.draw(&mut fb);
+        let any_set = fb.iter().any(|&px| px != 0);
+        assert!(any_set, "bluetooth scanning screen must render visible content");
     }
 
     #[test]


### PR DESCRIPTION
Fixes `TESTING/tautological-test` violations in thumos screen modules by adding framebuffer pixel-change assertions to previously assertion-free render tests.

**Changes:**
- `screen_call`: assert framebuffer renders visible pixels in `draw_does_not_panic`
- `screen_contacts`: assert add view renders visible pixels
- `screen_dialer`: assert dialer screen renders visible pixels
- `screen_messages`: assert compose screen renders visible pixels
- `screen_nous`: assert empty, with-messages, and with-proposal views render visible pixels
- `screen_privacy`: assert detail and purge-confirm views render visible pixels
- `screen_settings`: assert wifi disconnected, wifi connected, bt disabled, and bt scanning screens render visible pixels

**Verification:**
- `kanon lint`: zero `TESTING/tautological-test` violations in all seven screen modules
- `cargo test --workspace`: passed