### PR TITLE
fix(kernel): annotate fuzz result swallows; add quadrant tags to socket.rs TODOs

### DIFF
--- a/crates/thumos/src/socket.rs
+++ b/crates/thumos/src/socket.rs
@@ -293,7 +293,7 @@ unsafe fn alloc_ephemeral_port() -> Option<u16> {
 /// # Returns
 /// File descriptor number on success, negative errno on failure.
 pub(crate) fn sys_socket(domain: u32, sock_type: u32, _protocol: u32) -> u32 {
-    // TODO(#84): IPv6 (AF_INET6) -- only AF_INET supported
+    // TODO(#84)[deliberate-prudent]: IPv6 (AF_INET6) -- only AF_INET supported
     if domain != AF_INET {
         return EAFNOSUPPORT;
     }
@@ -458,7 +458,7 @@ pub(crate) fn sys_bind(fd: u32, addr_ptr: u32, addr_len: u32) -> u32 {
 /// # Returns
 /// EOPNOTSUPP — full listen/accept is deferred to a future phase.
 ///
-/// TODO(#84): listen/accept -- currently returns EOPNOTSUPP
+/// TODO(#84)[deliberate-prudent]: listen/accept -- currently returns EOPNOTSUPP
 pub(crate) fn sys_listen(_fd: u32, _backlog: u32) -> u32 {
     EOPNOTSUPP
 }
@@ -468,7 +468,7 @@ pub(crate) fn sys_listen(_fd: u32, _backlog: u32) -> u32 {
 /// # Returns
 /// EOPNOTSUPP — full listen/accept is deferred to a future phase.
 ///
-/// TODO(#84): listen/accept -- currently returns EOPNOTSUPP
+/// TODO(#84)[deliberate-prudent]: listen/accept -- currently returns EOPNOTSUPP
 pub(crate) fn sys_accept(_fd: u32, _addr_ptr: u32, _addr_len_ptr: u32) -> u32 {
     EOPNOTSUPP
 }

--- a/fuzz/fuzz_targets/fuzz_dns.rs
+++ b/fuzz/fuzz_targets/fuzz_dns.rs
@@ -31,12 +31,12 @@ fuzz_target!(|data: &[u8]| {
 
     // blocks_dns_payload calls extract_query_domain → is_blocked.
     // Any panic here is a bug.
-    let _ = bl.blocks_dns_payload(data);
+    let _ = bl.blocks_dns_payload(data); // WHY: fuzz target — only contract is no panic; Ok/Err are both valid outcomes
 
     // ── Phase 2: blocklist matching on extracted domain ──────────────────────
     // Also test is_blocked directly with the raw bytes interpreted as a string
     // to exercise the pattern matching paths independently of DNS parsing.
     if let Ok(s) = std::str::from_utf8(data) {
-        let _ = bl.is_blocked(s);
+        let _ = bl.is_blocked(s); // WHY: fuzz target — only contract is no panic; Ok/Err are both valid outcomes
     }
 });

--- a/fuzz/fuzz_targets/fuzz_gsm7.rs
+++ b/fuzz/fuzz_targets/fuzz_gsm7.rs
@@ -41,7 +41,7 @@ fuzz_target!(|data: &[u8]| {
     // path in klesis with maximally adversarial input byte sequences.
     let hex_pdu: String = data.iter().map(|b| format!("{b:02X}")).collect();
     // Errors are expected and fine; we only care that it never panics.
-    let _ = decode_deliver(&hex_pdu);
+    let _ = decode_deliver(&hex_pdu); // WHY: fuzz target — only contract is no panic; Ok/Err are both valid outcomes
 
     // ── Phase 2: encode path round-trip ─────────────────────────────────────
     // Interpret the fuzz bytes as UTF-8. If they form valid UTF-8, attempt to


### PR DESCRIPTION
Resolve kanon lint violations:

- fuzz/fuzz_targets/fuzz_dns.rs, fuzz_gsm7.rs: annotate intentional result swallows in fuzz targets with WHY comments
- crates/thumos/src/socket.rs: add [deliberate-prudent] quadrant tags to TODO markers

Gate-Passed: kanon lint zero violations on touched files