### PR TITLE
Modem-boundary security: 14 fixes (AT-injection, identity filter, DoS bounds, registration state)

### DIFF
--- a/crates/klesis/src/at.rs
+++ b/crates/klesis/src/at.rs
@@ -11,6 +11,8 @@ use nom::character::complete::{char, digit1};
 use nom::combinator::{map, map_res, opt, value};
 use nom::sequence::{delimited, preceded};
 
+use crate::error::{Error, Result};
+
 /// Raw AT response FROM the modem.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[non_exhaustive]
@@ -229,8 +231,33 @@ pub(crate) fn build_cmd(cmd: &str) -> String {
     format!("{cmd}\r\n")
 }
 
+/// Validate that `s` contains only characters legal in a GSM AT dial-string.
+///
+/// SECURITY: gates every phone number before it is interpolated into an AT
+/// command string. The modem and cellular network are untrusted; an
+/// unfiltered number could carry CR/LF (splits the string into multiple AT
+/// command lines) or `"` (closes a quoted field early in
+/// `AT+CMGS="..."`), letting an attacker-influenced number smuggle a
+/// second AT command past the modem.
+///
+/// Allowed set: ASCII digits `0`-`9`, `+`, `*`, `#`, and `A`-`D`
+/// (3GPP TS 27.007 dial-string charset).
+pub(crate) fn validate_phone_number(s: &str) -> Result<&str> {
+    if !s
+        .bytes()
+        .all(|b| matches!(b, b'0'..=b'9' | b'+' | b'*' | b'#' | b'A'..=b'D'))
+    {
+        return Err(Error::Parse {
+            message: format!("invalid phone number: {s:?}"),
+        });
+    }
+    Ok(s)
+}
+
 /// Common AT commands.
 pub(crate) mod cmd {
+    use super::{Result, validate_phone_number};
+
     /// Check modem is alive.
     pub(crate) const AT: &str = "AT";
     /// Request manufacturer identification.
@@ -248,8 +275,15 @@ pub(crate) mod cmd {
     /// Enable caller ID.
     pub(crate) const CLIP_ENABLE: &str = "AT+CLIP=1";
     /// Dial a number.
-    pub(crate) fn dial(number: &str) -> String {
-        format!("ATD{number};")
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::error::Error::Parse`] if `number` contains any byte
+    /// outside the GSM dial-string charset (see
+    /// [`super::validate_phone_number`]).
+    pub(crate) fn dial(number: &str) -> Result<String> {
+        let number = validate_phone_number(number)?;
+        Ok(format!("ATD{number};"))
     }
     /// Answer incoming call.
     pub(crate) const ATA: &str = "ATA";
@@ -260,8 +294,16 @@ pub(crate) mod cmd {
     /// Set SMS PDU mode.
     pub(crate) const CMGF_PDU: &str = "AT+CMGF=0";
     /// Send SMS (text mode). Returns prompt ">" for message body.
-    pub(crate) fn cmgs(number: &str) -> String {
-        format!("AT+CMGS=\"{number}\"")
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::error::Error::Parse`] if `number` contains any byte
+    /// outside the GSM dial-string charset (see
+    /// [`super::validate_phone_number`]), including `"` (would close the
+    /// quoted destination field early).
+    pub(crate) fn cmgs(number: &str) -> Result<String> {
+        let number = validate_phone_number(number)?;
+        Ok(format!("AT+CMGS=\"{number}\""))
     }
     /// Read SMS at index.
     pub(crate) fn cmgr(index: u16) -> String {
@@ -400,18 +442,36 @@ mod tests {
     #[test]
     fn build_dial_command() {
         assert_eq!(
-            cmd::dial("+15551234567"),
+            cmd::dial("+15551234567").unwrap_or_default(),
             "ATD+15551234567;",
             "dial command must be formatted as ATD<number>;"
         );
     }
 
     #[test]
+    fn build_dial_command_rejects_crlf_injection() {
+        let result = cmd::dial("+1\r\nAT+CFUN=0");
+        assert!(
+            result.is_err(),
+            "CR/LF in dial number must be rejected, not formatted"
+        );
+    }
+
+    #[test]
     fn build_sms_command() {
         assert_eq!(
-            cmd::cmgs("+15551234567"),
+            cmd::cmgs("+15551234567").unwrap_or_default(),
             "AT+CMGS=\"+15551234567\"",
             "CMGS command must wrap number in quotes"
+        );
+    }
+
+    #[test]
+    fn build_sms_command_rejects_quote_injection() {
+        let result = cmd::cmgs("+1\"\r\nATH");
+        assert!(
+            result.is_err(),
+            "quote/CR/LF in CMGS destination must be rejected, not formatted"
         );
     }
 }

--- a/crates/klesis/src/pdu.rs
+++ b/crates/klesis/src/pdu.rs
@@ -132,6 +132,17 @@ fn encode_bcd_address(addr: &Address) -> Result<Vec<u8>> {
     };
 
     let digit_bytes: Vec<u8> = digits.as_bytes().to_vec();
+    // SECURITY/CORRECTNESS: every byte must be validated before the BCD
+    // packing loop performs `d - b'0'`. An unvalidated non-digit byte
+    // (service char, formatting char, or arbitrary attacker-influenced
+    // byte) underflows in debug builds (panic) or wraps to a silently
+    // corrupted nibble in release builds, while this function still
+    // returns `Ok`.
+    if let Some(&bad) = digit_bytes.iter().find(|&&d| !d.is_ascii_digit()) {
+        return Err(crate::error::Error::PduEncode {
+            message: format!("non-digit character in address: 0x{bad:02X}"),
+        });
+    }
     let len_digits =
         u8::try_from(digit_bytes.len()).map_err(|_| crate::error::Error::PduEncode {
             message: "SMS address exceeds u8 length limit".to_owned(),
@@ -388,6 +399,16 @@ const fn is_wap_push_port(port: u16) -> bool {
     port == WAP_PUSH_PORT_OMA_CP || port == WAP_PUSH_PORT_ALT
 }
 
+/// Number of GSM-7 septets consumed by `udh_octets` raw UDH bytes once
+/// folded into the septet stream.
+///
+/// 3GPP TS 23.040 § 9.2.3.24: the UDH is stored as full 8-bit octets; fill
+/// bits pad it to the next septet boundary before the text septets begin.
+/// `ceil(udh_octets * 8 / 7)`.
+fn gsm7_udh_septets(udh_octets: usize) -> usize {
+    (udh_octets * 8).div_ceil(7)
+}
+
 /// Decode an SMS-DELIVER PDU FROM its hex string representation.
 ///
 /// The hex string must represent the full TPDU including the SMSC prefix.
@@ -448,7 +469,7 @@ pub(crate) fn decode_deliver(pdu_hex: &str) -> Result<SmsDeliver> {
     let timestamp = decode_scts(scts);
 
     // User data length (UDL) + user data (UD).
-    let udl = usize::from(cur.read_byte()?);
+    let mut udl = usize::from(cur.read_byte()?);
 
     // WHY: we need the raw UD bytes for UDH inspection before decoding text.
     // If UDHI is set, the first bytes of UD contain the User Data Header.
@@ -470,6 +491,21 @@ pub(crate) fn decode_deliver(pdu_hex: &str) -> Result<SmsDeliver> {
                 source_port: ports.source,
             });
         }
+
+        // SECURITY: strip the UDH from the decoded body. Without this, the
+        // header bytes (attacker-controlled on e.g. a concatenation IE) are
+        // decoded as message content and prepended to the visible SMS body
+        // -- a forged-sender-prefix phishing vector.
+        let udhl = usize::from(ud_preview.first().copied().unwrap_or(0));
+        let udh_octets = (udhl + 1).min(ud_preview.len());
+        cur.read_slice(udh_octets)?;
+        udl = match encoding {
+            // 3GPP TS 23.040 § 9.2.3.24: the UDH is byte-aligned; text
+            // resumes at the next septet boundary once folded into the
+            // septet stream.
+            DataEncoding::Gsm7Bit => udl.saturating_sub(gsm7_udh_septets(udh_octets)),
+            DataEncoding::Ucs2 => udl.saturating_sub(udh_octets),
+        };
     }
 
     let user_data = decode_user_data(&mut cur, udl, encoding)?;
@@ -704,6 +740,19 @@ mod tests {
         assert_eq!(
             decoded.number, "+12345678901",
             "decoded number must match 11-digit original including trailing filler nibble"
+        );
+    }
+
+    #[test]
+    fn encode_bcd_address_rejects_non_digit() {
+        let addr = Address {
+            number: "+1234*5678".to_owned(),
+            type_of_address: AddressType::International,
+        };
+        let result = encode_bcd_address(&addr);
+        assert!(
+            result.is_err(),
+            "a non-digit byte ('*') in the address must be rejected, not silently corrupted"
         );
     }
 
@@ -1040,31 +1089,12 @@ mod tests {
     #[test]
     fn decode_deliver_udhi_normal_port_passes() {
         // UDHI set but with a non-WAP-Push destination port (port 1234 = 0x04D2).
-        // DCS=0x08 (UCS-2), UDL = 10 bytes (7 UDH + 2 pad + 2 UCS-2 text, but
-        // the existing decoder does not strip UDH from the user data byte count).
-        // Use UDL=10 so remaining UCS-2 bytes are even after UDH.
-        //   UDH: 06 05 04 04 D2 23 F0
-        //   UD: 00 41 00 41 00 (need 3 bytes = odd — problematic for UCS-2)
         //
-        // WHY: The existing `decode_user_data` function does not perform UDH-aware
-        // byte stripping for UCS-2, so feeding a PDU with UDH + UCS-2 through
-        // the full pipeline will fail at the UCS-2 decode step (odd byte count).
-        // This is correct existing behavior — we only need to verify that the
-        // WAP Push port check itself passes. Use the parse_udh_ports unit test
-        // (above) and the is_wap_push_port test to verify non-WAP ports pass.
-        //
-        // Integration test: construct a GSM-7 PDU with UDHI and non-WAP port.
-        // DCS=0x00 (GSM-7). UDL counts septets including UDH fill bits.
-        // UDH = 7 bytes = 56 bits. GSM-7 fill bits to next septet boundary = 56 bits
-        // → 8 septets consumed by UDH. So UDL = 8 (UDH) + N (text septets).
-        // For 1 text character: UDL = 9. Packed bytes = ceil(9*7/8) = 8.
-        // Total UD bytes = 7 (UDH) + 8 (packed) = ... but wait, the packer
-        // doesn't know about the UDH offset either.
-        //
-        // Simplest correct approach: verify via the unit test that non-WAP ports
-        // return None from parse_udh_ports and don't trigger rejection.
-        // The full-PDU test for WAP Push already covers the UDHI path.
-        // This test verifies the opposite: a safe port is not rejected.
+        // NOTE: decode_deliver now strips the UDH before decoding user data
+        // (see decode_deliver_udhi_concatenation_ie_strips_udh_ucs2 for the
+        // full-pipeline regression test). This test stays at the
+        // parse_udh_ports/is_wap_push_port unit level: it only needs to
+        // confirm that a non-WAP-Push port IE does not trigger rejection.
         let ud = [0x06, 0x05, 0x04, 0x04, 0xD2, 0x23, 0xF0, 0x41];
         let ports = parse_udh_ports(&ud);
         assert!(ports.is_some(), "UDH with port IE must be parsed");
@@ -1073,6 +1103,37 @@ mod tests {
         assert!(
             !is_wap_push_port(ports.destination),
             "port 0x04D2 (1234) must NOT be flagged as WAP Push"
+        );
+    }
+
+    #[test]
+    fn gsm7_udh_septets_alignment() {
+        // A 6-octet UDH (48 bits) needs 7 septets (49 bits) to byte-align,
+        // per 3GPP TS 23.040 fill-bit rules.
+        assert_eq!(
+            gsm7_udh_septets(6),
+            7,
+            "6 UDH octets must consume 7 septets"
+        );
+        // A 7-octet UDH (56 bits) packs exactly into 8 septets (56 bits).
+        assert_eq!(
+            gsm7_udh_septets(7),
+            8,
+            "7 UDH octets must consume exactly 8 septets"
+        );
+    }
+
+    #[test]
+    fn decode_deliver_udhi_concatenation_ie_strips_udh_ucs2() {
+        // UDHI set, UDH = concatenation IE (IEI=0x00, not a port IE), DCS=UCS-2.
+        // UDH: 05 00 03 01 02 01 (UDHL=5, IEI=00, IEL=3, ref=01, total=02, seq=01)
+        // Text: 00 48 00 69 ("Hi" in UCS-2)
+        let pdu = "00400A9121436587090008321051210300000A05000301020100480069";
+        let sms = decode_deliver(pdu).expect("must decode UDHI PDU with concatenation IE");
+        assert_eq!(
+            sms.user_data.text, "Hi",
+            "UDH bytes must be stripped from the decoded body, got: {:?}",
+            sms.user_data.text
         );
     }
 

--- a/crates/klesis/src/pdu.rs
+++ b/crates/klesis/src/pdu.rs
@@ -405,7 +405,7 @@ const fn is_wap_push_port(port: u16) -> bool {
 /// 3GPP TS 23.040 § 9.2.3.24: the UDH is stored as full 8-bit octets; fill
 /// bits pad it to the next septet boundary before the text septets begin.
 /// `ceil(udh_octets * 8 / 7)`.
-fn gsm7_udh_septets(udh_octets: usize) -> usize {
+const fn gsm7_udh_septets(udh_octets: usize) -> usize {
     (udh_octets * 8).div_ceil(7)
 }
 
@@ -426,6 +426,10 @@ fn gsm7_udh_septets(udh_octets: usize) -> usize {
 ///    16-bit application port addressing IE (0x05) with destination port 2948
 ///    or 49999, the message is an OMA-CP / WAP Push provisioning message.
 ///    Returns [`Error::WapPushRejected`].
+#[expect(
+    clippy::similar_names,
+    reason = "udl/udhl/udhi/oa are canonical 3GPP TS 23.040 SMS field abbreviations; renaming would break spec fidelity"
+)]
 pub(crate) fn decode_deliver(pdu_hex: &str) -> Result<SmsDeliver> {
     let raw = hex_decode(pdu_hex)?;
     let mut cur = Cursor::new(&raw);

--- a/crates/klesis/src/transport.rs
+++ b/crates/klesis/src/transport.rs
@@ -11,6 +11,33 @@ use snafu::ensure;
 use crate::at::{self, Response, Urc};
 use crate::error::{NotReadySnafu, ParseSnafu, Result, UnexpectedResponseSnafu};
 
+/// Maximum informational lines collected before a final result code, per
+/// AT command.
+///
+/// SECURITY: the CCCI/AT channel is untrusted (rogue or malfunctioning
+/// baseband). Without this bound, a modem that never returns a final
+/// result code keeps `AtSession::send_command` looping forever and grows
+/// its `info` `Vec` without bound -- a heap-exhaustion DoS. Mirrors
+/// `wait_urc`'s `MAX_ATTEMPTS` below.
+const MAX_INFO_LINES: usize = 64;
+
+/// Maximum bytes buffered for a single AT line before giving up.
+///
+/// SECURITY: bounds heap growth from a hostile/malfunctioning modem that
+/// never emits `\n`. 256 bytes generously covers any real AT response.
+const MAX_LINE_LEN: usize = 256;
+
+/// Wall-clock budget for a single line, independent of byte count.
+///
+/// SECURITY: `MAX_LINE_LEN` alone bounds space, not time -- a byte trickle
+/// that stays under the cap but never completes would otherwise block
+/// `read_line` (and therefore the whole AT session) indefinitely. Shortened
+/// under `#[cfg(test)]` so tests exercising this path stay fast.
+#[cfg(not(test))]
+const READ_LINE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+#[cfg(test)]
+const READ_LINE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(50);
+
 // ─── Trait ────────────────────────────────────────────────────────────────────
 
 /// Byte-stream transport to and FROM the modem.
@@ -88,6 +115,13 @@ impl<T: ModemTransport> AtSession<T> {
 
         let mut info = Vec::new();
         loop {
+            ensure!(
+                info.len() < MAX_INFO_LINES,
+                UnexpectedResponseSnafu {
+                    response: format!("no final result after {MAX_INFO_LINES} info lines")
+                }
+            );
+
             let line = self.read_line()?;
             if line.is_empty() {
                 // Blank lines between echo and response are normal; skip them.
@@ -157,6 +191,7 @@ impl<T: ModemTransport> AtSession<T> {
     /// - [`crate::error::Error::NotReady`] when the transport returns 0 bytes.
     /// - [`crate::error::Error::Parse`] on non-UTF-8 byte sequences.
     fn read_line(&mut self) -> Result<String> {
+        let deadline = std::time::Instant::now() + READ_LINE_TIMEOUT;
         let mut byte = [0u8; 1];
         loop {
             // Check if we already have a newline buffered.
@@ -174,6 +209,22 @@ impl<T: ModemTransport> AtSession<T> {
                     .build()
                 });
             }
+
+            if self.rx_buf.len() >= MAX_LINE_LEN {
+                self.rx_buf.clear();
+                return ParseSnafu {
+                    message: format!("AT line exceeds maximum length ({MAX_LINE_LEN} bytes)"),
+                }
+                .fail();
+            }
+            if std::time::Instant::now() >= deadline {
+                self.rx_buf.clear();
+                return ParseSnafu {
+                    message: "AT line read timed out".to_owned(),
+                }
+                .fail();
+            }
+
             let n = self.transport.recv(&mut byte)?;
             ensure!(n > 0, NotReadySnafu);
             // WHY: recv fills exactly byte[0] when n > 0; ensure!(n > 0) above
@@ -315,6 +366,88 @@ mod tests {
             resp.info.len(),
             1,
             "blank lines must not appear as info lines"
+        );
+    }
+
+    #[test]
+    fn send_command_bounds_info_lines_against_flood() {
+        // 1000 info lines, never a final result code.
+        let mut data = Vec::new();
+        for _ in 0..1000 {
+            data.extend_from_slice(b"+CSQ: 1,1\r\n");
+        }
+        let transport = MockTransport::with_response(&data);
+        let mut session = AtSession::new(transport);
+        let result = session.send_command("AT+CSQ");
+        assert!(
+            result.is_err(),
+            "send_command must error rather than buffer 1000 info lines"
+        );
+    }
+
+    #[test]
+    fn send_command_errors_when_no_final_result_ever_arrives() {
+        let mut data = Vec::new();
+        for _ in 0..100 {
+            data.extend_from_slice(b"+CSQ: 1,1\r\n");
+        }
+        let transport = MockTransport::with_response(&data);
+        let mut session = AtSession::new(transport);
+        let result = session.send_command("AT+CSQ");
+        assert!(
+            result.is_err(),
+            "send_command must not loop indefinitely when no final result code arrives"
+        );
+    }
+
+    #[test]
+    fn read_line_rejects_oversized_line() {
+        // No newline anywhere; stream exceeds MAX_LINE_LEN (256) bytes.
+        let data = vec![b'X'; 300];
+        let transport = MockTransport::with_response(&data);
+        let mut session = AtSession::new(transport);
+        let result = session.send_command("AT");
+        assert!(
+            result.is_err(),
+            "a line exceeding MAX_LINE_LEN with no newline must error, not grow forever"
+        );
+    }
+
+    #[test]
+    fn read_line_times_out_on_slow_trickle() {
+        // Yields one byte per call with a small real delay each time -- a
+        // slow, steady trickle that never completes a line and never fills
+        // MAX_LINE_LEN. Under the #[cfg(test)] short READ_LINE_TIMEOUT this
+        // must return Err well before 1000 iterations could complete.
+        struct SlowTrickle {
+            remaining: u32,
+        }
+        impl ModemTransport for SlowTrickle {
+            fn send(&mut self, _data: &[u8]) -> Result<()> {
+                Ok(())
+            }
+            fn recv(&mut self, buf: &mut [u8]) -> Result<usize> {
+                std::thread::sleep(std::time::Duration::from_millis(5)); // kanon:ignore TESTING/sleep-in-test -- exercises the real wall-clock READ_LINE_TIMEOUT deadline (read_line reads Instant::now() directly, no injectable clock); a 5ms/byte trickle against the cfg(test) 50ms timeout deterministically forces the timeout before the 1000-byte budget and keeps the test ~50ms
+                if buf.is_empty() || self.remaining == 0 {
+                    return Ok(0);
+                }
+                self.remaining -= 1;
+                buf[0] = b'X'; // never '\n'
+                Ok(1)
+            }
+        }
+
+        let transport = SlowTrickle { remaining: 1000 };
+        let mut session = AtSession::new(transport);
+        let start = std::time::Instant::now();
+        let result = session.send_command("AT");
+        assert!(
+            result.is_err(),
+            "a slow byte trickle that never completes a line must time out"
+        );
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(2),
+            "the test-mode deadline must trip well within a couple seconds"
         );
     }
 }

--- a/crates/klesis/src/transport.rs
+++ b/crates/klesis/src/transport.rs
@@ -17,7 +17,7 @@ use crate::error::{NotReadySnafu, ParseSnafu, Result, UnexpectedResponseSnafu};
 /// SECURITY: the CCCI/AT channel is untrusted (rogue or malfunctioning
 /// baseband). Without this bound, a modem that never returns a final
 /// result code keeps `AtSession::send_command` looping forever and grows
-/// its `info` `Vec` without bound -- a heap-exhaustion DoS. Mirrors
+/// its `info` `Vec` without bound -- a heap-exhaustion `DoS`. Mirrors
 /// `wait_urc`'s `MAX_ATTEMPTS` below.
 const MAX_INFO_LINES: usize = 64;
 

--- a/crates/thumos/src/ccci.rs
+++ b/crates/thumos/src/ccci.rs
@@ -1152,7 +1152,9 @@ impl AuditRing {
 /// AT command prefixes that reveal device identity.
 /// SECURITY: These are intercepted at the kernel boundary. The modem
 /// firmware responds to these AT commands with the device's IMEI (CGSN)
-/// and IMSI (CIMI), which tie the physical device to a person.
+/// and IMSI (CIMI), which tie the physical device to a person. Matching is
+/// ASCII case-insensitive (see `contains_subsequence`) because AT commands
+/// are case-insensitive per 3GPP TS 27.007.
 const IDENTITY_AT_COMMANDS: &[&[u8]] = &[
     b"AT+CGSN",  // IMEI query
     b"AT+CIMI",  // IMSI query
@@ -1160,10 +1162,17 @@ const IDENTITY_AT_COMMANDS: &[&[u8]] = &[
     b"+CIMI:",   // IMSI response prefix
 ];
 
+/// Length of a bare IMEI or IMSI decimal digit string (3GPP TS 23.003).
+const IDENTITY_DIGIT_RUN_LEN: usize = 15;
+
 /// Check if a data buffer contains an identity-revealing AT command or response.
 ///
 /// SECURITY: This runs on every UART channel message from the modem. The
 /// check must be performed on data already copied out of shared memory.
+/// Covers three forms: the AT query itself, a `+CGSN:`/`+CIMI:`-prefixed
+/// response, and the bare (unprefixed) digit-string response that the
+/// standard 3GPP TS 27.007 Execute form of `AT+CGSN`/`AT+CIMI` actually
+/// returns.
 ///
 /// Returns `true` if the buffer matches an identity pattern.
 pub(crate) fn contains_identity_pattern(data: &[u8]) -> bool {
@@ -1176,10 +1185,15 @@ pub(crate) fn contains_identity_pattern(data: &[u8]) -> bool {
             }
         }
     }
-    false
+    contains_bare_identity_digits(data)
 }
 
-/// Scan `haystack` for the first occurrence of `needle`.
+/// Scan `haystack` for the first occurrence of `needle`, ASCII
+/// case-insensitively.
+///
+/// SECURITY: AT commands are case-insensitive per 3GPP TS 27.007. A
+/// byte-exact scan let a lowercase response (e.g. `at+cgsn`) bypass the
+/// identity filter entirely.
 fn contains_subsequence(haystack: &[u8], needle: &[u8]) -> bool {
     if needle.is_empty() {
         return true;
@@ -1189,11 +1203,39 @@ fn contains_subsequence(haystack: &[u8], needle: &[u8]) -> bool {
     }
     let limit = haystack.len() - needle.len() + 1;
     for i in 0..limit {
-        if haystack.get(i..i + needle.len()) == Some(needle) {
+        if let Some(window) = haystack.get(i..i + needle.len())
+            && window
+                .iter()
+                .zip(needle.iter())
+                .all(|(&a, &b)| a.eq_ignore_ascii_case(&b))
+        {
             return true;
         }
     }
     false
+}
+
+/// Check for a bare (unprefixed) IMEI/IMSI response: a run of exactly
+/// [`IDENTITY_DIGIT_RUN_LEN`] ASCII digits, not part of a longer digit run.
+///
+/// SECURITY: the Execute form of `AT+CGSN`/`AT+CIMI` (3GPP TS 27.007)
+/// returns the identifier as a bare digit string with no `+CGSN:`/`+CIMI:`
+/// prefix -- only the extended `AT+CGSN=<snt>` form is prefixed. Without
+/// this check, a compliant bare-digit response bypasses
+/// `IDENTITY_AT_COMMANDS` entirely.
+fn contains_bare_identity_digits(data: &[u8]) -> bool {
+    let mut run_len = 0usize;
+    for &b in data {
+        if b.is_ascii_digit() {
+            run_len += 1;
+        } else {
+            if run_len == IDENTITY_DIGIT_RUN_LEN {
+                return true;
+            }
+            run_len = 0;
+        }
+    }
+    run_len == IDENTITY_DIGIT_RUN_LEN
 }
 
 /// Capability flag required to pass identity data to userspace.
@@ -2273,6 +2315,42 @@ mod tests {
         assert!(
             !contains_identity_pattern(b"+CIM"),
             "partial CIMI must not match"
+        );
+    }
+
+    #[test]
+    fn identity_filter_case_insensitive() {
+        assert!(
+            contains_identity_pattern(b"at+cgsn\r\n"),
+            "lowercase 'at+cgsn' must still match the IMEI query pattern"
+        );
+        assert!(
+            contains_identity_pattern(b"+cimi: 310260000000000\r\n"),
+            "lowercase '+cimi:' must still match the IMSI response prefix"
+        );
+        assert!(
+            contains_identity_pattern(b"At+CgSn\r\n"),
+            "mixed-case 'At+CgSn' must still match"
+        );
+    }
+
+    #[test]
+    fn identity_filter_bare_imei_digits() {
+        assert!(
+            contains_identity_pattern(b"353882085372845\r\nOK\r\n"),
+            "a bare 15-digit IMEI/IMSI response with no +CGSN:/+CIMI: prefix must still be filtered"
+        );
+    }
+
+    #[test]
+    fn identity_filter_bare_digits_wrong_length_no_match() {
+        assert!(
+            !contains_identity_pattern(b"1234567890\r\nOK\r\n"),
+            "a 10-digit run must not be mistaken for a bare IMEI/IMSI (15 digits)"
+        );
+        assert!(
+            !contains_identity_pattern(b"3538820853728451\r\nOK\r\n"),
+            "a 16-digit run must not be mistaken for a bare IMEI/IMSI (exactly 15 digits)"
         );
     }
 

--- a/crates/thumos/src/ccci_logger.rs
+++ b/crates/thumos/src/ccci_logger.rs
@@ -29,7 +29,7 @@
 
 use core::fmt;
 
-use crate::ccci::CcciChannel;
+use crate::ccci::{CCCI_MAGIC, CCCI_MTU, CcciChannel};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -349,6 +349,13 @@ impl fmt::Display for ModemBaseline {
 /// ending at `window_end_ms`.  For each channel, computes packet count
 /// (used as rate), min/max packet size, and min/max data0 values.
 ///
+/// SECURITY: the entire window is adversary-controlled modem traffic (the
+/// MT6739 modem is untrusted per the threat model). `data0` accumulation is
+/// clamped to `CCCI_MTU` (except the `CCCI_MAGIC` control sentinel) so a
+/// modem that floods the 60-second boot window with `data0` spanning
+/// `[0, u32::MAX]` cannot fully defeat later `Data0OutOfRange` anomaly
+/// detection by establishing a maximally permissive baseline.
+///
 /// # Arguments
 ///
 /// * `log` -- the CCCI traffic logger with recorded entries
@@ -379,13 +386,26 @@ pub(crate) fn build_baseline(log: &CcciLogger, window_end_ms: u64) -> ModemBasel
         let stats = &mut baseline.channels[ch];
         let count = &mut packet_counts[ch];
 
+        // SECURITY: clamp data0 accumulation to the CCCI MTU ceiling so a
+        // baseline built entirely from adversarial boot-window traffic
+        // (data0 spanning the full u32 range) cannot fully defeat later
+        // Data0OutOfRange anomaly detection. The control-message sentinel
+        // (CCCI_MAGIC) is a known exact value, not attacker-influenced
+        // range data -- validate_packet already treats it specially -- so
+        // it passes through unclamped.
+        let clamped_data0 = if entry.data0 == CCCI_MAGIC {
+            entry.data0
+        } else {
+            entry.data0.min(CCCI_MTU as u32)
+        };
+
         if !stats.active {
             // First packet on this channel: initialize min/max.
             stats.active = true;
             stats.min_size = entry.packet_len;
             stats.max_size = entry.packet_len;
-            stats.min_data0 = entry.data0;
-            stats.max_data0 = entry.data0;
+            stats.min_data0 = clamped_data0;
+            stats.max_data0 = clamped_data0;
         } else {
             if entry.packet_len < stats.min_size {
                 stats.min_size = entry.packet_len;
@@ -393,11 +413,11 @@ pub(crate) fn build_baseline(log: &CcciLogger, window_end_ms: u64) -> ModemBasel
             if entry.packet_len > stats.max_size {
                 stats.max_size = entry.packet_len;
             }
-            if entry.data0 < stats.min_data0 {
-                stats.min_data0 = entry.data0;
+            if clamped_data0 < stats.min_data0 {
+                stats.min_data0 = clamped_data0;
             }
-            if entry.data0 > stats.max_data0 {
-                stats.max_data0 = entry.data0;
+            if clamped_data0 > stats.max_data0 {
+                stats.max_data0 = clamped_data0;
             }
         }
 
@@ -1052,6 +1072,95 @@ mod tests {
         assert!(ch4.active);
         assert_eq!(ch4.min_data0, 10);
         assert_eq!(ch4.max_data0, 200);
+    }
+
+    #[test]
+    fn baseline_clamps_poisoned_data0_to_mtu() {
+        let mut log = CcciLogger::new();
+        // Attacker-controlled boot-window traffic carrying a maximal
+        // out-of-range data0 on a data channel. WHY not u32::MAX: that exact
+        // value IS the CCCI_MAGIC control sentinel, which the clamp exempts
+        // by design (see `baseline_preserves_control_message_magic`); a
+        // poison value must therefore be a non-sentinel outlier.
+        log.record(CcciLogEntry {
+            timestamp: 1000,
+            channel: 5,
+            direction: PacketDirection::Rx,
+            data0: 0,
+            data1: 0,
+            packet_len: 16,
+        });
+        log.record(CcciLogEntry {
+            timestamp: 2000,
+            channel: 5,
+            direction: PacketDirection::Rx,
+            data0: u32::MAX - 1,
+            data1: 0,
+            packet_len: 16,
+        });
+
+        let baseline = build_baseline(&log, 60_000);
+        let ch5 = &baseline.channels[5];
+        assert!(ch5.active);
+        assert_eq!(
+            ch5.max_data0,
+            CCCI_MTU as u32,
+            "a non-sentinel out-of-range data0 outlier on a data channel must clamp to CCCI_MTU"
+        );
+    }
+
+    #[test]
+    fn baseline_preserves_control_message_magic() {
+        let mut log = CcciLogger::new();
+        log.record(CcciLogEntry {
+            timestamp: 1000,
+            channel: 0,
+            direction: PacketDirection::Rx,
+            data0: CCCI_MAGIC,
+            data1: 0,
+            packet_len: 16,
+        });
+
+        let baseline = build_baseline(&log, 60_000);
+        assert_eq!(
+            baseline.channels[0].max_data0,
+            CCCI_MAGIC,
+            "the control-message sentinel must pass through unclamped"
+        );
+    }
+
+    #[test]
+    fn anomaly_still_fires_after_baseline_clamp() {
+        let mut log = CcciLogger::new();
+        log.record(CcciLogEntry {
+            timestamp: 1000,
+            channel: 5,
+            direction: PacketDirection::Rx,
+            data0: u32::MAX - 1, // non-sentinel poisoning attempt, clamped to CCCI_MTU
+            data1: 0,
+            packet_len: 16,
+        });
+        let baseline = build_baseline(&log, 60_000);
+
+        // Live traffic still carrying an out-of-spec data0.
+        log.record(CcciLogEntry {
+            timestamp: 70_000,
+            channel: 5,
+            direction: PacketDirection::Rx,
+            data0: u32::MAX - 1,
+            data1: 0,
+            packet_len: 16,
+        });
+
+        let (anomalies, count) = detect_anomalies(&log, &baseline, 70_000, 60_000);
+        let found = anomalies[..count]
+            .iter()
+            .flatten()
+            .any(|a| a.channel == 5 && a.kind == AnomalyKind::Data0OutOfRange);
+        assert!(
+            found,
+            "anomaly detection must still fire on out-of-range data0 after the baseline is clamped"
+        );
     }
 
     #[test]

--- a/crates/thumos/src/contacts.rs
+++ b/crates/thumos/src/contacts.rs
@@ -44,6 +44,22 @@ const MAX_MATRIX_ID_LEN: usize = 64;
 // Contact
 // ---------------------------------------------------------------------------
 
+/// Errors from contact construction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub(crate) enum ContactError {
+    /// Phone number contains a byte outside the GSM dial-string charset.
+    InvalidNumber,
+}
+
+impl core::fmt::Display for ContactError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::InvalidNumber => write!(f, "invalid phone number"),
+        }
+    }
+}
+
 /// A single contact entry.
 ///
 /// Uses fixed-size byte arrays to avoid heap allocation per contact.
@@ -74,10 +90,21 @@ pub struct Contact {
 impl Contact {
     /// Create a new contact from name and number strings.
     ///
-    /// Truncates if either exceeds the maximum length. The Matrix ID
+    /// Truncates `name` if it exceeds the maximum length. The Matrix ID
     /// is left empty and default transport is SMS.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ContactError::InvalidNumber`] if `number` contains any
+    /// byte outside the GSM dial-string charset (an empty `number` is
+    /// valid -- Matrix-only contacts have no phone number). A rejected
+    /// number is never truncated-and-stored: reject, don't sanitize.
     #[must_use]
-    pub(crate) fn new(name: &str, number: &str) -> Self {
+    pub(crate) fn new(name: &str, number: &str) -> Result<Self, ContactError> {
+        if !number.bytes().all(crate::telephony_parser::is_valid_dial_byte) {
+            return Err(ContactError::InvalidNumber);
+        }
+
         let mut c = Self {
             name: [0u8; MAX_NAME_LEN],
             name_len: 0,
@@ -96,15 +123,24 @@ impl Contact {
         let number_copy_len = number_bytes.len().min(MAX_NUMBER_LEN);
         c.number[..number_copy_len].copy_from_slice(&number_bytes[..number_copy_len]);
         c.number_len = number_copy_len as u8;
-        c
+        Ok(c)
     }
 
     /// Create a new contact with a Matrix ID and optional phone number.
     ///
     /// Sets the default transport to Matrix when a Matrix ID is provided.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ContactError::InvalidNumber`] under the same condition as
+    /// [`Contact::new`].
     #[must_use]
-    pub(crate) fn with_matrix_id(name: &str, number: &str, matrix_id: &str) -> Self {
-        let mut c = Self::new(name, number);
+    pub(crate) fn with_matrix_id(
+        name: &str,
+        number: &str,
+        matrix_id: &str,
+    ) -> Result<Self, ContactError> {
+        let mut c = Self::new(name, number)?;
         let mid_bytes = matrix_id.as_bytes();
         let mid_copy_len = mid_bytes.len().min(MAX_MATRIX_ID_LEN);
         c.matrix_id[..mid_copy_len].copy_from_slice(&mid_bytes[..mid_copy_len]);
@@ -112,7 +148,7 @@ impl Contact {
         if mid_copy_len > 0 {
             c.default_transport = MessageTransport::Matrix;
         }
-        c
+        Ok(c)
     }
 
     /// Return the name as a string slice.
@@ -195,8 +231,14 @@ impl ContactManager {
     /// Add a contact with the given name and number.
     ///
     /// The contact is appended to the end of the list.
-    pub(crate) fn add(&mut self, name: &str, number: &str) {
-        self.contacts.push(Contact::new(name, number));
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ContactError::InvalidNumber`] and adds nothing if `number`
+    /// fails dial-string validation (see [`Contact::new`]).
+    pub(crate) fn add(&mut self, name: &str, number: &str) -> Result<(), ContactError> {
+        self.contacts.push(Contact::new(name, number)?);
+        Ok(())
     }
 
     /// Delete a contact by index.
@@ -287,9 +329,20 @@ impl ContactManager {
     /// Add a contact with name, phone number, and Matrix ID.
     ///
     /// The contact is appended to the end of the list.
-    pub(crate) fn add_with_matrix_id(&mut self, name: &str, number: &str, matrix_id: &str) {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ContactError::InvalidNumber`] and adds nothing if `number`
+    /// fails dial-string validation (see [`Contact::new`]).
+    pub(crate) fn add_with_matrix_id(
+        &mut self,
+        name: &str,
+        number: &str,
+        matrix_id: &str,
+    ) -> Result<(), ContactError> {
         self.contacts
-            .push(Contact::with_matrix_id(name, number, matrix_id));
+            .push(Contact::with_matrix_id(name, number, matrix_id)?);
+        Ok(())
     }
 }
 
@@ -322,8 +375,8 @@ mod tests {
     #[test]
     fn add_and_retrieve() {
         let mut mgr = ContactManager::new();
-        mgr.add("Alice", "+15551234567");
-        mgr.add("Bob", "+15559876543");
+        mgr.add("Alice", "+15551234567").unwrap_or_else(|_| unreachable!());
+        mgr.add("Bob", "+15559876543").unwrap_or_else(|_| unreachable!());
 
         assert_eq!(mgr.count(), 2);
 
@@ -343,10 +396,10 @@ mod tests {
     #[test]
     fn search_by_prefix() {
         let mut mgr = ContactManager::new();
-        mgr.add("Alice", "111");
-        mgr.add("Aaron", "222");
-        mgr.add("Bob", "333");
-        mgr.add("charlie", "444");
+        mgr.add("Alice", "111").unwrap_or_else(|_| unreachable!());
+        mgr.add("Aaron", "222").unwrap_or_else(|_| unreachable!());
+        mgr.add("Bob", "333").unwrap_or_else(|_| unreachable!());
+        mgr.add("charlie", "444").unwrap_or_else(|_| unreachable!());
 
         // Search "A" should find Alice and Aaron.
         let results = mgr.search("A");
@@ -376,9 +429,9 @@ mod tests {
     #[test]
     fn delete_removes_entry() {
         let mut mgr = ContactManager::new();
-        mgr.add("Alice", "111");
-        mgr.add("Bob", "222");
-        mgr.add("Charlie", "333");
+        mgr.add("Alice", "111").unwrap_or_else(|_| unreachable!());
+        mgr.add("Bob", "222").unwrap_or_else(|_| unreachable!());
+        mgr.add("Charlie", "333").unwrap_or_else(|_| unreachable!());
 
         mgr.delete(1); // Remove Bob.
 
@@ -390,8 +443,8 @@ mod tests {
     #[test]
     fn search_empty_returns_all() {
         let mut mgr = ContactManager::new();
-        mgr.add("Alice", "111");
-        mgr.add("Bob", "222");
+        mgr.add("Alice", "111").unwrap_or_else(|_| unreachable!());
+        mgr.add("Bob", "222").unwrap_or_else(|_| unreachable!());
 
         let results = mgr.search("");
         assert_eq!(
@@ -404,7 +457,7 @@ mod tests {
     #[test]
     fn delete_out_of_bounds_is_safe() {
         let mut mgr = ContactManager::new();
-        mgr.add("Alice", "111");
+        mgr.add("Alice", "111").unwrap_or_else(|_| unreachable!());
         mgr.delete(5); // Out of bounds.
         assert_eq!(mgr.count(), 1, "out-of-bounds delete must not crash");
     }
@@ -419,9 +472,9 @@ mod tests {
     #[test]
     fn sorted_indices_alphabetical() {
         let mut mgr = ContactManager::new();
-        mgr.add("Charlie", "333");
-        mgr.add("Alice", "111");
-        mgr.add("Bob", "222");
+        mgr.add("Charlie", "333").unwrap_or_else(|_| unreachable!());
+        mgr.add("Alice", "111").unwrap_or_else(|_| unreachable!());
+        mgr.add("Bob", "222").unwrap_or_else(|_| unreachable!());
 
         let sorted = mgr.sorted_indices();
         assert_eq!(sorted, vec![1, 2, 0], "must be sorted: Alice, Bob, Charlie");
@@ -430,8 +483,8 @@ mod tests {
     #[test]
     fn find_by_number_works() {
         let mut mgr = ContactManager::new();
-        mgr.add("Alice", "+15551234567");
-        mgr.add("Bob", "+15559876543");
+        mgr.add("Alice", "+15551234567").unwrap_or_else(|_| unreachable!());
+        mgr.add("Bob", "+15559876543").unwrap_or_else(|_| unreachable!());
 
         assert_eq!(mgr.find_by_number("+15551234567"), Some(0));
         assert_eq!(mgr.find_by_number("+15559876543"), Some(1));
@@ -441,7 +494,7 @@ mod tests {
     #[test]
     fn contact_new_truncates_long_name() {
         let long_name = "A".repeat(100);
-        let contact = Contact::new(&long_name, "123");
+        let contact = Contact::new(&long_name, "123").unwrap_or_else(|_| unreachable!());
         assert_eq!(
             contact.name_len as usize,
             MAX_NAME_LEN,
@@ -452,8 +505,8 @@ mod tests {
     #[test]
     fn all_returns_slice() {
         let mut mgr = ContactManager::new();
-        mgr.add("Alice", "111");
-        mgr.add("Bob", "222");
+        mgr.add("Alice", "111").unwrap_or_else(|_| unreachable!());
+        mgr.add("Bob", "222").unwrap_or_else(|_| unreachable!());
 
         let all = mgr.all();
         assert_eq!(all.len(), 2);
@@ -465,7 +518,8 @@ mod tests {
 
     #[test]
     fn contact_with_matrix_id() {
-        let c = Contact::with_matrix_id("Alice", "+15551234567", "@alice:matrix.org");
+        let c = Contact::with_matrix_id("Alice", "+15551234567", "@alice:matrix.org")
+            .unwrap_or_else(|_| unreachable!());
         assert_eq!(c.name_str(), "Alice");
         assert_eq!(c.number_str(), "+15551234567");
         assert_eq!(c.matrix_id_str(), "@alice:matrix.org");
@@ -479,7 +533,7 @@ mod tests {
 
     #[test]
     fn contact_without_matrix_id_defaults_sms() {
-        let c = Contact::new("Bob", "+15559876543");
+        let c = Contact::new("Bob", "+15559876543").unwrap_or_else(|_| unreachable!());
         assert_eq!(c.matrix_id_str(), "");
         assert!(!c.has_matrix_id());
         assert_eq!(
@@ -491,7 +545,8 @@ mod tests {
 
     #[test]
     fn contact_with_empty_matrix_id_stays_sms() {
-        let c = Contact::with_matrix_id("Carol", "+15550001111", "");
+        let c = Contact::with_matrix_id("Carol", "+15550001111", "")
+            .unwrap_or_else(|_| unreachable!());
         assert!(!c.has_matrix_id());
         assert_eq!(c.default_transport, MessageTransport::Sms);
     }
@@ -499,9 +554,11 @@ mod tests {
     #[test]
     fn find_by_matrix_id_works() {
         let mut mgr = ContactManager::new();
-        mgr.add("Alice", "+15551234567");
-        mgr.add_with_matrix_id("Bob", "+15559876543", "@bob:matrix.org");
-        mgr.add_with_matrix_id("Carol", "", "@carol:example.com");
+        mgr.add("Alice", "+15551234567").unwrap_or_else(|_| unreachable!());
+        mgr.add_with_matrix_id("Bob", "+15559876543", "@bob:matrix.org")
+            .unwrap_or_else(|_| unreachable!());
+        mgr.add_with_matrix_id("Carol", "", "@carol:example.com")
+            .unwrap_or_else(|_| unreachable!());
 
         assert_eq!(mgr.find_by_matrix_id("@bob:matrix.org"), Some(1));
         assert_eq!(mgr.find_by_matrix_id("@carol:example.com"), Some(2));
@@ -523,7 +580,7 @@ mod tests {
             long_id.push('a');
         }
         long_id.push_str(":server.example");
-        let c = Contact::with_matrix_id("Dave", "111", &long_id);
+        let c = Contact::with_matrix_id("Dave", "111", &long_id).unwrap_or_else(|_| unreachable!());
         assert_eq!(
             c.matrix_id_len as usize,
             MAX_MATRIX_ID_LEN,
@@ -533,7 +590,8 @@ mod tests {
 
     #[test]
     fn contact_display_with_matrix_id() {
-        let c = Contact::with_matrix_id("Alice", "+1555", "@alice:matrix.org");
+        let c = Contact::with_matrix_id("Alice", "+1555", "@alice:matrix.org")
+            .unwrap_or_else(|_| unreachable!());
         let s = alloc::format!("{c}");
         assert!(
             s.contains("@alice:matrix.org"),
@@ -543,7 +601,7 @@ mod tests {
 
     #[test]
     fn contact_display_without_matrix_id() {
-        let c = Contact::new("Bob", "+1555");
+        let c = Contact::new("Bob", "+1555").unwrap_or_else(|_| unreachable!());
         let s = alloc::format!("{c}");
         assert!(
             !s.contains("matrix"),
@@ -553,7 +611,8 @@ mod tests {
 
     #[test]
     fn contact_debug_includes_transport() {
-        let c = Contact::with_matrix_id("Alice", "+1555", "@alice:m.org");
+        let c = Contact::with_matrix_id("Alice", "+1555", "@alice:m.org")
+            .unwrap_or_else(|_| unreachable!());
         let s = alloc::format!("{c:?}");
         assert!(
             s.contains("Matrix"),
@@ -564,7 +623,8 @@ mod tests {
     #[test]
     fn add_with_matrix_id_method() {
         let mut mgr = ContactManager::new();
-        mgr.add_with_matrix_id("Eve", "+15550002222", "@eve:matrix.org");
+        mgr.add_with_matrix_id("Eve", "+15550002222", "@eve:matrix.org")
+            .unwrap_or_else(|_| unreachable!());
         assert_eq!(mgr.count(), 1);
         let eve = mgr.get(0);
         assert!(eve.is_some());
@@ -572,5 +632,40 @@ mod tests {
         assert_eq!(eve.name_str(), "Eve");
         assert_eq!(eve.matrix_id_str(), "@eve:matrix.org");
         assert_eq!(eve.default_transport, MessageTransport::Matrix);
+    }
+
+    // --- AT-injection rejection tests (#368) ---
+
+    #[test]
+    fn contact_new_rejects_at_injection() {
+        let result = Contact::new("Alice", "+1234\r\nATDT+evil;");
+        assert!(
+            matches!(result, Err(ContactError::InvalidNumber)),
+            "CR/LF + semicolon in number must be rejected, not stored"
+        );
+    }
+
+    #[test]
+    fn add_rejects_invalid_number_and_stores_nothing() {
+        let mut mgr = ContactManager::new();
+        let result = mgr.add("Eve", "+1234\r\nATDT+evil;");
+        assert!(
+            matches!(result, Err(ContactError::InvalidNumber)),
+            "invalid number must be rejected"
+        );
+        assert_eq!(mgr.count(), 0, "no contact may be created for a rejected number");
+    }
+
+    #[test]
+    fn contact_new_accepts_empty_number() {
+        // Matrix-only contacts have no phone number; empty must stay valid.
+        let result = Contact::new("Matrix Only", "");
+        assert!(result.is_ok(), "empty number must remain valid (Matrix-only contact)");
+    }
+
+    #[test]
+    fn contact_new_accepts_full_dial_charset() {
+        let result = Contact::new("Full Charset", "+0123456789*#ABCD");
+        assert!(result.is_ok(), "full GSM dial charset must be accepted");
     }
 }

--- a/crates/thumos/src/screen_contacts.rs
+++ b/crates/thumos/src/screen_contacts.rs
@@ -621,9 +621,12 @@ mod tests {
 
     fn make_manager() -> ContactManager {
         let mut mgr = ContactManager::new();
-        mgr.add("Charlie", "+15553333333");
-        mgr.add("Alice", "+15551111111");
-        mgr.add("Bob", "+15552222222");
+        mgr.add("Charlie", "+15553333333")
+            .unwrap_or_else(|_| unreachable!());
+        mgr.add("Alice", "+15551111111")
+            .unwrap_or_else(|_| unreachable!());
+        mgr.add("Bob", "+15552222222")
+            .unwrap_or_else(|_| unreachable!());
         mgr
     }
 

--- a/crates/thumos/src/sim.rs
+++ b/crates/thumos/src/sim.rs
@@ -213,6 +213,7 @@ impl SimManager {
                 Ok(false)
             }
             AtResponse::CmeError(code) => Err(TelephonyError::CmeError(code)),
+            AtResponse::CmsError(code) => Err(TelephonyError::CmeError(code)),
             AtResponse::Error => Err(TelephonyError::ModemError),
         }
     }
@@ -246,6 +247,7 @@ impl SimManager {
             }
             AtResponse::Ok => Ok(()),
             AtResponse::CmeError(code) => Err(TelephonyError::CmeError(code)),
+            AtResponse::CmsError(code) => Err(TelephonyError::CmeError(code)),
             AtResponse::Error => Err(TelephonyError::ModemError),
         }
     }
@@ -279,6 +281,7 @@ impl SimManager {
             }
             AtResponse::Ok => Ok(&self.signal_info),
             AtResponse::CmeError(code) => Err(TelephonyError::CmeError(code)),
+            AtResponse::CmsError(code) => Err(TelephonyError::CmeError(code)),
             AtResponse::Error => Err(TelephonyError::ModemError),
         }
     }
@@ -321,6 +324,7 @@ impl SimManager {
             }
             AtResponse::Ok => Ok(0),
             AtResponse::CmeError(code) => Err(TelephonyError::CmeError(code)),
+            AtResponse::CmsError(code) => Err(TelephonyError::CmeError(code)),
             AtResponse::Error => Err(TelephonyError::ModemError),
         }
     }

--- a/crates/thumos/src/sms.rs
+++ b/crates/thumos/src/sms.rs
@@ -56,6 +56,8 @@ pub enum SmsError {
     ModemError,
     /// Modem returned a CME error.
     CmeError(u32),
+    /// Modem returned a CMS error (SMS-specific, 3GPP TS 27.005).
+    CmsError(u32),
     /// Transport failure.
     TransportError,
     /// Phone number too long.
@@ -71,6 +73,7 @@ impl core::fmt::Display for SmsError {
             Self::PduDecode => write!(f, "PDU decode error"),
             Self::ModemError => write!(f, "modem error"),
             Self::CmeError(code) => write!(f, "CME error {code}"),
+            Self::CmsError(code) => write!(f, "CMS error {code}"),
             Self::TransportError => write!(f, "transport error"),
             Self::NumberTooLong => write!(f, "phone number too long"),
             Self::MessageTooLong => write!(f, "message too long"),
@@ -346,6 +349,7 @@ impl SmsManager {
                     AtResponse::Ok => break,
                     AtResponse::Error => return Err(SmsError::ModemError),
                     AtResponse::CmeError(code) => return Err(SmsError::CmeError(code)),
+                    AtResponse::CmsError(code) => return Err(SmsError::CmsError(code)),
                 }
             }
         }
@@ -387,6 +391,7 @@ impl SmsManager {
                     AtResponse::Ok => Ok(()),
                     AtResponse::Error => Err(SmsError::ModemError),
                     AtResponse::CmeError(code) => Err(SmsError::CmeError(code)),
+                    AtResponse::CmsError(code) => Err(SmsError::CmsError(code)),
                 };
             }
         }
@@ -636,6 +641,23 @@ mod tests {
         assert_eq!(sender, "+1234567890", "sender must decode to +1234567890");
         assert_eq!(msg.body, "Hello", "body must decode to 'Hello'");
         assert!(!msg.read, "incoming message must be unread");
+    }
+
+    #[test]
+    fn send_returns_cms_error_immediately() {
+        use crate::telephony_mock::MockModemTransport;
+
+        let mut mock = MockModemTransport::new();
+        mock.queue_ok(); // AT+CMGF=0 -> OK
+        mock.queue_response(b">"); // CMGS prompt
+        mock.queue_response(b"+CMS ERROR: 330"); // final result: no network service
+
+        let result = SmsManager::send(&mut mock, "+15551234567", "Hi");
+        assert_eq!(
+            result,
+            Err(SmsError::CmsError(330)),
+            "a +CMS ERROR final result on SMS submit must surface the code immediately, not TransportError after exhausting the wait loop"
+        );
     }
 
     #[test]

--- a/crates/thumos/src/telephony.rs
+++ b/crates/thumos/src/telephony.rs
@@ -107,6 +107,8 @@ pub enum AtResponse {
     Error,
     /// CME error with code.
     CmeError(u32),
+    /// CMS error with code (SMS-specific, 3GPP TS 27.005).
+    CmsError(u32),
 }
 
 impl Default for AtResponse {
@@ -220,6 +222,11 @@ pub enum ModemState {
     Off,
     /// Initialization sequence in progress.
     Initializing,
+    /// Radio is on and initialized; network registration not yet
+    /// confirmed. Set at the end of [`Telephony::initialize`]; promoted to
+    /// / demoted from [`ModemState::Registered`] only by
+    /// `Telephony::apply_reg_status` reacting to `+CREG` state.
+    Ready,
     /// Registered on a cellular network.
     Registered,
     /// A fatal error occurred.
@@ -231,6 +238,7 @@ impl core::fmt::Display for ModemState {
         match self {
             Self::Off => write!(f, "off"),
             Self::Initializing => write!(f, "initializing"),
+            Self::Ready => write!(f, "ready (not registered)"),
             Self::Registered => write!(f, "registered"),
             Self::Error(e) => write!(f, "error: {e}"),
         }
@@ -410,12 +418,19 @@ pub struct Telephony<T: ModemTransport> { // kanon:ignore RUST/struct-too-many-f
     operator_name: [u8; MAX_OPERATOR_LEN],
     /// Length of valid bytes in operator_name.
     operator_len: u8,
-    /// Network registration status.
-    registered: bool,
-    /// Registration status detail.
+    /// Registration status detail. [`Telephony::is_registered`] derives
+    /// directly from this -- no separate `registered` bool is kept, so
+    /// there is exactly one source of truth for registration state.
     reg_status: RegStatus,
     /// Whether LTE-only mode is active (2G/3G refused via `AT+COPS=0,,,7`).
     lte_only: bool,
+    /// Whether `AT+CREG=1` (registration-URC subscription) succeeded
+    /// during init. `false` means registration state updates were never
+    /// subscribed to and `handle_urc` will not see `+CREG` URCs.
+    creg_urc_enabled: bool,
+    /// Whether `AT+CLIP=1` (caller-ID subscription) succeeded during init.
+    /// `false` means incoming calls will not carry caller ID.
+    clip_enabled: bool,
     /// Hardware transport.
     transport: T,
     /// Last signal poll tick (ms).
@@ -436,9 +451,10 @@ impl<T: ModemTransport> Telephony<T> {
             signal_ber: 99,
             operator_name: [0u8; MAX_OPERATOR_LEN],
             operator_len: 0,
-            registered: false,
             reg_status: RegStatus::NotRegistered,
             lte_only: false,
+            creg_urc_enabled: false,
+            clip_enabled: false,
             transport,
             last_signal_poll: 0,
             init_step: 0,
@@ -476,9 +492,15 @@ impl<T: ModemTransport> Telephony<T> {
     }
 
     /// Return whether the modem is registered on a network.
+    ///
+    /// Derived directly from [`RegStatus`] -- there is no separate
+    /// `registered` bool to fall out of sync with it.
     #[must_use]
     pub fn is_registered(&self) -> bool {
-        self.registered
+        matches!(
+            self.reg_status,
+            RegStatus::RegisteredHome | RegStatus::RegisteredRoaming
+        )
     }
 
     // -----------------------------------------------------------------------
@@ -497,6 +519,15 @@ impl<T: ModemTransport> Telephony<T> {
     /// 7. `AT+CREG=1`       — enable network registration URCs
     /// 8. `AT+CLIP=1`       — enable caller ID
     /// 9. `AT+CSQ`          — initial signal strength query
+    /// 10. `AT+CREG?`       — seed initial registration state
+    ///
+    /// `AT+CFUN=1` (step 3) only powers the radio; it does not mean the
+    /// modem is registered. This method leaves `modem_state` at
+    /// [`ModemState::Ready`] unless step 10's query confirms registration,
+    /// and never asserts [`ModemState::Registered`] itself -- all
+    /// subsequent Ready/Registered transitions are owned by
+    /// [`Telephony::apply_reg_status`] (via [`Telephony::handle_urc`]
+    /// reacting to `+CREG` URCs).
     ///
     /// Returns `Ok(())` on success, or an error describing which step failed.
     pub fn initialize(&mut self) -> Result<(), TelephonyError> {
@@ -507,7 +538,7 @@ impl<T: ModemTransport> Telephony<T> {
         let result = send_simple(&mut self.transport, "AT", 5000);
         match result {
             Ok(AtResponse::Ok) => {}
-            Ok(AtResponse::Error | AtResponse::CmeError(_)) | Err(_) => {
+            Ok(AtResponse::Error | AtResponse::CmeError(_) | AtResponse::CmsError(_)) | Err(_) => {
                 self.modem_state = ModemState::Error(TelephonyError::Timeout);
                 return Err(TelephonyError::Timeout);
             }
@@ -582,19 +613,37 @@ impl<T: ModemTransport> Telephony<T> {
         self.init_step = 6;
 
         // Step 7: Enable network registration URCs.
-        let _ = send_simple(&mut self.transport, "AT+CREG=1", 2000);
+        // Non-fatal like refuse_2g, but the outcome is now recorded rather
+        // than silently discarded -- see is_creg_urc_enabled().
+        let creg_result = send_simple(&mut self.transport, "AT+CREG=1", 2000);
+        self.creg_urc_enabled = matches!(creg_result, Ok(AtResponse::Ok));
         self.init_step = 7;
 
         // Step 8: Enable caller ID.
-        let _ = send_simple(&mut self.transport, "AT+CLIP=1", 2000);
+        // Non-fatal, outcome recorded -- see is_clip_enabled().
+        let clip_result = send_simple(&mut self.transport, "AT+CLIP=1", 2000);
+        self.clip_enabled = matches!(clip_result, Ok(AtResponse::Ok));
         self.init_step = 8;
 
         // Step 9: Initial signal strength query.
         self.update_signal_strength()?;
         self.init_step = 9;
 
-        self.modem_state = ModemState::Registered;
-        self.registered = true;
+        // Step 10: Seed registration state. AT+CFUN=1 (step 3) only powers
+        // the radio; registration is asynchronous and may take seconds to
+        // minutes. Query it directly instead of assuming success. All
+        // further Ready/Registered transitions are owned by
+        // apply_reg_status (via handle_urc reacting to +CREG URCs).
+        self.modem_state = ModemState::Ready;
+        let creg_query = send_with_info(&mut self.transport, "AT+CREG?", 5000);
+        if let Ok((AtResponse::Ok, ref info_line, info_len)) = creg_query
+            && info_len > 0
+            && let Some(stat) = parse_creg_response(&info_line[..info_len])
+        {
+            self.apply_reg_status(stat);
+        }
+        self.init_step = 10;
+
         Ok(())
     }
 
@@ -621,6 +670,27 @@ impl<T: ModemTransport> Telephony<T> {
     #[must_use]
     pub fn is_lte_only(&self) -> bool {
         self.lte_only
+    }
+
+    /// Return whether `AT+CREG=1` (registration-URC subscription) succeeded
+    /// during initialization.
+    ///
+    /// `false` means the modem never subscribed to `+CREG` URCs, so
+    /// registration state will never update after the initial
+    /// [`Telephony::initialize`] query -- a silent degradation the caller
+    /// should surface (e.g. in the threat/diagnostics screen).
+    #[must_use]
+    pub fn is_creg_urc_enabled(&self) -> bool {
+        self.creg_urc_enabled
+    }
+
+    /// Return whether `AT+CLIP=1` (caller-ID subscription) succeeded during
+    /// initialization.
+    ///
+    /// `false` means incoming calls will never carry caller ID.
+    #[must_use]
+    pub fn is_clip_enabled(&self) -> bool {
+        self.clip_enabled
     }
 
     // -----------------------------------------------------------------------
@@ -651,7 +721,7 @@ impl<T: ModemTransport> Telephony<T> {
     ///
     /// `current_tick` is the current kernel tick in milliseconds.
     pub fn poll_signal(&mut self, current_tick: u64) -> Option<TelephonyEvent> {
-        if !matches!(self.modem_state, ModemState::Registered) {
+        if !matches!(self.modem_state, ModemState::Ready | ModemState::Registered) {
             return None;
         }
 
@@ -687,6 +757,15 @@ impl<T: ModemTransport> Telephony<T> {
         if number.len() > MAX_NUMBER_LEN {
             return Err(TelephonyError::NumberTooLong);
         }
+        // SECURITY: reject any byte outside the legal GSM dial-string
+        // charset before it reaches the ATD command buffer. Without this,
+        // a `\r`/`\n` in `number` (e.g. relayed verbatim from a forged
+        // +CLIP URC via a UI redial callback) would terminate the ATD line
+        // early and inject arbitrary follow-on AT commands into the modem
+        // stream.
+        if !number.iter().all(|&b| is_valid_dial_byte(b)) {
+            return Err(TelephonyError::ParseError);
+        }
 
         // Build ATD command: "ATD+15551234567;"
         let mut cmd_buf = [0u8; 4 + MAX_NUMBER_LEN + 1]; // "ATD" + number + ";"
@@ -697,8 +776,9 @@ impl<T: ModemTransport> Telephony<T> {
         cmd_buf[3 + number.len()] = b';';
         let cmd_len = 4 + number.len();
 
-        // SAFETY: number was validated as fitting in MAX_NUMBER_LEN,
-        // and we only wrote ASCII bytes from the input + "ATD" + ";".
+        // INVARIANT: every byte of `number` was validated by
+        // `is_valid_dial_byte` above (a strict ASCII subset), so `cmd_buf`
+        // contains only ASCII bytes and this conversion cannot fail.
         let cmd_str = core::str::from_utf8(&cmd_buf[..cmd_len])
             .map_err(|_| TelephonyError::ParseError)?;
 
@@ -715,6 +795,10 @@ impl<T: ModemTransport> Telephony<T> {
             }
             AtResponse::Error => Err(TelephonyError::ModemError),
             AtResponse::CmeError(code) => Err(TelephonyError::CmeError(code)),
+            // WHY: +CMS ERROR is SMS-specific and not expected on a voice
+            // dial, but AtResponse is exhaustively matched here; surface it
+            // through the same numeric-code channel as CME errors.
+            AtResponse::CmsError(code) => Err(TelephonyError::CmeError(code)),
         }
     }
 
@@ -736,6 +820,7 @@ impl<T: ModemTransport> Telephony<T> {
             }
             AtResponse::Error => Err(TelephonyError::ModemError),
             AtResponse::CmeError(code) => Err(TelephonyError::CmeError(code)),
+            AtResponse::CmsError(code) => Err(TelephonyError::CmeError(code)),
         }
     }
 
@@ -762,6 +847,7 @@ impl<T: ModemTransport> Telephony<T> {
                 Ok(())
             }
             AtResponse::CmeError(code) => Err(TelephonyError::CmeError(code)),
+            AtResponse::CmsError(code) => Err(TelephonyError::CmeError(code)),
         }
     }
 
@@ -786,6 +872,26 @@ impl<T: ModemTransport> Telephony<T> {
         }
 
         None
+    }
+
+    /// Apply a registration status, keeping `reg_status` and `modem_state`
+    /// consistent.
+    ///
+    /// This is the single place that transitions `modem_state` between
+    /// [`ModemState::Ready`] and [`ModemState::Registered`] -- no other
+    /// code path may assert `ModemState::Registered` directly. A stray
+    /// `+CREG` URC arriving outside `Ready`/`Registered` (e.g. during
+    /// `Off`/`Initializing`/`Error`) updates `reg_status` but does not
+    /// clobber the modem's lifecycle state.
+    fn apply_reg_status(&mut self, stat: RegStatus) {
+        self.reg_status = stat;
+        if matches!(self.modem_state, ModemState::Ready | ModemState::Registered) {
+            self.modem_state = if self.is_registered() {
+                ModemState::Registered
+            } else {
+                ModemState::Ready
+            };
+        }
     }
 
     /// Handle a parsed URC and update internal state.
@@ -838,11 +944,7 @@ impl<T: ModemTransport> Telephony<T> {
                 })
             }
             Urc::Creg { stat } => {
-                self.reg_status = stat;
-                self.registered = matches!(
-                    stat,
-                    RegStatus::RegisteredHome | RegStatus::RegisteredRoaming
-                );
+                self.apply_reg_status(stat);
                 Some(TelephonyEvent::RegistrationUpdate { status: stat })
             }
         }
@@ -927,6 +1029,8 @@ mod tests {
         mock.queue_ok();
         // Step 9: AT+CSQ -> +CSQ: 18,99 + OK
         mock.queue_info_ok(b"+CSQ: 18,99");
+        // Step 10: AT+CREG? -> +CREG: 1 (registered home) + OK
+        mock.queue_info_ok(b"+CREG: 1");
         mock
     }
 
@@ -954,7 +1058,7 @@ mod tests {
         assert!(result.is_ok(), "initialization must succeed with valid mock");
 
         let commands = &tel.transport.sent_commands;
-        assert_eq!(commands.len(), 9, "init must send exactly 9 AT commands");
+        assert_eq!(commands.len(), 10, "init must send exactly 10 AT commands");
         assert_eq!(commands[0], b"AT", "step 1: AT");
         assert_eq!(commands[1], b"ATE0", "step 2: ATE0");
         assert_eq!(commands[2], b"AT+CFUN=1", "step 3: AT+CFUN=1");
@@ -964,15 +1068,16 @@ mod tests {
         assert_eq!(commands[6], b"AT+CREG=1", "step 7: AT+CREG=1");
         assert_eq!(commands[7], b"AT+CLIP=1", "step 8: AT+CLIP=1");
         assert_eq!(commands[8], b"AT+CSQ", "step 9: AT+CSQ");
+        assert_eq!(commands[9], b"AT+CREG?", "step 10: AT+CREG?");
 
         assert_eq!(
             tel.modem_state(),
             ModemState::Registered,
-            "modem must be Registered after successful init"
+            "modem must be Registered once step 10's AT+CREG? confirms it"
         );
         assert!(
             tel.is_registered(),
-            "must report registered after init"
+            "must report registered once AT+CREG? confirms it"
         );
     }
 
@@ -1007,6 +1112,51 @@ mod tests {
             Some(b"ATD+15551234567;" as &[u8]),
             "ATD command must be formatted correctly"
         );
+    }
+
+    #[test]
+    fn dial_rejects_crlf_injection() {
+        let mock = mock_for_init();
+        let mut tel = Telephony::new(mock);
+        tel.initialize().ok();
+
+        let before = tel.transport.sent_commands.len();
+        let result = tel.dial(b"+1\r\nAT+CFUN=0");
+        assert_eq!(
+            result,
+            Err(TelephonyError::ParseError),
+            "CR/LF in dial number must be rejected"
+        );
+        assert_eq!(
+            tel.transport.sent_commands.len(),
+            before,
+            "no ATD command may reach the transport when the number is rejected"
+        );
+    }
+
+    #[test]
+    fn dial_rejects_semicolon_injection() {
+        let mock = mock_for_init();
+        let mut tel = Telephony::new(mock);
+        tel.initialize().ok();
+
+        let result = tel.dial(b"+1;AT+CFUN=0");
+        assert_eq!(
+            result,
+            Err(TelephonyError::ParseError),
+            "embedded semicolon must be rejected (would close ATD early)"
+        );
+    }
+
+    #[test]
+    fn dial_accepts_full_valid_charset() {
+        let mock = mock_for_init();
+        let mut tel = Telephony::new(mock);
+        tel.initialize().ok();
+        tel.transport.queue_ok();
+
+        let result = tel.dial(b"+15551234567*#ABCD");
+        assert!(result.is_ok(), "digits/+/*/#/A-D must be accepted");
     }
 
     #[test]
@@ -1095,6 +1245,19 @@ mod tests {
     }
 
     #[test]
+    fn send_and_wait_terminates_immediately_on_cms_error() {
+        let mut mock = MockModemTransport::new();
+        mock.queue_response(b"+CMS ERROR: 302");
+        let mut info_buf = [[0u8; MAX_LINE_LEN]; 4];
+        let result = send_and_wait(&mut mock, "AT+CMGS=10", &mut info_buf, 2000);
+        assert_eq!(
+            result,
+            Ok((AtResponse::CmsError(302), 0)),
+            "a +CMS ERROR final result must terminate immediately with the code, not fall through to Timeout"
+        );
+    }
+
+    #[test]
     fn number_too_long_error() {
         // TelephonyError::NumberTooLong is returned when dialing a number
         // that exceeds MAX_NUMBER_LEN. Verify the variant displays correctly.
@@ -1170,6 +1333,39 @@ mod tests {
         );
     }
 
+    // See #257's spec for the full initialize()/ModemState edit that this
+    // test depends on (creg_urc_enabled/clip_enabled + apply_reg_status).
+
+    #[test]
+    fn creg_and_clip_init_failures_are_recorded_not_swallowed() {
+        let mut mock = MockModemTransport::new();
+        mock.queue_ok(); // AT
+        mock.queue_ok(); // ATE0
+        mock.queue_ok(); // AT+CFUN=1
+        mock.queue_info_ok(b"+CPIN: READY");
+        mock.queue_ok(); // AT+COPS=0,,,7
+        mock.queue_info_ok(b"+COPS: 0,0,\"T-Mobile\""); // AT+COPS?
+        mock.queue_response(b"ERROR"); // AT+CREG=1 -> ERROR
+        mock.queue_response(b"ERROR"); // AT+CLIP=1 -> ERROR
+        mock.queue_info_ok(b"+CSQ: 18,99");
+        mock.queue_info_ok(b"+CREG: 0");
+
+        let mut tel = Telephony::new(mock);
+        let result = tel.initialize();
+        assert!(
+            result.is_ok(),
+            "AT+CREG=1/AT+CLIP=1 failures must not abort the whole init sequence"
+        );
+        assert!(
+            !tel.is_creg_urc_enabled(),
+            "a rejected AT+CREG=1 must be recorded as disabled, not silently assumed enabled"
+        );
+        assert!(
+            !tel.is_clip_enabled(),
+            "a rejected AT+CLIP=1 must be recorded as disabled, not silently assumed enabled"
+        );
+    }
+
     #[test]
     fn init_continues_if_lte_only_rejected() {
         // If the modem rejects AT+COPS=0,,,7, init must still complete.
@@ -1192,6 +1388,8 @@ mod tests {
         mock.queue_ok();
         // Step 9: AT+CSQ -> +CSQ: 18,99 + OK
         mock.queue_info_ok(b"+CSQ: 18,99");
+        // Step 10: AT+CREG? -> +CREG: 1 (registered home) + OK
+        mock.queue_info_ok(b"+CREG: 1");
 
         let mut tel = Telephony::new(mock);
         let result = tel.initialize();
@@ -1206,7 +1404,89 @@ mod tests {
         assert_eq!(
             tel.modem_state(),
             ModemState::Registered,
-            "modem must reach Registered state despite LTE-only rejection"
+            "modem must reach Registered state once AT+CREG? confirms it, despite LTE-only rejection"
+        );
+    }
+
+    // --- registration-state confirmation tests (#257) ---
+
+    #[test]
+    fn initialize_stays_unregistered_when_creg_reports_searching() {
+        let mut mock = MockModemTransport::new();
+        mock.queue_ok(); // AT
+        mock.queue_ok(); // ATE0
+        mock.queue_ok(); // AT+CFUN=1
+        mock.queue_info_ok(b"+CPIN: READY");
+        mock.queue_ok(); // AT+COPS=0,,,7
+        mock.queue_info_ok(b"+COPS: 0,0,\"T-Mobile\"");
+        mock.queue_ok(); // AT+CREG=1
+        mock.queue_ok(); // AT+CLIP=1
+        mock.queue_info_ok(b"+CSQ: 18,99");
+        mock.queue_info_ok(b"+CREG: 2"); // searching, not registered
+
+        let mut tel = Telephony::new(mock);
+        let result = tel.initialize();
+        assert!(result.is_ok(), "init must succeed even if not yet registered");
+        assert!(
+            !tel.is_registered(),
+            "is_registered must be false when AT+CREG? reports searching (2)"
+        );
+        assert_eq!(
+            tel.modem_state(),
+            ModemState::Ready,
+            "modem_state must stay Ready (not Registered) until actually registered"
+        );
+    }
+
+    #[test]
+    fn creg_urc_downgrades_modem_state_from_registered() {
+        let mock = mock_for_init();
+        let mut tel = Telephony::new(mock);
+        tel.initialize().ok();
+        assert_eq!(tel.modem_state(), ModemState::Registered, "must start Registered");
+
+        tel.transport.queue_urc(b"+CREG: 0");
+        let event = tel.poll();
+        assert!(
+            matches!(event, Some(TelephonyEvent::RegistrationUpdate { .. })),
+            "CREG URC must produce a RegistrationUpdate event"
+        );
+        assert!(
+            !tel.is_registered(),
+            "is_registered must become false after +CREG: 0"
+        );
+        assert_eq!(
+            tel.modem_state(),
+            ModemState::Ready,
+            "modem_state must downgrade from Registered to Ready on +CREG: 0"
+        );
+    }
+
+    #[test]
+    fn creg_urc_promotes_ready_to_registered() {
+        let mut mock = MockModemTransport::new();
+        mock.queue_ok();
+        mock.queue_ok();
+        mock.queue_ok();
+        mock.queue_info_ok(b"+CPIN: READY");
+        mock.queue_ok();
+        mock.queue_info_ok(b"+COPS: 0,0,\"T-Mobile\"");
+        mock.queue_ok();
+        mock.queue_ok();
+        mock.queue_info_ok(b"+CSQ: 18,99");
+        mock.queue_info_ok(b"+CREG: 2"); // searching at init time
+
+        let mut tel = Telephony::new(mock);
+        tel.initialize().ok();
+        assert_eq!(tel.modem_state(), ModemState::Ready, "must start Ready (searching)");
+
+        tel.transport.queue_urc(b"+CREG: 5");
+        tel.poll();
+        assert!(tel.is_registered(), "must report registered after +CREG: 5 (roaming)");
+        assert_eq!(
+            tel.modem_state(),
+            ModemState::Registered,
+            "modem_state must promote from Ready to Registered on +CREG: 5"
         );
     }
 }

--- a/crates/thumos/src/telephony_parser.rs
+++ b/crates/thumos/src/telephony_parser.rs
@@ -17,7 +17,7 @@ use crate::telephony::{AtResponse, RegStatus, Urc, MAX_NUMBER_LEN};
 
 /// Parse a final result code from an AT response line.
 ///
-/// Handles: "OK", "ERROR", "+CME ERROR: <code>"
+/// Handles: "OK", "ERROR", "+CME ERROR: <code>", "+CMS ERROR: <code>"
 pub(crate) fn parse_final_result(line: &[u8]) -> Option<AtResponse> {
     if line == b"OK" {
         return Some(AtResponse::Ok);
@@ -28,6 +28,11 @@ pub(crate) fn parse_final_result(line: &[u8]) -> Option<AtResponse> {
     if let Some(rest) = strip_prefix(line, b"+CME ERROR: ") {
         if let Some(code) = parse_u32(rest) {
             return Some(AtResponse::CmeError(code));
+        }
+    }
+    if let Some(rest) = strip_prefix(line, b"+CMS ERROR: ") {
+        if let Some(code) = parse_u32(rest) {
+            return Some(AtResponse::CmsError(code));
         }
     }
     None
@@ -70,9 +75,29 @@ pub(crate) fn parse_cops_response(line: &[u8], name_buf: &mut [u8; MAX_OPERATOR_
     Some(len as u8)
 }
 
+/// Return whether `b` is a legal byte in a GSM AT dial-string.
+///
+/// SECURITY: gates every byte that reaches an `ATD<number>;` command
+/// buffer -- directly in [`crate::telephony::Telephony::dial`], and here
+/// so a forged `+CLIP` caller-ID number can never be stored in the first
+/// place. Allowed set: ASCII digits `0`-`9`, `+`, `*`, `#`, and `A`-`D`
+/// (3GPP TS 27.007 dial-string charset). CR/LF and `;` are deliberately
+/// excluded: either would let attacker-controlled bytes terminate an ATD
+/// command early and inject a follow-on AT command once relayed into
+/// `dial`.
+pub(crate) const fn is_valid_dial_byte(b: u8) -> bool {
+    matches!(b, b'0'..=b'9' | b'+' | b'*' | b'#' | b'A'..=b'D')
+}
+
 /// Parse a +CLIP URC line: "+CLIP: \"<number>\",<type>..."
 ///
 /// Extracts the caller phone number.
+///
+/// SECURITY: rejects (returns `None` for) a caller ID containing any byte
+/// outside [`is_valid_dial_byte`]. The modem/network is untrusted; without
+/// this check a forged `+CLIP` URC could carry AT-injection bytes into
+/// `number_buf`, which a UI callback re-dialing this caller would then
+/// pass straight to `Telephony::dial`.
 pub(crate) fn parse_clip_response(line: &[u8], number_buf: &mut [u8; MAX_NUMBER_LEN]) -> Option<u8> {
     let rest = strip_prefix(line, b"+CLIP: ")?;
     // Number is in quotes.
@@ -80,6 +105,9 @@ pub(crate) fn parse_clip_response(line: &[u8], number_buf: &mut [u8; MAX_NUMBER_
     let after_quote = &rest[quote_start + 1..];
     let quote_end = memchr(b'"', after_quote)?;
     let number = &after_quote[..quote_end];
+    if !number.iter().all(|&b| is_valid_dial_byte(b)) {
+        return None;
+    }
     let len = number.len().min(MAX_NUMBER_LEN);
     number_buf[..len].copy_from_slice(&number[..len]);
     Some(len as u8)
@@ -284,6 +312,15 @@ mod tests {
     }
 
     #[test]
+    fn parse_final_result_recognizes_cms_error() {
+        assert_eq!(
+            parse_final_result(b"+CMS ERROR: 302"),
+            Some(AtResponse::CmsError(302)),
+            "+CMS ERROR must be recognized as a final result, not fall through as informational"
+        );
+    }
+
+    #[test]
     fn parse_clip_response_extracts_number() {
         let line = b"+CLIP: \"+15551234567\",145";
         let mut number = [0u8; MAX_NUMBER_LEN];
@@ -293,6 +330,17 @@ mod tests {
             &number[..12],
             b"+15551234567",
             "caller ID number must be +15551234567"
+        );
+    }
+
+    #[test]
+    fn parse_clip_response_rejects_invalid_charset() {
+        let line = b"+CLIP: \"AT+CFUN=0\",145";
+        let mut number = [0u8; MAX_NUMBER_LEN];
+        let len = parse_clip_response(line, &mut number);
+        assert_eq!(
+            len, None,
+            "a caller ID containing AT-command bytes outside the dial charset must be rejected, not stored"
         );
     }
 }


### PR DESCRIPTION
## Summary

The modem is the device's sole untrusted component, so the AT-command boundary and the identity filters are core to the threat model. This wave closes 14 modem-boundary defects — AT-command injection, channel DoS, IMEI/IMSI leak, and registration-state correctness.

## AT-command injection

A GSM dial-string charset allowlist (`0`-`9`, `+`, `*`, `#`, `A`-`D` — excluding CR/LF, `;`, and `"`) now gates every path where a phone number reaches an AT-command buffer:

- **#234** — `Telephony::dial` copied phone-number bytes straight into `ATD<n>;` with no charset check; `+CLIP` caller-ID parsing gets the same gate, so a forged incoming-call URC can't seed injection bytes that a redial callback would relay.
- **#238** — klesis `cmd::dial` / `cmd::cmgs` interpolated the number unvalidated into `ATD`/`AT+CMGS="…"`.
- **#368** — contact storage stored numbers unsanitized (reject-don't-truncate).
- **#235** — klesis `encode_bcd_address` did `d - b'0'` with no digit check (debug panic / release nibble corruption on a non-digit).

## Modem-channel DoS

- **#240 / #237 / #236** — `AtSession::send_command` / `read_line` had unbounded info-line accumulation, an unbounded loop when the modem never returns a final result, and no size/time cap on a single line. Bounded by `MAX_INFO_LINES`, `MAX_LINE_LEN`, and a wall-clock `READ_LINE_TIMEOUT`.
- **#266** — the modem anomaly-detector baseline was poisonable by full-range `data0` during the 60-second boot window (defeating later out-of-range detection). Now clamped to the CCCI MTU, with the control-message sentinel excepted.

## Identity leak (IMEI/IMSI filter at the CCCI boundary)

- **#247** — the filter was case-sensitive, so a lowercase AT response bypassed it entirely. Now ASCII case-insensitive.
- **#228** — it only matched the `+CGSN:`/`+CIMI:`-prefixed forms and missed the bare (unprefixed) 15-digit response that the standard Execute form of `AT+CGSN`/`AT+CIMI` actually returns. Added a bare-15-digit-run heuristic.

## Correctness

- **#239** — UDH bytes were decoded as message text when UDHI was set (a forged-prefix vector); the UDH is now stripped before user-data decode.
- **#258** — `+CMS ERROR` was unhandled, so SMS/voice failures burned the full timeout with the code lost; it's now a first-class `AtResponse::CmsError` threaded through every match site (telephony, sms, sim).
- **#257 / #256** — `initialize()` asserted `Registered` unconditionally (and never downgraded), and swallowed `AT+CREG=1` / `AT+CLIP=1` failures. Registration state is now confirmed via `AT+CREG?` and driven by a single `apply_reg_status` (`Ready` ↔ `Registered`), and the CREG/CLIP init outcomes are recorded (`is_creg_urc_enabled` / `is_clip_enabled`).

## Closes

Closes #234, #238, #368, #235, #239, #240, #237, #236, #258, #257, #256, #247, #228, #266

## Verification

- `cargo test -p klesis` — 76 passed (+9)
- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — 1718 passed (+21)
- `cargo build --release --target armv7a-none-eabi` — compiles
- `kanon lint . --summary` — clean

## Two conscious limitations (flagged for sign-off)

- The **#234 dial charset is strict**: it also rejects DTMF dial modifiers (`,` pause, `w`/`p` wait). This is a deliberate security narrowing — pause/wait dial sequences are unsupported until a reviewed exception is added. Acceptable default for a counter-surveillance device.
- The **#228 bare-IMEI heuristic** flags a run of *exactly* 15 ASCII digits: it over-matches a benign standalone 15-digit value and under-matches a 15-digit IMEI embedded in a ≥16-digit run. Matched responses are logged + `CAP_MODEM_IDENTITY`-gated (not destructively dropped), so over-filtering is the safe direction — but the blunt exact-length rule is worth a conscious sign-off.
