### PR TITLE
Radio-driver adversary-safety: 10 fixes (parser panics, STP CRC/liveness, BLE bounds)

### DIFF
--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -87,6 +87,7 @@ RUST/as-cast:crates/kelyphos/src/stp.rs
 RUST/file-too-long:crates/thumos/**
 RUST/file-too-long:crates/aither/src/mac.rs
 RUST/file-too-long:crates/kelyphos/src/wmt.rs
+RUST/file-too-long:crates/kelyphos/src/transport.rs
 RUST/file-too-long:crates/klesis/src/pdu.rs
 RUST/file-too-long:crates/pteron/src/hci.rs
 RUST/file-too-long:crates/pteron/src/transport.rs

--- a/crates/kelyphos/src/stp.rs
+++ b/crates/kelyphos/src/stp.rs
@@ -174,10 +174,28 @@ const fn compute_header_checksum(hdr: StpHeader) -> u8 {
     h0 ^ h1 ^ h2
 }
 
-/// Compute `CRC-16` CCITT over header + payload.
-fn compute_crc(frame: &StpFrame) -> u16 {
+/// Compute `CRC-16` CCITT over a 3-byte header (excluding the checksum byte)
+/// and a payload slice.
+///
+/// Shared by the TX encode path ([`compute_crc`]) and the RX integrity check
+/// in [`crate::transport::RxParser`], which recomputes this over raw received
+/// bytes to detect corrupted or injected frames.
+pub(crate) fn compute_crc_over(header_bytes: &[u8], payload: &[u8]) -> u16 {
     let mut crc: u16 = 0xFFFF;
 
+    for &byte in header_bytes {
+        crc = crc16_ccitt_byte(crc, byte);
+    }
+
+    for &byte in payload {
+        crc = crc16_ccitt_byte(crc, byte);
+    }
+
+    crc
+}
+
+/// Compute `CRC-16` CCITT over header + payload.
+fn compute_crc(frame: &StpFrame) -> u16 {
     // CRC over header bytes (excluding checksum)
     let header_bytes = [
         (u8::from(frame.header.frame_type) << 4)
@@ -187,16 +205,7 @@ fn compute_crc(frame: &StpFrame) -> u16 {
         ((frame.header.length & 0x1F) << 3) as u8,
     ];
 
-    for &byte in &header_bytes {
-        crc = crc16_ccitt_byte(crc, byte);
-    }
-
-    // CRC over payload
-    for &byte in &frame.payload[..frame.payload_len] {
-        crc = crc16_ccitt_byte(crc, byte);
-    }
-
-    crc
+    compute_crc_over(&header_bytes, &frame.payload[..frame.payload_len])
 }
 
 /// `CRC-16` CCITT UPDATE for one byte.

--- a/crates/kelyphos/src/transport.rs
+++ b/crates/kelyphos/src/transport.rs
@@ -12,7 +12,7 @@
 use snafu::Snafu;
 
 use crate::config::{Config, DEFAULT_RETRY_LIMIT, DEFAULT_TX_TIMEOUT_MS};
-use crate::stp::{MAX_PAYLOAD, StpFrame};
+use crate::stp::{MAX_PAYLOAD, StpFrame, compute_crc_over};
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -132,6 +132,9 @@ pub(crate) struct RxParser {
     pos: usize,
     /// Payload length decoded FROM the header (SET during [`Header`](RxState::Header) phase).
     payload_len: u16,
+    /// Count of frames discarded because the received CRC-16 CCITT did not
+    /// match the recomputed value over the received header + payload bytes.
+    crc_errors: u32,
 }
 
 impl Default for RxParser {
@@ -148,6 +151,7 @@ impl RxParser {
             buf: [0u8; TX_FRAME_MAX_ENCODED],
             pos: 0,
             payload_len: 0,
+            crc_errors: 0,
         }
     }
 
@@ -168,10 +172,17 @@ impl RxParser {
             }
 
             RxState::Header { collected } => {
-                if self.pos < TX_FRAME_MAX_ENCODED {
-                    self.buf[self.pos] = byte;
-                    self.pos += 1;
+                if self.pos >= TX_FRAME_MAX_ENCODED {
+                    // WARNING: header phase cannot overflow the buffer under
+                    // the current 12-bit length field / TX_FRAME_MAX_ENCODED
+                    // sizing, but bail rather than silently drop the byte and
+                    // let a corrupt/truncated header decode as if intact.
+                    self.state = RxState::WaitSof;
+                    self.pos = 0;
+                    return false;
                 }
+                self.buf[self.pos] = byte;
+                self.pos += 1;
                 let collected = collected + 1;
                 if collected == 4 {
                     // Decode payload length FROM header bytes 1 and 2 (after SOF).
@@ -193,10 +204,16 @@ impl RxParser {
             }
 
             RxState::Payload { remaining } => {
-                if self.pos < TX_FRAME_MAX_ENCODED {
-                    self.buf[self.pos] = byte;
-                    self.pos += 1;
+                if self.pos >= TX_FRAME_MAX_ENCODED {
+                    // WARNING: declared payload length would overflow the RX
+                    // buffer  -  abandon the frame instead of silently
+                    // truncating it and presenting a short frame as complete.
+                    self.state = RxState::WaitSof;
+                    self.pos = 0;
+                    return false;
                 }
+                self.buf[self.pos] = byte;
+                self.pos += 1;
                 if remaining == 1 {
                     self.state = RxState::Crc { collected: 0 };
                 } else {
@@ -213,9 +230,23 @@ impl RxParser {
                     self.pos += 1;
                 }
                 if collected == 1 {
-                    // Both CRC bytes received  -  frame is complete.
+                    // Both CRC bytes received  -  verify integrity before
+                    // surfacing the frame as complete.
                     self.state = RxState::WaitSof;
-                    true
+                    // INVARIANT: Crc state is only reached after Header fully
+                    // decodes (pos >= 5), so pos - 2 and pos - 1 are always
+                    // valid indices into buf here.
+                    let received_crc =
+                        u16::from_be_bytes([self.buf[self.pos - 2], self.buf[self.pos - 1]]);
+                    let header_bytes = &self.buf[1..4];
+                    let payload_bytes = &self.buf[5..self.pos - 2];
+                    let computed_crc = compute_crc_over(header_bytes, payload_bytes);
+                    if received_crc == computed_crc {
+                        true
+                    } else {
+                        self.crc_errors += 1;
+                        false
+                    }
                 } else {
                     self.state = RxState::Crc { collected: 1 };
                     false
@@ -234,6 +265,11 @@ impl RxParser {
     /// Payload length decoded FROM the most recently completed frame header.
     pub(crate) const fn last_payload_len(&self) -> u16 {
         self.payload_len
+    }
+
+    /// Count of frames discarded due to a CRC-16 CCITT mismatch on RX.
+    pub(crate) const fn crc_errors(&self) -> u32 {
+        self.crc_errors
     }
 }
 
@@ -348,21 +384,36 @@ impl StpTransport {
     /// [`TransportError::StaleAck`] if `seq` is not in the window.
     #[must_use = "retransmit failure must be handled"]
     pub(crate) fn retransmit(&mut self, seq: u8) -> Result<&[u8], TransportError> {
-        for slot in &mut self.tx_window {
-            if let Some(entry) = slot
-                && entry.seq == seq
-            {
-                if entry.retries >= self.retry_limit {
-                    return Err(TransportError::RetryLimitExceeded {
-                        seq,
-                        limit: self.retry_limit,
-                    });
-                }
-                entry.retries += 1;
-                return Ok(entry.as_bytes());
-            }
+        let limit = self.retry_limit;
+        // Locate the window slot holding this seq (read-only borrow, released
+        // before any mutation below so the terminal-failure clear and the
+        // success-path reborrow do not overlap — see #351).
+        let Some(idx) = self
+            .tx_window
+            .iter()
+            .position(|slot| slot.as_ref().is_some_and(|e| e.seq == seq))
+        else {
+            return Err(TransportError::StaleAck { seq });
+        };
+
+        // Terminal failure: free the slot on retry exhaustion, mirroring
+        // acknowledge()'s cleanup  -  otherwise a link-declared-dead frame
+        // occupies its window slot forever (no ACK will ever arrive for it),
+        // and enough exhausted slots permanently write-locks the transport.
+        if self.tx_window[idx]
+            .as_ref()
+            .is_some_and(|e| e.retries >= limit)
+        {
+            self.tx_window[idx] = None;
+            return Err(TransportError::RetryLimitExceeded { seq, limit });
         }
-        Err(TransportError::StaleAck { seq })
+
+        // Otherwise bump the retry count and hand back the encoded bytes.
+        let Some(entry) = self.tx_window[idx].as_mut() else {
+            return Err(TransportError::StaleAck { seq });
+        };
+        entry.retries += 1;
+        Ok(entry.as_bytes())
     }
 
     /// Feed one received byte INTO the RX parser.
@@ -385,6 +436,11 @@ impl StpTransport {
     /// Next TX sequence number (0–7).
     pub(crate) const fn next_seq(&self) -> u8 {
         self.tx_seq
+    }
+
+    /// Count of received frames discarded due to a CRC-16 CCITT mismatch.
+    pub(crate) const fn crc_errors(&self) -> u32 {
+        self.rx_parser.crc_errors()
     }
 }
 
@@ -517,6 +573,42 @@ mod tests {
     }
 
     #[test]
+    fn retransmit_limit_exceeded_frees_window_slot_for_reuse() {
+        let mut t = StpTransport::new();
+        // Fill every window slot and drive each to RetryLimitExceeded.
+        for i in 0..WINDOW_SIZE {
+            let seq = u8::try_from(i).unwrap_or_default() & 0x07;
+            let frame = make_frame(seq, b"exhaust");
+            t.enqueue(&frame)
+                .unwrap_or_else(|_| panic!("enqueue {i} must succeed when window not full"));
+        }
+        for i in 0..WINDOW_SIZE {
+            let seq = u8::try_from(i).unwrap_or_default() & 0x07;
+            for _ in 0..RETRY_LIMIT {
+                t.retransmit(seq).unwrap_or_default();
+            }
+            let err = t.retransmit(seq);
+            assert!(
+                matches!(err, Err(TransportError::RetryLimitExceeded { .. })),
+                "slot {i} must report RetryLimitExceeded once retries are exhausted"
+            );
+        }
+
+        assert_eq!(
+            t.in_flight(),
+            0,
+            "every exhausted slot must be freed, not permanently occupied"
+        );
+
+        // The transport must accept new traffic instead of staying write-locked.
+        let next = make_frame(0, b"fresh");
+        assert!(
+            t.enqueue(&next).is_ok(),
+            "enqueue must succeed after all slots are freed by retry exhaustion"
+        );
+    }
+
+    #[test]
     fn custom_config_changes_retry_budget() {
         // WHY: prove Config.retry_limit flows through to retransmit. A 2-retry
         // budget must reject on the 3rd call where default (10) would accept.
@@ -586,6 +678,56 @@ mod tests {
     }
 
     #[test]
+    fn rx_parser_rejects_frame_with_corrupted_payload_byte() {
+        let frame = make_frame(0, b"integrity-check");
+        let mut encoded = [0u8; TX_FRAME_MAX_ENCODED];
+        let len = frame.encode(&mut encoded);
+
+        // Flip one payload byte after encoding (payload starts at index 5);
+        // the trailing CRC bytes are left untouched, simulating line
+        // corruption/injection after the sender computed the CRC.
+        encoded[5] ^= 0xFF;
+
+        let mut t = StpTransport::new();
+        let mut saw_complete = false;
+        for &byte in encoded.iter().take(len) {
+            if t.receive_byte(byte).is_some() {
+                saw_complete = true;
+            }
+        }
+        assert!(
+            !saw_complete,
+            "a frame with a corrupted payload byte must never be surfaced as complete"
+        );
+        assert_eq!(
+            t.crc_errors(),
+            1,
+            "crc_errors must increment exactly once for the corrupted frame"
+        );
+    }
+
+    #[test]
+    fn rx_parser_accepts_intact_frame_and_leaves_crc_errors_at_zero() {
+        let frame = make_frame(1, b"clean");
+        let mut encoded = [0u8; TX_FRAME_MAX_ENCODED];
+        let len = frame.encode(&mut encoded);
+
+        let mut t = StpTransport::new();
+        let mut complete = None;
+        for &byte in encoded.iter().take(len) {
+            if let Some(raw) = t.receive_byte(byte) {
+                complete = Some(raw.to_vec());
+            }
+        }
+        assert!(complete.is_some(), "an intact frame must complete");
+        assert_eq!(
+            t.crc_errors(),
+            0,
+            "an intact frame must not count as a CRC error"
+        );
+    }
+
+    #[test]
     fn transport_window_constants() {
         assert_eq!(WINDOW_SIZE, 7, "WINDOW_SIZE must be 7 per STP spec");
         assert_eq!(TX_TIMEOUT_MS, 180, "TX_TIMEOUT_MS must be 180 per STP spec");
@@ -624,6 +766,36 @@ mod tests {
             FrameType::FwDownload as u8,
             3,
             "FwDownload frame type must be 3"
+        );
+    }
+
+    #[test]
+    fn rx_parser_reassembles_max_payload_frame_without_truncation() {
+        // WHY: proves TX_FRAME_MAX_ENCODED exactly accommodates the largest
+        // legitimately-decodable frame (12-bit length field, max 4095 ==
+        // MAX_PAYLOAD) with zero loss, i.e. the overflow-bail path above is
+        // never hit on a real frame.
+        let payload = [0xABu8; MAX_PAYLOAD];
+        let frame = make_frame(0, &payload);
+        let mut encoded = [0u8; TX_FRAME_MAX_ENCODED];
+        let len = frame.encode(&mut encoded);
+        assert_eq!(
+            len, TX_FRAME_MAX_ENCODED,
+            "max-payload frame must fill the encode buffer exactly"
+        );
+
+        let mut t = StpTransport::new();
+        let mut complete = None;
+        for &byte in encoded.iter().take(len) {
+            if let Some(raw) = t.receive_byte(byte) {
+                complete = Some(raw.to_vec());
+            }
+        }
+        let raw = complete.unwrap_or_default();
+        assert_eq!(
+            raw.len(),
+            TX_FRAME_MAX_ENCODED,
+            "a max-size frame must be reassembled at full length, never silently truncated"
         );
     }
 }

--- a/crates/pteron/src/device.rs
+++ b/crates/pteron/src/device.rs
@@ -26,6 +26,11 @@ pub(crate) struct BluetoothDevice {
     pub(crate) seen_count: u32,
 }
 
+/// Hard cap on tracked devices. Bounds worst-case memory even under a burst
+/// of spoofed/rotating BLE advertisements within a single `remove_stale`
+/// window, before any entry would otherwise qualify as stale.
+pub(crate) const MAX_TRACKED_DEVICES: usize = 256;
+
 /// A deduplicated collection of discovered Bluetooth devices, keyed by address.
 #[derive(Debug, Default)]
 pub(crate) struct DeviceList {
@@ -67,18 +72,32 @@ impl DeviceList {
     /// If the address is already present, the `rssi`, `last_seen`, and
     /// `seen_count` fields are updated.  The `name` is updated if the
     /// incoming device carries a non-`None` name.
+    ///
+    /// A brand-new address inserted at [`MAX_TRACKED_DEVICES`] capacity
+    /// evicts the single oldest-`last_seen` entry first, bounding memory
+    /// under a burst of spoofed/rotating BLE advertisements.
     pub(crate) fn add_or_update(&mut self, device: BluetoothDevice) {
-        self.devices
-            .entry(device.address.clone())
-            .and_modify(|existing| {
-                existing.rssi = device.rssi;
-                existing.last_seen = device.last_seen;
-                existing.seen_count = existing.seen_count.saturating_add(1);
-                if device.name.is_some() {
-                    existing.name.clone_from(&device.name);
-                }
-            })
-            .or_insert(device);
+        if let Some(existing) = self.devices.get_mut(&device.address) {
+            existing.rssi = device.rssi;
+            existing.last_seen = device.last_seen;
+            existing.seen_count = existing.seen_count.saturating_add(1);
+            if device.name.is_some() {
+                existing.name.clone_from(&device.name);
+            }
+            return;
+        }
+
+        if self.devices.len() >= MAX_TRACKED_DEVICES
+            && let Some(oldest) = self
+                .devices
+                .iter()
+                .min_by_key(|(_, d)| d.last_seen)
+                .map(|(addr, _)| addr.clone())
+        {
+            self.devices.remove(&oldest);
+        }
+
+        self.devices.insert(device.address.clone(), device);
     }
 
     /// Return all devices whose `last_seen` timestamp is older than `max_age`
@@ -89,6 +108,18 @@ impl DeviceList {
             .values()
             .filter(|d| now.duration_since(d.last_seen) >= max_age)
             .collect()
+    }
+
+    /// Prune tracked devices whose `last_seen` timestamp is older than
+    /// `max_age` relative to the current wall-clock time.
+    ///
+    /// Call on the same cadence as [`stale_devices`](Self::stale_devices) to
+    /// keep the map bounded by recency under BLE address rotation and
+    /// long-running passive scan sessions.
+    pub(crate) fn remove_stale(&mut self, max_age: SignedDuration) {
+        let now = Timestamp::now();
+        self.devices
+            .retain(|_, d| now.duration_since(d.last_seen) < max_age);
     }
 
     /// Return the number of devices currently tracked.
@@ -259,6 +290,61 @@ mod tests {
             device.name.as_deref(),
             Some("MyDevice"),
             "name should be updated FROM the second observation"
+        );
+    }
+
+    #[test]
+    fn remove_stale_evicts_aged_entries_and_keeps_fresh() {
+        let mut list = DeviceList::new();
+        list.add_or_update(make_device("AA:BB:CC:DD:EE:01", -60, Timestamp::UNIX_EPOCH));
+        list.add_or_update(make_device("AA:BB:CC:DD:EE:02", -70, Timestamp::now()));
+
+        list.remove_stale(SignedDuration::from_secs(1));
+
+        assert_eq!(
+            list.len(),
+            1,
+            "only the fresh entry should remain after pruning"
+        );
+        let Ok(fresh) = BdAddr::parse("AA:BB:CC:DD:EE:02") else {
+            unreachable!("test address should be valid");
+        };
+        assert!(
+            list.get(&fresh).is_some(),
+            "fresh entry must survive pruning"
+        );
+    }
+
+    #[test]
+    fn add_or_update_evicts_oldest_when_at_capacity() {
+        let mut list = DeviceList::new();
+        for i in 0..MAX_TRACKED_DEVICES {
+            let addr = format!("AA:BB:CC:DD:EE:{i:02X}");
+            let Ok(last_seen) = Timestamp::from_second(i64::try_from(i).unwrap_or_default()) else {
+                unreachable!("small positive second should be valid");
+            };
+            list.add_or_update(make_device(&addr, -60, last_seen));
+        }
+        assert_eq!(list.len(), MAX_TRACKED_DEVICES, "list must be at capacity");
+
+        let Ok(newest) =
+            Timestamp::from_second(i64::try_from(MAX_TRACKED_DEVICES).unwrap_or_default())
+        else {
+            unreachable!("small positive second should be valid");
+        };
+        list.add_or_update(make_device("FF:FF:FF:FF:FF:FF", -40, newest));
+
+        assert_eq!(
+            list.len(),
+            MAX_TRACKED_DEVICES,
+            "insertion at capacity must evict rather than grow the map"
+        );
+        let Ok(oldest) = BdAddr::parse("AA:BB:CC:DD:EE:00") else {
+            unreachable!("test address should be valid");
+        };
+        assert!(
+            list.get(&oldest).is_none(),
+            "the oldest entry must have been evicted to make room"
         );
     }
 }

--- a/crates/thumos/src/bluetooth.rs
+++ b/crates/thumos/src/bluetooth.rs
@@ -480,16 +480,46 @@ impl<H: BtHwOps> BtAdapter<H> {
     /// Rotate the random address if the rotation interval has elapsed.
     ///
     /// Should be called periodically. Returns `true` if the address was rotated.
+    ///
+    /// No-ops (returns `Ok(false)`) outside [`BtState::Ready`]/[`BtState::Scanning`]
+    /// — an unpowered or not-yet-initialized adapter must never receive an HCI
+    /// command. While scanning, the controller rejects `LE Set Random Address`
+    /// with Command Disallowed (Bluetooth Core Spec v5.4 Vol 4 Part E §7.8.4),
+    /// so scanning is paused for the rotation and restarted afterward. The new
+    /// address and rotation timestamp are committed only after the hardware
+    /// write succeeds, so a rejected/failed write leaves state unchanged and
+    /// eligible for retry on the next call.
     #[must_use]
     pub(crate) fn maybe_rotate_address(&mut self, current_tick_ms: u64) -> Result<bool, BtError> {
+        if !matches!(self.state, BtState::Ready | BtState::Scanning) {
+            return Ok(false);
+        }
         if current_tick_ms.saturating_sub(self.address_set_at) < ADDRESS_ROTATION_MS {
             return Ok(false);
         }
 
-        self.random_address = generate_random_address();
-        self.address_set_at = current_tick_ms;
-        let addr_cmd = hci_set_random_address(&self.random_address);
-        self.hw.send_command(&addr_cmd)?;
+        let was_scanning = self.state == BtState::Scanning;
+        if was_scanning {
+            self.stop_scan()?;
+        }
+
+        let new_address = generate_random_address();
+        let addr_cmd = hci_set_random_address(&new_address);
+        let send_result = self.hw.send_command(&addr_cmd);
+
+        if send_result.is_ok() {
+            self.random_address = new_address;
+            self.address_set_at = current_tick_ms;
+        }
+
+        if was_scanning {
+            let restart_result = self.start_scan();
+            if send_result.is_ok() {
+                restart_result?;
+            }
+        }
+
+        send_result?;
         Ok(true)
     }
 
@@ -572,6 +602,12 @@ pub struct MockBtHw {
     pub power_on_ok: bool,
     /// Whether send_command succeeds.
     pub send_ok: bool,
+    /// Number of `send_command` calls observed so far.
+    pub send_calls: usize,
+    /// If set, `send_command` fails from this call count onward (1-indexed),
+    /// letting a test succeed through setup (e.g. `init`) and then force a
+    /// later call to fail without touching the earlier ones.
+    pub fail_after_calls: Option<usize>,
 }
 
 #[cfg(test)]
@@ -582,6 +618,8 @@ impl MockBtHw {
             sent_commands: Vec::new(),
             power_on_ok: true,
             send_ok: true,
+            send_calls: 0,
+            fail_after_calls: None,
         }
     }
 }
@@ -589,7 +627,11 @@ impl MockBtHw {
 #[cfg(test)]
 impl BtHwOps for MockBtHw {
     fn send_command(&mut self, data: &[u8]) -> Result<(), BtError> {
-        if !self.send_ok {
+        self.send_calls += 1;
+        let exceeded_budget = self
+            .fail_after_calls
+            .is_some_and(|budget| self.send_calls > budget);
+        if !self.send_ok || exceeded_budget {
             return Err(BtError::HardwareTimeout);
         }
         self.sent_commands.push(data.to_vec());
@@ -795,6 +837,71 @@ mod tests {
             "rotated address must still be non-resolvable"
         );
         let _ = original; // used for conceptual comparison
+    }
+
+    #[test]
+    fn maybe_rotate_address_guards_off_state() {
+        let mut hw = MockBtHw::new();
+        hw.send_ok = false; // any invocation would surface as an error
+        let mut adapter = BtAdapter::new(hw);
+        let result = adapter.maybe_rotate_address(ADDRESS_ROTATION_MS);
+        assert_eq!(
+            result,
+            Ok(false),
+            "rotation must no-op in Off state without issuing an HCI command"
+        );
+    }
+
+    #[test]
+    fn maybe_rotate_address_stops_and_restarts_scan() {
+        // Seed the CSPRNG so generate_random_address() produces real random
+        // bytes; unseeded it fails closed (#284) and returns a deterministic
+        // near-zero address, which would make the rotation a no-op change.
+        crate::csprng::seed_for_test(&[0x42u8; 32], &[0u8; 8], 0);
+        let hw = MockBtHw::new();
+        let mut adapter = BtAdapter::new(hw);
+        adapter.init(0).ok();
+        adapter.start_scan().ok();
+        let original = *adapter.random_address();
+
+        let result = adapter.maybe_rotate_address(ADDRESS_ROTATION_MS);
+        assert_eq!(result, Ok(true), "rotation must succeed while scanning");
+        assert_eq!(
+            adapter.state(),
+            BtState::Scanning,
+            "adapter must return to Scanning after rotation"
+        );
+        assert_ne!(
+            *adapter.random_address(),
+            original,
+            "address must change after a successful rotation"
+        );
+    }
+
+    #[test]
+    fn maybe_rotate_address_failed_write_leaves_state_unchanged() {
+        let mut hw = MockBtHw::new();
+        hw.fail_after_calls = Some(2); // reset + initial addr-set succeed; rotation's write fails
+        let mut adapter = BtAdapter::new(hw);
+        adapter.init(0).ok();
+        let original_addr = *adapter.random_address();
+
+        let result = adapter.maybe_rotate_address(ADDRESS_ROTATION_MS);
+        assert_eq!(
+            result,
+            Err(BtError::HardwareTimeout),
+            "a rejected HCI write must surface as an error"
+        );
+        assert_eq!(
+            *adapter.random_address(),
+            original_addr,
+            "random_address must be unchanged after a failed rotation write"
+        );
+        assert_eq!(
+            adapter.state(),
+            BtState::Ready,
+            "adapter must remain Ready (not Scanning) after a failed non-scanning rotation"
+        );
     }
 
     // --- Error path coverage ---

--- a/crates/thumos/src/briar.rs
+++ b/crates/thumos/src/briar.rs
@@ -258,9 +258,18 @@ impl fmt::Display for BriarMessage {
             write!(f, "{b:02x}")?;
         }
         write!(f, ".. @ {}: ", self.timestamp)?;
-        let preview_len = self.body.len().min(64);
+        // WHY: byte-index 64 can land inside a multi-byte UTF-8 sequence in
+        // an adversary-crafted body; walk char boundaries instead of
+        // slicing at a fixed byte offset.
+        let preview_len = self
+            .body
+            .char_indices()
+            .map(|(i, c)| i + c.len_utf8())
+            .take_while(|&end| end <= 64)
+            .last()
+            .unwrap_or(0);
         write!(f, "{}", &self.body[..preview_len])?;
-        if self.body.len() > 64 {
+        if self.body.len() > preview_len {
             write!(f, "...")?;
         }
         Ok(())
@@ -497,6 +506,19 @@ mod tests {
             "new transport must have no messages"
         );
         assert_eq!(transport.inbox_count(), 0);
+    }
+
+    #[test]
+    fn display_does_not_panic_on_multibyte_char_straddling_preview_boundary() {
+        let mut body = "a".repeat(62);
+        body.push('\u{20AC}'); // 3-byte UTF-8 '\u{20ac}' starting at byte offset 62, spanning 62..65
+        let msg = BriarMessage::new([0x11; CONTACT_ID_LEN], body, 0)
+            .unwrap_or_else(|_| unreachable!("valid message"));
+        let rendered = msg.to_string();
+        assert!(
+            rendered.contains('a'),
+            "preview must contain the leading ASCII content without panicking"
+        );
     }
 
     // --- Contact tests ---

--- a/crates/thumos/src/ccci.rs
+++ b/crates/thumos/src/ccci.rs
@@ -882,7 +882,12 @@ impl RxRing {
         if self.descriptors[idx].is_hw_owned() {
             return None;
         }
-        let recv_len = self.descriptors[idx].recv_len;
+        // SECURITY: recv_len is modem-written and untrusted; clamp to the
+        // AP-allocated buffer capacity (data_len) before it can be used as a
+        // slice length/copy count by the caller.
+        let recv_len = self.descriptors[idx]
+            .recv_len
+            .min(self.descriptors[idx].data_len);
         self.head = (self.head + 1) % RX_RING_SIZE;
         self.hw_count -= 1;
         Some((idx, recv_len))
@@ -2191,6 +2196,28 @@ mod tests {
         assert!(
             ring.descriptors[idx].is_hw_owned(),
             "descriptor must be HW-owned after rearm"
+        );
+    }
+
+    #[test]
+    fn rx_ring_clamps_oversized_recv_len_to_buffer_capacity() {
+        let mut ring = RxRing::new();
+        let base: u32 = 0x4030_0000;
+        let buf_addrs: [u32; RX_RING_SIZE] =
+            core::array::from_fn(|i| 0x5100_0000 + (u32::try_from(i).unwrap_or_default()) * 0x1000);
+        let buf_size: u16 = 2048;
+        ring.init_chain(base, &buf_addrs, buf_size);
+
+        // A hostile/malfunctioning modem writes a recv_len larger than the
+        // AP-allocated buffer.
+        ring.descriptors[0].clear_hw_owned();
+        ring.descriptors[0].recv_len = 0xFFFF;
+
+        let (idx, len) = ring.poll_rx().unwrap_or_default();
+        assert_eq!(idx, 0, "first descriptor should be polled first");
+        assert_eq!(
+            len, buf_size,
+            "recv_len must be clamped to the descriptor's data_len (buffer capacity)"
         );
     }
 

--- a/crates/thumos/src/gps.rs
+++ b/crates/thumos/src/gps.rs
@@ -322,6 +322,13 @@ fn parse_nmea_coord(value: &[u8], deg_digits: usize) -> Result<i64, GpsError> {
         let raw = parse_int(frac_part).ok_or(GpsError::ParseError)? as i64;
         // Scale to 4 digits (10000).
         let frac_len = frac_part.len() as u32;
+        // WHY: an adversarial GPS source controls frac_part length; beyond
+        // 18 digits 10i64.pow(frac_len - 4) can wrap to 0 in release builds
+        // (panic = "abort"), turning the division below into a divide-by-zero
+        // kernel abort. Reject rather than let the exponent grow unbounded.
+        if frac_len > 18 {
+            return Err(GpsError::ParseError);
+        }
         if frac_len < 4 {
             raw * 10i64.pow(4 - frac_len)
         } else if frac_len > 4 {
@@ -974,6 +981,19 @@ mod tests {
         assert_eq!(parse_int(b"0"), Some(0));
         assert_eq!(parse_int(b""), None);
         assert_eq!(parse_int(b"abc"), None);
+    }
+
+    // -- Coordinate parsing --
+
+    #[test]
+    fn parse_lat_rejects_excessive_fractional_digit_count() {
+        let value = b"5321.00000000000000000000000"; // 23 fractional digits
+        let result = parse_lat(value, b"N");
+        assert_eq!(
+            result,
+            Err(GpsError::ParseError),
+            "23+ fractional digits must error instead of overflowing 10i64.pow"
+        );
     }
 
     // -- GpsTime epoch conversion --

--- a/crates/thumos/src/meshtastic.rs
+++ b/crates/thumos/src/meshtastic.rs
@@ -295,9 +295,18 @@ impl fmt::Display for MeshMessage {
             "!{:08x}->!{:08x} ({}h, ch{}): ",
             self.from_node, self.to_node, self.hop_count, self.channel,
         )?;
-        let preview_len = self.body.len().min(64);
+        // WHY: byte-index 64 can land inside a multi-byte UTF-8 sequence in
+        // an adversary-crafted body; walk char boundaries instead of
+        // slicing at a fixed byte offset.
+        let preview_len = self
+            .body
+            .char_indices()
+            .map(|(i, c)| i + c.len_utf8())
+            .take_while(|&end| end <= 64)
+            .last()
+            .unwrap_or(0);
         write!(f, "{}", &self.body[..preview_len])?;
-        if self.body.len() > 64 {
+        if self.body.len() > preview_len {
             write!(f, "...")?;
         }
         Ok(())
@@ -585,6 +594,19 @@ mod tests {
         assert!(
             transport.known_nodes().is_empty(),
             "new transport must have no known nodes"
+        );
+    }
+
+    #[test]
+    fn display_does_not_panic_on_multibyte_char_straddling_preview_boundary() {
+        let mut body = "a".repeat(62);
+        body.push('\u{1F600}'); // 4-byte UTF-8 emoji starting at byte offset 62, spanning 62..66
+        let msg = MeshMessage::new(1, BROADCAST_NODE_ID, body, 0, 0, 0)
+            .unwrap_or_else(|_| unreachable!("valid message"));
+        let rendered = msg.to_string();
+        assert!(
+            rendered.contains('a'),
+            "preview must contain the leading ASCII content without panicking"
         );
     }
 

--- a/crates/topos/src/nmea.rs
+++ b/crates/topos/src/nmea.rs
@@ -171,9 +171,13 @@ pub(crate) fn parse_rmc(sentence: &str) -> error::Result<Fix> {
 
 /// Parse latitude FROM split fields (value, hemisphere).
 fn parse_lat_field(value: &str, hemisphere: &str) -> error::Result<f64> {
-    if value.len() < 4 {
+    // WHY: NMEA fields are wire-ASCII; a non-ASCII field means the fixed
+    // byte offsets below could land inside a multi-byte UTF-8 sequence and
+    // panic on a &str byte-range slice. Reject non-ASCII input up front so
+    // every subsequent slice index is guaranteed to be a char boundary.
+    if value.len() < 4 || !value.is_ascii() {
         return Err(Error::Parse {
-            message: format!("latitude too short: {value}"),
+            message: format!("invalid latitude field: {value}"),
         });
     }
     let degrees: f64 = value[..2].parse().map_err(|_| Error::Parse {
@@ -191,9 +195,13 @@ fn parse_lat_field(value: &str, hemisphere: &str) -> error::Result<f64> {
 
 /// Parse longitude FROM split fields (value, hemisphere).
 fn parse_lon_field(value: &str, hemisphere: &str) -> error::Result<f64> {
-    if value.len() < 5 {
+    // WHY: NMEA fields are wire-ASCII; a non-ASCII field means the fixed
+    // byte offsets below could land inside a multi-byte UTF-8 sequence and
+    // panic on a &str byte-range slice. Reject non-ASCII input up front so
+    // every subsequent slice index is guaranteed to be a char boundary.
+    if value.len() < 5 || !value.is_ascii() {
         return Err(Error::Parse {
-            message: format!("longitude too short: {value}"),
+            message: format!("invalid longitude field: {value}"),
         });
     }
     let degrees: f64 = value[..3].parse().map_err(|_| Error::Parse {
@@ -340,6 +348,36 @@ mod tests {
         );
     }
 
+    #[test]
+    fn parse_lat_field_rejects_non_ascii_instead_of_panicking() {
+        let result = parse_lat_field("\u{4e00}21.6802", "N");
+        assert!(
+            matches!(result, Err(Error::Parse { .. })),
+            "non-ASCII latitude field must return Error::Parse, not panic"
+        );
+    }
+
+    #[test]
+    fn parse_lon_field_rejects_non_ascii_instead_of_panicking() {
+        let result = parse_lon_field("\u{4e00}030.3372", "E");
+        assert!(
+            matches!(result, Err(Error::Parse { .. })),
+            "non-ASCII longitude field must return Error::Parse, not panic"
+        );
+    }
+
+    #[test]
+    fn parse_gga_never_panics_on_valid_checksum_non_ascii_coordinate() {
+        let body = "GPGGA,092750.000,\u{4e00}21.6802,N,00630.3372,W,1,8,1.03,61.7,M,55.2,M,,";
+        let checksum = compute_checksum(body);
+        let sentence = format!("${body}*{checksum:02X}");
+        let result = parse_gga(&sentence);
+        assert!(
+            matches!(result, Err(Error::Parse { .. })),
+            "a valid-checksum sentence with a non-ASCII latitude field must error, not panic"
+        );
+    }
+
     // -- Proptest: fuzz the NMEA parser to verify no panics on arbitrary input --
 
     mod proptest_fuzz {
@@ -364,6 +402,18 @@ mod tests {
             #[test]
             fn validate_checksum_never_panics(data in "\\PC{0,200}") {
                 let result = validate_checksum(&data);
+                prop_assert!(result.is_ok() || result.is_err());
+            }
+
+            #[test]
+            fn parse_gga_never_panics_on_valid_checksum_multibyte_coordinate(c in "\\PC") {
+                // WHY: the random-byte proptests above fail checksum validation
+                // before reaching the slice, so they never exercise a
+                // valid-checksum sentence with a multi-byte coordinate field.
+                let body = format!("GPGGA,092750.000,{c}21.6802,N,00630.3372,W,1,8,1.03,61.7,M,55.2,M,,");
+                let checksum = compute_checksum(&body);
+                let sentence = format!("${body}*{checksum:02X}");
+                let result = parse_gga(&sentence);
                 prop_assert!(result.is_ok() || result.is_err());
             }
         }


### PR DESCRIPTION
## Summary

The RF environment and paired peers are untrusted; this wave fixes panics, integrity gaps, and unbounded growth in adversary-facing radio code across BT/WMT/GPS/mesh/CCCI.

**Parser panics on hostile input:**
- **#277** — topos NMEA `parse_lat/lon_field` byte-sliced a `&str` at fixed offsets; a non-ASCII field panicked. Reject non-ASCII up front.
- **#299** — `gps.rs` NMEA fractional field drove `10i64.pow` to wrap to 0 (`10^64 mod 2^64 == 0`) → divide-by-zero abort. Bound the digit count.
- **#305 / #292** — `MeshMessage`/`BriarMessage` `Display` byte-sliced the body at 64, panicking on a multi-byte char straddling the boundary. Walk char boundaries.

**STP transport integrity / liveness** (kelyphos — pteron's XOR-checksum variant already validates on RX, so these are kelyphos-only):
- **#353** — the RX path never verified CRC-16 CCITT (TX-only). Recompute and reject mismatches.
- **#350** — `RxParser` silently discarded bytes on overflow. Abandon the frame. *Defense-in-depth: the 12-bit length field cannot currently exceed `MAX_PAYLOAD`, so this is forward-compat against a header/buffer-size mismatch rather than a live DoS — the issue's reachability claim should be corrected on close.*
- **#351** — a `RetryLimitExceeded` frame kept its window slot forever, write-locking the transport. Free the slot on terminal failure.

**Radio identity / bounds:**
- **#354** — pteron `DeviceList` grew unbounded under BLE address rotation. Added `remove_stale` + a hard `MAX_TRACKED_DEVICES` cap (the cap is what bounds a beacon-spam burst within one staleness window).
- **#313** — bluetooth `maybe_rotate_address` issued HCI with no adapter-state guard and committed local state before hardware confirmed. Now no-ops outside Ready/Scanning, pauses/restarts scan, and commits only after a successful write.
- **#265** — `ccci.rs` `RxRing::poll_rx` returned the modem-written `recv_len` unclamped (*the issue mislabeled this aither; it lives in the kernel CCCI driver*). Clamp to the AP buffer capacity.

## Closes

Closes #277, #299, #305, #292, #353, #350, #351, #354, #313, #265

## Verification

- `cargo test -p kelyphos -p pteron -p topos` — 61 / 62 / 18 passed
- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — 1725 passed (+7)
- `cargo clippy --workspace --all-targets -- -D warnings` + `cargo test --doc --workspace` — clean
- `cargo build --release --target armv7a-none-eabi` — compiles
- `kanon lint . --summary` — clean