### PR TITLE
Security-medium: Sentinel-PIN KDF, anomaly-detection evasion, wipe-file test coverage

### DIFF
--- a/crates/leipsanon/src/engine.rs
+++ b/crates/leipsanon/src/engine.rs
@@ -261,8 +261,13 @@ fn wipe_file(
 // ----- Tests ----------------------------------------------------------------
 
 #[cfg(test)]
+#[expect(
+    clippy::expect_used,
+    reason = "test code — expect is intentional for asserting fixture setup/read/cleanup succeeded"
+)]
 mod tests {
     use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
 
     use crate::targets::{WipeLevel, plan};
 
@@ -398,6 +403,92 @@ mod tests {
             clamped.chunk_size(),
             CHUNK_SIZE,
             "too-small chunk_size must clamp to the default"
+        );
+    }
+
+    /// Deletes its backing file on drop so a fixture is cleaned up even if
+    /// an assertion later in the test panics.
+    struct TempFile {
+        path: PathBuf,
+    }
+
+    static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    impl TempFile {
+        fn with_contents(label: &str, contents: &[u8]) -> Self {
+            let n = TEMP_FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "leipsanon_wipe_test_{label}_{}_{n}",
+                std::process::id()
+            ));
+            std::fs::write(&path, contents).expect("write test fixture");
+            Self { path }
+        }
+    }
+
+    impl Drop for TempFile {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+
+    #[test]
+    fn real_wipe_zero_overwrites_file_contents() {
+        let original = vec![0xABu8; CHUNK_SIZE * 2 + 37];
+        let fixture = TempFile::with_contents("zero", &original);
+
+        let plan = vec![WipeAction {
+            path: fixture.path.clone(),
+            method: WipeMethod::Zero,
+            priority: 1,
+        }];
+        let mut engine = WipeEngine::new(false);
+        let result = engine.execute(&plan);
+
+        let wiped = std::fs::read(&fixture.path).expect("read wiped fixture");
+
+        assert_eq!(result.actions_completed, 1, "the wipe action must complete");
+        assert_eq!(result.actions_failed, 0, "the wipe action must not fail");
+        assert_eq!(
+            result.bytes_wiped,
+            original.len() as u64,
+            "bytes_wiped must equal the file size for a full-file Zero wipe"
+        );
+        assert!(
+            wiped.iter().all(|&b| b == 0),
+            "every byte must be zero after a Zero-method wipe"
+        );
+        assert_ne!(
+            wiped, original,
+            "wiped content must differ from the original fixture content"
+        );
+    }
+
+    #[test]
+    fn real_wipe_random_overwrites_file_contents() {
+        let original = vec![0x55u8; CHUNK_SIZE * 2 + 37];
+        let fixture = TempFile::with_contents("random", &original);
+
+        let plan = vec![WipeAction {
+            path: fixture.path.clone(),
+            method: WipeMethod::Random,
+            priority: 1,
+        }];
+        let mut engine = WipeEngine::new(false);
+        let result = engine.execute(&plan);
+
+        let wiped = std::fs::read(&fixture.path).expect("read wiped fixture");
+
+        assert_eq!(result.actions_completed, 1, "the wipe action must complete");
+        assert_eq!(result.actions_failed, 0, "the wipe action must not fail");
+        assert_eq!(
+            result.bytes_wiped,
+            original.len() as u64,
+            "bytes_wiped must equal the file size for a full-file Random wipe"
+        );
+        assert_ne!(
+            wiped, original,
+            "wiped content must no longer match the original fixture content after a Random-method wipe"
         );
     }
 }

--- a/crates/thumos/src/ccci_logger.rs
+++ b/crates/thumos/src/ccci_logger.rs
@@ -501,7 +501,7 @@ const MAX_ANOMALIES: usize = 16;
 /// 1. Unexpected channel active (was inactive during baseline).
 /// 2. Rate spike: packet count in the last `window_ms` exceeds
 ///    3x the baseline maximum rate.
