### PR TITLE
Kernel memory-safety: IRQ-safe allocators, PL1-only mapping, L2 reclaim (4 fixes)

### DIFF
--- a/crates/thumos/src/irq.rs
+++ b/crates/thumos/src/irq.rs
@@ -1,0 +1,230 @@
+//! IRQ-mask primitives for IRQ-safe critical sections.
+//!
+//! On the single-core MT6739 boot CPU, the only concurrent caller of a
+//! kernel data structure guarded by a plain spinlock is an IRQ handler
+//! running on top of interrupted non-IRQ code. A spinlock's atomic flag
+//! alone does not stop that reentrancy -- it converts it into a
+//! self-deadlock: if the IRQ fires while the interrupted context holds the
+//! lock and the handler tries to acquire it too, the handler spins forever
+//! on a lock the interrupted context can never release, because IRQ
+//! handlers run to completion before the interrupted context resumes
+//! (#322, #331). Masking IRQ delivery (the CPSR I-bit) for the duration of
+//! the critical section is what actually prevents that: while masked, the
+//! IRQ cannot fire at all, so it cannot observe the lock held.
+//!
+//! # Host testability
+//!
+//! The ARM CPSR I-bit is not observable off-target. The save/nest/restore
+//! CONTRACT -- a nested mask must not let an inner `restore` prematurely
+//! unmask an outer critical section -- is architecture-independent, so it is
+//! mirrored here through a mock global flag under
+//! `cfg(not(target_arch = "arm"))`, giving [`disable`]/[`restore`] (and
+//! everything built on them) the same tested contract on the host i686
+//! target used by `cargo nextest`.
+
+use core::sync::atomic::{AtomicBool, Ordering};
+
+/// Host-test mock of "IRQ delivery enabled" -- unused on the real ARM target,
+/// where the CPSR I-bit is the actual mask.
+#[cfg(not(target_arch = "arm"))]
+static MOCK_IRQ_ENABLED: AtomicBool = AtomicBool::new(true);
+
+/// Mask IRQ delivery on this core and return the prior mask state, for use
+/// with [`restore`]. Safe to call with IRQs already masked (nests
+/// correctly).
+#[cfg(target_arch = "arm")]
+#[inline(always)]
+fn disable() -> u32 {
+    let cpsr: u32;
+    // SAFETY: MRS is a non-faulting status-register read; CPSID only clears
+    // the CPSR I-bit (IRQ mask). Neither touches memory or requires any
+    // precondition beyond running at PL1, which the kernel does throughout.
+    unsafe {
+        core::arch::asm!("mrs {0}, cpsr", out(reg) cpsr);
+        core::arch::asm!("cpsid i");
+    }
+    cpsr
+}
+
+/// Restore the IRQ mask state previously returned by [`disable`]. If the
+/// saved state already had IRQs masked (a nested critical section), this is
+/// a no-op -- only the outermost `restore` re-enables delivery.
+#[cfg(target_arch = "arm")]
+#[inline(always)]
+fn restore(saved: u32) {
+    /// CPSR I-bit (bit 7): IRQ mask, 1 = masked.
+    const I_BIT: u32 = 1 << 7;
+    if saved & I_BIT == 0 {
+        // SAFETY: CPSIE only clears the CPSR I-bit; no memory access.
+        unsafe {
+            core::arch::asm!("cpsie i");
+        }
+    }
+}
+
+/// Host-test stand-in for [`disable`]: flips the mock flag instead of the
+/// CPSR I-bit, preserving the same "return prior state" contract.
+#[cfg(not(target_arch = "arm"))]
+#[inline(always)]
+fn disable() -> u32 {
+    let was_enabled = MOCK_IRQ_ENABLED.swap(false, Ordering::AcqRel);
+    u32::from(was_enabled)
+}
+
+/// Host-test stand-in for [`restore`]: mirrors the real nesting contract
+/// against the mock flag.
+#[cfg(not(target_arch = "arm"))]
+#[inline(always)]
+fn restore(saved: u32) {
+    if saved != 0 {
+        MOCK_IRQ_ENABLED.store(true, Ordering::Release);
+    }
+}
+
+/// Test-only accessor for the mock IRQ-enabled flag, so callers' own tests
+/// (slab, page) can assert masking/unmasking directly, not just this
+/// module's own nesting test.
+#[cfg(all(test, not(target_arch = "arm")))]
+pub(crate) fn mock_enabled() -> bool {
+    MOCK_IRQ_ENABLED.load(Ordering::Acquire)
+}
+
+/// Test-only reset of the mock IRQ-enabled flag to its default (enabled)
+/// state, for tests that need a known starting point.
+#[cfg(all(test, not(target_arch = "arm")))]
+pub(crate) fn reset_mock() {
+    MOCK_IRQ_ENABLED.store(true, Ordering::Release);
+}
+
+/// RAII guard: masks IRQ delivery on construction, restores the prior mask
+/// state on drop. Nests correctly -- an inner guard constructed while
+/// already masked leaves the mask alone on drop, so the outer critical
+/// section it is nested inside stays protected.
+pub(crate) struct IrqGuard(u32);
+
+impl IrqGuard {
+    /// Mask IRQ delivery and capture the prior mask state.
+    pub(crate) fn new() -> Self {
+        IrqGuard(disable())
+    }
+}
+
+impl Drop for IrqGuard {
+    fn drop(&mut self) {
+        restore(self.0);
+    }
+}
+
+/// IRQ-safe spinlock: an atomic flag guarded by IRQ masking.
+///
+/// The atomic flag alone only serializes against another CPU; on this
+/// single-core kernel the only other caller is an IRQ handler, so `lock()`
+/// masks IRQ delivery for the whole critical section (mask, then spin for
+/// the flag; release the flag, then unmask on drop) -- this is what actually
+/// makes the section IRQ-safe (#322, #331).
+pub(crate) struct IrqSpinlock {
+    locked: AtomicBool,
+}
+
+impl IrqSpinlock {
+    pub(crate) const fn new() -> Self {
+        IrqSpinlock {
+            locked: AtomicBool::new(false),
+        }
+    }
+
+    /// Mask IRQ delivery, then spin until the flag is acquired. Returns a
+    /// guard that releases the flag and restores the prior IRQ mask (in
+    /// that order) on drop.
+    pub(crate) fn lock(&self) -> IrqSpinGuard<'_> {
+        let irq = IrqGuard::new();
+        while self
+            .locked
+            .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            // Hint the CPU to yield. On ARM, `yield` is a NOP hint that allows
+            // speculative execution to be abandoned on in-order cores.
+            core::hint::spin_loop();
+        }
+        IrqSpinGuard { lock: self, _irq: irq }
+    }
+}
+
+pub(crate) struct IrqSpinGuard<'a> {
+    lock: &'a IrqSpinlock,
+    /// Restores the prior IRQ mask on drop, AFTER the flag is released below
+    /// -- field drops run after `Drop::drop`, in declaration order, and
+    /// `lock`'s reference drop is a no-op, so `_irq` unmasks last.
+    _irq: IrqGuard,
+}
+
+impl Drop for IrqSpinGuard<'_> {
+    fn drop(&mut self) {
+        self.lock.locked.store(false, Ordering::Release);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_guard_round_trips() {
+        reset_mock();
+        assert!(mock_enabled(), "starts unmasked");
+        let g = IrqGuard::new();
+        assert!(!mock_enabled(), "guard must mask IRQ delivery");
+        drop(g);
+        assert!(mock_enabled(), "dropping the guard must restore IRQ delivery");
+    }
+
+    #[test]
+    fn nested_guards_leave_irqs_masked_until_outer_drops() {
+        // The property that actually prevents the #322/#331 self-deadlock:
+        // an inner critical section entered while already masked must not
+        // unmask on its own drop and let a handler run before the OUTER
+        // critical section finishes.
+        reset_mock();
+        let outer = IrqGuard::new();
+        assert!(!mock_enabled(), "outer guard masks");
+        {
+            let inner = IrqGuard::new();
+            assert!(!mock_enabled(), "inner guard: still masked");
+            drop(inner);
+            assert!(!mock_enabled(), "inner drop must not unmask -- outer still holds");
+        }
+        drop(outer);
+        assert!(mock_enabled(), "outer drop restores unmasked");
+    }
+
+    #[test]
+    fn spinlock_masks_irqs_while_held() {
+        reset_mock();
+        let lock = IrqSpinlock::new();
+        assert!(mock_enabled(), "starts unmasked");
+        let guard = lock.lock();
+        assert!(!mock_enabled(), "lock() must mask IRQ delivery while held");
+        drop(guard);
+        assert!(mock_enabled(), "dropping the guard must restore IRQ delivery");
+    }
+
+    #[test]
+    fn spinlock_clears_the_flag_and_unmasks_on_drop() {
+        // The flag and the IRQ mask must both be back to their pre-lock
+        // state after drop; the DECLARATION order on IrqSpinGuard (see its
+        // doc comment) is what guarantees the flag is cleared before IRQs
+        // are unmasked, not just that both eventually happen.
+        reset_mock();
+        let lock = IrqSpinlock::new();
+        let guard = lock.lock();
+        assert!(lock.locked.load(Ordering::Acquire), "flag set while held");
+        drop(guard);
+        assert!(!lock.locked.load(Ordering::Acquire), "flag must be clear after drop");
+        assert!(mock_enabled(), "and IRQs unmasked after drop");
+    }
+}

