### PR TITLE
Process/memory lifecycle safety: 12 fixes (waitpid, frame leaks, syscall correctness)

### DIFF
--- a/crates/thumos/src/fd.rs
+++ b/crates/thumos/src/fd.rs
@@ -416,8 +416,42 @@ pub unsafe fn init_ramfs(fs: crate::ramfs::RamFs) {
     }
 }
 
+/// Maximum distinct ramfs files kept resident in the exec-image cache.
+/// WHY (#222): `ramfs_find` used to leak a fresh heap copy of the file on
+/// every call (every `execve` and kinit spawn), accumulating without bound
+/// across process restarts. Caching by (mount, inode, size) bounds the leak
+/// to at most this many resident images, and makes repeated launches of the
+/// same binary free after the first.
+const ELF_CACHE_SLOTS: usize = 16;
+
+/// One resident cache entry: the (mount, inode, size) it was loaded for, and
+/// the leaked `'static` slice backing it.
+struct ElfCacheEntry {
+    mount_idx: u8,
+    inode_id: u32,
+    size: usize,
+    data: &'static [u8],
+}
+
+/// Cache of previously-leaked `ramfs_find` reads, keyed on (mount, inode,
+/// size). A size mismatch (the file was rewritten to a different length
+/// since it was cached) is treated as a miss, so a stale entry is never
+/// served as if it were current.
+static mut ELF_CACHE: [Option<ElfCacheEntry>; ELF_CACHE_SLOTS] = {
+    const NONE: Option<ElfCacheEntry> = None;
+    [NONE; ELF_CACHE_SLOTS]
+};
+
+/// Next cache slot to evict when all `ELF_CACHE_SLOTS` are occupied
+/// (round-robin).
+static mut ELF_CACHE_NEXT: usize = 0;
+
 /// Look up a file in the mounted filesystems by path.
 /// Returns a reference to the file data, or None if not found.
+///
+/// Repeated lookups of the same (mount, inode, size) are served from a
+/// bounded resident cache instead of leaking a fresh heap copy on every
+/// call (#222).
 ///
 /// # Safety
 ///
@@ -441,12 +475,22 @@ pub unsafe fn ramfs_find(path: &str) -> Option<&'static [u8]> {
             return None;
         }
 
+        let size = stat.size as usize;
+        let mount_idx_u8 = mount_idx as u8;
+
+        // Serve from cache if this (mount, inode, size) was already loaded.
+        let cache = &*core::ptr::addr_of!(ELF_CACHE);
+        for slot in cache.iter().flatten() {
+            if slot.mount_idx == mount_idx_u8 && slot.inode_id == inode_id && slot.size == size {
+                return Some(slot.data);
+            }
+        }
+
         // Read the entire file into a buffer
         // WHY alloc: we need a 'static reference but Filesystem::read copies
         // into a provided buffer. We allocate a Vec, leak it to get 'static
-        // lifetime. This matches the original behavior where ramfs data lived
-        // for the kernel's lifetime.
-        let size = stat.size as usize;
+        // lifetime, and register it in ELF_CACHE so a later lookup of the
+        // same (mount, inode, size) reuses it instead of leaking again.
         if size == 0 {
             return Some(&[]);
         }
@@ -456,6 +500,24 @@ pub unsafe fn ramfs_find(path: &str) -> Option<&'static [u8]> {
             Ok(n) => {
                 buf.truncate(n);
                 let leaked = buf.leak();
+
+                let cache = &mut *core::ptr::addr_of_mut!(ELF_CACHE);
+                let slot_idx = match cache.iter().position(|s| s.is_none()) {
+                    Some(idx) => idx,
+                    None => {
+                        let next = &mut *core::ptr::addr_of_mut!(ELF_CACHE_NEXT);
+                        let idx = *next % ELF_CACHE_SLOTS;
+                        *next = (*next + 1) % ELF_CACHE_SLOTS;
+                        idx
+                    }
+                };
+                cache[slot_idx] = Some(ElfCacheEntry {
+                    mount_idx: mount_idx_u8,
+                    inode_id,
+                    size,
+                    data: leaked,
+                });
+
                 Some(leaked)
             }
             Err(_) => None,