-/// 3. data0 out of range: most recent packet's data0 falls outside
+/// 3. data0 out of range: any packet's data0 in the window falls outside
 ///    the baseline `[min_data0, max_data0]` range.
 ///
 /// # Arguments
@@ -564,26 +564,32 @@ pub(crate) fn detect_anomalies(
             }
         }
 
-        // 3. data0 out of range -- check the most recent packet on this channel.
+        // 3. data0 out of range -- check every packet on this channel in
+        // the window; flag on the first one that violates the baseline
+        // range. SECURITY: checking only the most recent packet let an
+        // adversarial modem smuggle an out-of-range data0 in any packet
+        // except the last and evade detection entirely (issue #248).
         let (older, newer) = log.entries();
-        let mut latest_data0: Option<u32> = None;
+        let mut out_of_range: Option<u32> = None;
         for entry in older.iter().chain(newer.iter()) {
             if entry.channel == ch_u32 && entry.timestamp >= since {
-                latest_data0 = Some(entry.data0);
+                let d0 = entry.data0;
+                if d0 < baseline_stats.min_data0 || d0 > baseline_stats.max_data0 {
+                    out_of_range = Some(d0);
+                    break;
+                }
             }
         }
-        if let Some(d0) = latest_data0 {
-            if d0 < baseline_stats.min_data0 || d0 > baseline_stats.max_data0 {
-                if count < MAX_ANOMALIES {
-                    anomalies[count] = Some(CcciAnomaly {
-                        timestamp: now,
-                        channel: ch_u32,
-                        kind: AnomalyKind::Data0OutOfRange,
-                        observed: d0,
-                        baseline_max: baseline_stats.max_data0,
-                    });
-                    count += 1;
-                }
+        if let Some(d0) = out_of_range {
+            if count < MAX_ANOMALIES {
+                anomalies[count] = Some(CcciAnomaly {
+                    timestamp: now,
+                    channel: ch_u32,
+                    kind: AnomalyKind::Data0OutOfRange,
+                    observed: d0,
+                    baseline_max: baseline_stats.max_data0,
+                });
+                count += 1;
             }
         }
     }
@@ -1293,6 +1299,62 @@ mod tests {
             a.channel == 4 && a.kind == AnomalyKind::Data0OutOfRange
         });
         assert!(found, "must detect data0 out of range on channel 4");
+    }
+
+    #[test]
+    fn anomaly_detects_data0_out_of_range_in_non_last_packet() {
+        let mut log = CcciLogger::new();
+
+        // Baseline: data0 range [100, 200] on channel 4.
+        for d0 in [100u32, 150, 200] {
+            log.record(CcciLogEntry {
+                timestamp: 1000,
+                channel: 4,
+                direction: PacketDirection::Rx,
+                data0: d0,
+                data1: 0,
+                packet_len: 16,
+            });
+        }
+        let baseline = build_baseline(&log, 60_000);
+
+        // Out-of-range packet is FIRST in the live window; every packet
+        // after it (including the last) is in-range. Regression test for
+        // #248: a check that only inspects the trailing packet lets an
+        // attacker smuggle the offending value anywhere but last.
+        log.record(CcciLogEntry {
+            timestamp: 70_000,
+            channel: 4,
+            direction: PacketDirection::Rx,
+            data0: 500,
+            data1: 0,
+            packet_len: 16,
+        });
+        log.record(CcciLogEntry {
+            timestamp: 71_000,
+            channel: 4,
+            direction: PacketDirection::Rx,
+            data0: 150,
+            data1: 0,
+            packet_len: 16,
+        });
+        log.record(CcciLogEntry {
+            timestamp: 72_000,
+            channel: 4,
+            direction: PacketDirection::Rx,
+            data0: 150,
+            data1: 0,
+            packet_len: 16,
+        });
+
+        let (anomalies, count) = detect_anomalies(&log, &baseline, 72_000, 60_000);
+        let found = anomalies[..count].iter().flatten().any(|a| {
+            a.channel == 4 && a.kind == AnomalyKind::Data0OutOfRange
+        });
+        assert!(
+            found,
+            "must detect data0 out of range even when the offending packet is not last in the window"
+        );
     }
 
     #[test]