--- a/crates/thumos/src/main.rs
+++ b/crates/thumos/src/main.rs
@@ -80,6 +80,7 @@ mod gic;
 mod heap;
 mod json_mini;
 mod ipc;
+mod irq;
 mod kconfig;
 mod key_manager;
 mod lock_screen;

--- a/crates/thumos/src/mmu.rs
+++ b/crates/thumos/src/mmu.rs
@@ -28,8 +28,12 @@ static mut L1: L1Table = L1Table { entries: [0; 4096] };
 mod flags {
     /// This is a section descriptor (bits [1:0] = 0b10).
     pub(crate) const SECTION: u32 = 0b10;
-    /// Access permission: full access (AP = 0b11, bits [11:10]).
-    pub(crate) const AP_FULL: u32 = 0b11 << 10;
+    /// Access permission: PL1 (kernel) read/write, PL0 (user) NO access
+    /// (AP[2:0] = 0b001: APX = 0 at bit 15 (unset), AP[1:0] = 0b01 at bits
+    /// [11:10]). WHY (#323): kernel RAM and device MMIO sections must never
+    /// grant PL0 access -- the prior AP_FULL (AP[2:0] = 0b011) let any user
+    /// process read and write kernel memory and MMIO directly.
+    pub(crate) const AP_PL1_ONLY: u32 = 0b01 << 10;
     /// Shareable (bit 16).
     pub(crate) const SHAREABLE: u32 = 1 << 16;
     /// Normal memory, OUTER/INNER write-back write-allocate.
@@ -199,8 +203,13 @@ pub unsafe fn map_page(l1_phys: usize, virt_addr: usize, phys_addr: usize, l2_at
 
 /// Unmap a single 4 KB page from a process's address space.
 ///
-/// Zeroes the L2 entry for the given virtual address. Does NOT free the
-/// L2 table even if all entries become zero (simplification).
+/// Zeroes the L2 entry for the given virtual address. If clearing that
+/// entry leaves every entry in the L2 table empty, the table is returned to
+/// the global pool (`free_l2_table`) and the owning L1 descriptor is
+/// cleared, so a sparse map/unmap workload cannot permanently strand pool
+/// slots (#330) -- the caller's existing post-unmap `flush_tlb_page(virt_addr)`
+/// call already invalidates the one translation this can affect; no other
+/// entry in a now-empty table was ever live in the TLB.
 ///
 /// # Safety
 ///
@@ -211,13 +220,29 @@ pub unsafe fn unmap_page(l1_phys: usize, virt_addr: usize) {
     let l2_index = (virt_addr >> 12) & 0xFF;
 
     unsafe {
-        let l1_entry_ptr = (l1_phys as *const u32).add(l1_index);
+        let l1_entry_ptr = (l1_phys as *mut u32).add(l1_index);
         let l1_val = l1_entry_ptr.read_volatile();
 
         if l1_val & 0b11 == page_flags::L1_PAGE_TABLE {
             let l2_phys = (l1_val & 0xFFFF_FC00) as usize;
             let l2_entry_ptr = (l2_phys as *mut u32).add(l2_index);
             l2_entry_ptr.write_volatile(0);
+
+            // WHY (#330): reclaim the table once every entry is empty,
+            // rather than leaking a global pool slot per touched 1 MB
+            // region forever.
+            let table_ptr = l2_phys as *const u32;
+            let mut all_empty = true;
+            for i in 0..256isize {
+                if table_ptr.offset(i).read_volatile() != 0 {
+                    all_empty = false;
+                    break;
+                }
+            }
+            if all_empty {
+                l1_entry_ptr.write_volatile(0);
+                free_l2_table(l2_phys);
+            }
         }
     }
 }
@@ -347,8 +372,8 @@ pub enum MemoryType {
 fn map_section(virt_mb: usize, phys_mb: usize, mem_type: MemoryType) {
     let base = (u32::try_from(phys_mb).unwrap_or_default()) << 20;
     let attrs = match mem_type {
-        MemoryType::Ram => flags::SECTION | flags::AP_FULL | flags::SHAREABLE | flags::NORMAL_WB_WA,
-        MemoryType::Device => flags::SECTION | flags::AP_FULL | flags::DEVICE | flags::XN,
+        MemoryType::Ram => flags::SECTION | flags::AP_PL1_ONLY | flags::SHAREABLE | flags::NORMAL_WB_WA,
+        MemoryType::Device => flags::SECTION | flags::AP_PL1_ONLY | flags::DEVICE | flags::XN,
     };
     unsafe {
         let table = &mut *core::ptr::addr_of_mut!(L1);
@@ -555,6 +580,14 @@ pub fn alloc_addr_space() -> Option<usize> {
 
 /// Return a user L1 page table slot to the pool.
 ///
+/// Also reclaims every L2 page table still referenced by this address
+/// space's L1 entries -- page-mapped mmap/heap/stack regions the process
+/// never individually unmapped before exit -- so a process that exits
+/// without tearing down its own mappings cannot permanently strand pool
+/// slots (#330). Cloned kernel identity-map entries are section descriptors
+/// (`flags::SECTION`, bits [1:0] = 0b10), never `page_flags::L1_PAGE_TABLE`
+/// (0b01), so this walk never touches or frees the kernel's own mappings.
+///
 /// # Safety
 ///
 /// `phys_addr` must have been returned by `alloc_addr_space` and not yet freed.
@@ -563,6 +596,15 @@ pub unsafe fn free_addr_space(phys_addr: usize) {
         let tables = &*core::ptr::addr_of!(USER_TABLES);
         for (i, table) in tables.iter().enumerate() {
             if core::ptr::addr_of!(*table) as usize == phys_addr {
+                let l1 = phys_addr as *const u32;
+                for idx in 0..4096isize {
+                    let entry = l1.offset(idx).read_volatile();
+                    if entry & 0b11 == page_flags::L1_PAGE_TABLE {
+                        let l2_phys = (entry & 0xFFFF_FC00) as usize;
+                        free_l2_table(l2_phys);
+                    }
+                }
+
                 let alloc = core::ptr::addr_of_mut!(ADDR_SPACE_ALLOC);
                 let mask = core::ptr::read_volatile(alloc);
                 core::ptr::write_volatile(alloc, mask & !(1 << i));
@@ -703,6 +745,156 @@ mod tests {
             assert_eq!(read_l2_phys(l1, virt), None,
                 "read_l2_phys must return None after unmap_page clears the entry");
             free_addr_space(l1);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // #323: kernel/device sections must be PL1-only
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn kernel_sections_are_pl1_only_not_ap_full() {
+        // Regression test for #323: AP[2:0] for every identity-mapped kernel
+        // RAM / device / modem section must be 0b001 (PL1 R/W, PL0 no
+        // access), never 0b011 (AP_FULL, PL0 R/W). The L1 table is plain
+        // memory -- populating it involves no ARM CPU instructions -- so
+        // this is host-testable even though the actual privilege-fault
+        // enforcement is ARM-only.
+        unsafe {
+            init_and_enable();
+            let table = &*core::ptr::addr_of!(L1);
+            // One section from each identity-mapped region: boot ROM/SRAM,
+            // peripheral MMIO, modem/CCCI, and DRAM (first and last MB).
+            for &mb in &[0x000usize, 0x100, 0x200, 0x400, 0x7FF] {
+                let entry = table.entries[mb];
+                assert_eq!(entry & 0b11, flags::SECTION,
+                    "section {mb:#x} must be a section descriptor");
+                let ap = (entry >> 10) & 0b11;
+                let apx = (entry >> 15) & 0b1;
+                assert_eq!((apx, ap), (0, 0b01),
+                    "section {mb:#x} must be AP[2:0]=001 (PL1-only R/W); PL0 must have zero access");
+            }
+        }
+    }
+
+    #[test]
+    fn cloned_user_table_still_denies_pl0_access_to_kernel_sections() {
+        // #323's clone_addr_space interaction: fork() copies the kernel L1
+        // verbatim into each per-process table, so the PL1-only fix must
+        // hold in the CLONED copy too, not just the primary kernel table.
+        reset();
+        unsafe {
+            init_and_enable();
+            let dst = alloc_addr_space().unwrap_or_default();
+            clone_addr_space(table_base(), dst);
+            let dst_l1 = dst as *const u32;
+            for &mb in &[0x100usize, 0x400] {
+                let entry = dst_l1.add(mb).read_volatile();
+                let ap = (entry >> 10) & 0b11;
+                let apx = (entry >> 15) & 0b1;
+                assert_eq!((apx, ap), (0, 0b01),
+                    "cloned user table section {mb:#x} must still deny PL0 access");
+            }
+            free_addr_space(dst);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // #330: L2 page table reclaim
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn unmap_reclaims_l2_table_once_fully_empty() {
+        reset();
+        reset_l2_pool();
+        let l1 = alloc_addr_space().unwrap_or_default();
+        let virt = 0x1000_0000usize;
+        let phys = 0x5000_0000usize;
+        let attrs = page_flags::SMALL_PAGE | page_flags::AP_FULL;
+        unsafe {
+            assert!(map_page(l1, virt, phys, attrs), "map_page must succeed");
+            let l1_index = virt >> 20;
+            let l1_val = (l1 as *const u32).add(l1_index).read_volatile();
+            assert_eq!(l1_val & 0b11, page_flags::L1_PAGE_TABLE,
+                "L1 entry must point at an L2 table after map_page");
+
+            unmap_page(l1, virt);
+
+            let l1_val_after = (l1 as *const u32).add(l1_index).read_volatile();
+            assert_eq!(l1_val_after, 0,
+                "L1 descriptor must be cleared once its only L2 entry is unmapped (#330)");
+
+            free_addr_space(l1);
+        }
+    }
+
+    #[test]
+    fn sparse_map_unmap_over_more_than_pool_size_regions_does_not_exhaust_l2_pool() {
+        // Regression test for #330: before the fix, unmap_page never called
+        // free_l2_table, so touching more than L2_POOL_SIZE distinct 1 MB
+        // regions permanently exhausted the global pool even though every
+        // region was unmapped before moving to the next.
+        reset();
+        reset_l2_pool();
+        let l1 = alloc_addr_space().unwrap_or_default();
+        let attrs = page_flags::SMALL_PAGE | page_flags::AP_FULL;
+        let phys = 0x5000_0000usize;
+        unsafe {
+            for region in 0..(L2_POOL_SIZE * 2) {
+                let virt = region << 20; // one distinct 1 MB region per iteration
+                assert!(map_page(l1, virt, phys, attrs),
+                    "map must succeed in region {region} -- pool must not be exhausted by prior, already-unmapped regions");
+                unmap_page(l1, virt);
+            }
+
+            // The pool must be back to fully available: every slot can be
+            // claimed fresh.
+            let mut reclaimed = [0usize; L2_POOL_SIZE];
+            for slot in reclaimed.iter_mut() {
+                *slot = alloc_l2_table()
+                    .expect("L2 pool must be fully reclaimed after every region was unmapped");
+            }
+            for &addr in &reclaimed {
+                free_l2_table(addr);
+            }
+
+            free_addr_space(l1);
+        }
+    }
+
+    #[test]
+    fn free_addr_space_reclaims_l2_tables_left_mapped_at_exit() {
+        // #330's other reclaim path: a process that exits WITHOUT calling
+        // munmap on its own mappings must not strand their L2 tables
+        // forever -- free_addr_space must walk the L1 and reclaim them.
+        reset();
+        reset_l2_pool();
+        let l1 = alloc_addr_space().unwrap_or_default();
+        let attrs = page_flags::SMALL_PAGE | page_flags::AP_FULL;
+        let phys = 0x5000_0000usize;
+        unsafe {
+            for region in 0..L2_POOL_SIZE {
+                let virt = region << 20;
+                assert!(map_page(l1, virt, phys, attrs),
+                    "map must succeed in region {region}");
+            }
+            // Every pool slot is now live and still mapped (no unmap_page
+            // calls) -- exactly the "process exits with mappings still up"
+            // case.
+            assert!(alloc_l2_table().is_none(), "pool must be fully consumed by the L2_POOL_SIZE live regions");
+
+            free_addr_space(l1);
+
+            // free_addr_space must have walked the L1 and reclaimed every
+            // still-referenced L2 table.
+            let mut reclaimed = [0usize; L2_POOL_SIZE];
+            for slot in reclaimed.iter_mut() {
+                *slot = alloc_l2_table()
+                    .expect("free_addr_space must reclaim L2 tables left mapped at process exit");
+            }
+            for &addr in &reclaimed {
+                free_l2_table(addr);
+            }
         }
     }
 }

--- a/crates/thumos/src/page.rs
+++ b/crates/thumos/src/page.rs
@@ -2,8 +2,22 @@
 //!
 //! Simple bitmap allocator for 4 KB pages. The MT6739 has ~914 MB RAM.
 //! The kernel, device memory, and reserved regions are marked as allocated at init.
+//!
+//! # Thread safety
+//!
+//! `PAGE_BITMAP`/`FREE_PAGES` mutations are serialized by `PAGE_LOCK`, an
+//! IRQ-safe spinlock (`irq::IrqSpinlock`) shared by every accessor --
+//! `alloc_page`, `try_free_page`, and `free_count` alike. Without it, an
+//! IRQ-context allocation (the slab allocator's refill path) can interleave
+//! its non-atomic `*word |= 1 << bit` with a direct, non-slab caller
+//! (process creation, mmap/brk, panic-wipe) and hand out the same physical
+//! frame twice (#331). `init()` also takes the lock for the same
+//! `PAGE_BITMAP`/`FREE_PAGES` writes, even though it runs once during early
+//! boot before interrupts are enabled -- no accessor is exempt.
 
 use core::ptr::addr_of_mut;
+
+use crate::irq;
 
 /// Page size: 4 KB (ARM standard).
 pub(crate) const PAGE_SIZE: usize = 4096;
@@ -21,12 +35,16 @@ static mut FIRST_PAGE: usize = 0;
 static mut USABLE_START_PAGE: usize = 0;
 static mut USABLE_END_PAGE: usize = 0;
 
+/// WHY (#331): guards every `PAGE_BITMAP`/`FREE_PAGES` accessor.
+static PAGE_LOCK: irq::IrqSpinlock = irq::IrqSpinlock::new();
+
 /// Initialize the page allocator.
 ///
 /// # Safety
 ///
 /// Must be called exactly once during kernel init, before any allocations.
 pub unsafe fn init(ram_start: usize, ram_end: usize, kernel_end: usize) {
+    let _g = PAGE_LOCK.lock();
     // SAFETY: page frame index is within physical memory bounds (checked by caller).
     unsafe {
         let usable_start = (kernel_end + PAGE_SIZE - 1) & !(PAGE_SIZE - 1);
@@ -134,6 +152,10 @@ pub unsafe fn zero_usable_range() -> usize {
 
 /// Allocate a single physical page. Returns the physical address, or None.
 pub(crate) fn alloc_page() -> Option<usize> {
+    // WHY (#331): serializes with every other PAGE_BITMAP/FREE_PAGES
+    // accessor, including an IRQ-context caller, so a duplicate-frame race
+    // cannot occur (see the module doc).
+    let _g = PAGE_LOCK.lock();
     // SAFETY: page frame index is within physical memory bounds (checked by caller).
     unsafe {
         if FREE_PAGES == 0 {
@@ -168,6 +190,10 @@ pub(crate) fn alloc_page() -> Option<usize> {
 /// bitmap-corruption / double-free primitive, but callers must still not use a
 /// page after freeing it.
 pub unsafe fn try_free_page(addr: usize) -> bool {
+    // WHY (#331): serializes with every other PAGE_BITMAP/FREE_PAGES
+    // accessor (see the module doc) so a concurrent alloc/free pair can
+    // never observe or corrupt a torn bitmap update.
+    let _g = PAGE_LOCK.lock();
     // SAFETY: every bitmap access below is bounds-checked against the array
     // length, and FREE_PAGES is incremented only when a set bit is actually
     // cleared, so an out-of-range or already-free address cannot corrupt
@@ -247,6 +273,9 @@ pub unsafe fn free_page(addr: usize) {
 
 /// Return the number of free pages.
 pub(crate) fn free_count() -> usize {
+    // WHY (#331): reads FREE_PAGES under the same lock every writer uses,
+    // so this can't observe a torn/partial update mid-mutation.
+    let _g = PAGE_LOCK.lock();
     // SAFETY: page frame index is within physical memory bounds (checked by caller).
     unsafe { FREE_PAGES }
 }
@@ -351,5 +380,51 @@ mod tests {
         // arbitrary base address is safe here.
         let zeroed = unsafe { zero_page_range(0, 5, 5) };
         assert_eq!(zeroed, 0, "an empty range must zero nothing");
+    }
+
+    // -----------------------------------------------------------------------
+    // #331: IRQ-safe locking
+    // -----------------------------------------------------------------------
+    //
+    // WHY these tests exercise PAGE_LOCK directly rather than going through
+    // alloc_page()/try_free_page(): those need page::init() first, and this
+    // file's tests deliberately avoid init() (see the file-level WHY comment
+    // above) because PAGE_BITMAP/FREE_PAGES/FIRST_PAGE are shared statics
+    // that a threaded harness could race across tests. PAGE_LOCK's
+    // masking/nesting contract is independent of whether init() ran, so it
+    // is fully testable in isolation the same way.
+
+    #[test]
+    fn page_lock_masks_irqs_for_the_critical_section() {
+        // Regression test for #331: PAGE_BITMAP/FREE_PAGES mutations must
+        // run inside an IRQ-masked critical section shared by every caller
+        // -- the slab-internal refill path AND the direct callers in
+        // process.rs/syscall.rs -- or an IRQ-context alloc_page() can
+        // interleave with a non-locked in-progress caller and hand out the
+        // same physical frame twice. Host-testable via the mock IRQ-state
+        // seam in `irq` (the real CPSR I-bit is ARM-only).
+        crate::irq::reset_mock();
+        assert!(crate::irq::mock_enabled(), "starts unmasked");
+        let guard = PAGE_LOCK.lock();
+        assert!(!crate::irq::mock_enabled(), "PAGE_LOCK.lock() must mask IRQ delivery while held");
+        drop(guard);
+        assert!(crate::irq::mock_enabled(), "dropping the guard must restore IRQ delivery");
+    }
+
+    #[test]
+    fn nested_irq_guard_does_not_unmask_while_page_lock_held() {
+        // The property that prevents the #331 double-allocation race: a
+        // nested critical section must not unmask IRQ delivery early and
+        // let an interrupt-context allocator run before the OUTER critical
+        // section -- the page lock -- has released.
+        crate::irq::reset_mock();
+        let outer = PAGE_LOCK.lock();
+        assert!(!crate::irq::mock_enabled());
+        let inner = crate::irq::IrqGuard::new();
+        assert!(!crate::irq::mock_enabled());
+        drop(inner);
+        assert!(!crate::irq::mock_enabled(), "inner drop must not unmask while the page lock is still held");
+        drop(outer);
+        assert!(crate::irq::mock_enabled(), "outer drop restores IRQ delivery");
     }
 }

--- a/crates/thumos/src/slab.rs
+++ b/crates/thumos/src/slab.rs
@@ -12,8 +12,13 @@
 //!
 //! # Thread safety
 //!
-//! A single spinlock guards the allocator. This is correct on the single-core
-//! MT6739 boot CPU; the lock also prevents re-entrancy from IRQ handlers.
+//! A single spinlock guards the allocator, with IRQ delivery masked for the
+//! duration of each critical section (mask, then acquire; release, then
+//! unmask -- see `irq::IrqSpinlock`). On the single-core MT6739 boot CPU the
+//! only concurrent caller is an IRQ handler; the atomic flag alone does not
+//! stop that reentrancy -- without masking, an IRQ firing while interrupted
+//! code holds the lock and then allocating would self-deadlock (#322). IRQ
+//! masking is what actually makes the section safe against that case.
 //!
 //! # Invariants
 //!
@@ -22,8 +27,8 @@
 
 use core::alloc::{GlobalAlloc, Layout};
 use core::ptr;
-use core::sync::atomic::{AtomicBool, Ordering};
 
+use crate::irq;
 use crate::page;
 
 // ---------------------------------------------------------------------------
@@ -326,55 +331,14 @@ impl SlabAllocator {
 }
 
 // ---------------------------------------------------------------------------
-// Spinlock
-// ---------------------------------------------------------------------------
-
-/// Ticket-free spinlock: a single `AtomicBool` flag.
-///
-/// On a single-core ARM kernel this is equivalent to disabling re-entrancy:
-/// the only concurrent caller is an IRQ handler. If the kernel later becomes
-/// SMP, replace this with a proper ticket lock.
-struct Spinlock {
-    locked: AtomicBool,
-}
-
-impl Spinlock {
-    const fn new() -> Self {
-        Spinlock {
-            locked: AtomicBool::new(false),
-        }
-    }
-
-    /// Spin until the lock is acquired, then return a guard.
-    fn lock(&self) -> SpinGuard<'_> {
-        while self
-            .locked
-            .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
-            .is_err()
-        {
-            // Hint the CPU to yield. On ARM, `yield` is a NOP hint that allows
-            // speculative execution to be abandoned on in-order cores.
-            core::hint::spin_loop();
-        }
-        SpinGuard { lock: self }
-    }
-}
-
-struct SpinGuard<'a> {
-    lock: &'a Spinlock,
-}
-
-impl Drop for SpinGuard<'_> {
-    fn drop(&mut self) {
-        self.lock.locked.store(false, Ordering::Release);
-    }
-}
-
-// ---------------------------------------------------------------------------
 // Global state
 // ---------------------------------------------------------------------------
 
-static LOCK: Spinlock = Spinlock::new();
+/// WHY (#322): an `irq::IrqSpinlock`, not a plain atomic flag -- IRQ
+/// delivery is masked for the whole critical section, which is what
+/// actually prevents an allocating IRQ handler from self-deadlocking
+/// against interrupted code that holds this lock.
+static LOCK: irq::IrqSpinlock = irq::IrqSpinlock::new();
 
 // SAFETY: SlabAllocator is only accessed under LOCK.
 static mut SLAB: SlabAllocator = SlabAllocator::new();
@@ -753,5 +717,42 @@ mod tests {
             let (_, frees) = sa.stats();
             assert_eq!(frees, 0, "dealloc(null) on an initialized allocator must be a no-op, not decrement/crash");
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // #322: IRQ-safe locking
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn global_lock_masks_irqs_for_the_critical_section() {
+        // Regression test for #322: the spinlock alone does not stop
+        // IRQ-context reentrancy -- an allocating IRQ handler that fires
+        // while this lock is held self-deadlocks unless IRQ delivery is
+        // masked for the critical section. Host-testable via the mock
+        // IRQ-state seam in `irq` (the real CPSR I-bit is ARM-only).
+        crate::irq::reset_mock();
+        assert!(crate::irq::mock_enabled(), "starts unmasked");
+        let guard = LOCK.lock();
+        assert!(!crate::irq::mock_enabled(), "LOCK.lock() must mask IRQ delivery while held");
+        drop(guard);
+        assert!(crate::irq::mock_enabled(), "dropping the guard must restore IRQ delivery");
+    }
+
+    #[test]
+    fn nested_irq_guard_does_not_unmask_while_global_lock_held() {
+        // The property that prevents the #322 self-deadlock: a nested
+        // critical section (e.g. an IRQ handler's own masking, or a second
+        // lock taken while this one is held) must not unmask IRQ delivery
+        // early and let a handler run before the OUTER critical section --
+        // the slab lock -- has released.
+        crate::irq::reset_mock();
+        let outer = LOCK.lock();
+        assert!(!crate::irq::mock_enabled());
+        let inner = crate::irq::IrqGuard::new();
+        assert!(!crate::irq::mock_enabled());
+        drop(inner);
+        assert!(!crate::irq::mock_enabled(), "inner drop must not unmask while the slab lock is still held");
+        drop(outer);
+        assert!(crate::irq::mock_enabled(), "outer drop restores IRQ delivery");
     }
 }


### PR DESCRIPTION
## Summary

Kernel memory-safety hardening. Introduces a shared `irq` module (`IrqGuard` / `IrqSpinlock` — save CPSR I-bit, mask, restore-on-drop, nests correctly) consumed by the two allocator locks. The mask/nest/restore **contract** is host-tested via a `cfg(not(arm))` mock seam; the CPSR I-bit effect itself is arm-only and review-verified.

- **#322** — the slab spinlock was a bare atomic flag that only self-deadlocks an allocating IRQ handler against interrupted code holding the lock (its doc falsely claimed it prevents re-entrancy). Now an `irq::IrqSpinlock` masking IRQ delivery for the critical section (mask→acquire; release→unmask — the guard's field order guarantees flag-release before unmask).
- **#323** (**security**) — kernel RAM + device MMIO sections were mapped `AP_FULL` (AP[2:0]=`0b011`, PL1 **and PL0** R/W), and `clone_addr_space` copies them into every per-process table, so any user process could read/write kernel memory, MMIO, and the modem region. Section AP is now `0b001` (PL1 R/W, PL0 no access). The unrelated L2 `page_flags::AP_FULL` (a process's own mmap pages) is correctly untouched.
- **#330** — `unmap_page` never freed a fully-empty L2 table and `free_addr_space` never walked the L1 to reclaim referenced L2 tables, so a sparse map/unmap workload (or a process exiting with live mappings) permanently stranded slots in the 64-entry global L2 pool. Both paths now reclaim (descriptor-type-safe: `0b01` L2 vs `0b10` section — the walk never touches kernel mappings).
- **#331** — the physical page allocator mutated `PAGE_BITMAP`/`FREE_PAGES` with plain non-atomic RMW while called from two disjoint domains (slab refill under slab's lock; direct callers in process/syscall under no lock) — a concurrent/IRQ interleave could hand out the same frame twice. All accessors now serialize on an `irq::IrqSpinlock` (lock order always slab→page, no inversion).

## Closes

Closes #322, #323, #330, #331

## Verification

- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — 1771 passed (+13): irq guard nesting/masking, slab lock masking, PL1-only AP bits on kernel/device/cloned sections, L2 reclaim on unmap + at address-space teardown, page-lock masking.
- `cargo build --release --target armv7a-none-eabi` — compiles (the `cpsid/cpsie` asm is arm-gated)
- `kanon lint . --summary` — clean

## Review posture & follow-ups

The **#323 privilege-escalation fix** and the two lock designs were reviewed at the orchestrator (Opus) tier, not just generated. Two defense-in-depth items are deliberately deferred and filed as follow-ups: (1) scoping XN to non-text kernel regions (redundant against the PL0-access threat once AP=001, and requires splitting the flat 1 MB RAM identity map at kernel-image boundaries); (2) the same unlocked non-atomic-RMW pattern in mmu.rs's `L2_ALLOC`/`ADDR_SPACE_ALLOC` pool bitmasks (same class as #331, different structure).