### PR TITLE
Kernel correctness: 7 fixes (timer, fault-drop, audit-stack, LFS bounds, SMS DCS, radio mesh, audio preempt)

### DIFF
--- a/crates/thumos/src/audio.rs
+++ b/crates/thumos/src/audio.rs
@@ -201,14 +201,21 @@ impl<C: AudioCodecOps> AudioManager<C> {
     ///
     /// 1. If this is the first session (refcount 0 -> 1), power on the codec.
     /// 2. If the session kind is `VoiceCall`, enable mic (ADC + bias).
-    /// 3. Preempt any lower-priority active sessions.
-    /// 4. Configure the codec for the requested route.
+    /// 3. Preempt any active session at lower-or-equal priority; if a
+    ///    strictly higher-priority session is active, the new session is
+    ///    inserted paused instead (#386).
+    /// 4. Configure the codec for the requested route — skipped if step 3
+    ///    inserted the new session paused.
     /// 5. Return the new session's ID.
     ///
     /// ## Preemption rules
     ///
     /// - Higher priority preempts lower priority (pauses them).
     /// - Same priority: most recent session wins (pauses earlier ones).
+    /// - A session opened while a strictly higher-priority session is
+    ///   active is itself inserted paused, not active: it does not touch
+    ///   the codec route and resumes automatically when the higher-priority
+    ///   session closes.
     /// - When the preempting session closes, preempted sessions resume.
     /// # Errors
     ///
@@ -249,20 +256,34 @@ impl<C: AudioCodecOps> AudioManager<C> {
             }
         }
 
-        // Set the codec output route for the new session.
-        self.codec.set_output(route)?;
-        self.active_route = route;
+        // WHY: the loop above only pauses <= priority sessions, so a
+        // strictly-higher-priority active session survives it by
+        // construction. The new session must not become active, and must
+        // not touch the codec route, or it silently displaces the
+        // higher-priority session's audio (#386).
+        let blocked_by_higher_priority =
+            self.sessions.iter().any(|s| s.active && s.priority > priority);
 
-        // Create and store the session.
+        // Set the codec output route for the new session, unless a
+        // strictly higher-priority session is already active.
+        if !blocked_by_higher_priority {
+            self.codec.set_output(route)?;
+            self.active_route = route;
+        }
+
+        // Create and store the session. Starts paused if a higher-priority
+        // session is active; it resumes automatically via
+        // resume_highest_priority() when that session closes.
         let session = AudioSession {
             id,
             kind,
             priority,
             route,
-            active: true,
+            active: !blocked_by_higher_priority,
         };
         self.sessions.push(session);
 
+        self.debug_check_single_active_invariant();
         Ok(id)
     }
 
@@ -295,6 +316,7 @@ impl<C: AudioCodecOps> AudioManager<C> {
             self.codec.disable_dac()?;
             self.codec.power_off()?;
             self.codec_powered = false;
+            self.debug_check_single_active_invariant();
             return Ok(());
         }
 
@@ -310,6 +332,7 @@ impl<C: AudioCodecOps> AudioManager<C> {
             self.power_down_mic()?;
         }
 
+        self.debug_check_single_active_invariant();
         Ok(())
     }
 
