### PR TITLE
Close 9 test-coverage gaps (crypto KATs, allocator exhaustion, LFS persistence)

### DIFF
--- a/crates/thumos/src/csprng.rs
+++ b/crates/thumos/src/csprng.rs
@@ -361,7 +361,14 @@ pub fn seed_for_test(key: &[u8; 32], nonce: &[u8; 8], counter: u64) {
     rng.set_stream(u64::from_le_bytes(*nonce));
     // set_word_pos is measured in 32-bit words; one 64-byte block = 16 words.
     rng.set_word_pos(u128::from(counter) * 16);
-    // SAFETY: test-only, single-threaded.
+    // SAFETY: cargo-nextest (the canonical runner for this crate/target — see
+    // ci.yml) spawns a fresh OS process per #[test] fn, so CSPRNG/INITIALIZED
+    // here are process-local: no other test's mutation of these statics is ever
+    // visible to this one, regardless of --test-threads. This is process
+    // isolation, not single-threaded execution (nextest parallelizes freely) —
+    // a different mechanism giving the same absence-of-data-race guarantee.
+    // WARNING: this does NOT hold under a bare `cargo test` inside crates/thumos/
+    // (threads in one process); nextest is enforced by CI, not by this code.
     unsafe {
         CSPRNG = Some(Csprng {
             rng,
@@ -527,5 +534,33 @@ mod tests {
             buf, [0xFFu8; 16],
             "buffer must be left untouched on fail-closed"
         );
+    }
+
+    #[test]
+    fn chacha20_rfc8439_test_vector_1() {
+        // NOTE: RFC 8439 §2.3.2 / Appendix A.1 Test Vector #1 — all-zero key,
+        // all-zero nonce, block counter 0. WHY it applies to rand_chacha 0.3.1's
+        // 64-bit-counter/64-bit-stream layout despite RFC 8439 using a
+        // 32-bit-counter/96-bit-nonce split: state words 12-15 are all zero in
+        // BOTH layouts here, so the initial state (hence the keystream) is
+        // identical — the published block applies directly, no derived vector.
+        let key = [0u8; 32];
+        let nonce = [0u8; 8];
+        seed_for_test(&key, &nonce, 0);
+
+        let mut buf = [0u8; 64];
+        kernel_random_bytes(&mut buf).expect("seeded test rng");
+
+        let expected: [u8; 64] = [
+            0x76, 0xb8, 0xe0, 0xad, 0xa0, 0xf1, 0x3d, 0x90,
+            0x40, 0x5d, 0x6a, 0xe5, 0x53, 0x86, 0xbd, 0x28,
+            0xbd, 0xd2, 0x19, 0xb8, 0xa0, 0x8d, 0xed, 0x1a,
+            0xa8, 0x36, 0xef, 0xcc, 0x8b, 0x77, 0x0d, 0xc7,
+            0xda, 0x41, 0x59, 0x7c, 0x51, 0x57, 0x48, 0x8d,
+            0x77, 0x24, 0xe0, 0x3f, 0xb8, 0xd8, 0x4a, 0x37,
+            0x6a, 0x43, 0xb8, 0xf4, 0x15, 0x18, 0xa1, 0x1c,
+            0xc3, 0x87, 0xb6, 0x69, 0xb2, 0xee, 0x65, 0x86,
+        ];
+        assert_eq!(buf, expected, "ChaCha20 block 0 must match RFC 8439 Test Vector #1");
     }
 }

--- a/crates/thumos/src/lfs.rs
+++ b/crates/thumos/src/lfs.rs
@@ -1574,11 +1574,11 @@ mod tests {
     }
 
     #[test]
-    fn write_file_data_persists_across_unmount_remount() {
+    fn write_sync_remount_persists_data() {
         let mut dev = block_device_for_lfs();
         format(&mut dev).expect("format");
 
-        // Write phase.
+        // First mount: write data and sync (checkpoint) it to the device.
         let mut fs = mount(Box::new(dev)).expect("mount");
         let root = fs.root_inode();
         let file_id = fs
@@ -1591,31 +1591,23 @@ mod tests {
 
         fs.sync().expect("sync");
 
-        // Extract the device for remount by taking ownership.
+        // WHY this is the real persistence boundary a reboot crosses: the
+        // in-memory Lfs is dropped, but the device bytes (including the
+        // checkpoint sync() just wrote) are handed intact to a fresh mount().
+        // fs.dev is RefCell<Box<dyn BlockDevice>>; into_inner() yields exactly
+        // the Box<dyn BlockDevice> that mount() consumes — no downcast needed,
+        // so the old test's stated blocker was spurious.
         let boxed_dev = fs.dev.into_inner();
-        // Re-mount from the same device. To get a MemBlockDevice back from
-        // Box<dyn BlockDevice>, we need to read the raw data. Instead, we
-        // verify the write persisted in the same mount.
-        drop(boxed_dev);
 
-        // Alternative: verify within the same mount that read returns correct data.
-        let mut dev2 = block_device_for_lfs();
-        format(&mut dev2).expect("format 2");
+        let fs2 = mount(boxed_dev).expect("remount");
 
-        let mut fs2 = mount(Box::new(dev2)).expect("mount 2");
-        let root2 = fs2.root_inode();
-        let file_id2 = fs2
-            .create(root2, "data.bin", InodeType::RegularFile)
-            .expect("create 2");
-
-        let data2 = b"Hello, LFS write path!";
-        fs2.write(file_id2, 0, data2).expect("write 2");
-
-        // Read back within the same mount.
         let mut buf = [0u8; 64];
-        let read = fs2.read(file_id2, 0, &mut buf).expect("read");
-        assert_eq!(read, 22);
-        assert_eq!(&buf[..22], b"Hello, LFS write path!");
+        let read = fs2.read(file_id, 0, &mut buf).expect("read after remount");
+        assert_eq!(read, data.len());
+        assert_eq!(
+            &buf[..data.len()], data,
+            "data written before sync must survive a real remount"
+        );
     }
 
     #[test]
@@ -1691,6 +1683,43 @@ mod tests {
 
         let stat = fs.stat(file_id).expect("stat after truncate");
         assert_eq!(stat.size, 100);
+    }
+
+    #[test]
+    fn truncate_grows_file_with_zeroed_extension() {
+        let mut dev = block_device_for_lfs();
+        format(&mut dev).expect("format");
+
+        let mut fs = mount(Box::new(dev)).expect("mount");
+        let root = fs.root_inode();
+
+        let file_id = fs
+            .create(root, "grow.txt", InodeType::RegularFile)
+            .expect("create");
+
+        // WHY payload confined to block 0: keeps the read-back assertion below
+        // targeting only the block the grow branch allocated, never write()'s
+        // own same-block zero padding.
+        let data = b"seed data";
+        let written = fs.write(file_id, 0, data).expect("write");
+        assert_eq!(written, data.len());
+
+        // NOTE: old_blocks=ceil(9/4096)=1, new_blocks=ceil(8192/4096)=2, so the
+        // grow loop runs once (block index 1) — exercises truncate's grow
+        // branch (ensure_writer + zeroed-block allocation), not the shrink path.
+        let new_size: u64 = 8192;
+        fs.truncate(file_id, new_size).expect("truncate grow");
+
+        let stat = fs.stat(file_id).expect("stat after grow");
+        assert_eq!(stat.size, new_size, "size must report the grown length");
+
+        let mut buf = [0u8; BLOCK_SIZE];
+        let read = fs.read(file_id, BLOCK_SIZE as u64, &mut buf).expect("read grown block");
+        assert_eq!(read, buf.len());
+        assert!(
+            buf.iter().all(|&b| b == 0),
+            "the newly grown block must read back zero, not stale memory"
+        );
     }
 
     #[test]

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -1403,6 +1403,56 @@ mod tests {
     }
 
     #[test]
+    fn fork_strips_privileged_capabilities() {
+        // SAFETY: test-only; reset_all reinitialises global state. Single-threaded
+        // test execution ensures no concurrent access to PROCS or CURRENT.
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            let pt = mmu::alloc_addr_space().unwrap();
+            procs[0] = Some(Process {
+                pid: 0,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: None,
+                exit_status: 0,
+                page_table_phys: pt,
+                stack_base: 0,
+                stack_pages: 0,
+                heap_break: DEFAULT_HEAP_BREAK,
+                mappings: [None; MAX_MAPPINGS],
+                signal_state: SignalState::new(),
+                uid: 0,
+                wake_tick: 0,
+                capabilities: crate::capability::Capabilities::ALL,
+            });
+            CURRENT = 0;
+
+            let child_pid = fork().unwrap_or_default();
+            let procs = &*core::ptr::addr_of!(PROCS);
+            let parent_caps = procs[0].as_ref().unwrap().capabilities;
+            let child_caps = procs[usize::from(child_pid)].as_ref().unwrap().capabilities;
+
+            // WHY: production computes child_caps = parent_caps & FORK_DEFAULT
+            // (process.rs). A `|`-for-`&` slip would grant the child every
+            // parent capability, including MODEM (baseband) and AUDIT (log).
+            assert_eq!(
+                child_caps,
+                parent_caps & crate::capability::Capabilities::FORK_DEFAULT,
+                "child capabilities must equal parent_caps & FORK_DEFAULT"
+            );
+            assert_eq!(
+                child_caps & crate::capability::Capabilities::MODEM, 0,
+                "MODEM must be stripped from a forked child"
+            );
+            assert_eq!(
+                child_caps & crate::capability::Capabilities::AUDIT, 0,
+                "AUDIT must be stripped from a forked child"
+            );
+        }
+    }
+
+    #[test]
     fn address_space_independence() {
         // SAFETY: test-only; reset_all reinitialises global state. Single-threaded
         // test execution ensures no concurrent access to PROCS or CURRENT.
@@ -2122,6 +2172,90 @@ mod tests {
             let expected_bit = 1u32 << (crate::signal::Signal::Sigusr1 as u32);
             assert_ne!(pending & expected_bit, 0,
                 "SIGUSR1 pending bit should be set after kill");
+        }
+    }
+
+    #[test]
+    fn check_pending_signal_returns_handler() {
+        // SAFETY: test-only; reset_all reinitialises global state. Single-threaded
+        // test execution ensures no concurrent access to PROCS or CURRENT.
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            let pt = mmu::alloc_addr_space().unwrap();
+            procs[0] = Some(Process {
+                pid: 0,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: None,
+                exit_status: 0,
+                page_table_phys: pt,
+                stack_base: 0,
+                stack_pages: 0,
+                heap_break: DEFAULT_HEAP_BREAK,
+                mappings: [None; MAX_MAPPINGS],
+                signal_state: SignalState::new(),
+                uid: 0,
+                wake_tick: 0,
+                capabilities: crate::capability::Capabilities::ALL,
+            });
+            CURRENT = 0;
+
+            let child_pid = fork().unwrap_or_default();
+
+            // NOTE: install the handler on the child (set_signal_action acts on CURRENT).
+            CURRENT = child_pid;
+            let handler_addr: u32 = 0x4020_0000;
+            set_signal_action(
+                crate::signal::Signal::Sigusr1,
+                crate::signal::SignalAction::Handler(handler_addr),
+            );
+            CURRENT = 0;
+
+            // WHY: with a Handler action installed, deliver_signal_to marks the
+            // signal pending (rather than applying the default Terminate).
+            let ret = deliver_signal_to(child_pid, crate::signal::Signal::Sigusr1);
+            assert_eq!(ret, 0, "deliver_signal_to should succeed");
+
+            // NOTE: check_pending_signal reads CURRENT's state — switch to the
+            // child as the exception-return path does after scheduling it.
+            CURRENT = child_pid;
+            let result = check_pending_signal();
+            assert_eq!(
+                result,
+                Some((crate::signal::Signal::Sigusr1, handler_addr)),
+                "a pending signal with a Handler action must yield (sig, handler_addr)"
+            );
+        }
+    }
+
+    #[test]
+    fn check_pending_signal_none_when_clear() {
+        // SAFETY: test-only; reset_all reinitialises global state.
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            let pt = mmu::alloc_addr_space().unwrap();
+            procs[0] = Some(Process {
+                pid: 0,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: None,
+                exit_status: 0,
+                page_table_phys: pt,
+                stack_base: 0,
+                stack_pages: 0,
+                heap_break: DEFAULT_HEAP_BREAK,
+                mappings: [None; MAX_MAPPINGS],
+                signal_state: SignalState::new(),
+                uid: 0,
+                wake_tick: 0,
+                capabilities: crate::capability::Capabilities::ALL,
+            });
+            CURRENT = 0;
+
+            let result = check_pending_signal();
+            assert_eq!(result, None, "no pending signal must yield None");
         }
     }
 

--- a/crates/thumos/src/security.rs
+++ b/crates/thumos/src/security.rs
@@ -628,6 +628,23 @@ mod tests {
         assert_eq!(mac, expected, "HMAC-SHA256 RFC 4231 test case 2");
     }
 
+    #[test]
+    fn hmac_sha256_rfc4231_test_case_6() {
+        // NOTE: RFC 4231 Test Case 6 — key = 131 bytes of 0xaa, longer than the
+        // 64-byte SHA-256 block size; exercises the long-key normalization
+        // path (now owned by RustCrypto Hmac::new_from_slice) end-to-end.
+        let key = [0xaau8; 131];
+        let data = b"Test Using Larger Than Block-Size Key - Hash Key First";
+        let mac = hmac_sha256(key.as_slice(), data);
+        let expected = [
+            0x60, 0xe4, 0x31, 0x59, 0x1e, 0xe0, 0xb6, 0x7f,
+            0x0d, 0x8a, 0x26, 0xaa, 0xcb, 0xf5, 0xb7, 0x7f,
+            0x8e, 0x0b, 0xc6, 0x21, 0x37, 0x28, 0xc5, 0x14,
+            0x05, 0x46, 0x04, 0x0f, 0x0e, 0xe3, 0x7f, 0x54,
+        ];
+        assert_eq!(mac, expected, "HMAC-SHA256 RFC 4231 test case 6 (long key)");
+    }
+
     // -- PBKDF2 tests --
 
     #[test]
@@ -754,6 +771,21 @@ mod tests {
             0x16, 0xd5, 0xf1, 0x84, 0xdf, 0x9c, 0x25, 0x9a, 0x7c, 0x79,
         ];
         assert_eq!(mac, expected, "HMAC-SHA1 RFC 2202 test case 2");
+    }
+
+    #[test]
+    fn hmac_sha1_rfc2202_test_case_6() {
+        // NOTE: RFC 2202 Test Case 6 — key = 80 bytes of 0xaa, longer than the
+        // 64-byte SHA-1 block size; exercises hmac_sha1's hand-rolled
+        // key-hashing normalization branch (key.len() > SHA1_BLOCK_SIZE).
+        let key = [0xaau8; 80];
+        let data = b"Test Using Larger Than Block-Size Key - Hash Key First";
+        let mac = hmac_sha1(key.as_slice(), data);
+        let expected = [
+            0xaa, 0x4a, 0xe5, 0xe1, 0x52, 0x72, 0xd0, 0x0e, 0x95, 0x70,
+            0x56, 0x37, 0xce, 0x8a, 0x3b, 0x55, 0xed, 0x40, 0x21, 0x12,
+        ];
+        assert_eq!(mac, expected, "HMAC-SHA1 RFC 2202 test case 6 (long key)");
     }
 
     // -- PBKDF2-HMAC-SHA1 tests (RFC 6070 test vectors) --

