### PR TITLE
Fix fork() child stack corruption + leak (#208), repair QEMU smoke path

### DIFF
--- a/crates/thumos/examples/qemu_smoke.rs
+++ b/crates/thumos/examples/qemu_smoke.rs
@@ -92,9 +92,13 @@ unsafe fn uart_write_str(s: &str) {
 // ARM semihosting — SYS_EXIT
 // -----------------------------------------------------------------------------
 
-// Operation number for SYS_EXIT (angel_SWIreason_ReportException with
-// ADP_Stopped_ApplicationExit, the canonical "clean exit" path).
-const SYS_EXIT: u32 = 0x18;
+// SYS_EXIT_EXTENDED (angel_SWIreason_ReportExceptionExtended). WHY: on AArch32
+// the plain SYS_EXIT (0x18) call takes the reason code DIRECTLY in r1 and cannot
+// convey an explicit status; only SYS_EXIT_EXTENDED (0x20) accepts a
+// [reason, exit_code] parameter block, so pass (0) and fail (1) are
+// distinguishable. On A64 SYS_EXIT already takes the block, but this example is
+// A32-only.
+const SYS_EXIT_EXTENDED: u32 = 0x20;
 const ADP_STOPPED_APPLICATION_EXIT: u32 = 0x2002_6;
 
 /// Triggers a clean QEMU exit via ARM semihosting. Exit code 0 means
@@ -103,17 +107,17 @@ const ADP_STOPPED_APPLICATION_EXIT: u32 = 0x2002_6;
 /// This never returns.
 fn semihost_exit(status: u32) -> ! {
     let params = [ADP_STOPPED_APPLICATION_EXIT, status];
-    // ARM semihosting call: r0 = operation, r1 = &params, then `bkpt 0xAB`
-    // (on A32) traps into the emulator/debugger.
-    // SAFETY: inline asm performs a deterministic semihosting trap; QEMU
-    // handles it and terminates the guest, so control never returns to Rust.
+    // WHY: the AArch32 semihosting trap instruction is `svc 0x123456`. QEMU does
+    // NOT treat `bkpt 0xAB` as a semihosting call in ARM state, so a bkpt-based
+    // exit is never serviced — the guest faults and hangs until the runner times
+    // out. `svc 0x123456` is the architecturally-defined A32 trap.
+    // SAFETY: inline asm performs the deterministic AArch32 semihosting trap;
+    // QEMU handles it and terminates the guest, so control never returns.
     unsafe {
         core::arch::asm!(
-            "mov r0, {op}",
-            "mov r1, {p}",
-            "bkpt 0xAB",
-            op = in(reg) SYS_EXIT,
-            p = in(reg) params.as_ptr(),
+            "svc #0x123456",
+            in("r0") SYS_EXIT_EXTENDED,
+            in("r1") params.as_ptr(),
             options(noreturn, nostack),
         );
     }

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -325,6 +325,54 @@ pub(crate) fn fork() -> Option<Pid> {
         let parent_ref = procs[usize::from(parent_pid)].as_ref();
         let parent_ctx = parent_ref.map(|p| p.ctx).unwrap_or_else(Context::zero);
         let parent_break = parent_ref.map_or(DEFAULT_HEAP_BREAK, |p| p.heap_break);
+
+        // WHY(#208): the child MUST run on its OWN freshly-allocated stack, not
+        // the parent's. Inheriting the parent's saved context verbatim would
+        // leave ctx.sp pointing into the PARENT's stack, so the child would
+        // corrupt the parent as soon as it ran, while exit_cleanup freed the
+        // untouched `stack_base` pages instead of the ones the child ran on.
+        // Retarget ctx.sp into the child's stack, preserving the parent's
+        // offset-within-stack so the child resumes at the equivalent frame.
+        // NOTE: the child stack needs no explicit page mapping — DRAM is
+        // identity-mapped as 1 MB L1 sections (see mmu::init_and_enable), which
+        // the cloned address space inherits; map_page would in fact refuse to
+        // overlay a section descriptor. Isolation is by distinct sp + distinct
+        // physical pages, matching how spawn() sets up kernel-thread stacks.
+        let parent_stack_base = parent_ref.map_or(0, |p| p.stack_base);
+        let parent_stack_pages = parent_ref.map_or(0, |p| p.stack_pages);
+        let mut child_ctx = parent_ctx;
+        child_ctx.sp = translate_stack_pointer(
+            parent_ctx.sp,
+            parent_stack_base,
+            parent_stack_pages,
+            stack_base,
+        );
+
+        // WHY(#208): clone_addr_space copies only L1 page-table entries, never
+        // the stack's backing RAM, so the child's freshly allocated pages are
+        // uninitialised. Copy the parent's live stack image into them so the
+        // translated sp lands on the SAME frame the parent had, not on garbage.
+        // Only meaningful when the parent owns a real stack (PID 0 runs on the
+        // boot stack with stack_pages == 0 — nothing to copy).
+        // WHY(arm-only): on the host, stack_base is a bitmap-allocator physical
+        // address that is never a valid host pointer; the context switch is a
+        // no-op stub there, so the child is never resumed and the copy is both
+        // unnecessary and unsound. On ARM these are identity-mapped DRAM.
+        // SAFETY: parent_stack_base and stack_base are distinct, page-aligned
+        // physical addresses of STACK_PAGES identity-mapped DRAM pages each
+        // (separate allocations — no overlap). The length is clamped to the
+        // child's stack so the copy never runs past its freshly allocated pages.
+        // Executes inside fork()'s outer `unsafe` block (like page::free_page /
+        // clone_addr_space above).
+        #[cfg(target_arch = "arm")]
+        if parent_stack_pages > 0 {
+            core::ptr::copy_nonoverlapping(
+                parent_stack_base as *const u8,
+                stack_base as *mut u8,
+                parent_stack_pages.min(STACK_PAGES) * page::PAGE_SIZE,
+            );
+        }
+
         let parent_mappings = parent_ref.map_or([None; MAX_MAPPINGS], |p| p.mappings);
         // WHY: children inherit signal handlers from parent (POSIX fork semantics).
         // Pending signals are NOT inherited — the child starts with a clean pending mask.
@@ -346,7 +394,7 @@ pub(crate) fn fork() -> Option<Pid> {
         let child = Process {
             pid: child_pid,
             state: State::Ready,
-            ctx: parent_ctx,
+            ctx: child_ctx,
             parent: Some(parent_pid),
             exit_status: 0,
             page_table_phys: child_pt,
@@ -363,6 +411,45 @@ pub(crate) fn fork() -> Option<Pid> {
         procs[slot] = Some(child);
         Some(child_pid)
     }
+}
+
+/// Retarget a saved stack pointer FROM the parent's stack region INTO the
+/// child's freshly-allocated stack, preserving the offset-within-stack.
+///
+/// WHY(#208): `fork()` inherits the parent's saved context so the child resumes
+/// at the equivalent call frame, but the child must run on its OWN stack. This
+/// maps `parent_sp` (an offset within the parent's stack) to the same offset
+/// within the child's stack. If `parent_sp` does not lie inside the parent's
+/// stack region — e.g. PID 0 / kinit runs on the boot stack with
+/// `parent_stack_pages == 0`, or an exec'd image resized its stack — the child
+/// starts at the base of its fresh stack.
+///
+/// INVARIANT: the result always lies in
+/// `[child_stack_base, child_stack_base + STACK_PAGES * PAGE_SIZE)`, so the
+/// child never aliases the parent's stack and `exit_cleanup` frees exactly the
+/// pages that back the returned sp.
+fn translate_stack_pointer(
+    parent_sp: u32,
+    parent_stack_base: usize,
+    parent_stack_pages: usize,
+    child_stack_base: usize,
+) -> u32 {
+    let child_stack_size = (STACK_PAGES * page::PAGE_SIZE) as u32;
+    let parent_base = parent_stack_base as u32;
+    let parent_span = (parent_stack_pages * page::PAGE_SIZE) as u32;
+    let child_base = child_stack_base as u32;
+
+    if parent_stack_pages > 0 && parent_sp >= parent_base {
+        let offset = parent_sp - parent_base;
+        // The offset must name a location inside BOTH the parent's stack (so it
+        // is a real translated frame) and the child's stack (so the invariant
+        // holds). Child stacks are STACK_PAGES; a same-sized parent makes these
+        // two bounds identical.
+        if offset < parent_span && offset < child_stack_size {
+            return child_base + offset;
+        }
+    }
+    child_base
 }
 
 /// Non-blocking wait for a child exit status.
@@ -1821,6 +1908,157 @@ mod tests {
             let sigchld_bit = 1u32 << (crate::signal::Signal::Sigchld as u32);
             assert_eq!(pending & sigchld_bit, 0,
                 "SIGCHLD should not be pending when default action is Ignore");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // fork() stack-isolation tests (#208)
+    // These pin the invariants the #208 defect violated: the child ran on the
+    // PARENT's stack (ctx.sp inherited verbatim) and exit_cleanup freed the
+    // wrong pages. The host cannot execute the context switch (a no-op stub),
+    // but it can verify these PCB/allocator invariants directly.
+    // -----------------------------------------------------------------------
+
+    /// Install PID 0 with a REAL allocated `STACK_PAGES` stack whose saved sp
+    /// sits `sp_page_offset` pages FROM the stack base. Returns
+    /// `(stack_base, sp)`.
+    ///
+    /// WHY: the #208 tests need a parent whose stack is a concrete physical
+    /// region so the child's sp can be checked against it — the default proc 0
+    /// runs on the boot stack (`stack_pages` == 0) and has no range to alias.
+    unsafe fn install_parent_with_stack(sp_page_offset: usize) -> (usize, u32) {
+        // SAFETY: test-only; caller has run reset_all(). Single-threaded test
+        // execution ensures no concurrent access to PROCS or CURRENT.
+        unsafe {
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            let pt = mmu::alloc_addr_space().unwrap();
+            let mut stack_base = 0usize;
+            for i in 0..STACK_PAGES {
+                let pg = page::alloc_page().unwrap();
+                if i == 0 {
+                    stack_base = pg;
+                }
+            }
+            let sp = (stack_base + sp_page_offset * page::PAGE_SIZE) as u32;
+            let mut ctx = Context::zero();
+            ctx.sp = sp;
+            procs[0] = Some(Process {
+                pid: 0,
+                state: State::Running,
+                ctx,
+                parent: None,
+                exit_status: 0,
+                page_table_phys: pt,
+                stack_base,
+                stack_pages: STACK_PAGES,
+                heap_break: DEFAULT_HEAP_BREAK,
+                mappings: [None; MAX_MAPPINGS],
+                signal_state: SignalState::new(),
+                uid: 0,
+                wake_tick: 0,
+                capabilities: crate::capability::Capabilities::ALL,
+            });
+            CURRENT = 0;
+            (stack_base, sp)
+        }
+    }
+
+    /// #208 invariant 1: the child's sp lands in the child's OWN stack, NOT the
+    /// parent's, and preserves the parent's offset-within-stack.
+    #[test]
+    fn fork_child_sp_in_own_stack_not_parent() {
+        // SAFETY: test-only; reset_all reinitialises global state. Single-threaded.
+        unsafe {
+            reset_all();
+            let (parent_base, parent_sp) = install_parent_with_stack(3);
+            let parent_top = parent_base + STACK_PAGES * page::PAGE_SIZE;
+
+            let child_pid = fork().unwrap_or_default();
+            let procs = &*core::ptr::addr_of!(PROCS);
+            let child = procs[usize::from(child_pid)].as_ref().unwrap();
+            let child_base = child.stack_base;
+            let child_top = child_base + STACK_PAGES * page::PAGE_SIZE;
+            let child_sp = child.ctx.sp as usize;
+
+            // Half-open: within the child's own stack region.
+            assert!(child_sp >= child_base && child_sp < child_top,
+                "child.ctx.sp must lie within [child.stack_base, +STACK_PAGES)");
+            // The #208 corruption: sp must NOT alias the parent's stack.
+            assert!(child_sp < parent_base || child_sp >= parent_top,
+                "child.ctx.sp must NOT alias the parent's stack (#208)");
+            // Offset-within-stack preserved -> same frame depth as the parent.
+            assert_eq!(child_sp - child_base, parent_sp as usize - parent_base,
+                "child sp must preserve the parent's offset-within-stack");
+        }
+    }
+
+    /// #208 invariant 2: the child's stack pages are distinct physical pages
+    /// FROM the parent's — no aliasing of the parent stack.
+    #[test]
+    fn fork_child_stack_pages_distinct_from_parent() {
+        // SAFETY: test-only; reset_all reinitialises global state. Single-threaded.
+        unsafe {
+            reset_all();
+            let (parent_base, _sp) = install_parent_with_stack(2);
+            let parent_top = parent_base + STACK_PAGES * page::PAGE_SIZE;
+
+            let child_pid = fork().unwrap_or_default();
+            let procs = &*core::ptr::addr_of!(PROCS);
+            let child = procs[usize::from(child_pid)].as_ref().unwrap();
+            let child_base = child.stack_base;
+            let child_top = child_base + STACK_PAGES * page::PAGE_SIZE;
+
+            assert_ne!(child_base, parent_base,
+                "child stack must start at a different physical page");
+            // Ranges must not overlap in either direction.
+            assert!(child_top <= parent_base || parent_top <= child_base,
+                "child stack pages must be physically distinct from the parent's");
+        }
+    }
+
+    /// #208 invariant 3: fork then `exit_cleanup(child)` returns EXACTLY
+    /// `STACK_PAGES` pages, leaves the parent's stack pages untouched, and the
+    /// second free of the child's stack is a rejected no-op (no double-free).
+    #[test]
+    fn fork_then_exit_frees_exactly_child_stack() {
+        // SAFETY: test-only; reset_all reinitialises global state. Single-threaded.
+        unsafe {
+            reset_all();
+            let (parent_base, _sp) = install_parent_with_stack(3);
+
+            let child_pid = fork().unwrap_or_default();
+            let child_base = {
+                let procs = &*core::ptr::addr_of!(PROCS);
+                procs[usize::from(child_pid)].as_ref().unwrap().stack_base
+            };
+
+            // Free count AFTER fork: both parent and child stacks are allocated.
+            let free_before = page::free_count();
+
+            CURRENT = child_pid;
+            exit_cleanup(0);
+
+            let free_after = page::free_count();
+            // Exactly the child's STACK_PAGES returned — not 0 (wrong pages
+            // freed), not 2x (parent's freed too).
+            assert_eq!(free_after - free_before, STACK_PAGES,
+                "exit_cleanup must return exactly the child's STACK_PAGES");
+
+            // Double-free guard: the child's stack is already free, so a second
+            // free is a rejected no-op that does not inflate the pool (#208's
+            // potential double-free).
+            let count = page::free_count();
+            assert!(!page::try_free_page(child_base),
+                "double-free of the child stack must be rejected");
+            assert_eq!(page::free_count(), count,
+                "a rejected free must not change the free-page count");
+
+            // The parent's stack pages were NOT touched by the child's exit:
+            // parent_base is still allocated, so try_free_page succeeds here
+            // (returns true) — had the child freed the parent's stack, this page
+            // would already be free and the call would be rejected.
+            assert!(page::try_free_page(parent_base),
+                "parent stack page must remain allocated after the child exits (#208)");
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes the fork() stack bug (#208) — a kernel memory-corruption / page-leak / double-free primitive in the most security-sensitive control path — and repairs the `qemu_smoke` example so the QEMU verification path works end-to-end.

## The bug (#208)

`fork()` copied the parent's saved context verbatim (`ctx: parent_ctx`), so the child's `ctx.sp` pointed into the **parent's** stack. When scheduled, the child ran on and corrupted the parent's stack; the 4 freshly-allocated child stack pages were never used (leaked); and `exit_cleanup` freed the orphaned pages rather than the ones the child ran on. The defect was latent because the existing fork tests only inspected PCB fields and never checked `ctx.sp`.

## The fix

The child's `ctx.sp` is now `translate_stack_pointer(parent_sp, ...)` — the parent's offset-within-stack mapped to the same offset in the child's own fresh stack, so the child resumes at the equivalent frame on its own pages. The helper is invariant-guarded: **the result always lies in `[child_stack_base, child_stack_base + STACK_PAGES*PAGE_SIZE)` and never in the parent's range** (fail-safe to `child_stack_base` for PID 0/kinit's borrowed boot stack, or an out-of-range `sp`; no unsigned underflow). The parent's live stack image is copied into the child's pages (ARM-only — `clone_addr_space` copies L1 entries, not backing RAM; on the host the context switch is a no-op stub, so the copy is unnecessary and unsound there). `exit_cleanup` is unchanged and now correct: `stack_base` backs `ctx.sp`, so it frees exactly the pages the child ran on.

`mmu.rs` is untouched — DRAM is identity-mapped as 1 MB L1 sections that the cloned address space inherits, so the child's distinct physical stack pages are already reachable. Isolation is by distinct `sp` + distinct physical pages, matching how `spawn()` sets up kernel-thread stacks.

## Tests

Three host tests verify the exact invariants the bug violated:
- child `sp` is inside the child's stack range (not the parent's) and preserves the frame offset;
- child stack pages are distinct, non-overlapping physical pages from the parent's;
- fork-then-exit frees **exactly** `STACK_PAGES`, with the parent's pages untouched (plus the double-free guard rejecting a second free).

## qemu_smoke / QEMU path

`bkpt 0xAB` is not serviced as a semihosting call by qemu-system-arm 10.2.2 in A32 state, so the example hung and the runner timed out. Switched to the architectural `svc #0x123456` trap with `SYS_EXIT_EXTENDED` (pass=0 / fail=1 preserved). It now builds, runs, and exits 0 through `scripts/qemu-runner.sh` — confirming the QEMU toolchain path works end-to-end.

## Closes

Closes #208

## Verification

- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — 1671 passed (was 1668; +3)
- `cargo build --release --target armv7a-none-eabi` — compiles
- `scripts/qemu-runner.sh …/qemu_smoke` — exits 0
- `kanon lint . --summary` — clean

## Follow-ups (tracked separately, not in this PR)

- The shallow L1 clone means parent/child share L2 tables for mmap/brk pages — a real limitation for a full copy-on-write fork of heap/mmap (unrelated to the stack, which is section-mapped). Worth a dedicated issue.
- A faithful **fork-under-QEMU** test needs a bounded `virt`-board port: a `cfg(qemu)` UART/PL011 shim + a `cfg(qemu)` kernel self-test boot mode, avoiding full MT6739 driver bring-up. Scoped but not built here.
