### PR TITLE
chore(ci): add osv-scanner to security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -73,3 +73,29 @@ jobs:
         # .cargo/audit.toml, which mirrors deny.toml's [[advisories.ignore]]
         # entries — no silent --ignore flags here.
         run: cargo audit --deny unmaintained --deny unsound --deny yanked
+
+  osv-scanner:
+    name: osv-scanner
+    # WHY (direct CLI, not the reusable workflow): the org/repo Actions policy
+    # rejects external reusable workflows (google/osv-scanner-action/...), which
+    # startup-failed the whole Security workflow. Invoking the pinned CLI as a
+    # normal run step needs only the default read-only token and no external
+    # reusable-workflow permission. fail-on-vuln is the CLI default.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Install osv-scanner (pinned + checksum-verified)
+        env:
+          OSV_VERSION: v2.4.0
+          OSV_SHA256: 15314940c10d26af9c6649f150b8a47c1262e8fc7e17b1d1029b0e479e8ed8a0
+        run: |
+          set -euo pipefail
+          curl -sSfL "https://github.com/google/osv-scanner/releases/download/${OSV_VERSION}/osv-scanner_linux_amd64" -o osv-scanner
+          echo "${OSV_SHA256}  osv-scanner" | sha256sum -c -
+          chmod +x osv-scanner
+      - name: Scan Cargo.lock (fail on vulnerability)
+        run: ./osv-scanner --lockfile=./Cargo.lock --config=./osv-scanner.toml

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,10 @@
+# OSV-Scanner advisory waiver list.
+# Entries must mirror .cargo/audit.toml [[advisories.ignore]] and deny.toml
+# [[advisories.ignore]] so all three scanners agree. Add entries with a
+# WHY comment and the date added.
+
+# WHY: mirrors deny.toml [[advisories.ignore]] + .cargo/audit.toml so all three
+# scanners agree (osv-scanner surfaced this one; the other two already waive it).
+[[IgnoredVulns]]
+id = "RUSTSEC-2023-0089"
+reason = "atomic-polyfill unmaintained -- transitive via heapless 0.7.17 -> postcard 1.1.3 -> sema/krypta. heapless 0.8+ drops atomic-polyfill for portable-atomic, but postcard 1.x has not bumped its heapless pin past 0.7. No fix available; track postcard upstream."


### PR DESCRIPTION
Add OSV-Scanner reusable workflow job to `security.yml` and create `osv-scanner.toml` waiver list (empty — no active waivers).

Refs: kanon#508