### PR TITLE
fix(kernel): type Matrix domain identifiers

### DIFF
--- a/crates/thumos/src/harmostes.rs
+++ b/crates/thumos/src/harmostes.rs
@@ -45,6 +45,7 @@ use alloc::vec::Vec;
 
 use crate::http_client::{self, HttpRequest, HttpResponse, HttpError};
 use crate::json_mini::{JsonParser, JsonWriter, JsonValue, JsonError};
+use crate::matrix_ids::{MatrixEventId, MatrixRoomId};
 use crate::matrix_crypto::{self, MatrixCrypto, MegolmSession, CryptoError};
 use crate::security_mode::SecurityMode;
 
@@ -172,9 +173,9 @@ impl fmt::Display for SyncResult {
 #[non_exhaustive]
 pub struct IncomingMessage {
     /// The room this message belongs to.
-    pub room_id: String,
+    pub room_id: MatrixRoomId,
     /// The Matrix event ID.
-    pub event_id: String,
+    pub event_id: MatrixEventId,
     /// The sender's Matrix user ID.
     pub sender: String,
     /// The message body (plaintext).
@@ -205,7 +206,7 @@ impl fmt::Display for IncomingMessage {
 #[non_exhaustive]
 pub struct Room {
     /// The Matrix room ID (e.g., `!abc123:matrix.example.com`).
-    pub room_id: String,
+    pub room_id: MatrixRoomId,
     /// Human-readable display name for the room.
     pub display_name: String,
     /// Whether this room is a direct message (1:1).
@@ -221,7 +222,7 @@ impl Room {
     #[must_use]
     fn new(room_id: String, display_name: String, is_dm: bool) -> Self {
         Self {
-            room_id,
+            room_id: room_id.into(),
             display_name,
             is_dm,
             messages: Vec::new(),
@@ -262,7 +263,7 @@ impl fmt::Display for Room {
 #[non_exhaustive]
 pub struct MatrixMessage {
     /// The Matrix event ID (e.g., `$event123`).
-    pub event_id: String,
+    pub event_id: MatrixEventId,
     /// The sender's Matrix user ID (e.g., `@user:server`).
     pub sender: String,
     /// The message body (plaintext).
@@ -295,7 +296,7 @@ impl fmt::Display for MatrixMessage {
 #[non_exhaustive]
 pub struct PendingMessage {
     /// Target room ID.
-    pub room_id: String,
+    pub room_id: MatrixRoomId,
     /// Message body to send.
     pub body: String,
     /// Client-generated transaction ID for idempotent retries.
@@ -569,7 +570,7 @@ impl MatrixClient {
                 let msg = parse_timeline_event(event, room_id, &self.crypto);
                 if let Some(msg) = msg {
                     let incoming = IncomingMessage {
-                        room_id: String::from(room_id.as_str()),
+                        room_id: String::from(room_id.as_str()).into(),
                         event_id: msg.event_id.clone(),
                         sender: msg.sender.clone(),
                         body: msg.body.clone(),
@@ -752,7 +753,7 @@ impl MatrixClient {
         let (req, txn_id) = self.build_send_request(room_id, body)?;
 
         self.outbox.push(PendingMessage {
-            room_id: String::from(room_id),
+            room_id: String::from(room_id).into(),
             body: String::from(body),
             txn_id,
         });
@@ -777,7 +778,7 @@ impl MatrixClient {
         self.next_txn_id = self.next_txn_id.saturating_add(1);
 
         self.outbox.push(PendingMessage {
-            room_id: String::from(room_id),
+            room_id: String::from(room_id).into(),
             body: String::from(body),
             txn_id,
         });
@@ -1054,7 +1055,7 @@ fn parse_timeline_event(
     };
 
     Some(MatrixMessage {
-        event_id: String::from(event_id),
+        event_id: String::from(event_id).into(),
         sender: String::from(sender),
         body,
         timestamp: if timestamp >= 0 {
@@ -1700,7 +1701,7 @@ mod tests {
                 event_id: {
                     let mut id = String::from("$msg");
                     push_u32(&mut id, i as u32);
-                    id
+                    id.into()
                 },
                 sender: String::from("@test:example.com"),
                 body: String::from("msg"),
@@ -1712,7 +1713,7 @@ mod tests {
 
         // Add one more — oldest should be evicted.
         room.add_message(MatrixMessage {
-            event_id: String::from("$new"),
+            event_id: String::from("$new").into(),
             sender: String::from("@test:example.com"),
             body: String::from("newest"),
             timestamp: MAX_MESSAGES_PER_ROOM as u64,

--- a/crates/thumos/src/main.rs
+++ b/crates/thumos/src/main.rs
@@ -59,6 +59,7 @@ mod gps;
 mod gsm7;
 mod harmostes;
 mod heorte;
+mod matrix_ids;
 // WHY: not test-gated because matrix_crypto types will be used by harmostes
 // at runtime for E2E message encryption/decryption.
 mod matrix_crypto;

--- a/crates/thumos/src/matrix_crypto.rs
+++ b/crates/thumos/src/matrix_crypto.rs
@@ -43,6 +43,7 @@ use aes::cipher::generic_array::GenericArray;
 
 use crate::csprng;
 use crate::json_mini::{JsonParser, JsonWriter, JsonValue};
+use crate::matrix_ids::MatrixRoomId;
 use crate::security::{self, KEY_SIZE, SHA256_DIGEST_LEN};
 
 // ---------------------------------------------------------------------------
@@ -207,7 +208,7 @@ pub struct MegolmSession {
     /// Number of messages encrypted with this session.
     pub message_index: u32,
     /// The Matrix room ID this session is bound to.
-    pub room_id: String,
+    pub room_id: MatrixRoomId,
 }
 
 impl fmt::Display for MegolmSession {
@@ -462,7 +463,7 @@ impl MatrixCrypto {
             session_id,
             session_key,
             message_index: 0,
-            room_id: String::from(room_id),
+            room_id: String::from(room_id).into(),
         };
 
         // Replace existing session for this room, or add new one.
@@ -1156,7 +1157,7 @@ mod tests {
                 session_id: [0u8; KEY_SIZE],
                 session_key: [0u8; KEY_SIZE],
                 message_index: 0,
-                room_id: String::new(),
+                room_id: String::new().into(),
             });
 
         // Get mutable reference to the outbound session.
@@ -1407,7 +1408,7 @@ mod tests {
             session_id: [0x42; KEY_SIZE],
             session_key: [0xFF; KEY_SIZE],
             message_index: 0,
-            room_id: String::from("!room:example.com"),
+            room_id: String::from("!room:example.com").into(),
         };
 
         let result = crypto.add_inbound_megolm(session);

--- a/crates/thumos/src/matrix_ids.rs
+++ b/crates/thumos/src/matrix_ids.rs
@@ -1,0 +1,60 @@
+//! Typed Matrix identifiers.
+
+extern crate alloc;
+
+use core::{fmt, ops::Deref};
+
+use alloc::string::String;
+
+use serde::{Deserialize, Serialize};
+
+macro_rules! matrix_id {
+    ($name:ident) => {
+        #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+        #[must_use]
+        pub struct $name(String);
+
+        impl $name {
+            pub(crate) fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl From<String> for $name {
+            fn from(value: String) -> Self {
+                Self(value)
+            }
+        }
+
+        impl From<&str> for $name {
+            fn from(value: &str) -> Self {
+                Self(String::from(value))
+            }
+        }
+
+        impl Deref for $name {
+            type Target = str;
+
+            fn deref(&self) -> &Self::Target {
+                self.as_str()
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(self.as_str())
+            }
+        }
+
+        impl PartialEq<&str> for $name {
+            fn eq(&self, other: &&str) -> bool {
+                self.as_str() == *other
+            }
+        }
+    };
+}
+
+matrix_id!(MatrixDeviceId);
+matrix_id!(MatrixEventId);
+matrix_id!(MatrixRoomId);
+matrix_id!(MatrixUserId);

--- a/crates/thumos/src/nous.rs
+++ b/crates/thumos/src/nous.rs
@@ -59,6 +59,8 @@ use core::fmt;
 use alloc::string::String;
 use alloc::vec::Vec;
 
+use crate::matrix_ids::MatrixUserId;
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -306,7 +308,7 @@ pub struct NousEntity {
     /// Number of valid bytes in `name`.
     pub name_len: u8,
     /// Matrix user ID (e.g., "@syn:thumos.lan").
-    pub matrix_id: String,
+    pub matrix_id: MatrixUserId,
     /// Capability preset governing what this entity can do.
     pub capability_preset: CapabilityPreset,
 }
@@ -335,7 +337,7 @@ impl NousEntity {
         Ok(Self {
             name: name_buf,
             name_len: name_bytes.len() as u8,
-            matrix_id,
+            matrix_id: matrix_id.into(),
             capability_preset: preset,
         })
     }
@@ -409,7 +411,7 @@ pub(crate) fn default_syn() -> NousEntity {
         NousEntity {
             name,
             name_len: 1,
-            matrix_id: String::from("@syn:thumos.lan"),
+            matrix_id: String::from("@syn:thumos.lan").into(),
             capability_preset: CapabilityPreset::Off,
         }
     })
@@ -428,7 +430,7 @@ pub(crate) fn default_phrouros() -> NousEntity {
         NousEntity {
             name,
             name_len: 1,
-            matrix_id: String::from("@phrouros:thumos.lan"),
+            matrix_id: String::from("@phrouros:thumos.lan").into(),
             capability_preset: CapabilityPreset::Off,
         }
     })
@@ -447,7 +449,7 @@ pub(crate) fn default_paideia() -> NousEntity {
         NousEntity {
             name,
             name_len: 1,
-            matrix_id: String::from("@paideia:thumos.lan"),
+            matrix_id: String::from("@paideia:thumos.lan").into(),
             capability_preset: CapabilityPreset::Off,
         }
     })

--- a/crates/thumos/src/provision.rs
+++ b/crates/thumos/src/provision.rs
@@ -43,6 +43,7 @@ use alloc::vec::Vec;
 
 use serde::{Deserialize, Serialize};
 
+use crate::matrix_ids::{MatrixDeviceId, MatrixUserId};
 use crate::security;
 
 // ---------------------------------------------------------------------------
@@ -147,9 +148,9 @@ impl fmt::Display for ProvisionState {
 #[non_exhaustive]
 pub struct ProvisionBundle {
     /// Matrix user ID (e.g., `@cody:matrix.example.com`).
-    pub user_id: String,
+    pub user_id: MatrixUserId,
     /// Device ID assigned during registration.
-    pub device_id: String,
+    pub device_id: MatrixDeviceId,
     /// Access token for Bearer auth.
     pub access_token: String,
     /// Homeserver hostname (e.g., `matrix.example.com`).
@@ -407,8 +408,8 @@ mod tests {
     /// Create a test bundle with deterministic data.
     fn provision_bundle_with_cross_signing() -> ProvisionBundle {
         ProvisionBundle {
-            user_id: String::from("@cody:matrix.example.com"),
-            device_id: String::from("THMSTESTDEV01"),
+            user_id: String::from("@cody:matrix.example.com").into(),
+            device_id: String::from("THMSTESTDEV01").into(),
             access_token: String::from("syt_test_provision_token_1234"),
             homeserver: String::from("matrix.example.com"),
             ed25519_key: [0xAA; 32],
@@ -420,8 +421,8 @@ mod tests {
     /// Create a test bundle without cross-signing key.
     fn provision_bundle_without_cross_signing() -> ProvisionBundle {
         ProvisionBundle {
-            user_id: String::from("@test:example.org"),
-            device_id: String::from("DEVNOCSIGN"),
+            user_id: String::from("@test:example.org").into(),
+            device_id: String::from("DEVNOCSIGN").into(),
             access_token: String::from("syt_no_cross_sign"),
             homeserver: String::from("example.org"),
             ed25519_key: [0x11; 32],


### PR DESCRIPTION
## Summary
- add typed Matrix room, event, user, and device identifiers
- use those types in Matrix-facing kernel structs
- clear RUST/primitive-for-domain-id warnings

## Verification
- Gate-Passed: kanon 0.1.0
- Kernel-Check-Passed: cargo check --release --target armv7a-none-eabi

## Review
Touches kernel public data shapes and should stay open for T0 review.