### PR TITLE
fix(fuzz): use standalone fuzz crate name

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 
 [package]
-name = "thumos-fuzz"
+name = "peirama"
 version = "0.0.0"
 publish = false
 edition = "2024"


### PR DESCRIPTION
## Summary
- rename the internal cargo-fuzz package from thumos-fuzz to peirama
- keep fuzz target names and cargo-fuzz metadata unchanged
- clear NAMING/no-owner-prefix

## Verification
- Gate-Passed: kanon 0.1.0
- Fuzz-Metadata-Passed: cargo metadata --manifest-path fuzz/Cargo.toml --no-deps --format-version 1