--- a/crates/thumos/src/slab.rs
+++ b/crates/thumos/src/slab.rs
@@ -639,4 +639,119 @@ mod tests {
             assert_eq!(sa.large_free_count, 1, "large_free_count incremented");
         }
     }
+
+    // WHY a second, scarce fake page_fn: the shared fake_alloc_page pool holds
+    // TEST_PAGES(64) pages, well above MAX_SLABS(32), so a single size class
+    // always trips MAX_SLABS before the page pool empties — a distinct 3-page
+    // source is needed to isolate refill's page_fn()==None branch.
+    static mut TEST_SCARCE_NEXT_PAGE: usize = 0;
+    const TEST_SCARCE_PAGES: usize = 3;
+
+    unsafe fn fake_alloc_page_scarce() -> Option<usize> {
+        // SAFETY: single-threaded test execution; TEST_SCARCE_NEXT_PAGE is private.
+        unsafe {
+            if TEST_SCARCE_NEXT_PAGE >= TEST_SCARCE_PAGES {
+                return None;
+            }
+            let base = core::ptr::addr_of_mut!(TEST_POOL) as *mut u8 as usize;
+            let addr = base + TEST_SCARCE_NEXT_PAGE * page::PAGE_SIZE;
+            TEST_SCARCE_NEXT_PAGE += 1;
+            Some(addr)
+        }
+    }
+
+    #[test]
+    fn slab_exhaustion_returns_null_after_max_slabs() {
+        // SAFETY: test is single-threaded; sa is local.
+        unsafe {
+            let mut sa = make_allocator();
+            let layout = Layout::from_size_align(32, 4).unwrap();
+            // WHY the 32B class: PAGE_SIZE/32 objects per slab page, so
+            // MAX_SLABS pages of capacity stay under TEST_PAGES — the null
+            // below is the MAX_SLABS guard in refill(), not page exhaustion.
+            let objs_per_slab = page::PAGE_SIZE / 32;
+            let total_capacity = objs_per_slab * MAX_SLABS;
+            for _ in 0..total_capacity {
+                let ptr = sa.alloc_inner(layout, fake_alloc_page, fake_alloc_page);
+                assert!(!ptr.is_null(), "allocation within MAX_SLABS capacity must succeed");
+            }
+            let ptr = sa.alloc_inner(layout, fake_alloc_page, fake_alloc_page);
+            assert!(ptr.is_null(), "allocation beyond MAX_SLABS must return null, not panic");
+        }
+    }
+
+    #[test]
+    fn page_allocator_exhaustion_returns_null() {
+        // SAFETY: single-threaded; sa is local; the scarce page_fn holds only
+        // TEST_SCARCE_PAGES(3) pages, far below MAX_SLABS, isolating the
+        // page_fn()==None branch from the MAX_SLABS cap.
+        unsafe {
+            let mut sa = make_allocator();
+            let layout = Layout::from_size_align(32, 4).unwrap();
+            let objs_per_slab = page::PAGE_SIZE / 32;
+            for _ in 0..(objs_per_slab * TEST_SCARCE_PAGES) {
+                let ptr = sa.alloc_inner(layout, fake_alloc_page_scarce, fake_alloc_page_scarce);
+                assert!(!ptr.is_null(), "allocation within the scarce page budget must succeed");
+            }
+            let ptr = sa.alloc_inner(layout, fake_alloc_page_scarce, fake_alloc_page_scarce);
+            assert!(
+                ptr.is_null(),
+                "allocation once the page allocator is exhausted must return null, not panic"
+            );
+        }
+    }
+
+    #[test]
+    fn oversized_allocation_rejected() {
+        // SAFETY: test is single-threaded; sa is local.
+        unsafe {
+            let mut sa = make_allocator();
+            // WHY 4097: needs 2 pages; multi-page large allocs are unsupported
+            // and must be rejected before the page allocator is touched.
+            let layout = Layout::from_size_align(4097, 1).unwrap();
+            let ptr = sa.alloc_inner(layout, fake_alloc_page, fake_alloc_page);
+            assert!(ptr.is_null(), "a >4096-byte request must be rejected, not silently truncated");
+            assert_eq!(
+                sa.large_alloc_count, 0,
+                "a rejected multi-page request must not be counted as a successful large alloc"
+            );
+        }
+    }
+
+    #[test]
+    fn uninitialized_allocator_returns_null() {
+        // SAFETY: single-threaded; sa is local; init() deliberately not called.
+        unsafe {
+            let mut sa = SlabAllocator::new();
+            let layout = Layout::from_size_align(32, 4).unwrap();
+            let ptr = sa.alloc_inner(layout, fake_alloc_page, fake_alloc_page);
+            assert!(ptr.is_null(), "alloc on an uninitialized allocator must return null, not panic");
+        }
+    }
+
+    #[test]
+    fn uninitialized_dealloc_is_noop() {
+        // SAFETY: single-threaded; sa is local; init() deliberately not called.
+        // WHY the bogus non-null ptr: if the !initialized guard were removed,
+        // dealloc_obj would dereference it — the guard must bail out first.
+        unsafe {
+            let mut sa = SlabAllocator::new();
+            let layout = Layout::from_size_align(32, 4).unwrap();
+            let fake_ptr = 0x1000 as *mut u8;
+            sa.dealloc_inner(fake_ptr, layout, fake_free_page);
+            assert_eq!(sa.stats(), (0, 0), "dealloc on an uninitialized allocator must be a pure no-op");
+        }
+    }
+
+    #[test]
+    fn null_ptr_dealloc_is_noop() {
+        // SAFETY: test is single-threaded; sa is local.
+        unsafe {
+            let mut sa = make_allocator();
+            let layout = Layout::from_size_align(32, 4).unwrap();
+            sa.dealloc_inner(ptr::null_mut(), layout, fake_free_page);
+            let (_, frees) = sa.stats();
+            assert_eq!(frees, 0, "dealloc(null) on an initialized allocator must be a no-op, not decrement/crash");
+        }
+    }
 }

