### PR TITLE
Harden the ELF loader against a crafted execve image (5 fixes)

### DIFF
--- a/crates/thumos/src/elf.rs
+++ b/crates/thumos/src/elf.rs
@@ -4,9 +4,11 @@
 //! Only supports statically-linked ARM ELF binaries (what our userspace
 //! crates compile to with `armv7-unknown-linux-musleabihf` target).
 //!
-//! The loader allocates pages for each segment, copies the data,
-//! and returns the entry point address for process creation.
+//! The loader validates a per-image page budget (#327) and writes each
+//! segment's data directly to its identity-mapped virtual address (#318),
+//! then returns the entry point address for process creation.
 
+use crate::memguard::validate_user_buffer;
 use crate::page;
 
 /// ELF magic: 0x7F 'E' 'L' 'F'
@@ -61,11 +63,31 @@ struct Elf32Phdr {
     p_align: u32,
 }
 
+/// Size of an on-disk `Elf32Phdr`: eight `u32` fields = 32 bytes.
+///
+/// WHY size_of, not the header-declared `e_phentsize` (#317): the phdr read
+/// in `validate()` always consumes exactly this many bytes regardless of
+/// what the attacker-controlled `e_phentsize` claims, so both the entsize
+/// floor and the per-header bounds check must be pinned to the type's
+/// actual size.
+const PHDR_SIZE: usize = core::mem::size_of::<Elf32Phdr>();
+
+/// Maximum total PT_LOAD segment memory, in pages, a single ELF image may
+/// declare (#327).
+///
+/// WHY 2048 (8 MB): generous headroom for a statically-linked ARM musl
+/// binary's .text+.data+.bss on this device, while bounding a crafted
+/// `p_memsz` from driving an unbounded page-count computation or physical
+/// page exhaustion on this 1 GB device.
+const MAX_ELF_PAGES: usize = 2048;
+
 /// Result of loading an ELF binary.
+#[derive(Debug)]
 pub(crate) struct LoadedElf {
     /// Entry point address.
     pub entry: usize,
-    /// Number of pages allocated.
+    /// Number of pages written (#328: no longer a count of
+    /// `page::alloc_page()` reservations — see `load()`'s doc comment).
     pub pages_used: usize,
 }
 
