### PR TITLE
fix(manifest): add kanon maturity metadata

### DIFF
--- a/crates/aither/Cargo.toml
+++ b/crates/aither/Cargo.toml
@@ -19,3 +19,8 @@ log = { workspace = true }
 
 [lints]
 workspace = true
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-27"
+exit-criteria = "operator-reviewed hardware validation and release-readiness gate"

--- a/crates/asphaleia/Cargo.toml
+++ b/crates/asphaleia/Cargo.toml
@@ -14,3 +14,8 @@ log = { workspace = true }
 
 [lints]
 workspace = true
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-27"
+exit-criteria = "operator-reviewed hardware validation and release-readiness gate"

--- a/crates/eidolon/Cargo.toml
+++ b/crates/eidolon/Cargo.toml
@@ -14,3 +14,8 @@ haphe = { path = "../haphe", version = "0.1.3" }
 
 [lints]
 workspace = true
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-27"
+exit-criteria = "operator-reviewed hardware validation and release-readiness gate"

--- a/crates/haphe/Cargo.toml
+++ b/crates/haphe/Cargo.toml
@@ -11,3 +11,8 @@ repository.workspace = true
 
 [lints]
 workspace = true
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-27"
+exit-criteria = "operator-reviewed hardware validation and release-readiness gate"

--- a/crates/kelyphos/Cargo.toml
+++ b/crates/kelyphos/Cargo.toml
@@ -13,3 +13,8 @@ snafu.workspace = true
 
 [lints]
 workspace = true
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-27"
+exit-criteria = "operator-reviewed hardware validation and release-readiness gate"

--- a/crates/klesis/Cargo.toml
+++ b/crates/klesis/Cargo.toml
@@ -15,3 +15,8 @@ log = { workspace = true }
 
 [lints]
 workspace = true
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-27"
+exit-criteria = "operator-reviewed hardware validation and release-readiness gate"

--- a/crates/krypta/Cargo.toml
+++ b/crates/krypta/Cargo.toml
@@ -22,3 +22,8 @@ x25519-dalek = { workspace = true }
 
 [lints]
 workspace = true
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-27"
+exit-criteria = "operator-reviewed hardware validation and release-readiness gate"

--- a/crates/leipsanon/Cargo.toml
+++ b/crates/leipsanon/Cargo.toml
@@ -16,3 +16,8 @@ zeroize = "1"
 
 [lints]
 workspace = true
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-27"
+exit-criteria = "operator-reviewed hardware validation and release-readiness gate"

--- a/crates/metaxu/Cargo.toml
+++ b/crates/metaxu/Cargo.toml
@@ -17,3 +17,8 @@ ulid = { workspace = true }
 
 [lints]
 workspace = true
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-27"
+exit-criteria = "operator-reviewed hardware validation and release-readiness gate"

--- a/crates/pteron/Cargo.toml
+++ b/crates/pteron/Cargo.toml
@@ -14,3 +14,8 @@ log = { workspace = true }
 
 [lints]
 workspace = true
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-27"
+exit-criteria = "operator-reviewed hardware validation and release-readiness gate"

--- a/crates/sema/Cargo.toml
+++ b/crates/sema/Cargo.toml
@@ -16,3 +16,8 @@ postcard = { workspace = true }
 
 [lints]
 workspace = true
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-27"
+exit-criteria = "operator-reviewed hardware validation and release-readiness gate"

--- a/crates/stegnos/Cargo.toml
+++ b/crates/stegnos/Cargo.toml
@@ -22,3 +22,8 @@ zeroize = "1"
 
 [lints]
 workspace = true
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-27"
+exit-criteria = "operator-reviewed hardware validation and release-readiness gate"

--- a/crates/thumos/Cargo.toml
+++ b/crates/thumos/Cargo.toml
@@ -53,3 +53,8 @@ unimplemented = "deny"
 opt-level = "s"
 lto = true
 panic = "abort"
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-27"
+exit-criteria = "operator-reviewed hardware validation and release-readiness gate"

--- a/crates/topos/Cargo.toml
+++ b/crates/topos/Cargo.toml
@@ -18,3 +18,8 @@ proptest = "1"
 
 [lints]
 workspace = true
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-27"
+exit-criteria = "operator-reviewed hardware validation and release-readiness gate"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -45,3 +45,8 @@ opt-level = 1
 [package.metadata]
 # WHY: required marker so `cargo fuzz list` recognises this as a fuzz project.
 cargo-fuzz = true
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-05-27"
+exit-criteria = "operator-reviewed hardware validation and release-readiness gate"


### PR DESCRIPTION
## Summary
- add kanon maturity metadata to all crate manifests
- mark current maturity as alpha with explicit exit criteria

## Verification
- Gate-Passed: kanon 0.1.0
- Kernel-Check-Passed: cargo check --release --target armv7a-none-eabi