--- a/crates/thumos/src/telephony_parser.rs
+++ b/crates/thumos/src/telephony_parser.rs
@@ -321,6 +321,51 @@ mod tests {
     }
 
     #[test]
+    fn parse_final_result_ok() {
+        assert_eq!(
+            parse_final_result(b"OK"),
+            Some(AtResponse::Ok),
+            "a bare OK line must classify as AtResponse::Ok"
+        );
+    }
+
+    #[test]
+    fn parse_final_result_error() {
+        assert_eq!(
+            parse_final_result(b"ERROR"),
+            Some(AtResponse::Error),
+            "a bare ERROR line must classify as AtResponse::Error"
+        );
+    }
+
+    #[test]
+    fn parse_final_result_recognizes_cme_error() {
+        assert_eq!(
+            parse_final_result(b"+CME ERROR: 10"),
+            Some(AtResponse::CmeError(10)),
+            "+CME ERROR must extract its numeric code into AtResponse::CmeError"
+        );
+    }
+
+    #[test]
+    fn parse_final_result_malformed_cme_code_returns_none() {
+        assert_eq!(
+            parse_final_result(b"+CME ERROR: x"),
+            None,
+            "a non-numeric CME error code must not classify as any final result"
+        );
+    }
+
+    #[test]
+    fn parse_final_result_unrecognized_line_returns_none() {
+        assert_eq!(
+            parse_final_result(b"OKK"),
+            None,
+            "a near-miss line must not be classified as OK by prefix/substring confusion"
+        );
+    }
+
+    #[test]
     fn parse_clip_response_extracts_number() {
         let line = b"+CLIP: \"+15551234567\",145";
         let mut number = [0u8; MAX_NUMBER_LEN];


### PR DESCRIPTION
Adds the missing tests the audit flagged — each exercises a real branch a prior wave built but never verified.

- **#275** fork() capability stripping (child caps = parent & FORK_DEFAULT, MODEM/AUDIT cleared)
- **#276** check_pending_signal() Handler arm end-to-end + None path
- **#308** ChaCha20 RFC 8439 A.1 Test Vector #1 KAT through the real seed→bytes path (crate is now rand_chacha-backed)
- **#309** LFS truncate grow-file branch
- **#310** LFS write→sync→**real** remount persistence (the old same-named test never actually remounted — replaced with an `into_inner()`→`mount()` round-trip)
- **#312** HMAC-SHA256 (RFC 4231 TC6) + HMAC-SHA1 (RFC 2202 TC6) long-key KATs
- **#335** slab exhaustion / page-exhaustion / oversized-rejection / uninitialized / null-dealloc (all 6 null-return paths)
- **#336** parse_final_result outcome matrix (Ok/Error/+CME ERROR/malformed None; CmsError already covered by #258)
- **#298** corrects the false "single-threaded" CSPRNG SAFETY comment to the real reason (nextest process isolation)

Closes #275, #276, #308, #309, #310, #312, #335, #336, #298

**Verification:** kernel nextest 1740→1758; armv7a compiles; kanon lint clean. All crypto vectors are published KATs (RFC 8439/4231/2202).