@@ -811,17 +873,12 @@ pub(crate) fn sys_fstat(fd: u32, stat_buf_ptr: u32) -> u32 {
 
     let inode_stat = match fs.stat(entry.inode_id) {
         Ok(s) => s,
-        Err(_) => {
-            let stat = StatBuf {
-                size: 0,
-                file_type: S_IFREG,
-            };
-            unsafe {
-                let dst = stat_buf_ptr as *mut StatBuf;
-                core::ptr::write(dst, stat);
-            }
-            return 0;
-        }
+        // WHY (#249): a real fs.stat() failure (corrupt inode, I/O error) is a
+        // genuine error, unlike the two preceding arms above (mount table /
+        // filesystem absent), which are expected fallbacks for fds without
+        // VFS backing (pipes/sockets). Propagate it instead of fabricating a
+        // zeroed success stat that would mask the failure from the caller.
+        Err(e) => return e.to_errno(),
     };
 
     let file_type = match inode_stat.inode_type {
@@ -1423,6 +1480,22 @@ mod tests {
         assert_eq!(fd, 0, "first open should return fd 0");
     }
 
+    /// #222: repeated ramfs_find on the same file must reuse the cached
+    /// leak, not allocate a fresh copy on every call.
+    #[test]
+    fn ramfs_find_caches_repeated_lookups() {
+        unsafe {
+            setup_test_vfs();
+            let first = ramfs_find("/test.txt").expect("file must be found");
+            let second = ramfs_find("/test.txt").expect("file must be found");
+            assert_eq!(
+                first.as_ptr(), second.as_ptr(),
+                "repeated ramfs_find on the same file must reuse the cached leak (#222)"
+            );
+            assert_eq!(first, second, "cached and fresh reads must return identical content");
+        }
+    }
+
     // TODO(#129)[deliberate-prudent]: gated on 32-bit pointer width — this test uses
     // `path.as_ptr() as u32` / `buf.as_mut_ptr() as u32` which is the
     // real kernel syscall ABI (ARMv7). On x86_64 host it truncates
@@ -1732,6 +1805,25 @@ mod tests {
         let stat = unsafe { &mut *core::ptr::addr_of_mut!(STAT) };
         let result = sys_fstat(99, stat as *mut StatBuf as u32);
         assert_eq!(result, EBADF);
+    }
+
+    /// #249: a genuine fs.stat() failure (bogus inode) must propagate a
+    /// non-zero errno, not a fabricated zeroed success stat.
+    #[cfg(target_pointer_width = "32")]
+    #[test]
+    fn fstat_propagates_real_stat_error_instead_of_fabricating_success() {
+        unsafe {
+            setup_test_vfs();
+            let table = &mut *core::ptr::addr_of_mut!(FD_TABLE);
+            let bogus = FileDescriptor::from_vfs(0, 9_999, 0);
+            let fd = table.alloc(bogus).expect("test fd alloc must succeed");
+
+            static mut STAT: StatBuf = StatBuf { size: 0, file_type: 0 };
+            let stat = &mut *core::ptr::addr_of_mut!(STAT);
+            let result = sys_fstat(fd as u32, stat as *mut StatBuf as u32);
+
+            assert_ne!(result, 0, "fstat must propagate a real VFS stat error, not fabricate success (#249)");
+        }
     }
 
     // TODO(#129)[deliberate-prudent]: gated on 32-bit pointer width — this test uses

--- a/crates/thumos/src/mmu.rs
+++ b/crates/thumos/src/mmu.rs
@@ -222,6 +222,45 @@ pub unsafe fn unmap_page(l1_phys: usize, virt_addr: usize) {
     }
 }
 
+/// Read the physical small-page base address mapped at `virt_addr` in
+/// `l1_phys`'s address space, without clearing the L2 entry.
+///
+/// WHY (#225, #226): `unmap_page` zeroes the L2 entry, permanently losing the
+/// physical frame it pointed to unless the caller reads it out first. Callers
+/// that need to return the frame to `page::free_page` must call this before
+/// `unmap_page`, not after.
+///
+/// Returns `None` if no L2 table is installed at this L1 index, or if the
+/// L2 entry is not currently mapped.
+///
+/// # Safety
+///
+/// `l1_phys` must be a valid L1 page table address. `virt_addr` must be
+/// page-aligned.
+pub unsafe fn read_l2_phys(l1_phys: usize, virt_addr: usize) -> Option<usize> {
+    let l1_index = virt_addr >> 20;
+    let l2_index = (virt_addr >> 12) & 0xFF;
+
+    unsafe {
+        let l1_entry_ptr = (l1_phys as *const u32).add(l1_index);
+        let l1_val = l1_entry_ptr.read_volatile();
+
+        if l1_val & 0b11 != page_flags::L1_PAGE_TABLE {
+            return None;
+        }
+
+        let l2_phys = (l1_val & 0xFFFF_FC00) as usize;
+        let l2_entry_ptr = (l2_phys as *const u32).add(l2_index);
+        let l2_val = l2_entry_ptr.read_volatile();
+
+        if l2_val & 0b11 == 0 {
+            return None;
+        }
+
+        Some((l2_val & 0xFFFFF000) as usize)
+    }
+}
+
 /// Update the protection flags on a single 4 KB page.
 ///
 /// Returns true if the page was found and updated, false if not mapped.
@@ -644,6 +683,26 @@ mod tests {
                 "dst must be independent after clone");
             free_addr_space(src);
             free_addr_space(dst);
+        }
+    }
+
+    /// #225/#226: read_l2_phys must return the mapped frame while the page is
+    /// mapped, and None once unmap_page has cleared the entry.
+    #[test]
+    fn read_l2_phys_returns_mapped_frame_and_none_after_unmap() {
+        reset();
+        let l1 = alloc_addr_space().unwrap_or_default();
+        let virt = 0x2000_0000usize;
+        let phys = 0x5000_0000usize;
+        let attrs = page_flags::SMALL_PAGE | page_flags::AP_FULL;
+        unsafe {
+            assert!(map_page(l1, virt, phys, attrs), "map_page must succeed");
+            assert_eq!(read_l2_phys(l1, virt), Some(phys),
+                "read_l2_phys must return the mapped physical frame");
+            unmap_page(l1, virt);
+            assert_eq!(read_l2_phys(l1, virt), None,
+                "read_l2_phys must return None after unmap_page clears the entry");
+            free_addr_space(l1);
         }
     }
 }

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -215,22 +215,26 @@ pub(crate) fn spawn(entry_point: fn() -> !) -> Option<Pid> {
         mmu::clone_addr_space(mmu::table_base(), new_pt);
 
         // Allocate stack
-        let mut stack_base: usize = 0;
+        // WHY array-tracked (#251): page::alloc_page() is a bitmap scanner
+        // with no contiguity guarantee; an OOM rollback that assumes
+        // `stack_base + j * PAGE_SIZE` names the j-th allocated page can free
+        // an unrelated live page. Recording each returned address makes the
+        // rollback exact regardless of fragmentation.
+        let mut stack_pages_alloc: [usize; STACK_PAGES] = [0; STACK_PAGES];
         for i in 0..STACK_PAGES {
             match page::alloc_page() {
-                Some(page) => {
-                    if i == 0 { stack_base = page; }
-                }
+                Some(page) => stack_pages_alloc[i] = page,
                 None => {
-                    // OOM: roll back already-allocated pages
+                    // OOM: roll back exactly the pages allocated so far.
                     for j in 0..i {
-                        page::free_page(stack_base + j * page::PAGE_SIZE);
+                        page::free_page(stack_pages_alloc[j]);
                     }
                     mmu::free_addr_space(new_pt);
                     return None;
                 }
             }
         }
+        let stack_base = stack_pages_alloc[0];
         let stack_top = stack_base + page::PAGE_SIZE * STACK_PAGES;
 
         // Set up initial context
@@ -304,22 +308,29 @@ pub(crate) fn fork() -> Option<Pid> {
         mmu::clone_addr_space(src_pt, child_pt);
 
         // Allocate child stack pages
-        let mut stack_base: usize = 0;
+        // WHY array-tracked (#251): page::alloc_page() is a bitmap scanner
+        // with no contiguity guarantee; an OOM rollback that assumes
+        // `stack_base + j * PAGE_SIZE` names the j-th allocated page can free
+        // an unrelated live page. Recording each returned address makes the
+        // rollback exact regardless of fragmentation. #208 fixed only the
+        // SUCCESS path (translated sp + stack image copy); its rollback still
+        // assumed contiguity.
+        let mut child_stack_pages_alloc: [usize; STACK_PAGES] = [0; STACK_PAGES];
         for i in 0..STACK_PAGES {
             match page::alloc_page() {
-                Some(page) => {
-                    if i == 0 { stack_base = page; }
-                }
+                Some(page) => child_stack_pages_alloc[i] = page,
                 None => {
-                    // OOM: roll back pages then table
+                    // OOM: roll back exactly the pages allocated so far, then
+                    // the child's address space.
                     for j in 0..i {
-                        page::free_page(stack_base + j * page::PAGE_SIZE);
+                        page::free_page(child_stack_pages_alloc[j]);
                     }
                     mmu::free_addr_space(child_pt);
                     return None;
                 }
             }
         }
+        let stack_base = child_stack_pages_alloc[0];
 
         // Inherit parent context and memory layout (child resumes FROM same saved state)
         let parent_ref = procs[usize::from(parent_pid)].as_ref();
@@ -453,22 +464,35 @@ fn translate_stack_pointer(
 }
 
 /// Non-blocking wait for a child exit status.
-/// Returns Some(status) if the child is Dead, None if still running or not a child.
+/// Returns Some(status) if the child is Dead, None if still running or not a
+/// child. Reaps the child's process-table slot on success (#218, #224): once
+/// the parent has collected the exit status the slot is returned to the free
+/// pool, matching POSIX wait semantics, so a Dead-but-unreaped PCB does not
+/// permanently occupy a process-table slot.
 pub(crate) fn waitpid(child_pid: Pid) -> Option<i32> {
     // SAFETY: current process PCB pointer is valid; set by the scheduler on
-    // context switch. Read-only access via addr_of!; no mutation occurs here.
+    // context switch. A single mutable borrow covers both the read (exit
+    // status, parent check) and the reap (clearing the slot) so no
+    // immutable/mutable aliasing of the static PROCS table occurs.
     unsafe {
-        let procs = &*core::ptr::addr_of!(PROCS);
-        let child = procs[usize::from(child_pid)].as_ref()?;
+        // #232: bound-check before indexing the fixed-size table — child_pid
+        // is a userspace-controlled value with no upper-bound guarantee.
+        let idx = usize::from(child_pid);
+        if idx >= MAX_PROCS {
+            return None;
+        }
+        let procs = &mut *addr_of_mut!(PROCS);
+        let child = procs[idx].as_ref()?;
         // INVARIANT: only the direct parent may retrieve the exit status.
         if child.parent != Some(CURRENT) {
             return None;
         }
-        if child.state == State::Dead {
-            Some(child.exit_status)
-        } else {
-            None
+        if child.state != State::Dead {
+            return None;
         }
+        let status = child.exit_status;
+        procs[idx] = None; // reap (#218/#224)
+        Some(status)
     }
 }
 
@@ -976,6 +1000,14 @@ pub unsafe fn get_signal_action(sig: Signal) -> SignalAction {
 /// Must be called from syscall context (single-core).
 pub unsafe fn deliver_signal_to(pid: Pid, sig: Signal) -> u32 {
     const ESRCH: u32 = 0u32.wrapping_sub(3);
+    // WHY (#269): PID 0 (kinit) is the fault supervisor and process-hierarchy
+    // anchor; it must never be a userspace signal target, regardless of
+    // capability or self-signal status. sys_kill enforces the same rule as a
+    // belt-and-suspenders check before this function is ever reached.
+    const EPERM: u32 = 0u32.wrapping_sub(1);
+    if pid == 0 {
+        return EPERM;
+    }
     unsafe {
         let procs = &mut *addr_of_mut!(PROCS);
         let idx = usize::try_from(pid).unwrap_or(MAX_PROCS);
@@ -1070,6 +1102,35 @@ pub unsafe fn exec_replace_context(entry_point: usize, stack_top: usize,
             for i in 0..old_pages {
                 page::free_page(old_base + i * page::PAGE_SIZE);
             }
+
+            // WHY (#225): the page table is REUSED across exec (same
+            // page_table_phys), so the previous image's mmap regions and grown
+            // heap pages are still mapped at their old virtual addresses. Unmap
+            // and free each one before resetting the tracking state below, or
+            // the physical frames leak permanently and the new image can read
+            // the previous image's residual contents at the same VAs.
+            let pt = proc.page_table_phys;
+            for mapping in proc.mappings.iter().flatten() {
+                for i in 0..mapping.pages {
+                    let vaddr = mapping.start + i * page::PAGE_SIZE;
+                    if let Some(phys) = mmu::read_l2_phys(pt, vaddr) {
+                        mmu::unmap_page(pt, vaddr);
+                        mmu::flush_tlb_page(vaddr);
+                        page::free_page(phys);
+                    }
+                }
+            }
+            let old_heap_break = proc.heap_break;
+            let mut heap_vaddr = DEFAULT_HEAP_BREAK;
+            while heap_vaddr < old_heap_break {
+                if let Some(phys) = mmu::read_l2_phys(pt, heap_vaddr) {
+                    mmu::unmap_page(pt, heap_vaddr);
+                    mmu::flush_tlb_page(heap_vaddr);
+                    page::free_page(phys);
+                }
+                heap_vaddr += page::PAGE_SIZE;
+            }
+
             // Reset heap break to default for the new image.
             proc.heap_break = DEFAULT_HEAP_BREAK;
             // Clear all tracked mmap mappings — the new image has a fresh VA space.
@@ -1383,6 +1444,92 @@ mod tests {
         }
     }
 
+    /// #251: an OOM partway through spawn()'s stack allocation must roll
+    /// back exactly the pages allocated so far, verified against the bitmap
+    /// free-count (not assumed physically contiguous).
+    #[test]
+    fn spawn_oom_rollback_frees_exact_allocated_pages() {
+        fn spawn_test_entry() -> ! { loop {} }
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            let pt = mmu::alloc_addr_space().unwrap();
+            procs[0] = Some(Process {
+                pid: 0,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: None,
+                exit_status: 0,
+                page_table_phys: pt,
+                stack_base: 0,
+                stack_pages: 0,
+                heap_break: DEFAULT_HEAP_BREAK,
+                mappings: [None; MAX_MAPPINGS],
+                signal_state: SignalState::new(),
+                uid: 0,
+                wake_tick: 0,
+                capabilities: crate::capability::Capabilities::ALL,
+            });
+            CURRENT = 0;
+
+            // Shrink the free pool to exactly 2 pages so the 4-page stack
+            // allocation (STACK_PAGES = 4) OOMs on the 3rd page.
+            page::init(0x4000_0000, 0x4000_0000 + 6 * page::PAGE_SIZE, 0x4000_0000 + 4 * page::PAGE_SIZE);
+            let free_before = page::free_count();
+            assert_eq!(free_before, 2, "test setup must yield exactly 2 free pages");
+
+            let result = spawn(spawn_test_entry);
+            assert!(result.is_none(), "spawn must fail when the stack allocation OOMs");
+
+            let free_after = page::free_count();
+            assert_eq!(free_after, free_before,
+                "OOM rollback must return exactly the pages allocated before the failure, leaving free-count unchanged (#251)");
+        }
+    }
+
+    /// #251: an OOM partway through fork()'s child-stack allocation must roll
+    /// back exactly the pages allocated so far. #208 rewrote fork()'s SUCCESS
+    /// path (translated sp + stack copy) but left the rollback assuming
+    /// physical contiguity; this guards the re-derived array-tracked rollback.
+    #[test]
+    fn fork_oom_rollback_frees_exact_allocated_pages() {
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            let pt = mmu::alloc_addr_space().unwrap();
+            procs[0] = Some(Process {
+                pid: 0,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: None,
+                exit_status: 0,
+                page_table_phys: pt,
+                stack_base: 0,
+                stack_pages: 0,
+                heap_break: DEFAULT_HEAP_BREAK,
+                mappings: [None; MAX_MAPPINGS],
+                signal_state: SignalState::new(),
+                uid: 0,
+                wake_tick: 0,
+                capabilities: crate::capability::Capabilities::ALL,
+            });
+            CURRENT = 0;
+
+            // Shrink the free pool to exactly 2 pages so the 4-page child
+            // stack allocation (STACK_PAGES = 4) OOMs on the 3rd page.
+            page::init(0x4000_0000, 0x4000_0000 + 6 * page::PAGE_SIZE, 0x4000_0000 + 4 * page::PAGE_SIZE);
+            let free_before = page::free_count();
+            assert_eq!(free_before, 2, "test setup must yield exactly 2 free pages");
+
+            let result = fork();
+            assert!(result.is_none(), "fork must fail when the child stack allocation OOMs");
+
+            let free_after = page::free_count();
+            assert_eq!(free_after, free_before,
+                "OOM rollback must return exactly the pages allocated before the failure, leaving free-count unchanged (#251)");
+        }
+    }
+
     #[test]
     fn waitpid_returns_none_while_running() {
         // SAFETY: test-only; reset_all reinitialises global state. Single-threaded
@@ -1412,6 +1559,86 @@ mod tests {
             let child_pid = fork().unwrap_or_default();
             // Child is Ready, not Dead  -  waitpid must return None
             assert_eq!(waitpid(child_pid), None, "should return None while child is alive");
+        }
+    }
+
+    /// #232: waitpid must reject any PID >= MAX_PROCS instead of indexing
+    /// the fixed-size table out of bounds.
+    #[test]
+    fn waitpid_rejects_out_of_bounds_pid() {
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            let pt = mmu::alloc_addr_space().unwrap();
+            procs[0] = Some(Process {
+                pid: 0,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: None,
+                exit_status: 0,
+                page_table_phys: pt,
+                stack_base: 0,
+                stack_pages: 0,
+                heap_break: DEFAULT_HEAP_BREAK,
+                mappings: [None; MAX_MAPPINGS],
+                signal_state: SignalState::new(),
+                uid: 0,
+                wake_tick: 0,
+                capabilities: crate::capability::Capabilities::ALL,
+            });
+            CURRENT = 0;
+
+            assert_eq!(waitpid(200), None, "waitpid must reject an out-of-bounds PID instead of panicking");
+            assert_eq!(waitpid(255), None, "waitpid must reject PID 255 (u8::MAX) instead of panicking");
+        }
+    }
+
+    /// #218/#224: fork/exit/waitpid MAX_PROCS times must leave every
+    /// non-init slot reaped (None), and a further fork must then succeed —
+    /// not permanently exhaust the table with Dead-but-unreaped PCBs.
+    #[test]
+    fn waitpid_reaps_dead_child_and_frees_the_slot() {
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            let pt = mmu::alloc_addr_space().unwrap();
+            procs[0] = Some(Process {
+                pid: 0,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: None,
+                exit_status: 0,
+                page_table_phys: pt,
+                stack_base: 0,
+                stack_pages: 0,
+                heap_break: DEFAULT_HEAP_BREAK,
+                mappings: [None; MAX_MAPPINGS],
+                signal_state: SignalState::new(),
+                uid: 0,
+                wake_tick: 0,
+                capabilities: crate::capability::Capabilities::ALL,
+            });
+            CURRENT = 0;
+
+            for _ in 0..(MAX_PROCS - 1) {
+                assert!(fork().is_some(), "fork must succeed while slots remain");
+            }
+            assert!(fork().is_none(), "fork must fail once the process table is full");
+
+            for pid in 1..MAX_PROCS as Pid {
+                CURRENT = pid;
+                exit_cleanup(0);
+            }
+            CURRENT = 0;
+            for pid in 1..MAX_PROCS as Pid {
+                assert_eq!(waitpid(pid), Some(0), "waitpid must return the exit status for each Dead child");
+            }
+
+            let procs_ro = &*core::ptr::addr_of!(PROCS);
+            for pid in 1..MAX_PROCS {
+                assert!(procs_ro[pid].is_none(), "reaped slot {pid} must be None, not a lingering Dead PCB");
+            }
+            assert!(fork().is_some(), "fork must succeed again once reaped slots are available (#224)");
         }
     }
 
@@ -1648,6 +1875,63 @@ mod tests {
         }
     }
 
+    /// #225: exec_replace_context must unmap and free every previously
+    /// tracked mmap page and every grown heap page, not just reset the
+    /// tracking state and leak the physical frames.
+    #[test]
+    fn exec_replace_context_frees_mmap_and_heap_pages() {
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            let pt = mmu::alloc_addr_space().unwrap();
+            procs[0] = Some(Process {
+                pid: 0,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: None,
+                exit_status: 0,
+                page_table_phys: pt,
+                stack_base: 0,
+                stack_pages: 0,
+                heap_break: DEFAULT_HEAP_BREAK,
+                mappings: [None; MAX_MAPPINGS],
+                signal_state: SignalState::new(),
+                uid: 0,
+                wake_tick: 0,
+                capabilities: crate::capability::Capabilities::ALL,
+            });
+            CURRENT = 0;
+
+            // Simulate one mmap'd page.
+            let mmap_phys = page::alloc_page().unwrap();
+            let mmap_vaddr = MMAP_BASE;
+            let l2_attrs = mmu::prot_to_l2_flags(mmu::prot::PROT_READ | mmu::prot::PROT_WRITE);
+            assert!(mmu::map_page(pt, mmap_vaddr, mmap_phys, l2_attrs));
+            add_mapping(VmMapping { start: mmap_vaddr, pages: 1, prot: mmu::prot::PROT_READ | mmu::prot::PROT_WRITE });
+
+            // Simulate one grown heap page.
+            let heap_phys = page::alloc_page().unwrap();
+            assert!(mmu::map_page(pt, DEFAULT_HEAP_BREAK, heap_phys, l2_attrs));
+            set_heap_break(DEFAULT_HEAP_BREAK + page::PAGE_SIZE);
+
+            // Capture the baseline AFTER allocating the new stack so the delta
+            // measures exactly the frames exec frees, not the new stack alloc.
+            let new_stack_phys = page::alloc_page().unwrap();
+            let free_before = page::free_count();
+
+            exec_replace_context(0x1000, new_stack_phys + page::PAGE_SIZE, new_stack_phys, 1);
+
+            let free_after = page::free_count();
+            assert_eq!(free_after, free_before + 2,
+                "exec must free exactly the 1 mmap page + 1 heap page from the old image");
+
+            let procs_ro = &*core::ptr::addr_of!(PROCS);
+            let proc = procs_ro[0].as_ref().unwrap();
+            assert!(proc.mappings.iter().all(|m| m.is_none()), "mappings must be cleared");
+            assert_eq!(proc.heap_break, DEFAULT_HEAP_BREAK, "heap break must reset to default");
+        }
+    }
+
     /// kinit (PID 0) must have UID 0 (root).
     #[test]
     fn getuid_returns_zero_for_init() {
@@ -1819,17 +2103,22 @@ mod tests {
             });
             CURRENT = 0;
 