@@ -396,6 +419,20 @@ impl<C: AudioCodecOps> AudioManager<C> {
     // -----------------------------------------------------------------------
     // Internal helpers
     // -----------------------------------------------------------------------
+
+    /// Debug invariant: at most one session may be active at a time.
+    ///
+    /// Compiled out in release builds (`debug_assert!`). Invoked at the end
+    /// of [`Self::open_session`] and [`Self::close_session`] — the two
+    /// methods that mutate session activation state — to catch a
+    /// preemption-logic regression like #386 immediately instead of via a
+    /// silently-corrupted `active_route`.
+    fn debug_check_single_active_invariant(&self) {
+        debug_assert!(
+            self.sessions.iter().filter(|s| s.active).count() <= 1,
+            "AudioManager invariant violated: more than one active session"
+        );
+    }
 
     /// Resume the highest-priority paused session.
     ///
@@ -892,6 +929,60 @@ mod tests {
         assert!(
             ops.contains(&alloc::string::String::from("enable_dac")),
             "enable_dac must be recorded: {ops:?}"
+        );
+    }
+
+    #[test]
+    fn lower_priority_open_does_not_preempt_active_higher_priority() {
+        // WHY: regression test for #386 — the preemption loop only paused
+        // sessions at priority <= the new session's priority, so opening a
+        // LOWER-priority session while a HIGHER-priority one was active
+        // left both active and silently rerouted the codec to the new
+        // session.
+        let mut mgr = make_manager();
+
+        let call_id = mgr
+            .open_session(SessionKind::VoiceCall, AudioRoute::Earpiece)
+            .unwrap_or(0);
+        assert!(
+            mgr.active_sessions().iter().find(|s| s.id == call_id).map_or(false, |s| s.active),
+            "voice call must be active"
+        );
+
+        // Open a lower-priority Music (Normal) session while the call is active.
+        let music_id = mgr
+            .open_session(SessionKind::Music, AudioRoute::Speaker)
+            .unwrap_or(0);
+
+        // The call must remain the sole active session and keep its route.
+        let call = mgr.active_sessions().iter().find(|s| s.id == call_id);
+        assert!(
+            call.map_or(false, |s| s.active),
+            "higher-priority call must remain active"
+        );
+        assert_eq!(
+            mgr.active_route(),
+            AudioRoute::Earpiece,
+            "codec route must not be stolen by the lower-priority open (#386)"
+        );
+
+        // The new lower-priority session must be inserted paused, not active.
+        let music = mgr.active_sessions().iter().find(|s| s.id == music_id);
+        assert!(
+            !music.map_or(true, |s| s.active),
+            "lower-priority session opened over an active higher-priority one must start paused"
+        );
+
+        // At most one session may be active.
+        let active_count = mgr.active_sessions().iter().filter(|s| s.active).count();
+        assert_eq!(active_count, 1, "at most one session may be active at a time");
+
+        // When the call closes, the paused Music session must resume.
+        mgr.close_session(call_id).ok();
+        let music = mgr.active_sessions().iter().find(|s| s.id == music_id);
+        assert!(
+            music.map_or(false, |s| s.active),
+            "music must resume once the call closes"
         );
     }
 }

--- a/crates/thumos/src/audit.rs
+++ b/crates/thumos/src/audit.rs
@@ -45,6 +45,9 @@
 
 use core::fmt;
 
+extern crate alloc;
+use alloc::{boxed::Box, vec::Vec};
+
 use subtle::ConstantTimeEq;
 
 use crate::security::{self, KEY_SIZE, SHA256_DIGEST_LEN};
