### PR TITLE
test(kernel): assert alternate kernel test paths

### DIFF
--- a/crates/thumos/src/panic_wipe.rs
+++ b/crates/thumos/src/panic_wipe.rs
@@ -517,11 +517,12 @@ mod tests {
     #[test]
     fn scrub_user_pages_returns_result() {
         // NOTE: in test mode, the page allocator may not be initialized,
-        // so free_count() returns 0. We verify the function handles that.
+        // so free_count() returns 0. We verify the return value reflects
+        // whether there was memory available to scrub.
+        let free_before = page::free_count();
         let result = scrub_user_pages();
-        // On host (test), no pages are initialized so this returns false.
-        // The important thing is it doesn't panic.
-        let _ = result;
+        assert_eq!(result, free_before > 0);
+        assert_eq!(page::free_count(), free_before);
     }
 
     // -----------------------------------------------------------------------

--- a/crates/thumos/src/screen_radio.rs
+++ b/crates/thumos/src/screen_radio.rs
@@ -389,6 +389,11 @@ mod tests {
         screen.apply_preset(0);
         let mut fb = [0u16; CONTENT_PIXELS];
         screen.draw(&mut fb);
+        let off_status_rendered = fb.iter().any(|&px| px == color::RED);
+        assert!(
+            off_status_rendered,
+            "covert lock must render OFF radio status text"
+        );
     }
 
     #[test]

--- a/crates/thumos/src/screen_search.rs
+++ b/crates/thumos/src/screen_search.rs
@@ -581,9 +581,11 @@ mod tests {
     fn draw_with_filter_does_not_panic() {
         let mut screen = SearchScreen::new();
         screen.append_t9_key(Key::Num6); // 'm'
+        assert!(screen.match_count() > 0, "filter must keep matching entries");
         let mut fb = [0u16; SCREEN_WIDTH as usize * CONTENT_HEIGHT as usize];
         screen.draw(&mut fb);
-        // Should still render without panic.
+        let any_set = fb.iter().any(|&px| px != 0);
+        assert!(any_set, "filtered search screen must render visible content");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add assertions to panic wipe scrub behavior
- verify alternate radio/search draw paths render visible content
- clear the remaining TESTING/tautological-test warnings

## Verification
- Gate-Passed: kanon 0.1.0
- Kernel-Check-Passed: cargo check --release --target armv7a-none-eabi
- Kernel-Host-Test-Blocked: cargo test --target x86_64-unknown-linux-gnu (pre-existing kernel test harness compile errors)