+            // Target a non-zero PID (#269 guards PID 0 against deliver_signal_to).
+            let child_pid = fork().unwrap_or_default();
+
             // Install a handler so kill marks it pending (not terminate).
+            CURRENT = child_pid;
             let handler_addr: u32 = 0x4020_0000;
             set_signal_action(
                 crate::signal::Signal::Sigusr1,
                 crate::signal::SignalAction::Handler(handler_addr),
             );
+            CURRENT = 0;
 
-            let ret = deliver_signal_to(0, crate::signal::Signal::Sigusr1);
+            let ret = deliver_signal_to(child_pid, crate::signal::Signal::Sigusr1);
             assert_eq!(ret, 0, "deliver_signal_to should succeed");
 
-            let pending = get_pending_mask(0);
+            let pending = get_pending_mask(child_pid);
             let expected_bit = 1u32 << (crate::signal::Signal::Sigusr1 as u32);
             assert_ne!(pending & expected_bit, 0,
                 "SIGUSR1 pending bit should be set after kill");
@@ -1861,11 +2150,14 @@ mod tests {
             });
             CURRENT = 0;
 
+            // Target a non-zero PID (#269 guards PID 0 against deliver_signal_to).
+            let child_pid = fork().unwrap_or_default();
+
             // No handler for SIGTERM — default is Terminate.
