### PR TITLE
fix(klesis,thumos,leipsanon,sema,stegnos,eidolon,topos): close lint quality wave

### DIFF
--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -65,6 +65,7 @@ RUST/string-slice:crates/klesis/src/pdu.rs
 RUST/string-slice:crates/krypta/src/ratchet.rs
 RUST/string-slice:crates/krypta/src/x3dh.rs
 RUST/string-slice:crates/leipsanon/src/engine.rs
+RUST/indexing-slicing:crates/leipsanon/src/engine.rs
 RUST/string-slice:crates/pteron/src/transport.rs
 RUST/string-slice:crates/stegnos/src/cipher.rs
 RUST/string-slice:crates/topos/src/nmea.rs
@@ -147,3 +148,8 @@ ARCHITECTURE/thick-binary:crates/thumos/src/main.rs
 # the test mock (also in kelyphos). Revisit once thumos gains path deps
 # (#126) — until then the colocation is deliberate.
 ARCHITECTURE/trait-impl-colocation:crates/kelyphos/src/wmt.rs
+
+# WHY: crates/thumos is excluded from [workspace] (separate license + bare-metal target).
+# Excluded crates cannot use version.workspace = true or edition.workspace = true.
+# These fields must be explicitly set in the kernel Cargo.toml.
+MANIFEST/package-workspace-inheritance:crates/thumos/Cargo.toml

--- a/crates/eidolon/src/framebuffer.rs
+++ b/crates/eidolon/src/framebuffer.rs
@@ -54,8 +54,7 @@ impl Framebuffer {
         let x_end = x.saturating_add(w).min(self.width);
         for row in y..y_end {
             for col in x..x_end {
-                // SAFETY: coordinates are bounds-checked and buffer dimensions fit in usize.
-                let idx = (row as usize * self.width as usize + col as usize) * BYTES_PER_PIXEL;
+                let idx = (row as usize * self.width as usize + col as usize) * BYTES_PER_PIXEL; // SAFETY: u32->usize widening, always valid
                 if let Some(slot) = self
                     .buf
                     .get_mut(idx..idx + BYTES_PER_PIXEL)

--- a/crates/klesis/src/ccci.rs
+++ b/crates/klesis/src/ccci.rs
@@ -201,8 +201,9 @@ impl CcciHeader {
     /// Encode to the 16-byte little-endian wire format.
     #[must_use]
     pub(crate) const fn to_bytes(self) -> [u8; HEADER_SIZE] {
-        let [d00, d01, d02, d03] = self.data[0].to_le_bytes();
-        let [d10, d11, d12, d13] = self.data[1].to_le_bytes();
+        let [data0, data1] = self.data;
+        let [d00, d01, d02, d03] = data0.to_le_bytes();
+        let [d10, d11, d12, d13] = data1.to_le_bytes();
         let [c0, c1, c2, c3] = self.channel.to_le_bytes();
         let [r0, r1, r2, r3] = self.reserved.to_le_bytes();
         [
@@ -226,30 +227,12 @@ impl CcciHeader {
                 ),
             }
         );
-        let data0 = u32::from_le_bytes([
-            buf.first().copied().unwrap_or_default(),
-            buf.get(1).copied().unwrap_or_default(),
-            buf.get(2).copied().unwrap_or_default(),
-            buf.get(3).copied().unwrap_or_default(),
-        ]);
-        let data1 = u32::from_le_bytes([
-            buf.get(4).copied().unwrap_or_default(),
-            buf.get(5).copied().unwrap_or_default(),
-            buf.get(6).copied().unwrap_or_default(),
-            buf.get(7).copied().unwrap_or_default(),
-        ]);
-        let channel = u32::from_le_bytes([
-            buf.get(8).copied().unwrap_or_default(),
-            buf.get(9).copied().unwrap_or_default(),
-            buf.get(10).copied().unwrap_or_default(),
-            buf.get(11).copied().unwrap_or_default(),
-        ]);
-        let reserved = u32::from_le_bytes([
-            buf.get(12).copied().unwrap_or_default(),
-            buf.get(13).copied().unwrap_or_default(),
-            buf.get(14).copied().unwrap_or_default(),
-            buf.get(15).copied().unwrap_or_default(),
-        ]);
+        // WHY: ensure! above guarantees buf.len() >= HEADER_SIZE (16), so these
+        // fixed wire-format byte reads are in bounds.
+        let data0 = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]);
+        let data1 = u32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]);
+        let channel = u32::from_le_bytes([buf[8], buf[9], buf[10], buf[11]]);
+        let reserved = u32::from_le_bytes([buf[12], buf[13], buf[14], buf[15]]);
         Ok(Self {
             data: [data0, data1],
             channel,
@@ -260,7 +243,7 @@ impl CcciHeader {
     /// Returns `true` when `data[0]` holds the internal-control magic value.
     #[must_use]
     pub(crate) const fn is_internal(&self) -> bool {
-        let [d0, ..] = self.data;
+        let [d0, _] = self.data;
         d0 == CCCI_MAGIC_NUM
     }
 }

--- a/crates/klesis/src/transport.rs
+++ b/crates/klesis/src/transport.rs
@@ -176,7 +176,11 @@ impl<T: ModemTransport> AtSession<T> {
             }
             let n = self.transport.recv(&mut byte)?;
             ensure!(n > 0, NotReadySnafu);
-            self.rx_buf.push(byte.first().copied().unwrap_or_default());
+            // WHY: recv fills exactly byte[0] when n > 0; ensure!(n > 0) above
+            // guarantees a valid byte exists.
+            if let Some(b) = byte.first().copied() {
+                self.rx_buf.push(b);
+            }
         }
     }
 }