@@ -273,10 +276,15 @@ impl fmt::Display for AuditError {
 /// The ring buffer overwrites the oldest entry when full.  The `head`
 /// index tracks the next write position, and `count` tracks how many
 /// entries are live (up to `MAX_ENTRIES`).
+// INVARIANT: `entries` is heap-allocated (`Box<[AuditEntry]>`), never an
+// inline `[AuditEntry; MAX_ENTRIES]` array. MAX_ENTRIES * size_of::<AuditEntry>()
+// is ~64 KiB; an inline array field would make `AuditLog` itself ~64 KiB and
+// risk a stack overflow the moment a caller binds `AuditLog::new()` to a
+// local on the 64 KiB MT6739 boot stack (#297).
 #[must_use]
 pub(crate) struct AuditLog {
-    /// Ring buffer of audit entries.
-    entries: [AuditEntry; MAX_ENTRIES],
+    /// Ring buffer of audit entries (heap-allocated; see struct INVARIANT).
+    entries: Box<[AuditEntry]>,
     /// Index of the next write position in the ring.
     head: usize,
     /// Number of live entries (0..=MAX_ENTRIES).
@@ -287,17 +295,25 @@ pub(crate) struct AuditLog {
 
 impl AuditLog {
     /// Create a new, empty audit log.
+    ///
+    /// `entries` is built element-by-element into a heap-allocated `Vec`
+    /// and converted to a boxed slice, so the ~64 KiB backing storage is
+    /// never materialized as a single stack frame (#297).
     #[must_use]
     pub(crate) fn new() -> Self {
-        Self {
-            entries: core::array::from_fn(|_| AuditEntry {
+        let mut entries = Vec::with_capacity(MAX_ENTRIES);
+        for _ in 0..MAX_ENTRIES {
+            entries.push(AuditEntry {
                 timestamp: 0,
                 event_type: AuditEventType::AuthFail,
                 pid: 0,
                 detail: [0u8; DETAIL_LEN],
                 detail_len: 0,
                 hmac: [0u8; SHA256_DIGEST_LEN],
-            }),
+            });
+        }
+        Self {
+            entries: entries.into_boxed_slice(),
             head: 0,
             count: 0,
             last_hmac: GENESIS_HMAC,
@@ -972,6 +988,19 @@ mod tests {
         assert!(
             utilization_pct >= 80,
             "buffer utilization must be >= 80%: {utilization_pct}%"
+        );
+    }
+
+    #[test]
+    fn audit_log_struct_is_stack_safe() {
+        // WHY: guards the #297 fix — AuditLog itself must stay small (a
+        // Box<[AuditEntry]> fat pointer + a few scalars), never an inline
+        // ~64 KiB array, so AuditLog::new() is safe to bind to a local on
+        // the 64 KiB MT6739 boot stack.
+        let size = core::mem::size_of::<AuditLog>();
+        assert!(
+            size < 256,
+            "AuditLog must stay small (heap-backed entries); got {size} bytes"
         );
     }
 }

--- a/crates/thumos/src/heorte_timer.rs
+++ b/crates/thumos/src/heorte_timer.rs
@@ -100,7 +100,12 @@ impl Timer {
         }
 
         self.remaining_secs = self.remaining_secs.saturating_sub(elapsed_secs);
-        self.started_tick = current_tick;
+        // WHY: advance the epoch by only the consumed whole seconds, not to
+        // current_tick, so the sub-second remainder (elapsed_ms % 1000)
+        // carries forward into the next update() instead of being
+        // discarded — a timer polled faster than 1 Hz must still advance
+        // wall-clock seconds (#342).
+        self.started_tick = self.started_tick.saturating_add(u64::from(elapsed_secs) * 1000);
         false
     }
 
@@ -358,6 +363,38 @@ mod tests {
         timer.set_duration(0);
         let buf = timer.format_remaining();
         assert_eq!(&buf, b"00:00");
+    }
+
+    #[test]
+    fn timer_sub_second_polls_accumulate_at_500ms() {
+        // WHY: regression test for #342 — update() must not discard the
+        // sub-second remainder every call; a 2s timer polled at 500ms
+        // intervals must expire after exactly 4 calls (2000ms).
+        let mut timer = Timer::new();
+        timer.set_duration(2);
+        timer.start(0);
+
+        assert!(!timer.update(500), "must not expire after 500ms");
+        assert!(!timer.update(1_000), "must not expire after 1000ms");
+        assert!(!timer.update(1_500), "must not expire after 1500ms");
+        assert!(timer.update(2_000), "must expire after exactly 2000ms (4th call)");
+    }
+
+    #[test]
+    fn timer_sub_second_polls_accumulate_at_100ms() {
+        // WHY: regression test for #342 — the same 2s timer polled at
+        // 100ms intervals must expire after exactly 20 calls (2000ms); a
+        // truncating update() never accumulates past 0 elapsed_secs per
+        // call and never expires.
+        let mut timer = Timer::new();
+        timer.set_duration(2);
+        timer.start(0);
+
+        let mut expired = false;
+        for i in 1..=20 {
+            expired = timer.update(i * 100);
+        }
+        assert!(expired, "timer polled at 100ms intervals must expire after 20 calls (2000ms)");
     }
 
     #[test]

--- a/crates/thumos/src/lfs_imap.rs
+++ b/crates/thumos/src/lfs_imap.rs
@@ -163,7 +163,15 @@ impl LfsImap {
             buf[..4].try_into().map_err(|_| LfsError::Corrupt)?,
         ) as usize;
 
-        let expected_len = IMAP_HEADER_SIZE + count * IMAP_ENTRY_SIZE;
+        // WHY: count is an attacker-controlled on-disk field; count *
+        // IMAP_ENTRY_SIZE wraps on the 32-bit target for a crafted large
+        // count, defeating this length guard and letting the entry-parse
+        // loop below index past `buf` (#333). Checked arithmetic rejects
+        // the overflowing case instead of silently wrapping.
+        let expected_len = count
+            .checked_mul(IMAP_ENTRY_SIZE)
+            .and_then(|entries_len| entries_len.checked_add(IMAP_HEADER_SIZE))
+            .ok_or(LfsError::Corrupt)?;
         if buf.len() < expected_len {
             return Err(LfsError::Corrupt);
         }
@@ -237,7 +245,22 @@ impl LfsImap {
         start_block: u64,
         block_count: u32,
     ) -> Result<Self, LfsError> {
-        let mut data = Vec::with_capacity(block_count as usize * BLOCK_SIZE);
+        // WHY: block_count is an attacker-controlled on-disk field
+        // (CheckpointHeader::imap_block_count, validated for magic only —
+        // see lfs::mount). Bound it with checked arithmetic against the
+        // device's actual capacity before sizing any allocation from it,
+        // so a crafted/bit-flipped value cannot wrap the multiply (32-bit
+        // target) or request an allocation the device could never back
+        // (#333).
+        let byte_len = (block_count as usize)
+            .checked_mul(BLOCK_SIZE)
+            .ok_or(LfsError::Corrupt)?;
+        let device_bytes = dev.sector_count().saturating_mul(dev.sector_size() as u64);
+        if byte_len as u64 > device_bytes {
+            return Err(LfsError::Corrupt);
+        }
+
+        let mut data = Vec::with_capacity(byte_len);
         let mut buf = [0u8; BLOCK_SIZE];
 
         for i in 0..block_count {
@@ -376,5 +399,50 @@ mod tests {
 
         let restored = LfsImap::deserialize(&buf).expect("deserialize empty");
         assert!(restored.is_empty());
+    }
+
+    #[test]
+    fn deserialize_rejects_overflowing_count() {
+        // WHY: count * IMAP_ENTRY_SIZE must not wrap on a 32-bit usize. A
+        // crafted count near usize::MAX must be rejected via checked
+        // arithmetic, not silently truncated into a short expected_len that
+        // then lets the entry-parse loop index past `buf` (#333).
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&0xFFFF_FFFFu32.to_le_bytes());
+        buf.extend_from_slice(&[0u8; 16]);
+
+        let result = LfsImap::deserialize(&buf);
+        assert!(
+            matches!(result, Err(LfsError::Corrupt)),
+            "overflowing count must be rejected as Corrupt, not wrap and OOB-index"
+        );
+    }
+
+    #[test]
+    fn load_from_disk_rejects_block_count_exceeding_device_capacity() {
+        // WHY: block_count is an attacker-controlled on-disk field; an
+        // oversized value must be rejected against the device's actual
+        // capacity before Vec::with_capacity is sized from it (#333).
+        let mut dev = MemBlockDevice::new(64).expect("create device"); // 32 KiB device
+        let mut cache = BlockCache::new();
+
+        let result = LfsImap::load_from_disk(&mut dev, &mut cache, 0, 262_145);
+        assert!(
+            matches!(result, Err(LfsError::Corrupt)),
+            "block_count implying ~1 GiB on a 32 KiB device must be rejected before allocating"
+        );
+    }
+
+    #[test]
+    fn load_from_disk_rejects_overflowing_block_count() {
+        // WHY: block_count * BLOCK_SIZE must not wrap on a 32-bit usize (#333).
+        let mut dev = MemBlockDevice::new(64).expect("create device");
+        let mut cache = BlockCache::new();
+
+        let result = LfsImap::load_from_disk(&mut dev, &mut cache, 0, u32::MAX);
+        assert!(
+            matches!(result, Err(LfsError::Corrupt)),
+            "overflowing block_count must be rejected, not wrap into a tiny allocation"
+        );
     }
 }

--- a/crates/thumos/src/power.rs
+++ b/crates/thumos/src/power.rs
@@ -361,6 +361,8 @@ pub enum Radio {
     Gps,
     /// FM radio receiver.
     Fm,
+    /// Mesh (`LoRa`/Meshtastic) transceiver.
+    Mesh,
     /// All radios.
     All,
 }
@@ -394,7 +396,7 @@ pub enum PowerMode {
 
 /// Power manager state.
 pub(crate) struct PowerManager {
-    states: [(Radio, PowerState); 5],
+    states: [(Radio, PowerState); 6],
     mode: PowerMode,
 }
 
@@ -408,6 +410,7 @@ impl PowerManager {
                 (Radio::Bluetooth, PowerState::Off),
                 (Radio::Gps, PowerState::Off),
                 (Radio::Fm, PowerState::Off),
+                (Radio::Mesh, PowerState::Off),
             ],
             mode: PowerMode::Silent,
         }
@@ -480,6 +483,7 @@ impl PowerManager {
                 self.set_state(Radio::Bluetooth, PowerState::Off);
                 self.set_state(Radio::Gps, PowerState::Off);
                 self.set_state(Radio::Fm, PowerState::Off);
+                self.set_state(Radio::Mesh, PowerState::Off);
             }
             PowerMode::Silent => {
                 self.set_state(Radio::All, PowerState::Off);
@@ -490,6 +494,7 @@ impl PowerManager {
                 self.set_state(Radio::Bluetooth, PowerState::On);
                 self.set_state(Radio::Gps, PowerState::Off);
                 self.set_state(Radio::Fm, PowerState::Off);
+                self.set_state(Radio::Mesh, PowerState::Off);
             }
         }
         self.mode = mode;
@@ -564,8 +569,9 @@ impl Default for PowerManager {
 ///
 /// Maps boolean enable/disable flags from a [`ModePolicy`] to
 /// [`PowerState::On`] / [`PowerState::Off`] and calls
-/// [`PowerManager::set_state`] for each radio.  FM is always turned
-/// off in security mode transitions (not a security-relevant radio).
+/// [`PowerManager::set_state`] for each radio, including Mesh/LoRa (#254).
+/// FM is always turned off in security mode transitions (not a
+/// security-relevant radio).
 ///
 /// Used by the boot sequence (Wave 8) and by [`ModeManager`] on mode
 /// transitions to enforce radio policy without coupling security_mode
@@ -582,6 +588,7 @@ pub(crate) fn apply_mode_policy(
     pm.set_state(Radio::Wifi, to_state(policy.wifi_enabled));
     pm.set_state(Radio::Bluetooth, to_state(policy.bluetooth_enabled));
     pm.set_state(Radio::Gps, to_state(policy.gps_enabled));
+    pm.set_state(Radio::Mesh, to_state(policy.mesh_enabled));
     // FM is always off during security mode transitions.
     pm.set_state(Radio::Fm, PowerState::Off);
 }
@@ -765,9 +772,10 @@ mod tests {
     fn full_mode() {
         let mut pm = PowerManager::new();
         pm.apply_mode(PowerMode::Full);
-        assert_eq!(pm.active_count(), 5);
+        assert_eq!(pm.active_count(), 6);
         assert_eq!(pm.state(Radio::Cellular), PowerState::On);
         assert_eq!(pm.state(Radio::Wifi), PowerState::On);
+        assert_eq!(pm.state(Radio::Mesh), PowerState::On, "Full mode must enable mesh (#254)");
     }
 
     #[test]
@@ -828,7 +836,7 @@ mod tests {
         pm.apply_mode(PowerMode::Full);
         pm.hardware_kill(Radio::All);
 
-        let radios = [Radio::Cellular, Radio::Wifi, Radio::Bluetooth, Radio::Gps, Radio::Fm];
+        let radios = [Radio::Cellular, Radio::Wifi, Radio::Bluetooth, Radio::Gps, Radio::Fm, Radio::Mesh];
         for radio in radios {
             assert_eq!(pm.state(radio), PowerState::HardwareKilled);
         }
@@ -889,6 +897,8 @@ mod tests {
             "Sentinel must keep GPS on");
         assert_eq!(pm.state(Radio::Fm), PowerState::Off,
             "FM must always be off in security modes");
+        assert_eq!(pm.state(Radio::Mesh), PowerState::On,
+            "Sentinel must keep mesh on (#254)");
     }
 
     #[test]
@@ -919,6 +929,33 @@ mod tests {
             "Daily must enable Bluetooth");
         assert_eq!(pm.state(Radio::Gps), PowerState::On,
             "Daily must enable GPS");
+        assert_eq!(pm.state(Radio::Mesh), PowerState::On,
+            "Daily must enable mesh (#254)");
+    }
+
+    #[test]
+    fn mode_policy_applies_radio_state_panic_disables_mesh() {
+        use crate::security::SleepTier;
+        use crate::security_mode::ModePolicy;
+
+        let mut pm = PowerManager::new();
+        pm.apply_mode(PowerMode::Full);
+
+        // Panic policy: everything off, including mesh (#254).
+        let panic_policy = ModePolicy {
+            cellular_enabled: false,
+            wifi_enabled: false,
+            bluetooth_enabled: false,
+            gps_enabled: false,
+            mesh_enabled: false,
+            sleep_tier: SleepTier::Long,
+            scan_interval_ms: 0,
+        };
+
+        apply_mode_policy(&panic_policy, &mut pm);
+
+        assert_eq!(pm.state(Radio::Mesh), PowerState::Off,
+            "Panic must disable mesh/LoRa (#254)");
     }
 
     // -----------------------------------------------------------------------

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -524,7 +524,7 @@ pub(crate) fn notify_fault(faulting_pid: Pid, kind: FaultKind) {
     // SAFETY: current process PCB pointer is valid; set by the scheduler on
     // context switch. Temporarily mutating CURRENT to deliver the fault message
     // with the faulting PID as sender; CURRENT is restored before returning.
-    unsafe {
+    let sent = unsafe {
         let procs = &mut *addr_of_mut!(PROCS);
         if let Some(ref mut proc) = procs[usize::from(faulting_pid)] {
             proc.state = State::Dead;
@@ -533,8 +533,21 @@ pub(crate) fn notify_fault(faulting_pid: Pid, kind: FaultKind) {
         // to faulting_pid so the message arrives with the correct sender identity.
         let saved = CURRENT;
         CURRENT = faulting_pid;
-        ipc::send(0, msg);
+        let sent = ipc::send(0, msg);
         CURRENT = saved;
+        sent
+    };
+
+    // WHY: kinit (PID 0) is the userspace fault supervisor; a full inbox
+    // means this fault notification is silently lost and the Dead process
+    // (already marked above) is never reaped (#252). Surface the drop on
+    // UART, matching the CAPDEN diagnostic pattern in capability.rs.
+    if !sent {
+        use core::fmt::Write;
+
+        use crate::uart::Uart;
+        let mut serial = Uart::new();
+        write!(serial, "FAULTDROP pid={faulting_pid} tag={tag} kinit-inbox-full\r\n").ok();
     }
 }
 
@@ -1880,6 +1893,71 @@ mod tests {
             let msg = ipc::recv().expect("UndefinedInstruction fault must deliver a message to pid 0");
             assert_eq!(msg.tag, 3, "UndefinedInstruction tag must be 3");
             assert_eq!(msg.payload()[0], 1u8, "first payload byte must be faulting PID");
+        }
+    }
+
+    #[test]
+    fn notify_fault_full_inbox_does_not_panic() {
+        // WHY: regression test for #252 — ipc::send's bool return was
+        // previously discarded inside notify_fault; a full kinit inbox must
+        // not panic, and the faulting process must still be marked Dead
+        // even when the notification itself is dropped.
+        // SAFETY: test-only; reset_all reinitialises global state. Single-threaded
+        // test execution ensures no concurrent access to PROCS or CURRENT.
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+
+            let pt0 = mmu::alloc_addr_space().unwrap();
+            procs[0] = Some(Process {
+                pid: 0,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: None,
+                exit_status: 0,
+                page_table_phys: pt0,
+                stack_base: 0,
+                stack_pages: 0,
+                heap_break: DEFAULT_HEAP_BREAK,
+                mappings: [None; MAX_MAPPINGS],
+                signal_state: SignalState::new(),
+                uid: 0,
+                wake_tick: 0,
+                capabilities: crate::capability::Capabilities::ALL,
+            });
+            let pt1 = mmu::alloc_addr_space().unwrap();
+            procs[1] = Some(Process {
+                pid: 1,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: Some(0),
+                exit_status: 0,
+                page_table_phys: pt1,
+                stack_base: 0,
+                stack_pages: 0,
+                heap_break: DEFAULT_HEAP_BREAK,
+                mappings: [None; MAX_MAPPINGS],
+                signal_state: SignalState::new(),
+                uid: 0,
+                wake_tick: 0,
+                capabilities: crate::capability::Capabilities::ALL,
+            });
+            CURRENT = 0;
+
+            // Saturate PID 0's inbox so ipc::send(0, ...) returns false.
+            for _ in 0..20 {
+                ipc::send(0, ipc::Message::new(99, b"fill"));
+            }
+
+            // Must not panic even though the fault notification cannot be delivered.
+            notify_fault(1, FaultKind::UndefinedInstruction);
+
+            let procs = &*core::ptr::addr_of!(PROCS);
+            assert_eq!(
+                procs[1].as_ref().unwrap().state,
+                State::Dead,
+                "faulting process must still be marked Dead when the fault notification is dropped"
+            );
         }
     }
 

--- a/crates/thumos/src/security_mode.rs
+++ b/crates/thumos/src/security_mode.rs
@@ -522,20 +522,15 @@ impl ModeManager {
     }
 
     /// Apply the current effective policy to the power manager.
+    ///
+    /// Delegates to [`crate::power::apply_mode_policy`] — the single
+    /// authoritative `ModePolicy` -> radio-actuation mapping, including
+    /// Mesh/LoRa (#254). Do not hand-roll radio actuation here again: a
+    /// second, independently-drifting copy of this mapping is exactly how
+    /// Mesh went unactuated in two places at once.
     fn apply_radio_policy(&self, pm: &mut PowerManager) {
         let policy = self.effective_policy();
-
-        let cell_state = if policy.cellular_enabled { PowerState::On } else { PowerState::Off };
-        let wifi_state = if policy.wifi_enabled { PowerState::On } else { PowerState::Off };
-        let bt_state = if policy.bluetooth_enabled { PowerState::On } else { PowerState::Off };
-        let gps_state = if policy.gps_enabled { PowerState::On } else { PowerState::Off };
-
-        pm.set_state(Radio::Cellular, cell_state);
-        pm.set_state(Radio::Wifi, wifi_state);
-        pm.set_state(Radio::Bluetooth, bt_state);
-        pm.set_state(Radio::Gps, gps_state);
-        // FM is always off in security modes (not a security-relevant radio).
-        pm.set_state(Radio::Fm, PowerState::Off);
+        crate::power::apply_mode_policy(&policy, pm);
     }
 
     // -----------------------------------------------------------------------
@@ -994,11 +989,13 @@ mod tests {
         assert!(event.keys_zeroized);
         assert_eq!(event.triggered_at, 1000);
 
-        // All radios must be off.
+        // All radios must be off, including Mesh/LoRa (#254).
         assert_eq!(pm.state(Radio::Cellular), PowerState::Off);
         assert_eq!(pm.state(Radio::Wifi), PowerState::Off);
         assert_eq!(pm.state(Radio::Bluetooth), PowerState::Off);
         assert_eq!(pm.state(Radio::Gps), PowerState::Off);
+        assert_eq!(pm.state(Radio::Mesh), PowerState::Off,
+            "Panic must leave the Mesh/LoRa transceiver off (#254)");
     }
 
     // -----------------------------------------------------------------------
@@ -1063,6 +1060,8 @@ mod tests {
         assert_eq!(pm.state(Radio::Wifi), PowerState::Off);
         assert_eq!(pm.state(Radio::Bluetooth), PowerState::Off);
         assert_eq!(pm.state(Radio::Gps), PowerState::Off);
+        assert_eq!(pm.state(Radio::Mesh), PowerState::On,
+            "Covert Lock must keep mesh on (#254)");
 
         // Deactivate Covert Lock — Daily mode restores all radios.
         mm.toggle_covert_lock(&mut pm);
@@ -1072,6 +1071,7 @@ mod tests {
         assert_eq!(pm.state(Radio::Wifi), PowerState::On);
         assert_eq!(pm.state(Radio::Bluetooth), PowerState::On);
         assert_eq!(pm.state(Radio::Gps), PowerState::On);
+        assert_eq!(pm.state(Radio::Mesh), PowerState::On);
     }
 
     // -----------------------------------------------------------------------

--- a/crates/thumos/src/sms.rs
+++ b/crates/thumos/src/sms.rs
@@ -440,8 +440,7 @@ impl SmsManager {
 
         // DCS: only GSM-7 (0x00) supported in this kernel build.
         let dcs = cur.read_byte()?;
-        let class_bits = (dcs >> 2) & 0x03;
-        if class_bits != 0x00 {
+        if dcs != 0x00 {
             return Err(SmsError::PduDecode);
         }
 
@@ -641,6 +640,36 @@ mod tests {
         assert_eq!(sender, "+1234567890", "sender must decode to +1234567890");
         assert_eq!(msg.body, "Hello", "body must decode to 'Hello'");
         assert!(!msg.read, "incoming message must be unread");
+    }
+
+    #[test]
+    fn handle_incoming_rejects_non_gsm7_dcs() {
+        // WHY: regression test for #306 — bits-3:2-only validation admitted
+        // any DCS whose bits 3:2 were 0b00, letting compressed-GSM-7 (0x20,
+        // 0x30), message-waiting-indication (0xC0), and other non-GSM-7
+        // schemes reach the septet decoder. Only DCS 0x00 is supported.
+        let base: [u8; 24] = [
+            0x00, // SCA len
+            0x00, // first octet (MTI=0)
+            0x0A, // OA len (10 digits)
+            0x91, // OA type (international)
+            0x21, 0x43, 0x65, 0x87, 0x09, // BCD +1234567890
+            0x00, // PID
+            0x00, // DCS (overwritten per case below)
+            0x32, 0x10, 0x51, 0x21, 0x03, 0x00, 0x00, // SCTS
+            0x05, // UDL (5 septets)
+            0xC8, 0x32, 0x9B, 0xFD, 0x06, // "Hello" packed
+        ];
+
+        for &adversarial_dcs in &[0x10u8, 0xF0, 0xC0, 0x20, 0x30] {
+            let mut pdu = base.to_vec();
+            pdu[10] = adversarial_dcs;
+            let result = SmsManager::handle_incoming(&pdu);
+            assert!(
+                matches!(result, Err(SmsError::PduDecode)),
+                "DCS {adversarial_dcs:#04x} must be rejected, not admitted as GSM-7"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Seven host-testable correctness defects across the kernel.

- **#342** — `Timer::update()` advanced `started_tick` to `current_tick` every call, discarding `elapsed_ms % 1000`; a timer polled faster than 1 Hz never accrued a whole second and never expired. The epoch now advances by only the consumed whole seconds, carrying the sub-second remainder forward.
- **#252** — `notify_fault` discarded `ipc::send`'s bool; a full kinit inbox silently dropped the fault notification while the process was already marked Dead (never reaped). The drop is now surfaced on UART.
- **#297** — `AuditLog` held a ~64 KB inline array and `new()` returned it by value — a kernel-stack-overflow risk once wired. `entries` is now `Box<[AuditEntry]>` built through a `Vec`, so the backing store never transits the stack.
- **#333** (security) — `LfsImap` deserialize/`load_from_disk` sized parsing/allocation from attacker-controlled on-disk length fields with unchecked multiply (wraps on 32-bit). Now checked arithmetic + a device-capacity bound.
- **#306** — SMS DCS validation masked only bits 3:2, admitting 64 non-GSM-7 coding schemes that reached the septet decoder. Now only DCS `0x00` is accepted.
- **#254** — `apply_radio_policy` hand-rolled a second copy of the policy→radio map and never actuated Mesh/LoRa. Added `Radio::Mesh`, fixed the mapping once in the existing `power::apply_mode_policy` (which `security_mode`'s own doc already named as the single authority), and made `apply_radio_policy` delegate to it — closing the gap and deleting the duplicate-logic class.
- **#386** — audio `open_session` preemption only paused `<=`-priority sessions then seized the codec route, so a new *lower*-priority session displaced an active higher-priority one. A session blocked by a strictly-higher active one is now inserted paused (no codec touch) and resumes on close; a `debug_assert` guards the single-active invariant.

## Closes

Closes #342, #252, #297, #333, #306, #254, #386

## Verification

- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — 1781 passed (+10)
- `cargo build --release --target armv7a-none-eabi` — compiles
- `kanon lint . --summary` — clean

#219 (also in this area) was found already-fixed by #405 and closed separately.