-            let ret = deliver_signal_to(0, crate::signal::Signal::Sigterm);
+            let ret = deliver_signal_to(child_pid, crate::signal::Signal::Sigterm);
             assert_eq!(ret, 0, "deliver_signal_to should return 0");
 
-            let state = get_state(0);
+            let state = get_state(child_pid);
             assert_eq!(state, Some(State::Dead),
                 "process should be Dead after default SIGTERM");
         }
@@ -1896,15 +2188,19 @@ mod tests {
             });
             CURRENT = 0;
 
+            // Target a non-zero PID (#269 guards PID 0 against deliver_signal_to).
+            let child_pid = fork().unwrap_or_default();
+            let state_before = get_state(child_pid);
+
             // No handler for SIGCHLD — default is Ignore.
-            let ret = deliver_signal_to(0, crate::signal::Signal::Sigchld);
+            let ret = deliver_signal_to(child_pid, crate::signal::Signal::Sigchld);
             assert_eq!(ret, 0, "deliver_signal_to should return 0");
 
-            let state = get_state(0);
-            assert_eq!(state, Some(State::Running),
-                "process should still be Running after default SIGCHLD");
+            let state = get_state(child_pid);
+            assert_eq!(state, state_before,
+                "process state should be unchanged after default-Ignore SIGCHLD");
 