--- a/crates/thumos/src/security_mode.rs
+++ b/crates/thumos/src/security_mode.rs
@@ -32,6 +32,8 @@ extern crate alloc;
 
 use core::fmt;
 
+use subtle::ConstantTimeEq;
+
 use crate::audit::{AuditEventType, AuditLog};
 use crate::key_manager::KeyManager;
 use crate::power::{PowerManager, PowerState, Radio};
@@ -52,6 +54,14 @@ const SCAN_INTERVAL_SENTINEL_MS: u32 = 10_000;
 
 /// Scan interval for Panic mode (0 — no scanning).
 const SCAN_INTERVAL_PANIC_MS: u32 = 0;
+
+/// Salt for the Sentinel-exit PIN PBKDF2 derivation.
+///
+/// NOTE: fixed (not per-device random) for determinism, mirroring the
+/// `PBKDF2_SALT` pattern in `key_manager.rs`, until the key-slot
+/// provisioning infrastructure (kinit.rs Step 8f, currently PENDING) wires
+/// a per-device random salt into persistent storage.
+const PIN_PBKDF2_SALT: &[u8] = b"thumos-sentinel-pin-salt-v1";
 
 // ---------------------------------------------------------------------------
 // SecurityMode
@@ -271,17 +281,16 @@ pub(crate) struct ModeManager {
     pre_panic_mode: SecurityMode,
     /// Most recent panic event, if any.
     last_panic_event: Option<PanicEvent>,
-    /// Stored PIN hash for Sentinel exit verification.
-    /// In production this would be a SHA-256 hash; for now a simple
-    /// fixed-size array suffices until Wave 3 wires the real PIN system.
+    /// PBKDF2-HMAC-SHA256 derived value for Sentinel exit PIN verification
+    /// (RFC 8018, salted + iterated — see [`ModeManager::exit_sentinel`]).
     pin_hash: [u8; 32],
 }
 
 impl ModeManager {
     /// Create a new `ModeManager` starting in Daily mode.
     ///
-    /// `pin_hash` is the SHA-256 hash of the user's PIN for Sentinel
-    /// exit verification.
+    /// `pin_hash` is the PBKDF2-HMAC-SHA256 derived value of the user's PIN
+    /// for Sentinel exit verification (see [`ModeManager::exit_sentinel`]).
     #[must_use]
     pub(crate) const fn new(pin_hash: [u8; 32]) -> Self {
         Self {
@@ -343,8 +352,12 @@ impl ModeManager {
 
     /// Transition from Sentinel back to Daily mode.
     ///
-    /// Requires PIN confirmation. The provided `pin` is hashed with SHA-256
-    /// and compared against the stored hash.
+    /// Requires PIN confirmation. The provided `pin` is derived with
+    /// PBKDF2-HMAC-SHA256 (RFC 8018, `PIN_PBKDF2_SALT`,
+    /// `security::PBKDF2_ITERATIONS` rounds) and compared in constant time
+    /// against the stored derived value — a single fast unsalted hash is
+    /// brute-forceable offline in milliseconds over the PIN's small
+    /// candidate space (CWE-916 / CWE-759).
     ///
     /// # Errors
     ///
@@ -367,9 +380,24 @@ impl ModeManager {
             return Err(ModeTransitionError::PinRequired);
         }
 
-        // Verify PIN by comparing SHA-256 hash.
-        let pin_hash = crate::security::sha256(pin);
-        if !constant_time_eq(&pin_hash, &self.pin_hash) {
+        // WHY: PBKDF2-HMAC-SHA256 (RFC 8018) replaces the prior single-round
+        // unsalted SHA-256 hash — a 4-6 digit PIN has only 1e4-1e6
+        // candidates, exhaustively searchable offline in milliseconds
+        // against a fast unsalted hash and reusable across every device via
+        // one precomputed table (CWE-916 / CWE-759). The salted, iterated
+        // derivation costs a full PBKDF2 round per guess.
+        let mut derived_pin = [0u8; KEY_SIZE];
+        // INVARIANT: PBKDF2_ITERATIONS is a nonzero constant, so
+        // ZeroIterations is unreachable here; mapped to PinMismatch
+        // (fail-closed) rather than unwrapped.
+        let derive_ok = crate::security::pbkdf2_sha256(
+            pin,
+            PIN_PBKDF2_SALT,
+            crate::security::PBKDF2_ITERATIONS,
+            &mut derived_pin,
+        )
+        .is_ok();
+        if !derive_ok || !constant_time_eq(&derived_pin, &self.pin_hash) {
             return Err(ModeTransitionError::PinMismatch);
         }
 
@@ -764,12 +792,16 @@ pub(crate) fn sync_firewall_mode(
 
 /// Constant-time byte array comparison to prevent timing side-channels
 /// on PIN verification.
+///
+/// WHY: backed by `subtle::ConstantTimeEq`, which inserts optimization
+/// barriers the compiler cannot elide — a hand-rolled XOR loop can be
+/// defeated by an optimizing backend. Mirrors the `lock_screen.rs`
+/// constant-time compare: the duress/coercion surface has the same
+/// timing-oracle requirement as Sentinel-exit PIN verification.
 fn constant_time_eq(a: &[u8; 32], b: &[u8; 32]) -> bool {
-    let mut diff: u8 = 0;
-    for (x, y) in a.iter().zip(b.iter()) {
-        diff |= x ^ y;
-    }
-    diff == 0
+    let a_slice: &[u8] = a;
+    let b_slice: &[u8] = b;
+    a_slice.ct_eq(b_slice).unwrap_u8() == 1
 }
 
 // ---------------------------------------------------------------------------
@@ -782,14 +814,24 @@ mod tests {
 
     use super::*;
 
-    /// Helper: compute SHA-256 hash of a test PIN.
-    fn sha256_hash_of_pin(pin: &[u8]) -> [u8; 32] {
-        crate::security::sha256(pin)
+    /// Helper: derive the PBKDF2-HMAC-SHA256 value of a test PIN, matching
+    /// `ModeManager::exit_sentinel`'s verification derivation exactly (same
+    /// salt + iteration count) so the stored fixture round-trips.
+    fn derive_test_pin_hash(pin: &[u8]) -> [u8; 32] {
+        let mut derived = [0u8; 32];
+        crate::security::pbkdf2_sha256(
+            pin,
+            PIN_PBKDF2_SALT,
+            crate::security::PBKDF2_ITERATIONS,
+            &mut derived,
+        )
+        .expect("pbkdf2 derivation failed in test");
+        derived
     }
 
     /// Helper: create a ModeManager with a known test PIN.
     fn mode_manager_with_test_pin() -> ModeManager {
-        ModeManager::new(sha256_hash_of_pin(b"123456"))
+        ModeManager::new(derive_test_pin_hash(b"123456"))
     }
 
     /// Helper: create a KeyManager with loaded keys for testing.
@@ -864,6 +906,70 @@ mod tests {
 
         // Correct PIN should succeed.
         mm.exit_sentinel(b"123456", &mut pm).expect("exit_sentinel failed");
+        assert_eq!(mm.mode(), SecurityMode::Daily);
+    }
+
+    // -----------------------------------------------------------------------
+    // Sentinel-exit PIN uses a salted, iterated KDF (#272)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn exit_sentinel_pin_is_not_verified_by_plain_sha256() {
+        // Regression test for #272: exit_sentinel previously verified the
+        // PIN via a single-round, unsalted SHA-256 hash. Proves the
+        // stored/derived value is now the PBKDF2-HMAC-SHA256 derivation,
+        // not a bare SHA-256 digest of the same PIN.
+        let derived = derive_test_pin_hash(b"123456");
+        let bare_sha256 = crate::security::sha256(b"123456");
+        assert_ne!(
+            derived, bare_sha256,
+            "Sentinel-exit PIN verification must use a KDF, not a bare SHA-256 hash"
+        );
+    }
+
+    #[test]
+    fn exit_sentinel_pin_derivation_is_salted() {
+        // A KDF without a salt input does not resist a precomputed /
+        // rainbow-table attack. Confirm the salt is load-bearing: a
+        // different salt must produce a different derived value for the
+        // same PIN.
+        let mut with_salt = [0u8; 32];
+        crate::security::pbkdf2_sha256(
+            b"123456",
+            PIN_PBKDF2_SALT,
+            crate::security::PBKDF2_ITERATIONS,
+            &mut with_salt,
+        )
+        .expect("pbkdf2 failed");
+
+        let mut different_salt = [0u8; 32];
+        crate::security::pbkdf2_sha256(
+            b"123456",
+            b"a-different-salt",
+            crate::security::PBKDF2_ITERATIONS,
+            &mut different_salt,
+        )
+        .expect("pbkdf2 failed");
+
+        assert_ne!(
+            with_salt, different_salt,
+            "different salts must produce different derived PIN values"
+        );
+    }
+
+    #[test]
+    fn exit_sentinel_still_succeeds_with_correct_pin_after_kdf_fix() {
+        // Round-trip regression: the salted KDF must not break legitimate
+        // Sentinel exit with the correct PIN (covered indirectly by
+        // transition_sentinel_to_daily_requires_pin above; asserted
+        // directly here for #272 traceability).
+        let mut mm = mode_manager_with_test_pin();
+        let mut km = key_manager_with_derived_keys();
+        let mut pm = PowerManager::new();
+
+        mm.enter_sentinel(&mut km, &mut pm).expect("enter_sentinel failed");
+        mm.exit_sentinel(b"123456", &mut pm)
+            .expect("correct PIN must still unlock after KDF fix");
         assert_eq!(mm.mode(), SecurityMode::Daily);
     }
 


### PR DESCRIPTION
## Summary

Three security-medium fixes.

- **#272** — the Sentinel-exit PIN was verified via a single-round, unsalted SHA-256. A 4–6 digit PIN has only 10⁴–10⁶ candidates, exhaustively searchable offline in milliseconds against a fast unsalted hash, with one precomputed table reusable across every device (CWE-916 / CWE-759). It now derives with PBKDF2-HMAC-SHA256 (RFC 8018, salted, 100k rounds — the same RustCrypto primitive and budget already used for the boot-passphrase key) and compares in constant time via `subtle` (the file's hand-rolled XOR compare is replaced with the subtle-backed one too).
- **#248** — the CCCI modem anomaly detector's `Data0OutOfRange` check inspected only the chronologically *last* packet per window, so an adversarial modem could put an out-of-range `data0` in any earlier packet and evade detection. It now checks every packet in the window and flags the first violation.
- **#246** — leipsanon's `wipe_file` real-I/O path had zero test coverage (only dry-run was exercised; the two non-dry-run tests failed at `open()` before the overwrite loop). Adds real-I/O tests (Zero + Random over a multi-chunk temp file, RAII cleanup) asserting the bytes are actually overwritten and `bytes_wiped` equals the file size.

## Closes

Closes #272, #248, #246

## Verification

- `cargo test -p leipsanon` — 46 passed (+2)
- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — 1729 passed (+4)
- `cargo clippy --workspace --all-targets -- -D warnings` + `cargo test --doc --workspace` — clean
- `cargo build --release --target armv7a-none-eabi` — compiles
- `kanon lint . --summary` — clean

## Notes

- #272's tests now exercise the real 100k-round PBKDF2 (~15 call sites via the shared fixture), adding a few seconds to the kernel test run — deliberate, since tests should use the real KDF.
- Related follow-ups surfaced but out of scope here: `lock_screen.rs` verifies the real PIN / duress PIN / boot passphrase via bare `security::sha256` (same class as #272, distinct surface); USB provisioning authenticity (#270) is being done as a focused follow-up (it's a wire-format-breaking Ed25519-signature change); X3DH initiator-identity pinning (#241) is deferred — #207 already closed its DH-binding half, and the remaining identity-pinning half is a design task blocked on the krypta kernel-integration (#126) + a Contact pinned-key schema.