@@ -128,16 +150,43 @@ fn validate(data: &[u8]) -> Result<(usize, ValidatedElf), ElfError> {
     let mut segments = ValidatedElf {
         segments: [(0, 0, 0, 0); 16],
         count: 0,
+        total_pages: 0,
     };
+
+    // WHY (#317): e_phentsize is attacker-controlled but the read below
+    // always consumes exactly PHDR_SIZE bytes. Reject up front if the
+    // header declares a stride narrower than what will actually be read,
+    // rather than trusting phentsize as the read width.
+    if phnum > 0 && phentsize < PHDR_SIZE {
+        return Err(ElfError::InvalidSegment);
+    }
 
     // Process program headers
     for i in 0..phnum {
-        let offset = phoff + i * phentsize;
-        if offset + phentsize > data.len() {
+        // WHY (#316): phoff/phentsize are attacker-controlled u32 header
+        // fields; plain addition/multiplication can wrap a 32-bit usize
+        // target and bypass the bounds check below. checked_mul/checked_add
+        // reject a header that would wrap instead of silently admitting it.
+        let offset = match i
+            .checked_mul(phentsize)
+            .and_then(|stride| stride.checked_add(phoff))
+        {
+            Some(o) => o,
+            None => return Err(ElfError::InvalidSegment),
+        };
+        // WHY (#317): bounds-check against PHDR_SIZE (the bytes actually
+        // read below), not phentsize (the attacker-controlled stride) — a
+        // phentsize >= PHDR_SIZE is enforced above, but the read width
+        // itself must never depend on the untrusted field.
+        let offset_end = match offset.checked_add(PHDR_SIZE) {
+            Some(e) => e,
+            None => return Err(ElfError::InvalidSegment),
+        };
+        if offset_end > data.len() {
             return Err(ElfError::InvalidSegment);
         }
 
-        // SAFETY: offset + phentsize <= data.len() was verified above.
+        // SAFETY: offset + PHDR_SIZE <= data.len() was verified above.
         // read_unaligned is used because the program header is packed and
         // the byte slice offset may not satisfy Elf32Phdr's alignment.
         let phdr: Elf32Phdr =
@@ -152,9 +201,41 @@ fn validate(data: &[u8]) -> Result<(usize, ValidatedElf), ElfError> {
         let filesz = phdr.p_filesz as usize;
         let file_offset = phdr.p_offset as usize;
 
-        if file_offset + filesz > data.len() {
+        // WHY (#316): file_offset/filesz are attacker-controlled; checked_add
+        // rejects a wrap instead of letting it bypass this guard.
+        let file_end = match file_offset.checked_add(filesz) {
+            Some(e) => e,
+            None => return Err(ElfError::InvalidSegment),
+        };
+        if file_end > data.len() {
             return Err(ElfError::InvalidSegment);
         }
+
+        // WHY (#318): p_vaddr is a fully attacker-controlled physical write
+        // target — load() below writes segment bytes directly to vaddr
+        // (identity-mapped, no per-process page table yet). Reject any
+        // segment whose [vaddr, vaddr+memsz) falls outside sanctioned
+        // user-accessible DRAM before a single byte is written, closing the
+        // arbitrary-write primitive.
+        if !validate_user_buffer(vaddr, memsz) {
+            return Err(ElfError::InvalidSegment);
+        }
+
+        // WHY (#327): bound this segment's page count, and the running
+        // total across all segments, via checked arithmetic (memsz +
+        // PAGE_SIZE - 1 can itself overflow a 32-bit usize) before any page
+        // is allocated.
+        let seg_pages = match memsz
+            .checked_add(page::PAGE_SIZE - 1)
+            .map(|rounded| rounded / page::PAGE_SIZE)
+        {
+            Some(n) => n,
+            None => return Err(ElfError::InvalidSegment),
+        };
+        segments.total_pages = match segments.total_pages.checked_add(seg_pages) {
+            Some(t) if t <= MAX_ELF_PAGES => t,
+            _ => return Err(ElfError::InvalidSegment),
+        };
 
         if segments.count < 16 {
             segments.segments[segments.count] = (vaddr, memsz, filesz, file_offset);
@@ -172,12 +253,22 @@ struct ValidatedElf {
     segments: [(usize, usize, usize, usize); 16],
     /// Number of valid entries in `segments`.
     count: usize,
+    /// Sum of each segment's page count (`ceil(memsz / PAGE_SIZE)`),
+    /// already bounded by `MAX_ELF_PAGES` (#327). `load()`'s single
+    /// up-front OOM precheck (#328) uses this instead of allocating a page
+    /// per iteration.
+    total_pages: usize,
 }
 
 /// Load an ELF binary FROM a byte slice INTO memory.
 ///
-/// Allocates pages for each PT_LOAD segment, copies data, zeros BSS.
-/// Returns the entry point for process creation.
+/// Writes each PT_LOAD segment directly to its identity-mapped `vaddr`
+/// (validated by `validate()`'s load-region check, #318), zeroing BSS.
+/// Returns the entry point for process creation. #328: does not call
+/// `page::alloc_page()` per segment page — nothing would ever free such a
+/// reservation, since the write target is `vaddr`, not the allocated
+/// frame — so the only physical-memory gate is the up-front `free_count()`
+/// budget check below.
 ///
 /// # Safety
 ///
@@ -185,19 +276,35 @@ struct ValidatedElf {
 /// user/kernel memory separation (Wave 4+).
 pub(crate) fn load(data: &[u8]) -> Result<LoadedElf, ElfError> {
     let (entry, validated) = validate(data)?;
+
+    // WHY (#328): a single up-front budget check replaces the old per-page
+    // page::alloc_page() reservation. That reservation's returned address
+    // was immediately discarded — segment data is written straight to the
+    // identity-mapped vaddr, validated above by #318 — and never freed,
+    // leaking pages_used physical frames on every load. validated.total_pages
+    // is already bounded by MAX_ELF_PAGES (#327), so this is a bounded,
+    // one-shot check rather than an unbounded leak.
+    if page::free_count() < validated.total_pages {
+        return Err(ElfError::OutOfMemory);
+    }
+
     let mut pages_used = 0;
 
     for idx in 0..validated.count {
         let (vaddr, memsz, filesz, file_offset) = validated.segments[idx];
 
-        // Allocate pages for this segment
+        // WHY: identical to the checked computation validate() already
+        // performed for this same memsz while building validated.total_pages
+        // (#327) — if it did not overflow there, it cannot overflow here —
+        // so plain arithmetic is safe without re-deriving the check.
         let num_pages = (memsz + page::PAGE_SIZE - 1) / page::PAGE_SIZE;
         for p in 0..num_pages {
-            let page_addr = page::alloc_page().ok_or(ElfError::OutOfMemory)?;
             pages_used += 1;
 
-            // NOTE: identity-mapped, so we can write directly to physical addresses
-            // The segment's virtual address must match our identity mapping range
+            // NOTE: identity-mapped, so we write directly to the
+            // page::PAGE_SIZE-aligned physical address vaddr + p*PAGE_SIZE.
+            // #318 validated [vaddr, vaddr+memsz) above, so this offset
+            // cannot leave that range or overflow.
             let dest = vaddr + p * page::PAGE_SIZE;
             let dest_ptr = dest as *mut u8;
 
@@ -206,23 +313,29 @@ pub(crate) fn load(data: &[u8]) -> Result<LoadedElf, ElfError> {
             let page_end = (page_start + page::PAGE_SIZE).min(memsz);
 
             for byte_offset in page_start..page_end {
+                // WHY (#316): file_offset + byte_offset cannot overflow —
+                // validate() proved file_offset + filesz <= data.len() via
+                // checked_add, and byte_offset < filesz here — but
+                // checked_add plus a safe fallback keeps this line's
+                // arithmetic self-evidently guarded rather than leaning on
+                // a fact proven elsewhere.
                 let val = if byte_offset < filesz {
-                    data[file_offset + byte_offset]
+                    match file_offset.checked_add(byte_offset).and_then(|i| data.get(i)) {
+                        Some(&b) => b,
+                        None => 0, // INVARIANT: unreachable per validate()'s file_end check
+                    }
                 } else {
                     0 // BSS: zero-filled
                 };
-                // SAFETY: dest (vaddr) is identity-mapped DRAM within the MMU's
-                // normal RAM region. byte_offset - page_start < PAGE_SIZE, so
-                // the write stays within the allocated page.
+                // SAFETY: dest (vaddr) is identity-mapped DRAM within
+                // user-accessible RAM (validated by #318's
+                // validate_user_buffer check above). byte_offset -
+                // page_start < PAGE_SIZE, so the write stays within the
+                // segment's declared page range.
                 unsafe {
                     dest_ptr.add(byte_offset - page_start).write(val);
                 }
             }
-
-            // NOTE: page_addr is unused because we write to vaddr directly
-            // In a real implementation with separate page tables per process,
-            // we'd map page_addr to vaddr in the process's page table
-            let _ = page_addr;
         }
     }
 
@@ -331,6 +444,92 @@ mod tests {
         assert_eq!(validate(&h).unwrap_err(), ElfError::InvalidSegment);
     }
 
+    /// #316: e_phoff chosen so `phoff + i*phentsize` would wrap a 32-bit
+    /// usize (this crate's host tests run on i686, so the wrap reproduces
+    /// without a target-width mock) and bypass the bounds guard.
+    #[test]
+    fn parse_rejects_phoff_overflow_near_u32_max() {
+        let mut h = make_valid_ehdr();
+        h[44] = 1; // e_phnum = 1
+        // e_phoff (offset 28): chosen so phoff + i*phentsize wraps a 32-bit usize.
+        h[28..32].copy_from_slice(&0xFFFF_FFF0u32.to_le_bytes());
+        assert_eq!(validate(&h).unwrap_err(), ElfError::InvalidSegment);
+    }
+
+    /// #316: p_offset/p_filesz chosen so `file_offset + filesz` would wrap
+    /// a 32-bit usize, attempting to smuggle a bogus segment past the
+    /// file-extent bounds guard.
+    #[test]
+    fn parse_rejects_file_extent_overflow() {
+        let mut buf = [0u8; ELF32_EHDR_SIZE + ELF32_PHDR_SIZE];
+        let h = make_valid_ehdr();
+        buf[..ELF32_EHDR_SIZE].copy_from_slice(&h);
+        buf[44] = 1; // e_phnum = 1
+
+        // Elf32Phdr at offset 52: p_type = PT_LOAD (1).
+        buf[52..56].copy_from_slice(&1u32.to_le_bytes());
+        // p_offset (offset 56): chosen so file_offset + filesz wraps a 32-bit usize.
+        buf[56..60].copy_from_slice(&0xFFFF_FFF0u32.to_le_bytes());
+        // p_filesz (offset 68) and p_memsz (offset 72): 0x100.
+        buf[68..72].copy_from_slice(&0x100u32.to_le_bytes());
+        buf[72..76].copy_from_slice(&0x100u32.to_le_bytes());
+
+        assert_eq!(validate(&buf).unwrap_err(), ElfError::InvalidSegment);
+    }
+
+    /// #317: e_phentsize smaller than size_of::<Elf32Phdr>() must be
+    /// rejected before any phdr is read, not admitted by a bounds check
+    /// that trusts the attacker-controlled stride.
+    #[test]
+    fn parse_rejects_phentsize_smaller_than_phdr() {
+        let mut h = make_valid_ehdr();
+        h[44] = 1; // e_phnum = 1
+        // e_phentsize (offset 42): 16, well under the real 32-byte Elf32Phdr.
+        h[42] = 16;
+        assert_eq!(validate(&h).unwrap_err(), ElfError::InvalidSegment);
+    }
+
+    /// #318: a PT_LOAD segment whose p_vaddr lies outside the sanctioned
+    /// user-accessible DRAM load region must be rejected before any byte
+    /// is written.
+    #[test]
+    fn parse_rejects_vaddr_outside_load_region() {
+        let mut buf = [0u8; ELF32_EHDR_SIZE + ELF32_PHDR_SIZE];
+        let h = make_valid_ehdr();
+        buf[..ELF32_EHDR_SIZE].copy_from_slice(&h);
+        buf[44] = 1; // e_phnum = 1
+
+        // Elf32Phdr at offset 52: p_type = PT_LOAD (1).
+        buf[52..56].copy_from_slice(&1u32.to_le_bytes());
+        // p_vaddr (offset 60): well below user-accessible DRAM.
+        buf[60..64].copy_from_slice(&0x1000u32.to_le_bytes());
+        // p_memsz (offset 72): 0x1000.
+        buf[72..76].copy_from_slice(&0x1000u32.to_le_bytes());
+
+        assert_eq!(validate(&buf).unwrap_err(), ElfError::InvalidSegment);
+    }
+
+    /// #327: a PT_LOAD segment declaring memory far beyond the configured
+    /// per-image budget must be rejected before any page is allocated.
+    #[test]
+    fn parse_rejects_segment_memory_over_budget() {
+        let mut buf = [0u8; ELF32_EHDR_SIZE + ELF32_PHDR_SIZE];
+        let h = make_valid_ehdr();
+        buf[..ELF32_EHDR_SIZE].copy_from_slice(&h);
+        buf[44] = 1; // e_phnum = 1
+
+        // Elf32Phdr at offset 52: p_type = PT_LOAD (1).
+        buf[52..56].copy_from_slice(&1u32.to_le_bytes());
+        // p_vaddr (offset 60): kconfig::KERNEL_END, inside the allowed load
+        // region so #318's check does not fire first.
+        buf[60..64].copy_from_slice(&0x4010_0000u32.to_le_bytes());
+        // p_memsz (offset 72): 32 MB, comfortably inside RAM but four times
+        // over MAX_ELF_PAGES (2048 pages = 8 MB).
+        buf[72..76].copy_from_slice(&0x0200_0000u32.to_le_bytes());
+
+        assert_eq!(validate(&buf).unwrap_err(), ElfError::InvalidSegment);
+    }
+
     #[test]
     fn parse_accepts_valid_elf() {
         // A valid ELF header with phnum=0 should parse successfully
@@ -340,5 +539,105 @@ mod tests {
             .expect("valid ELF header with no segments must parse");
         assert_eq!(entry, 0x8000, "entry point must match e_entry");
         assert_eq!(validated.count, 0, "no PT_LOAD segments expected");
+    }
+
+    // ---- #328: load() must not leak physical pages ----
+
+    /// #328: a successful load must not permanently consume physical pages
+    /// from the allocator — the old per-page `page::alloc_page()` call
+    /// reserved a frame whose address was immediately discarded (data is
+    /// written to `vaddr`, not the reserved frame) and never freed it,
+    /// leaking one page per loaded page on every exec.
+    #[cfg(target_pointer_width = "32")]
+    #[test]
+    fn load_does_not_leak_pages_on_success() {
+        // WHY function-local `static mut`: load() writes segment bytes
+        // directly to the ELF's p_vaddr. This binary's PIE image (hence any
+        // `static`) loads inside [kconfig::KERNEL_END, kconfig::RAM_END) on
+        // this host toolchain, so its address passes validate_user_buffer
+        // and is safe to dereference — unlike a fabricated physical address
+        // or a stack array (glibc places thread stacks above RAM_END).
+        static mut BUF: [u8; 16] = [0u8; 16];
+        // WHY no unsafe: addr_of_mut! only forms the static's address; it
+        // does not dereference it, so this line needs no unsafe block —
+        // only reading/writing through the resulting pointer would.
+        let vaddr = core::ptr::addr_of_mut!(BUF) as *mut u8 as usize;
+
+        let mut data = [0u8; ELF32_EHDR_SIZE + ELF32_PHDR_SIZE + 4];
+        let h = make_valid_ehdr();
+        data[..ELF32_EHDR_SIZE].copy_from_slice(&h);
+        data[44] = 1; // e_phnum = 1
+
+        // Elf32Phdr at offset 52: p_type = PT_LOAD (1).
+        data[52..56].copy_from_slice(&1u32.to_le_bytes());
+        // p_offset (offset 56): file data starts right after the phdr.
+        let file_offset = (ELF32_EHDR_SIZE + ELF32_PHDR_SIZE) as u32;
+        data[56..60].copy_from_slice(&file_offset.to_le_bytes());
+        // p_vaddr (offset 60): the scratch buffer's real address.
+        data[60..64].copy_from_slice(&(vaddr as u32).to_le_bytes());
+        // p_filesz (offset 68): 4 bytes of real content.
+        data[68..72].copy_from_slice(&4u32.to_le_bytes());
+        // p_memsz (offset 72): 16 bytes total (12 bytes BSS beyond filesz).
+        data[72..76].copy_from_slice(&16u32.to_le_bytes());
+        data[84..88].copy_from_slice(b"TEST");
+
+        // Free pool large enough for the 1 page this segment rounds up to.
+        // SAFETY: test-only page-allocator state; single-threaded per test
+        // (matches the established page::init() test precedent).
+        unsafe {
+            page::init(0x4000_0000, 0x4000_0000 + 8 * page::PAGE_SIZE, 0x4000_0000 + 4 * page::PAGE_SIZE);
+        }
+        let free_before = page::free_count();
+        assert_eq!(free_before, 4, "test setup must yield exactly 4 free pages");
+
+        let loaded = load(&data).expect("well-formed single-page segment must load");
+        assert_eq!(loaded.pages_used, 1, "a 16-byte segment must round up to exactly 1 page");
+
+        // SAFETY: BUF is a private test-only static, read after load() wrote
+        // to its address.
+        unsafe {
+            assert_eq!(&BUF[..4], b"TEST", "file bytes must be copied to vaddr");
+            assert_eq!(&BUF[4..16], &[0u8; 12], "bytes beyond filesz must be BSS-zeroed");
+        }
+
+        assert_eq!(
+            page::free_count(), free_before,
+            "a successful load must not permanently consume any page from the allocator (#328)"
+        );
+    }
+
+    /// #328: when the free pool is smaller than the segment budget, load()
+    /// must reject up front (before writing anything) rather than fail
+    /// partway through — there is no partial state to roll back because no
+    /// allocation happens until after this check passes.
+    #[cfg(target_pointer_width = "32")]
+    #[test]
+    fn load_oom_precheck_rejects_before_any_write() {
+        static mut BUF: [u8; 16] = [0u8; 16];
+        // WHY no unsafe: addr_of_mut! only forms the static's address; it
+        // does not dereference it, so this line needs no unsafe block —
+        // only reading/writing through the resulting pointer would.
+        let vaddr = core::ptr::addr_of_mut!(BUF) as *mut u8 as usize;
+
+        let mut data = [0u8; ELF32_EHDR_SIZE + ELF32_PHDR_SIZE];
+        let h = make_valid_ehdr();
+        data[..ELF32_EHDR_SIZE].copy_from_slice(&h);
+        data[44] = 1; // e_phnum = 1
+        data[52..56].copy_from_slice(&1u32.to_le_bytes()); // p_type = PT_LOAD
+        data[60..64].copy_from_slice(&(vaddr as u32).to_le_bytes());
+        data[72..76].copy_from_slice(&16u32.to_le_bytes()); // p_memsz = 16
+
+        // Empty free pool: usable range collapses to zero pages.
+        // SAFETY: test-only page-allocator state; single-threaded per test.
+        unsafe {
+            page::init(0x4000_0000, 0x4000_0000, 0x4000_0000);
+        }
+        assert_eq!(page::free_count(), 0, "test setup must yield zero free pages");
+
+        let result = load(&data);
+        assert_eq!(result.unwrap_err(), ElfError::OutOfMemory,
+            "a segment budget exceeding the free pool must be rejected up front");
+
+        assert_eq!(unsafe { BUF }, [0u8; 16], "no byte may be written before the OOM precheck passes");
     }
 }


### PR DESCRIPTION
## Summary

`execve` loads an attacker-influenced ELF from ramfs, so the loader's header math and write targets are a direct attack surface. On the 32-bit target (and the i686 host tests), plain `usize` arithmetic on `u32` header fields wraps silently.

- **#316** — the phdr-stride offset, the file-extent check, and the segment byte-read all used unchecked add/mul on attacker-controlled fields; a crafted `phoff`/`phentsize`/`p_offset` could wrap the bounds guard. Now `checked_mul`/`checked_add` reject a wrapping header with `InvalidSegment`.
- **#317** — the phdr bounds check trusted the header-declared `e_phentsize` while the read always consumes `size_of::<Elf32Phdr>()` (32) bytes; a `phentsize < 32` admitted an offset whose read overran the buffer. Now a `phentsize` floor is enforced and the check pins to `PHDR_SIZE`.
- **#318** (security) — `p_vaddr` was a fully attacker-controlled physical write target (segments write straight to `vaddr` under identity mapping) — an arbitrary-write primitive. Every `[vaddr, vaddr+memsz)` is now validated against sanctioned user-accessible DRAM (`memguard::validate_user_buffer`) before any byte is written.
- **#327** — total segment memory was unbounded; a crafted `p_memsz` could drive an unbounded page-count computation / physical exhaustion. Bounded to `MAX_ELF_PAGES` (8 MB) via checked arithmetic.
- **#328** — `load()` called `page::alloc_page()` per segment page and immediately discarded the address (writes go to `vaddr`, not the frame), leaking every page on every load. The vestigial allocation is removed; the only physical-memory gate is a single up-front `free_count()` budget check. A successful load allocates nothing; a failing one fails before the first write (no partial state to roll back).

## Closes

Closes #316, #317, #318, #327, #328

## Verification

- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — 1740 passed (+7): overflow, phentsize-floor, vaddr-region, memory-budget, and two page-leak tests (asserting `free_count()` is unchanged across a successful load and that OOM rejects before any write).
- `cargo build --release --target armv7a-none-eabi` — compiles
- `kanon lint . --summary` — clean

## Note

#215 (in the same exec/syscall-memory-safety area) was found already-fixed by #405 (`validate_user_buffer` in `fd::sys_write`) and closed separately with a citation.