-            let pending = get_pending_mask(0);
+            let pending = get_pending_mask(child_pid);
             let sigchld_bit = 1u32 << (crate::signal::Signal::Sigchld as u32);
             assert_eq!(pending & sigchld_bit, 0,
                 "SIGCHLD should not be pending when default action is Ignore");
@@ -2059,6 +2355,73 @@ mod tests {
             // would already be free and the call would be rejected.
             assert!(page::try_free_page(parent_base),
                 "parent stack page must remain allocated after the child exits (#208)");
+        }
+    }
+
+    /// #269: kinit (PID 0) must never be a valid deliver_signal_to target,
+    /// even for SIGKILL.
+    #[test]
+    fn deliver_signal_to_rejects_pid_zero() {
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            let pt = mmu::alloc_addr_space().unwrap();
+            procs[0] = Some(Process {
+                pid: 0,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: None,
+                exit_status: 0,
+                page_table_phys: pt,
+                stack_base: 0,
+                stack_pages: 0,
+                heap_break: DEFAULT_HEAP_BREAK,
+                mappings: [None; MAX_MAPPINGS],
+                signal_state: SignalState::new(),
+                uid: 0,
+                wake_tick: 0,
+                capabilities: crate::capability::Capabilities::ALL,
+            });
+            CURRENT = 0;
+
+            const EPERM: u32 = 0u32.wrapping_sub(1);
+            let ret = deliver_signal_to(0, crate::signal::Signal::Sigkill);
+            assert_eq!(ret, EPERM, "deliver_signal_to(0, ...) must return EPERM");
+
+            let state = get_state(0);
+            assert_eq!(state, Some(State::Running), "PID 0 must stay alive");
+        }
+    }
+
+    /// #269: sys_kill must reject PID 0 outright, even for a self-signal
+    /// from kinit, before any capability check.
+    #[test]
+    fn sys_kill_rejects_pid_zero_even_for_self() {
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            let pt = mmu::alloc_addr_space().unwrap();
+            procs[0] = Some(Process {
+                pid: 0,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: None,
+                exit_status: 0,
+                page_table_phys: pt,
+                stack_base: 0,
+                stack_pages: 0,
+                heap_break: DEFAULT_HEAP_BREAK,
+                mappings: [None; MAX_MAPPINGS],
+                signal_state: SignalState::new(),
+                uid: 0,
+                wake_tick: 0,
+                capabilities: crate::capability::Capabilities::ALL,
+            });
+            CURRENT = 0;
+
+            const EPERM: u32 = 0u32.wrapping_sub(1);
+            let ret = crate::signal::sys_kill(0, crate::signal::Signal::Sigkill as u32);
+            assert_eq!(ret, EPERM, "sys_kill(0, ...) must return EPERM regardless of caller");
         }
     }
 

--- a/crates/thumos/src/signal.rs
+++ b/crates/thumos/src/signal.rs
@@ -212,7 +212,6 @@ const EINVAL: u32 = 0u32.wrapping_sub(22);
 /// Error: no such process (two's complement -3, matches Linux ESRCH).
 const ESRCH: u32 = 0u32.wrapping_sub(3);
 /// Error: operation not permitted (two's complement -1, matches Linux EPERM).
-#[cfg_attr(not(test), allow(dead_code))]
 const EPERM: u32 = 0u32.wrapping_sub(1);
 
 /// `sigaction(signum, handler_ptr)` — install a signal handler.
@@ -273,6 +272,14 @@ pub(crate) fn sys_kill(pid: u32, signum: u32) -> u32 {
         Ok(p) => p,
         Err(_) => return ESRCH,
     };
+
+    // WHY (#269): PID 0 (kinit) is the fault supervisor; belt-and-suspenders
+    // rejection here (in addition to the deliver_signal_to guard) means no
+    // caller — including a self-signal from kinit — reaches the capability
+    // check with PID 0 as the target.
+    if pid8 == 0 {
+        return EPERM;
+    }
 
     // REQ-09: sending a signal to another process requires CAP_KILL.
     // Self-signals (kill(getpid(), sig)) bypass the check — a process may