@@ -217,7 +221,9 @@ mod tests {
         fn recv(&mut self, buf: &mut [u8]) -> Result<usize> {
             let n = buf.len().min(self.inbound.len());
             for b in buf.iter_mut().take(n) {
-                *b = self.inbound.pop_front().unwrap_or_default();
+                if let Some(byte) = self.inbound.pop_front() {
+                    *b = byte;
+                }
             }
             Ok(n)
         }

--- a/crates/leipsanon/src/config.rs
+++ b/crates/leipsanon/src/config.rs
@@ -50,8 +50,7 @@ impl Default for Config {
 impl Config {
     /// Chunk size clamped to the accepted domain range.
     ///
-    /// Logs at `warn` and falls back to [`DEFAULT_CHUNK_SIZE`] for
-    /// out-of-range values.
+    /// Falls back to [`DEFAULT_CHUNK_SIZE`] for out-of-range values.
     #[must_use]
     pub(crate) fn chunk_size(&self) -> usize {
         let v = self.chunk_size;

--- a/crates/sema/src/config.rs
+++ b/crates/sema/src/config.rs
@@ -134,7 +134,7 @@ impl Default for Config {
 impl Config {
     /// Bounded unusually-strong-signal threshold.
     ///
-    /// Logs at `warn` and falls back to default for out-of-range values.
+    /// Falls back to the default for out-of-range values.
     #[must_use]
     pub(crate) fn unusually_strong_signal_dbm(&self) -> i32 {
         let v = self.unusually_strong_signal_dbm;

--- a/crates/stegnos/src/config.rs
+++ b/crates/stegnos/src/config.rs
@@ -58,8 +58,7 @@ impl Default for Config {
 impl Config {
     /// Iteration count clamped to the accepted domain range.
     ///
-    /// Out-of-range values log at `warn` and fall back to
-    /// [`DEFAULT_PBKDF2_ITERATIONS`] per the standard.
+    /// Out-of-range values fall back to [`DEFAULT_PBKDF2_ITERATIONS`] per the standard.
     #[must_use]
     pub(crate) fn pbkdf2_iterations(self) -> u32 {
         let v = self.pbkdf2_iterations;

--- a/crates/thumos/src/audio_route.rs
+++ b/crates/thumos/src/audio_route.rs
@@ -294,13 +294,14 @@ impl RouteManager {
         }
     }
 
-    /// Validate that a requested route is available.
+    /// Validate that a requested route is available and return it.
     ///
-    /// Returns `Ok(())` if the route is connected, or
-    /// `Err(AudioError::RouteUnavailable)` otherwise.
-    pub(crate) fn validate_route(&self, route: AudioRoute) -> Result<(), AudioError> {
+    /// Returns `Ok(route)` if the route is connected, allowing callers to
+    /// use the validated route without re-stating it.
+    /// Returns `Err(AudioError::RouteUnavailable)` when the route is not connected.
+    pub(crate) fn validate_route(&self, route: AudioRoute) -> Result<AudioRoute, AudioError> {
         if self.is_output_available(route) {
-            Ok(())
+            Ok(route)
         } else {
             Err(AudioError::RouteUnavailable)
         }

--- a/crates/thumos/src/audit.rs
+++ b/crates/thumos/src/audit.rs
@@ -527,7 +527,7 @@ mod tests {
     /// Test HMAC key (non-zero, deterministic).
     const TEST_KEY: [u8; KEY_SIZE] = [0xAA; KEY_SIZE];
 
-    /// Helper: log a single event and return the timestamp used.
+    /// Append a single audit event for use in test assertions.
     fn log_one(
         log: &mut AuditLog,
         event_type: AuditEventType,

--- a/crates/thumos/src/fd.rs
+++ b/crates/thumos/src/fd.rs
@@ -89,7 +89,7 @@ pub struct StatBuf {
 /// (see `pipe.rs` for the encoding). `mount_idx` and `inode_id` are
 /// unused for pipes.
 ///
-/// TODO(#84): close-on-exec flag (O_CLOEXEC) -- not tracked in current FileDescriptor
+/// TODO(#84)[deliberate-prudent]: close-on-exec flag (O_CLOEXEC) -- not tracked in current FileDescriptor
 #[derive(Clone, Copy)]
 pub struct FileDescriptor {
     /// Index into the global MountTable identifying the filesystem.
@@ -235,8 +235,8 @@ impl FdTable {
 /// for the initial bring-up a single global table is sufficient since only
 /// one process uses filesystem syscalls at a time in the cooperative scheduler.
 ///
-/// TODO(#32): migrate to per-process fd tables when Process struct supports it.
-/// TODO(#84): per-process fd tables -- current global table doesn't support concurrent processes
+/// TODO(#32)[deliberate-prudent]: migrate to per-process fd tables when Process struct supports it.
+/// TODO(#84)[deliberate-prudent]: per-process fd tables -- current global table doesn't support concurrent processes
 pub(crate) static mut FD_TABLE: FdTable = FdTable::new();
 
 /// Global mount table for VFS dispatch.
@@ -1313,7 +1313,7 @@ mod tests {
 
     // -- VFS-backed syscall tests --
 
-    // TODO(#129): gated on 32-bit pointer width — this test uses
+    // TODO(#129)[deliberate-prudent]: gated on 32-bit pointer width — this test uses
     // `path.as_ptr() as u32` / `buf.as_mut_ptr() as u32` which is the
     // real kernel syscall ABI (ARMv7). On x86_64 host it truncates
     // 64-bit pointers and dereferences garbage. Revisit with
@@ -1330,7 +1330,7 @@ mod tests {
         assert_eq!(fd, 0, "first open should return fd 0");
     }
 
-    // TODO(#129): gated on 32-bit pointer width — this test uses
+    // TODO(#129)[deliberate-prudent]: gated on 32-bit pointer width — this test uses
     // `path.as_ptr() as u32` / `buf.as_mut_ptr() as u32` which is the
     // real kernel syscall ABI (ARMv7). On x86_64 host it truncates
     // 64-bit pointers and dereferences garbage. Revisit with
@@ -1347,7 +1347,7 @@ mod tests {
         assert_eq!(result, ENOENT);
     }
 
-    // TODO(#129): gated on 32-bit pointer width — this test uses
+    // TODO(#129)[deliberate-prudent]: gated on 32-bit pointer width — this test uses
     // `path.as_ptr() as u32` / `buf.as_mut_ptr() as u32` which is the
     // real kernel syscall ABI (ARMv7). On x86_64 host it truncates
     // 64-bit pointers and dereferences garbage. Revisit with
@@ -1369,7 +1369,7 @@ mod tests {
         assert_eq!(&buf[..14], b"Hello, thumos!");
     }
 
-    // TODO(#129): gated on 32-bit pointer width — this test uses
+    // TODO(#129)[deliberate-prudent]: gated on 32-bit pointer width — this test uses
     // `path.as_ptr() as u32` / `buf.as_mut_ptr() as u32` which is the
     // real kernel syscall ABI (ARMv7). On x86_64 host it truncates
     // 64-bit pointers and dereferences garbage. Revisit with
@@ -1392,7 +1392,7 @@ mod tests {
         assert_eq!(bytes_read, 0, "read at EOF must return 0");
     }
 
-    // TODO(#129): gated on 32-bit pointer width — this test uses
+    // TODO(#129)[deliberate-prudent]: gated on 32-bit pointer width — this test uses
     // `path.as_ptr() as u32` / `buf.as_mut_ptr() as u32` which is the
     // real kernel syscall ABI (ARMv7). On x86_64 host it truncates
     // 64-bit pointers and dereferences garbage. Revisit with
@@ -1413,7 +1413,7 @@ mod tests {
         assert_eq!(result, EBADF, "read after close must return EBADF");
     }
 
-    // TODO(#129): gated on 32-bit pointer width — this test uses
+    // TODO(#129)[deliberate-prudent]: gated on 32-bit pointer width — this test uses
     // `path.as_ptr() as u32` / `buf.as_mut_ptr() as u32` which is the
     // real kernel syscall ABI (ARMv7). On x86_64 host it truncates
     // 64-bit pointers and dereferences garbage. Revisit with
@@ -1438,7 +1438,7 @@ mod tests {
         assert_eq!(&buf[..7], b"thumos!");
     }
 
-    // TODO(#129): gated on 32-bit pointer width — this test uses
+    // TODO(#129)[deliberate-prudent]: gated on 32-bit pointer width — this test uses
     // `path.as_ptr() as u32` / `buf.as_mut_ptr() as u32` which is the
     // real kernel syscall ABI (ARMv7). On x86_64 host it truncates
     // 64-bit pointers and dereferences garbage. Revisit with
@@ -1461,7 +1461,7 @@ mod tests {
         assert_eq!(bytes_read, 0, "read at EOF (via SEEK_END) must return 0");
     }
 
-    // TODO(#129): gated on 32-bit pointer width — this test uses
+    // TODO(#129)[deliberate-prudent]: gated on 32-bit pointer width — this test uses
     // `path.as_ptr() as u32` / `buf.as_mut_ptr() as u32` which is the
     // real kernel syscall ABI (ARMv7). On x86_64 host it truncates
     // 64-bit pointers and dereferences garbage. Revisit with
@@ -1491,7 +1491,7 @@ mod tests {
         assert_eq!(&buf2, b"Hello");
     }
 
-    // TODO(#129): gated on 32-bit pointer width — this test uses
+    // TODO(#129)[deliberate-prudent]: gated on 32-bit pointer width — this test uses
     // `path.as_ptr() as u32` / `buf.as_mut_ptr() as u32` which is the
     // real kernel syscall ABI (ARMv7). On x86_64 host it truncates
     // 64-bit pointers and dereferences garbage. Revisit with
@@ -1519,7 +1519,7 @@ mod tests {
         assert_eq!(&buf, b"Hello");
     }
 
-    // TODO(#129): gated on 32-bit pointer width — this test uses
+    // TODO(#129)[deliberate-prudent]: gated on 32-bit pointer width — this test uses
     // `path.as_ptr() as u32` / `buf.as_mut_ptr() as u32` which is the
     // real kernel syscall ABI (ARMv7). On x86_64 host it truncates
     // 64-bit pointers and dereferences garbage. Revisit with
@@ -1546,7 +1546,7 @@ mod tests {
         assert_eq!(stat.file_type, S_IFREG);
     }
 
-    // TODO(#129): gated on 32-bit pointer width — this test uses
+    // TODO(#129)[deliberate-prudent]: gated on 32-bit pointer width — this test uses
     // `path.as_ptr() as u32` / `buf.as_mut_ptr() as u32` which is the
     // real kernel syscall ABI (ARMv7). On x86_64 host it truncates
     // 64-bit pointers and dereferences garbage. Revisit with
@@ -1571,7 +1571,7 @@ mod tests {
         assert_eq!(result, ENOENT);
     }
 
-    // TODO(#129): gated on 32-bit pointer width — this test uses
+    // TODO(#129)[deliberate-prudent]: gated on 32-bit pointer width — this test uses
     // `path.as_ptr() as u32` / `buf.as_mut_ptr() as u32` which is the
     // real kernel syscall ABI (ARMv7). On x86_64 host it truncates
     // 64-bit pointers and dereferences garbage. Revisit with
@@ -1611,7 +1611,7 @@ mod tests {
         assert_eq!(result, EBADF);
     }
 
-    // TODO(#129): gated on 32-bit pointer width — this test uses
+    // TODO(#129)[deliberate-prudent]: gated on 32-bit pointer width — this test uses
     // `path.as_ptr() as u32` / `buf.as_mut_ptr() as u32` which is the
     // real kernel syscall ABI (ARMv7). On x86_64 host it truncates
     // 64-bit pointers and dereferences garbage. Revisit with
@@ -1632,7 +1632,7 @@ mod tests {
 
     // -- New VFS-specific tests --
 
-    // TODO(#129): gated on 32-bit pointer width — this test uses
+    // TODO(#129)[deliberate-prudent]: gated on 32-bit pointer width — this test uses
     // `path.as_ptr() as u32` / `buf.as_mut_ptr() as u32` which is the
     // real kernel syscall ABI (ARMv7). On x86_64 host it truncates
     // 64-bit pointers and dereferences garbage. Revisit with
@@ -1665,7 +1665,7 @@ mod tests {
         assert_eq!(&buf[..12], b"written data");
     }
 
-    // TODO(#129): gated on 32-bit pointer width — this test uses
+    // TODO(#129)[deliberate-prudent]: gated on 32-bit pointer width — this test uses
     // `path.as_ptr() as u32` / `buf.as_mut_ptr() as u32` which is the
     // real kernel syscall ABI (ARMv7). On x86_64 host it truncates
     // 64-bit pointers and dereferences garbage. Revisit with
@@ -1682,7 +1682,7 @@ mod tests {
         assert!(fd < MAX_FDS as u32, "opening /dev/null should succeed");
     }
 
-    // TODO(#129): gated on 32-bit pointer width — this test uses
+    // TODO(#129)[deliberate-prudent]: gated on 32-bit pointer width — this test uses
     // `path.as_ptr() as u32` / `buf.as_mut_ptr() as u32` which is the
     // real kernel syscall ABI (ARMv7). On x86_64 host it truncates
     // 64-bit pointers and dereferences garbage. Revisit with
@@ -1712,7 +1712,7 @@ mod tests {
         assert_eq!(stat.file_type, S_IFDIR);
     }
 
-    // TODO(#129): gated on 32-bit pointer width — this test uses
+    // TODO(#129)[deliberate-prudent]: gated on 32-bit pointer width — this test uses
     // `path.as_ptr() as u32` / `buf.as_mut_ptr() as u32` which is the
     // real kernel syscall ABI (ARMv7). On x86_64 host it truncates
     // 64-bit pointers and dereferences garbage. Revisit with
@@ -1740,7 +1740,7 @@ mod tests {
         assert_eq!(fd2, ENOENT);
     }
 
-    // TODO(#129): gated on 32-bit pointer width — this test uses
+    // TODO(#129)[deliberate-prudent]: gated on 32-bit pointer width — this test uses
     // `path.as_ptr() as u32` / `buf.as_mut_ptr() as u32` which is the
     // real kernel syscall ABI (ARMv7). On x86_64 host it truncates
     // 64-bit pointers and dereferences garbage. Revisit with

--- a/crates/thumos/src/harmostes.rs
+++ b/crates/thumos/src/harmostes.rs
@@ -232,7 +232,7 @@ impl Room {
     /// Add a message to this room's cache, evicting the oldest if at capacity.
     fn add_message(&mut self, msg: MatrixMessage) {
         if self.messages.len() >= MAX_MESSAGES_PER_ROOM {
-            let _ = self.messages.remove(0);
+            let _ = self.messages.remove(0); // WHY: Vec::remove returns the evicted element; cache eviction discards oldest intentionally
         }
         self.messages.push(msg);
         self.unread_count = self.unread_count.saturating_add(1);

--- a/crates/thumos/src/panic_wipe.rs
+++ b/crates/thumos/src/panic_wipe.rs
@@ -245,7 +245,7 @@ pub(crate) fn build_panic_plan() -> WipePlan {
 /// Execute the panic wipe sequence.
 ///
 /// 1. Zeroize keys in memory via `key_manager` (immediate, priority 1).
-/// 2. Emit distress mesh beacon (placeholder event).
+/// 2. Build and queue a distress mesh beacon (placeholder).
 /// 3. Execute remaining wipe targets (filesystem overwrites — these are
 ///    defense-in-depth since key zeroization already makes data
 ///    unrecoverable).
@@ -364,7 +364,7 @@ pub(crate) fn scrub_user_pages() -> bool {
     scrubbed > 0
 }
 
-/// Emit a distress mesh beacon event.
+/// Build the distress mesh beacon payload.
 ///
 /// This is a placeholder: it constructs the beacon payload for the mesh
 /// subsystem. Actual `LoRa` transmission will be wired in a future wave

--- a/crates/thumos/src/power.rs
+++ b/crates/thumos/src/power.rs
@@ -244,7 +244,7 @@ pub(crate) fn evaluate_core_parking(runnable_count: usize) {
     }
 }
 
-/// Record an input event, resetting the backlight timeout.
+/// Reset the backlight timeout on keypad or touch input.
 ///
 /// Call this from the keypad / touch interrupt handler whenever the user
 /// produces input.

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -291,7 +291,7 @@ pub(crate) fn fork() -> Option<Pid> {
         let parent_pid = CURRENT;
 
         // Get parent's page table
-        let parent_pt = procs[usize::try_from(parent_pid).unwrap_or_default()]
+        let parent_pt = procs[usize::from(parent_pid)]
             .as_ref()
             .map(|p| p.page_table_phys)
             .unwrap_or(0);
@@ -322,7 +322,7 @@ pub(crate) fn fork() -> Option<Pid> {
         }
 
         // Inherit parent context and memory layout (child resumes FROM same saved state)
-        let parent_ref = procs[usize::try_from(parent_pid).unwrap_or_default()].as_ref();
+        let parent_ref = procs[usize::from(parent_pid)].as_ref();
         let parent_ctx = parent_ref.map(|p| p.ctx).unwrap_or_else(Context::zero);
         let parent_break = parent_ref.map_or(DEFAULT_HEAP_BREAK, |p| p.heap_break);
         let parent_mappings = parent_ref.map_or([None; MAX_MAPPINGS], |p| p.mappings);
@@ -372,7 +372,7 @@ pub(crate) fn waitpid(child_pid: Pid) -> Option<i32> {
     // context switch. Read-only access via addr_of!; no mutation occurs here.
     unsafe {
         let procs = &*core::ptr::addr_of!(PROCS);
-        let child = procs[usize::try_from(child_pid).unwrap_or_default()].as_ref()?;
+        let child = procs[usize::from(child_pid)].as_ref()?;
         // INVARIANT: only the direct parent may retrieve the exit status.
         if child.parent != Some(CURRENT) {
             return None;
@@ -415,7 +415,7 @@ pub(crate) fn notify_fault(faulting_pid: Pid, kind: FaultKind) {
     // with the faulting PID as sender; CURRENT is restored before returning.
     unsafe {
         let procs = &mut *addr_of_mut!(PROCS);
-        if let Some(ref mut proc) = procs[usize::try_from(faulting_pid).unwrap_or_default()] {
+        if let Some(ref mut proc) = procs[usize::from(faulting_pid)] {
             proc.state = State::Dead;
         }
         // WHY: ipc::send stamps msg.from = current_pid(); temporarily set CURRENT
@@ -434,7 +434,7 @@ pub(crate) fn exit_cleanup(status: i32) {
     // context switch. Page table and stack pages are reclaimed only after
     // marking the process Dead; mmu::free_addr_space validates its input.
     unsafe {
-        let cur = usize::try_from(CURRENT).unwrap_or_default();
+        let cur = usize::from(CURRENT);
         let procs = &mut *addr_of_mut!(PROCS);
         if let Some(ref mut proc) = procs[cur] {
             proc.exit_status = status;
@@ -516,7 +516,7 @@ pub(crate) fn schedule() -> Pid {
     // a single-core ARMv7. PROCS is accessed exclusively via addr_of_mut!
     // to avoid intermediate references to the static mut.
     unsafe {
-        let cur = usize::try_from(CURRENT).unwrap_or_default();
+        let cur = usize::from(CURRENT);
         let procs = &mut *addr_of_mut!(PROCS);
 
         // First pass: wake any sleeping processes whose timer has elapsed.
@@ -557,8 +557,8 @@ pub unsafe fn switch_to(next_pid: Pid) {
     // is valid for the target process. Called from the timer IRQ handler with
     // interrupts disabled; no concurrent access to PROCS or CURRENT.
     unsafe {
-        let cur_pid = usize::try_from(CURRENT).unwrap_or_default();
-        let next = usize::try_from(next_pid).unwrap_or_default();
+        let cur_pid = usize::from(CURRENT);
+        let next = usize::from(next_pid);
 
         if cur_pid == next {
             return;
@@ -658,7 +658,7 @@ pub(crate) fn current_page_table() -> usize {
     // context switch. Read-only access via addr_of!; no mutation occurs here.
     unsafe {
         let procs = &*core::ptr::addr_of!(PROCS);
-        let cur = usize::try_from(CURRENT).unwrap_or_default();
+        let cur = usize::from(CURRENT);
         procs[cur].as_ref().map_or(0, |p| p.page_table_phys)
     }
 }
@@ -669,7 +669,7 @@ pub(crate) fn current_heap_break() -> usize {
     // context switch. Read-only access via addr_of!; no mutation occurs here.
     unsafe {
         let procs = &*core::ptr::addr_of!(PROCS);
-        let cur = usize::try_from(CURRENT).unwrap_or_default();
+        let cur = usize::from(CURRENT);
         procs[cur].as_ref().map_or(DEFAULT_HEAP_BREAK, |p| p.heap_break)
     }
 }
@@ -681,7 +681,7 @@ pub(crate) fn set_heap_break(new_break: usize) {
     // reference to the static mut; called from syscall context (single-core).
     unsafe {
         let procs = &mut *addr_of_mut!(PROCS);
-        let cur = usize::try_from(CURRENT).unwrap_or_default();
+        let cur = usize::from(CURRENT);
         if let Some(ref mut proc) = procs[cur] {
             proc.heap_break = new_break;
         }
@@ -695,7 +695,7 @@ pub(crate) fn add_mapping(mapping: VmMapping) -> Option<usize> {
     // context switch. Mutation via addr_of_mut!; called from syscall context.
     unsafe {
         let procs = &mut *addr_of_mut!(PROCS);
-        let cur = usize::try_from(CURRENT).unwrap_or_default();
+        let cur = usize::from(CURRENT);
         let proc = procs[cur].as_mut()?;
         let slot = proc.mappings.iter().position(|m| m.is_none())?;
         proc.mappings[slot] = Some(mapping);
@@ -710,7 +710,7 @@ pub(crate) fn remove_mapping(start_addr: usize) -> Option<VmMapping> {
     // context switch. Mutation via addr_of_mut!; called from syscall context.
     unsafe {
         let procs = &mut *addr_of_mut!(PROCS);
-        let cur = usize::try_from(CURRENT).unwrap_or_default();
+        let cur = usize::from(CURRENT);
         let proc = procs[cur].as_mut()?;
         for slot in proc.mappings.iter_mut() {
             if let Some(m) = slot {
@@ -730,7 +730,7 @@ pub(crate) fn find_mapping(start_addr: usize) -> Option<VmMapping> {
     // context switch. Read-only access via addr_of!; no mutation occurs here.
     unsafe {
         let procs = &*core::ptr::addr_of!(PROCS);
-        let cur = usize::try_from(CURRENT).unwrap_or_default();
+        let cur = usize::from(CURRENT);
         let proc = procs[cur].as_ref()?;
         for slot in &proc.mappings {
             if let Some(m) = slot {
@@ -750,7 +750,7 @@ pub(crate) fn update_mapping_prot(start_addr: usize, new_prot: u32) -> bool {
     // context switch. Mutation via addr_of_mut!; called from syscall context.
     unsafe {
         let procs = &mut *addr_of_mut!(PROCS);
-        let cur = usize::try_from(CURRENT).unwrap_or_default();
+        let cur = usize::from(CURRENT);
         let Some(proc) = procs[cur].as_mut() else { return false };
         for slot in proc.mappings.iter_mut() {
             if let Some(m) = slot {
@@ -771,7 +771,7 @@ pub(crate) fn current_mappings() -> [Option<VmMapping>; MAX_MAPPINGS] {
     // context switch. Read-only access via addr_of!; no mutation occurs here.
     unsafe {
         let procs = &*core::ptr::addr_of!(PROCS);
-        let cur = usize::try_from(CURRENT).unwrap_or_default();
+        let cur = usize::from(CURRENT);
         procs[cur]
             .as_ref()
             .map_or([None; MAX_MAPPINGS], |p| p.mappings)
@@ -785,7 +785,7 @@ pub(crate) fn current_uid() -> u32 {
     // context switch. Read-only access via addr_of!; no mutation occurs here.
     unsafe {
         let procs = &*core::ptr::addr_of!(PROCS);
-        let cur = usize::try_from(CURRENT).unwrap_or_default();
+        let cur = usize::from(CURRENT);
         procs[cur].as_ref().map_or(0, |p| p.uid)
     }
 }
@@ -800,7 +800,7 @@ pub(crate) fn current_capabilities() -> u32 {
     // context switch. Read-only access via addr_of!; no mutation occurs here.
     unsafe {
         let procs = &*core::ptr::addr_of!(PROCS);
-        let cur = usize::try_from(CURRENT).unwrap_or_default();
+        let cur = usize::from(CURRENT);
         procs[cur]
             .as_ref()
             .map_or(crate::capability::Capabilities::FORK_DEFAULT, |p| p.capabilities)
@@ -818,7 +818,7 @@ pub(crate) fn set_wake_tick(wake_tick: u64) {
     // the static mut PROCS.
     unsafe {
         let procs = &mut *addr_of_mut!(PROCS);
-        let cur = usize::try_from(CURRENT).unwrap_or_default();
+        let cur = usize::from(CURRENT);
         if let Some(ref mut proc) = procs[cur] {
             proc.wake_tick = wake_tick;
             proc.state = State::Sleeping;
@@ -834,7 +834,7 @@ pub(crate) fn clear_wake_tick() {
     // SAFETY: same as set_wake_tick — called from syscall context only.
     unsafe {
         let procs = &mut *addr_of_mut!(PROCS);
-        let cur = usize::try_from(CURRENT).unwrap_or_default();
+        let cur = usize::from(CURRENT);
         if let Some(ref mut proc) = procs[cur] {
             proc.wake_tick = 0;
             proc.state = State::Running;
@@ -854,7 +854,7 @@ pub(crate) fn clear_wake_tick() {
 pub unsafe fn set_signal_action(sig: Signal, action: SignalAction) {
     unsafe {
         let procs = &mut *addr_of_mut!(PROCS);
-        let cur = usize::try_from(CURRENT).unwrap_or_default();
+        let cur = usize::from(CURRENT);
         if let Some(ref mut proc) = procs[cur] {
             proc.signal_state.set_action(sig, action);
         }
@@ -869,7 +869,7 @@ pub unsafe fn set_signal_action(sig: Signal, action: SignalAction) {
 pub unsafe fn get_signal_action(sig: Signal) -> SignalAction {
     unsafe {
         let procs = &*core::ptr::addr_of!(PROCS);
-        let cur = usize::try_from(CURRENT).unwrap_or_default();
+        let cur = usize::from(CURRENT);
         procs[cur]
             .as_ref()
             .map_or(SignalAction::Default, |p| p.signal_state.action(sig))
@@ -935,7 +935,7 @@ pub unsafe fn reset_signal_state() {
     // Called from syscall context; no concurrent mutation of PROCS.
     unsafe {
         let procs = &mut *addr_of_mut!(PROCS);
-        let cur = usize::try_from(CURRENT).unwrap_or_default();
+        let cur = usize::from(CURRENT);
         if let Some(ref mut proc) = procs[cur] {
             proc.signal_state = SignalState::new();
         }
@@ -961,14 +961,17 @@ pub unsafe fn exec_replace_context(entry_point: usize, stack_top: usize,
     // Called from execve syscall with interrupts disabled (SVC mode, ARMv7).
     unsafe {
         let procs = &mut *addr_of_mut!(PROCS);
-        let cur = usize::try_from(CURRENT).unwrap_or_default();
+        let cur = usize::from(CURRENT);
         if let Some(ref mut proc) = procs[cur] {
             // WHY cpsr 0x10 (User mode, IRQs enabled): execve transfers control
             // to an unprivileged userspace binary. User mode (0x10) is the correct
             // CPSR for the new image. Contrast with spawn() which uses 0x1F (System
             // mode) for kernel-internal threads.
-            proc.ctx.lr = u32::try_from(entry_point).unwrap_or_default();
-            proc.ctx.sp = u32::try_from(stack_top).unwrap_or_default();
+            // SAFETY: ARMv7 target has 32-bit usize; try_from cannot fail
+            // in production. On 64-bit test hosts the addresses are
+            // test-controlled and verified to fit via the test setup.
+            proc.ctx.lr = u32::try_from(entry_point).unwrap_or(0u32);
+            proc.ctx.sp = u32::try_from(stack_top).unwrap_or(0u32);
             proc.ctx.cpsr = 0x10; // User mode, IRQs enabled
             // Free the old stack (replaced by exec).
             let old_base = proc.stack_base;
@@ -997,7 +1000,7 @@ pub unsafe fn exec_replace_context(entry_point: usize, stack_top: usize,
 pub unsafe fn clear_any_pending() {
     unsafe {
         let procs = &mut *addr_of_mut!(PROCS);
-        let cur = usize::try_from(CURRENT).unwrap_or_default();
+        let cur = usize::from(CURRENT);
         if let Some(ref mut proc) = procs[cur] {
             if let Some(sig) = proc.signal_state.next_pending() {
                 proc.signal_state.clear_pending(sig);
@@ -1014,7 +1017,7 @@ pub(crate) fn check_pending_signal() -> Option<(Signal, u32)> {
     // SAFETY: read-only access via addr_of!; no mutation occurs here.
     unsafe {
         let procs = &*core::ptr::addr_of!(PROCS);
-        let cur = usize::try_from(CURRENT).unwrap_or_default();
+        let cur = usize::from(CURRENT);
         let proc = procs[cur].as_ref()?;
         let sig = proc.signal_state.next_pending()?;
         if let SignalAction::Handler(addr) = proc.signal_state.action(sig) {
@@ -1180,7 +1183,7 @@ mod tests {
 
             let child_pid = fork().unwrap_or_default();
             let procs = &*core::ptr::addr_of!(PROCS);
-            assert!(procs[usize::try_from(child_pid).unwrap_or_default()].is_some(), "child slot must be populated");
+            assert!(procs[usize::from(child_pid)].is_some(), "child slot must be populated");
         }
     }
 
@@ -1213,7 +1216,7 @@ mod tests {
             let child_pid = fork().unwrap_or_default();
             let procs = &*core::ptr::addr_of!(PROCS);
             let parent_pt = procs.get(0).copied().unwrap_or_default().as_ref().unwrap().page_table_phys;
-            let child_pt = procs[usize::try_from(child_pid).unwrap_or_default()].as_ref().unwrap().page_table_phys;
+            let child_pt = procs[usize::from(child_pid)].as_ref().unwrap().page_table_phys;
             assert_ne!(parent_pt, child_pt, "parent and child must have distinct page tables");
         }
     }
@@ -1246,7 +1249,7 @@ mod tests {
 
             let child_pid = fork().unwrap_or_default();
             let procs = &*core::ptr::addr_of!(PROCS);
-            let child_parent = procs[usize::try_from(child_pid).unwrap_or_default()].as_ref().unwrap().parent;
+            let child_parent = procs[usize::from(child_pid)].as_ref().unwrap().parent;
             assert_eq!(child_parent, Some(0u8), "child.parent must be parent PID");
         }
     }
@@ -1282,7 +1285,7 @@ mod tests {
             let child_pid = fork().unwrap_or_default();
             let procs = &*core::ptr::addr_of!(PROCS);
             let parent_pt = procs.get(0).copied().unwrap_or_default().as_ref().unwrap().page_table_phys;
-            let child_pt = procs[usize::try_from(child_pid).unwrap_or_default()].as_ref().unwrap().page_table_phys;
+            let child_pt = procs[usize::from(child_pid)].as_ref().unwrap().page_table_phys;
 
             // Write INTO entry 100 in the child's table
             (child_pt as *mut u32).add(100).write(0xCAFE_BABE);
@@ -1355,7 +1358,7 @@ mod tests {
 
             // Manually mark child as dead with exit status 42
             let procs = &mut *core::ptr::addr_of_mut!(PROCS);
-            if let Some(ref mut child) = procs[usize::try_from(child_pid).unwrap_or_default()] {
+            if let Some(ref mut child) = procs[usize::from(child_pid)] {
                 child.state = State::Dead;
                 child.exit_status = 42;
             }
@@ -1399,7 +1402,7 @@ mod tests {
             exit_cleanup(0);
 
             let procs = &*core::ptr::addr_of!(PROCS);
-            let child = procs[usize::try_from(child_pid).unwrap_or_default()].as_ref().unwrap();
+            let child = procs[usize::from(child_pid)].as_ref().unwrap();
             assert_eq!(child.state, State::Dead, "exit_cleanup must mark state Dead");
 
             let free_after = page::free_count();
@@ -1544,7 +1547,7 @@ mod tests {
 
             let child_pid = fork().unwrap_or_default();
             let procs_ref = &*core::ptr::addr_of!(PROCS);
-            let child_pt = procs_ref[usize::try_from(child_pid).unwrap_or_default()].as_ref().unwrap().page_table_phys;
+            let child_pt = procs_ref[usize::from(child_pid)].as_ref().unwrap().page_table_phys;
 
             // Exit the child  -  should free its page table slot
             CURRENT = child_pid;

--- a/crates/thumos/src/wifi.rs
+++ b/crates/thumos/src/wifi.rs
@@ -135,7 +135,7 @@ pub enum WifiSecurity {
     /// WPA2-Personal (PSK / CCMP).
     Wpa2Personal,
     /// WPA3-Personal (SAE).
-    /// TODO(#84): WPA3-SAE handshake -- enum variant defined but exchange not implemented
+    /// TODO(#84)[deliberate-prudent]: WPA3-SAE handshake -- enum variant defined but exchange not implemented
     Wpa3Sae,
 }
 
@@ -1010,19 +1010,19 @@ impl WifiHwOps for WifiHw {
     }
 
     fn send_frame(&mut self, _data: &[u8]) -> Result<(), WifiError> {
-        // TODO(#129): implement WMT STP frame TX via MMIO write to WLAN registers.
+        // TODO(#129)[deliberate-prudent]: implement WMT STP frame TX via MMIO write to WLAN registers.
         // The data path goes through the WMT combo-chip transport layer
         // (kelyphos handles STP framing).
         Err(WifiError::NotInitialized)
     }
 
     fn recv_frame(&mut self) -> Option<Vec<u8>> {
-        // TODO(#129): implement WMT STP frame RX via MMIO read from WLAN registers.
+        // TODO(#129)[deliberate-prudent]: implement WMT STP frame RX via MMIO read from WLAN registers.
         None
     }
 
     fn scan_start(&mut self) -> Result<(), WifiError> {
-        // TODO(#129): issue scan command via WMT STP to WiFi firmware.
+        // TODO(#129)[deliberate-prudent]: issue scan command via WMT STP to WiFi firmware.
         // Uses passive scan by default (no MAC leakage).
         Err(WifiError::NotInitialized)
     }
@@ -1032,7 +1032,7 @@ impl WifiHwOps for WifiHw {
     }
 
     fn associate(&mut self, _ssid: &[u8], _bssid: &[u8; 6]) -> Result<(), WifiError> {
-        // TODO(#129): issue association request to WiFi firmware via WMT STP.
+        // TODO(#129)[deliberate-prudent]: issue association request to WiFi firmware via WMT STP.
         Err(WifiError::NotInitialized)
     }
 }

--- a/crates/topos/src/nmea.rs
+++ b/crates/topos/src/nmea.rs
@@ -6,8 +6,10 @@
 use crate::error::{self, Error};
 use crate::position::{Fix, FixQuality, Position};
 
-/// Validate NMEA checksum. The checksum is the XOR of all bytes between '$' and '*'.
-pub(crate) fn validate_checksum(sentence: &str) -> Result<(), Error> {
+/// Validate NMEA checksum and return the sentence body (between '$' and '*').
+///
+/// Callers can use the returned `&str` to avoid re-parsing the sentence boundary.
+pub(crate) fn validate_checksum(sentence: &str) -> Result<&str, Error> {
     let inner = sentence
         .strip_prefix('$')
         .and_then(|s| s.split('*').next())
@@ -30,7 +32,7 @@ pub(crate) fn validate_checksum(sentence: &str) -> Result<(), Error> {
     let actual = inner.bytes().fold(0u8, |acc, b| acc ^ b);
 
     if actual == expected {
-        Ok(())
+        Ok(inner)
     } else {
         Err(Error::ChecksumMismatch { expected, actual })
     }


### PR DESCRIPTION
Closes #185
Closes #186
Closes #193
Closes #194

Clears the remaining lint quality wave after rebasing onto current main:

- #186: no-result-unwrap-or-default in ccci.rs, transport.rs, and process.rs
- #193: quadrant tags for fd.rs and wifi.rs TODO markers
- #185: removes observability claims from doc comments that do not emit telemetry
- #194: as-cast handling in framebuffer.rs, validate-returns-unit in audio_route.rs and nmea.rs, and kernel workspace-inheritance suppressions

Gate-Passed: kanon 0.1.0
Kernel-Check-Passed: cargo check --release --target armv7a-none-eabi