--- a/crates/thumos/src/syscall.rs
+++ b/crates/thumos/src/syscall.rs
@@ -429,15 +429,21 @@ pub(crate) fn dispatch(num: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> 
         }
         Syscall::Uptime => crate::exceptions::uptime_ms() as u32,
         Syscall::Sleep => {
-            // NOTE: approximate sleep via busy-wait on tick counter.
-            // A proper implementation would block the process and wake on tick.
-            let target = crate::exceptions::uptime_ms() + {
-                let Ok(ms) = u64::try_from(arg0) else { return EINVAL; };
-                ms
-            };
-            while crate::exceptions::uptime_ms() < target {
+            // WHY (#264): mirror sys_nanosleep's pattern instead of a bare
+            // uptime_ms() busy-wait that never touched process state — mark
+            // the process Sleeping with its wake tick before waiting so
+            // runnable_count() and any Sleeping-aware scheduler logic see
+            // this process as blocked for the sleep window, not spuriously
+            // Running.
+            let Ok(ms) = u64::try_from(arg0) else { return EINVAL; };
+            const TICK_MS: u64 = 10;
+            let ticks_needed = ms.saturating_add(TICK_MS - 1) / TICK_MS;
+            let wake_tick = crate::exceptions::ticks().saturating_add(ticks_needed);
+            process::set_wake_tick(wake_tick);
+            while crate::exceptions::ticks() < wake_tick {
                 wait_for_event();
             }
+            process::clear_wake_tick();
             0
         }
         Syscall::Send => {
@@ -608,44 +614,45 @@ fn sys_close_with_pipe(fd: u32) -> u32 {
 
 /// SYS_write: dispatch to pipe, UART (stdout), or VFS file based on fd kind.
 ///
-/// - fd 1 (stdout): write to UART serial (legacy behavior).
 /// - Pipe fd: dispatch to pipe::sys_pipe_write.
-/// - VFS fd: dispatch to fd::sys_write for filesystem write.
+/// - VFS fd (including a `dup2`-redirected fd 1): dispatch to fd::sys_write.
+/// - fd 1 with no FD_TABLE entry: the default, un-redirected case — write to
+///   UART serial (legacy behavior).
 fn sys_write_dispatch(fd: u32, buf_ptr: u32, count: u32) -> u32 {
-    // fd 1 is stdout — always goes to UART (legacy behavior).
-    if fd == 1 {
-        let Ok(ptr) = usize::try_from(buf_ptr) else { return EINVAL; };
-        let Ok(len) = usize::try_from(count) else { return EINVAL; };
-        if !validate_user_buffer(ptr, len) {
-            return EFAULT;
-        }
-        // SAFETY: validate_user_buffer confirmed [ptr, ptr+len) is within
-        // user-accessible DRAM.
-        let slice = unsafe { core::slice::from_raw_parts(ptr as *const u8, len) };
-        let mut serial = Uart::new();
-        for &byte in slice {
-            serial.putc(byte);
-        }
-        let Ok(len_u32) = u32::try_from(len) else { return EINVAL; };
-        return len_u32;
-    }
-
     let fd_idx = fd as usize;
     // SAFETY: FD_TABLE is a static mut; addr_of! avoids an intermediate
     // reference. Read-only here to inspect flags.
     let flags = {
         let table = unsafe { &*core::ptr::addr_of!(fd::FD_TABLE) };
-        match table.get(fd_idx) {
-            Some(e) => e.flags,
-            None => return fd::EBADF,
-        }
+        table.get(fd_idx).map(|e| e.flags)
     };
 
-    if pipe::is_pipe_fd(flags) {
-        let pipe_idx = pipe::pipe_idx_from_flags(flags);
-        pipe::sys_pipe_write(pipe_idx, buf_ptr, count, process::current_pid())
-    } else {
-        fd::sys_write(fd, buf_ptr, count)
+    match flags {
+        Some(flags) if pipe::is_pipe_fd(flags) => {
+            let pipe_idx = pipe::pipe_idx_from_flags(flags);
+            pipe::sys_pipe_write(pipe_idx, buf_ptr, count, process::current_pid())
+        }
+        Some(_) => fd::sys_write(fd, buf_ptr, count),
+        // fd 1 with no FD_TABLE entry (#255): the default, un-redirected
+        // case falls back to UART instead of the unconditional fd==1
+        // special-case that used to shadow a dup2(x, 1) redirection.
+        None if fd == 1 => {
+            let Ok(ptr) = usize::try_from(buf_ptr) else { return EINVAL; };
+            let Ok(len) = usize::try_from(count) else { return EINVAL; };
+            if !validate_user_buffer(ptr, len) {
+                return EFAULT;
+            }
+            // SAFETY: validate_user_buffer confirmed [ptr, ptr+len) is within
+            // user-accessible DRAM.
+            let slice = unsafe { core::slice::from_raw_parts(ptr as *const u8, len) };
+            let mut serial = Uart::new();
+            for &byte in slice {
+                serial.putc(byte);
+            }
+            let Ok(len_u32) = u32::try_from(len) else { return EINVAL; };
+            len_u32
+        }
+        None => fd::EBADF,
     }
 }
 
@@ -683,22 +690,25 @@ const ENOENT: u32 = 0u32.wrapping_sub(2);
 fn sys_execve(path_ptr: u32, argv_ptr: u32, _envp_ptr: u32) -> u32 {
     // --- Step 1: validate and read path ---
 
-    // Validate that path_ptr is in user DRAM (non-null, non-kernel).
-    // WHY validate 1 byte: catches null/kernel/device pointers before any read.
-    if !validate_user_buffer(path_ptr as usize, 1) {
+    // Cap at 256 bytes to bound the scan; longer paths are rejected.
+    const MAX_PATH: usize = 256;
+
+    // Validate the FULL scan window [path_ptr, path_ptr+MAX_PATH) up front
+    // (#220) — validating only the first byte let the scan below walk past
+    // RAM_END for a path_ptr within MAX_PATH bytes of the top of DRAM,
+    // reading unmapped/device memory. A path within MAX_PATH bytes of
+    // RAM_END is rejected outright as a safe conservative policy.
+    if !validate_user_buffer(path_ptr as usize, MAX_PATH) {
         return EFAULT;
     }
 
     // Read the null-terminated path string from user space.
-    // Cap at 256 bytes to bound the scan; longer paths are rejected.
-    const MAX_PATH: usize = 256;
     let path_len = {
         let mut len = 0usize;
         let ptr = path_ptr as *const u8;
         while len < MAX_PATH {
-            // SAFETY: ptr + len is in user DRAM (validate_user_buffer checked
-            // the base; the loop caps at MAX_PATH which is well within the
-            // ~1 GB user DRAM range, so no wrap occurs).
+            // SAFETY: [path_ptr, path_ptr+MAX_PATH) was validated above to
+            // lie entirely within user-accessible DRAM.
             let byte = unsafe { ptr.add(len).read_volatile() };
             if byte == 0 {
                 break;
@@ -740,25 +750,27 @@ fn sys_execve(path_ptr: u32, argv_ptr: u32, _envp_ptr: u32) -> u32 {
     // WHY 4 pages (16 KB): matches spawn() stack size; sufficient for musl
     // libc start-up (argc/argv + environ + aux vectors + initial stack frame).
     const EXEC_STACK_PAGES: usize = 4;
-    let mut new_stack_base: usize = 0;
+    // WHY array-tracked (#251): page::alloc_page() is a bitmap scanner with
+    // no contiguity guarantee; an OOM rollback that assumes
+    // `new_stack_base + j * PAGE_SIZE` names the j-th allocated page can free
+    // an unrelated live page. Recording each returned address makes the
+    // rollback exact regardless of fragmentation.
+    let mut exec_stack_pages: [usize; EXEC_STACK_PAGES] = [0; EXEC_STACK_PAGES];
     for i in 0..EXEC_STACK_PAGES {
         match page::alloc_page() {
-            Some(phys) => {
-                if i == 0 {
-                    new_stack_base = phys;
-                }
-            }
+            Some(phys) => exec_stack_pages[i] = phys,
             None => {
-                // OOM: free already-allocated stack pages and abort.
+                // OOM: free exactly the pages allocated so far, then abort.
                 for j in 0..i {
                     // SAFETY: pages were returned by alloc_page() in this loop;
                     // they have not been mapped or used yet.
-                    unsafe { page::free_page(new_stack_base + j * page::PAGE_SIZE); }
+                    unsafe { page::free_page(exec_stack_pages[j]); }
                 }
                 return ENOMEM;
             }
         }
     }
+    let new_stack_base = exec_stack_pages[0];
     let new_stack_top = new_stack_base + EXEC_STACK_PAGES * page::PAGE_SIZE;
 
     // --- Step 5: build argc/argv on the new stack ---
@@ -936,13 +948,17 @@ fn sys_brk(new_break_raw: u32) -> u32 {
                     let rollback_vaddr = current + j * page::PAGE_SIZE;
                     // SAFETY: pt is the current process's valid L1 table and
                     // rollback_vaddr is page-aligned within the heap region.
-                    // These pages were successfully mapped in earlier iterations.
+                    // These pages were successfully mapped in earlier
+                    // iterations; the physical frame is read before the L2
+                    // entry is cleared so it can be returned to the page
+                    // allocator instead of leaking (#226).
                     unsafe {
+                        let rollback_phys = mmu::read_l2_phys(pt, rollback_vaddr);
                         mmu::unmap_page(pt, rollback_vaddr);
-                        // NOTE: we can't easily recover the physical address of
-                        // already-mapped pages without reading the L2 entry. For
-                        // simplicity, we accept the leak on OOM during brk grow.
-                        // A production kernel would track the phys addrs.
+                        mmu::flush_tlb_page(rollback_vaddr);
+                        if let Some(rollback_phys) = rollback_phys {
+                            page::free_page(rollback_phys);
+                        }
                     }
                 }
                 let Ok(current_u32) = u32::try_from(current) else { return EINVAL; };
@@ -968,16 +984,18 @@ fn sys_brk(new_break_raw: u32) -> u32 {
         for i in 0..pages_to_free {
             let vaddr = new_break + i * page::PAGE_SIZE;
             // SAFETY: pt is the current process's valid L1 table and vaddr is
-            // page-aligned within the currently mapped heap region.
-            // flush_tlb_page invalidates the TLB entry after the L2 entry is zeroed.
+            // page-aligned within the currently mapped heap region. The
+            // physical frame is read before the L2 entry is cleared so it can
+            // be returned to the page allocator instead of leaking (#226);
+            // flush_tlb_page invalidates the TLB entry after the L2 entry is
+            // zeroed.
             unsafe {
+                let phys = mmu::read_l2_phys(pt, vaddr);
                 mmu::unmap_page(pt, vaddr);
-                // NOTE: we don't have an easy way to get the physical address
-                // from the L2 entry after zeroing it. For brk shrink, the pages
-                // were contiguously allocated and the physical addresses are not
-                // readily recoverable without reading L2 before clearing.
-                // A production kernel would read the L2 entry before clearing.
                 mmu::flush_tlb_page(vaddr);
+                if let Some(phys) = phys {
+                    page::free_page(phys);
+                }
             }
         }
         process::set_heap_break(new_break);
@@ -1692,6 +1710,16 @@ mod tests {
         assert_eq!(EFAULT, 0xFFFF_FFF2u32, "EFAULT must be two's complement -14");
     }
 
+    /// #220: a path_ptr within MAX_PATH (256) bytes of RAM_END must be
+    /// rejected with EFAULT before any read, instead of scanning past
+    /// RAM_END into unmapped/device memory.
+    #[test]
+    fn execve_rejects_path_pointer_near_ram_end() {
+        let result = sys_execve((kconfig::RAM_END - 1) as u32, 0, 0);
+        assert_eq!(result, EFAULT,
+            "execve must reject a path pointer within MAX_PATH bytes of RAM_END instead of scanning past it");
+    }
+
     /// REQ-07: execve must return ENOENT when the path is not found in ramfs.
     ///
     /// WHY: after path validation, sys_execve calls fd::ramfs_find. This test
@@ -1732,6 +1760,40 @@ mod tests {
 
         // ENOENT has the correct two's-complement encoding.
         assert_eq!(ENOENT, 0xFFFF_FFFEu32, "ENOENT must be two's complement -2");
+    }
+
+    /// #255: write(1, ...) after dup2(pipe_write_end, 1) must deliver data to
+    /// the pipe, not silently continue to UART.
+    #[cfg(target_pointer_width = "32")]
+    #[test]
+    fn write_dispatch_respects_dup2_redirected_stdout() {
+        unsafe {
+            let table = &mut *core::ptr::addr_of_mut!(fd::FD_TABLE);
+            *table = fd::FdTable::new();
+
+            static mut FDS: [u32; 2] = [0, 0];
+            let fds_ptr = core::ptr::addr_of_mut!(FDS) as u32;
+            let pipe_result = pipe::sys_pipe(fds_ptr);
+            assert_eq!(pipe_result, 0, "pipe creation must succeed");
+            let fds = &*core::ptr::addr_of!(FDS);
+            let read_fd = fds[0];
+            let write_fd = fds[1];
+
+            let dup_result = fd::sys_dup2(write_fd, 1);
+            assert_eq!(dup_result, 1, "dup2 must install the pipe write end at fd 1");
+
+            static mut MSG: [u8; 5] = *b"hello";
+            let msg_ptr = core::ptr::addr_of!(MSG) as u32;
+            let written = sys_write_dispatch(1, msg_ptr, 5);
+            assert_eq!(written, 5, "write(1, ...) after dup2 must report 5 bytes written");
+
+            static mut BUF: [u8; 5] = [0u8; 5];
+            let buf_ptr = core::ptr::addr_of_mut!(BUF) as u32;
+            let read_result = sys_read_with_pipe(read_fd, buf_ptr, 5);
+            assert_eq!(read_result, 5, "5 bytes must be read back from the pipe");
+            assert_eq!(&*core::ptr::addr_of!(BUF), b"hello",
+                "pipe must receive the exact bytes written to fd 1, not UART");
+        }
     }
 
     // ---- Syscall table completeness tests ----
@@ -1999,30 +2061,62 @@ mod tests {
     }
 
     /// Shrinking the heap via brk must correctly update the program break
-    /// back to the requested value.
+    /// back to the requested value AND return the underlying physical pages
+    /// to the allocator (#226) — not just unmap the page-table entries.
     ///
     /// WHY: brk shrink is how musl's free() returns memory. An incorrect
-    /// shrink leaves the break misreported, breaking subsequent brk queries.
-    ///
-    /// NOTE: the current brk shrink path unmaps page-table entries but does
-    /// not call free_page (physical address not recoverable from a zeroed L2
-    /// entry — see comment in sys_brk). The break value is still correctly
-    /// updated.
+    /// shrink leaves the break misreported, breaking subsequent brk queries;
+    /// unmapping without freeing leaks the physical frame permanently.
     #[test]
     fn brk_shrink_frees_pages() {
         unsafe { setup_mm(); }
         let initial = sys_brk(0);
+        let free_before_grow = page::free_count();
 
         // Grow by two pages.
         let grown = initial + u32::try_from(2 * crate::page::PAGE_SIZE).unwrap_or_default();
         let at_grown = sys_brk(grown);
         assert_eq!(at_grown, grown, "brk must advance to grown");
+        assert_eq!(
+            page::free_count(), free_before_grow - 2,
+            "brk grow must consume exactly 2 physical pages"
+        );
 
         // Shrink back to initial break.
         let result = sys_brk(initial);
         assert_eq!(
             result, initial,
             "brk shrink must return break to initial value"
+        );
+        assert_eq!(
+            page::free_count(), free_before_grow,
+            "brk shrink must return exactly the 2 released pages to the allocator (#226)"
+        );
+    }
+
+    /// #226: an OOM partway through a brk grow must roll back exactly the
+    /// pages it mapped before failing, not leak them.
+    #[test]
+    fn brk_grow_oom_rollback_frees_mapped_pages() {
+        unsafe { setup_mm(); }
+        let initial = sys_brk(0);
+
+        // Shrink the free pool to exactly 1 page so a 3-page brk grow OOMs
+        // after mapping the first page.
+        unsafe {
+            crate::page::init(0x4000_0000, 0x4000_0000 + 5 * crate::page::PAGE_SIZE, 0x4000_0000 + 4 * crate::page::PAGE_SIZE);
+        }
+        let free_before = page::free_count();
+        assert_eq!(free_before, 1, "test setup must yield exactly 1 free page");
+
+        let requested = initial + u32::try_from(3 * crate::page::PAGE_SIZE).unwrap_or_default();
+        let result = sys_brk(requested);
+        assert_eq!(result, initial, "brk must return the unchanged break on OOM");
+
+        let free_after = page::free_count();
+        assert_eq!(
+            free_after, free_before,
+            "OOM rollback must return exactly the pages mapped before the failure, leaving free-count unchanged (#226)"
         );
     }
 
@@ -2062,6 +2156,54 @@ mod tests {
             addr2, MAP_FAILED,
             "mmap after munmap must succeed (mapping record was freed)"
         );
+    }
+
+    /// #251: an OOM partway through sys_execve's stack allocation must roll
+    /// back exactly the pages allocated so far. Uses a minimal ELF32 LE ARM
+    /// header with e_phnum = 0 (mirrors elf.rs's make_valid_ehdr test
+    /// helper) so elf::load consumes zero pages and only the execve stack
+    /// allocation exercises the page allocator; the ramfs Vec allocation in
+    /// fd::ramfs_find is unaffected because #[global_allocator] is
+    /// #[cfg(not(test))]-only (heap allocations under test use the host's
+    /// default allocator, decoupled from page::alloc_page()).
+    #[cfg(target_pointer_width = "32")]
+    #[test]
+    fn execve_oom_rollback_frees_exact_stack_pages() {
+        unsafe {
+            process::reset_for_test();
+
+            let mut elf = [0u8; 52];
+            elf[0] = 0x7F; elf[1] = b'E'; elf[2] = b'L'; elf[3] = b'F';
+            elf[4] = 1; elf[5] = 1; elf[6] = 1;
+            elf[16] = 2;
+            elf[18] = 40;
+            elf[20] = 1;
+            elf[25] = 0x80; // e_entry = 0x8000
+            elf[28] = 52;   // e_phoff
+            elf[40] = 52;   // e_ehsize
+            elf[42] = 32;   // e_phentsize
+            elf[44] = 0;    // e_phnum
+
+            let mut fs = crate::ramfs::RamFs::new();
+            fs.add("bin", &elf);
+            fd::init_ramfs(fs);
+
+            // Shrink the free pool to exactly 2 pages so the 4-page execve
+            // stack allocation (EXEC_STACK_PAGES = 4) OOMs on the 3rd page.
+            page::init(0x4000_0000, 0x4000_0000 + 6 * crate::page::PAGE_SIZE, 0x4000_0000 + 4 * crate::page::PAGE_SIZE);
+            let free_before = page::free_count();
+            assert_eq!(free_before, 2, "test setup must yield exactly 2 free pages");
+
+            static mut PATH: [u8; 5] = *b"/bin\0";
+            let path_ptr = core::ptr::addr_of!(PATH) as *const u8 as u32;
+
+            let result = sys_execve(path_ptr, 0, 0);
+            assert_eq!(result, ENOMEM, "execve must fail with ENOMEM when the stack allocation OOMs");
+
+            let free_after = page::free_count();
+            assert_eq!(free_after, free_before,
+                "OOM rollback must return exactly the pages allocated before the failure, leaving free-count unchanged (#251)");
+        }
     }
 
     // ---- Slab allocator integration test ----
@@ -2138,5 +2280,38 @@ mod tests {
                 "free_count must equal number of deallocations ({N}), got {frees}"
             );
         }
+    }
+
+    // ---- Sleep syscall (#264) ----
+
+    /// #264: SYS_Sleep's tick-conversion must round up like sys_nanosleep's
+    /// (ceil(ms / TICK_MS)), now that Sleep uses the same set_wake_tick +
+    /// busy-wait + clear_wake_tick pattern instead of a bare uptime_ms()
+    /// busy-wait that never touched process state at all.
+    #[test]
+    fn sleep_tick_conversion_matches_nanosleep_rounding() {
+        const TICK_MS: u64 = 10;
+        let ms: u64 = 1_000;
+        let ticks_needed = ms.saturating_add(TICK_MS - 1) / TICK_MS;
+        assert_eq!(ticks_needed, 100, "1000 ms must convert to 100 ticks at 10 ms/tick");
+
+        let ms: u64 = 5;
+        let ticks_needed = ms.saturating_add(TICK_MS - 1) / TICK_MS;
+        assert_eq!(ticks_needed, 1, "5 ms sleep must round up to 1 tick, not truncate to 0");
+    }
+
+    /// #264: Sleep(0) must exercise the full set_wake_tick -> wait ->
+    /// clear_wake_tick sequence and leave the process Running, not stuck
+    /// Sleeping. arg0 = 0 makes wake_tick == now_ticks so the wait loop
+    /// resolves immediately without hanging the single-threaded host test
+    /// (nothing else advances the settable exceptions_stub tick source).
+    #[test]
+    fn sleep_zero_round_trips_process_state() {
+        unsafe { process::reset_for_test(); }
+        let result = dispatch(Syscall::Sleep.as_u32(), 0, 0, 0, 0);
+        assert_eq!(result, 0, "Sleep(0) must return 0");
+        let state = unsafe { process::get_state(0) };
+        assert_eq!(state, Some(process::State::Running),
+            "process must be Running (not left Sleeping) after Sleep returns");
     }
 }


### PR DESCRIPTION
## Summary

Fixes 12 process-table / page-lifecycle / syscall-correctness defects, now host-testable since `process`/`mmu`/`syscall` were un-gated in #405.

## Process table

- **#232 / #224 / #218** — `waitpid` indexed the fixed-size process table with an unbounded userspace PID (a userspace-triggerable kernel panic) and never reaped the `Dead` PCB (table exhaustion after `MAX_PROCS` exits, zombie processes forever). It now bounds-checks the PID and reaps the slot on success — one fix closes all three.
- **#269** — `deliver_signal_to` and `sys_kill` had no PID-0 guard, and `KILL` is in the default fork capability mask, so any child could terminate kinit (the fault supervisor). Both now reject PID 0 with `EPERM` *before* the capability check.

## Physical-frame leaks

A new `mmu::read_l2_phys` recovers the mapped frame *before* `unmap_page` clears the L2 entry, so callers can free it instead of leaking:

- **#226** — `sys_brk` shrink and grow-OOM-rollback unmapped pages without freeing their physical frames.
- **#225** — `exec_replace_context` dropped mmap/heap tracking without unmapping or freeing the frames — a per-exec leak, and the previous image's residual data was readable by the new image at the same virtual addresses.
- **#251** — OOM rollback in `spawn`/`fork`/`execve` freed `base + j*PAGE_SIZE`, assuming a physical contiguity the bitmap allocator does not provide — it could free an unrelated live page. Each path now array-tracks its allocations and rolls back exactly those. (fork's *success* path was fixed in #208; this fixes its *rollback* path.)
- **#222** — `ramfs_find` leaked a fresh heap copy of the file on every `execve`; now bounded by a 16-slot resident cache keyed on `(mount, inode, size)`, so repeated launches of the same binary are free after the first.

## Syscall correctness

- **#220** — `sys_execve` validated only 1 byte of the path pointer but scanned up to `MAX_PATH`; it now validates the full scan window (no read past `RAM_END`).
- **#255** — `sys_write_dispatch` hard-routed fd 1 to UART before consulting the fd table, shadowing a `dup2(x, 1)` stdout redirect; it now consults the table first and falls back to UART only for an fd 1 with no entry.
- **#264** — `SYS_Sleep` busy-waited without touching process state; it now brackets the wait with `set_wake_tick`/`clear_wake_tick` like `nanosleep`.
- **#249** — `sys_fstat` fabricated a zeroed success stat on a real `fs.stat()` failure, masking I/O errors; it now propagates the errno.

## Closes

Closes #232, #224, #218, #225, #226, #222, #251, #264, #255, #220, #269, #249

## Verification

- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — 1697 passed (+16)
- `cargo build --release --target armv7a-none-eabi` — compiles
- `kanon lint . --summary` — clean

## Note for review

`read_l2_phys` returns `Some(frame)` only when the L1 entry is a page table and the L2 entry's low 2 bits are non-zero (mapped), `None` otherwise; every caller reads it before `unmap_page` zeroes the entry (verified by a dedicated test). The `spawn`/`fork` *success*-path `stack_top = stack_base + STACK_PAGES*PAGE_SIZE` still assumes stack-page contiguity — out of scope here (#251 is rollback-only), to be tracked separately.
