### PR TITLE
MediaTek driver register-access correctness (6 MMIO fixes)

### DIFF
--- a/crates/thumos/src/ccci.rs
+++ b/crates/thumos/src/ccci.rs
@@ -289,6 +289,13 @@ impl CcifChannel {
     }
 }
 
+/// True if the raw CCIF `BUSY` register value has `channel`'s bit set,
+/// meaning the modem has not yet consumed a previously sent message on
+/// that channel (issue #261).
+fn ccif_channel_busy(busy: u32, channel: CcifChannel) -> bool {
+    busy & channel.mask() != 0
+}
+
 // ---------------------------------------------------------------------------
 // CCCI message format
 // ---------------------------------------------------------------------------
@@ -554,6 +561,8 @@ pub(crate) enum CcciError {
     PayloadTooLarge(usize),
     /// Ring buffer is full — no free descriptors.
     RingBufferFull,
+    /// CCIF channel is still busy with an unconsumed message (issue #261).
+    CcifChannelBusy(CcifChannel),
     /// Modem watchdog timeout.
     ModemWatchdog(u32),
     /// Identity response blocked by kernel filter.
@@ -589,6 +598,7 @@ impl fmt::Display for CcciError {
                 write!(f, "payload {size} exceeds MTU {CCCI_MTU}")
             }
             Self::RingBufferFull => write!(f, "ring buffer full"),
+            Self::CcifChannelBusy(channel) => write!(f, "CCIF channel {channel:?} busy"),
             Self::ModemWatchdog(status) => write!(f, "modem WDT: {status:#010x}"),
             Self::IdentityFiltered => write!(f, "identity response filtered"),
             Self::MalformedHeader => write!(f, "malformed CCCI header"),
@@ -663,6 +673,24 @@ const TX_RING_SIZE: usize = 16;
 /// Number of descriptors per RX queue (single queue).
 const RX_RING_SIZE: usize = 16;
 
+/// Full-system memory barrier (ARM `dmb sy`), used to order CLDMA GPD
+/// descriptor field writes/reads across the AP/DMA-engine ownership
+/// handoff (issue #262).
+#[cfg(target_arch = "arm")]
+#[inline(always)]
+fn dmb_sy() {
+    // SAFETY: dmb is a non-privileged memory-barrier instruction; always safe to execute.
+    unsafe {
+        core::arch::asm!("dmb sy");
+    }
+}
+
+/// No-op stub for non-ARM builds so ccci.rs unit tests compile on the host,
+/// where there is no real DMA engine to synchronize with.
+#[cfg(not(target_arch = "arm"))]
+#[inline(always)]
+fn dmb_sy() {}
+
 /// CLDMA GPD (General Purpose Descriptor) for DMA transfer.
 ///
 /// Each descriptor describes one DMA buffer. Descriptors are chained
@@ -706,18 +734,65 @@ impl CldmaGpd {
     }
 
     /// Whether hardware currently owns this descriptor.
+    ///
+    /// WHY: `flags` is shared with the CLDMA DMA engine (issue #262) -- a
+    /// volatile load is required so a caller polling this method observes
+    /// a hardware-side ownership change rather than a value the compiler
+    /// cached from an earlier read.
     pub(crate) fn is_hw_owned(&self) -> bool {
-        self.flags & GPD_FLAG_HWO != 0
+        // SAFETY: `flags` is a `repr(C)` field of a descriptor the CLDMA
+        // engine writes concurrently; a volatile read is required.
+        let flags = unsafe { core::ptr::read_volatile(core::ptr::addr_of!(self.flags)) };
+        let owned = flags & GPD_FLAG_HWO != 0;
+        if !owned {
+            // Acquire half of the ownership handoff: once HWO reads clear,
+            // this barrier ensures a subsequent read of a DMA-written field
+            // (e.g. recv_len) observes the data the CLDMA engine wrote
+            // before it cleared HWO, rather than a stale/reordered value.
+            dmb_sy();
+        }
+        owned
     }
 
     /// Set hardware ownership (give to DMA engine).
+    ///
+    /// WHY: this is the release half of the ownership handoff (issue
+    /// #262) -- the barrier ensures data_ptr/data_len/recv_len writes the
+    /// caller made before this call are visible to the CLDMA engine before
+    /// it can observe HWO set.
     pub(crate) fn set_hw_owned(&mut self) {
-        self.flags |= GPD_FLAG_HWO;
+        dmb_sy();
+        let flags = self.flags | GPD_FLAG_HWO;
+        // SAFETY: `flags` is a `repr(C)` field shared with the CLDMA DMA
+        // engine; a volatile store is required so the compiler does not
+        // reorder, elide, or coalesce the ownership-transfer write.
+        unsafe { core::ptr::write_volatile(core::ptr::addr_of_mut!(self.flags), flags) };
     }
 
     /// Clear hardware ownership (reclaim from DMA engine).
     pub(crate) fn clear_hw_owned(&mut self) {
-        self.flags &= !GPD_FLAG_HWO;
+        let flags = self.flags & !GPD_FLAG_HWO;
+        // SAFETY: `flags` is a `repr(C)` field shared with the CLDMA DMA
+        // engine; a volatile store is required for the same reason as
+        // `set_hw_owned`.
+        unsafe { core::ptr::write_volatile(core::ptr::addr_of_mut!(self.flags), flags) };
+    }
+
+    /// Read `recv_len` with a volatile access.
+    ///
+    /// WHY: `recv_len` is written by the CLDMA DMA engine while the AP does
+    /// not hold Rust-visible ownership of the descriptor (issue #262); a
+    /// plain field read could return the AP's own last write (`0`, set at
+    /// `submit`/`rearm` time) instead of the hardware-written value.
+    ///
+    /// Callers must only trust the result after [`is_hw_owned`] has
+    /// observed `false` for this descriptor.
+    ///
+    /// [`is_hw_owned`]: CldmaGpd::is_hw_owned
+    pub(crate) fn recv_len_volatile(&self) -> u16 {
+        // SAFETY: `recv_len` is a `repr(C)` field the CLDMA engine writes
+        // concurrently; a volatile read is required.
+        unsafe { core::ptr::read_volatile(core::ptr::addr_of!(self.recv_len)) }
     }
 }
 
@@ -885,8 +960,11 @@ impl RxRing {
         // SECURITY: recv_len is modem-written and untrusted; clamp to the
         // AP-allocated buffer capacity (data_len) before it can be used as a
         // slice length/copy count by the caller.
+        // WHY: recv_len_volatile, not the plain field -- see
+        // CldmaGpd::recv_len_volatile for why a plain read is unsound here
+        // (issue #262).
         let recv_len = self.descriptors[idx]
-            .recv_len
+            .recv_len_volatile()
             .min(self.descriptors[idx].data_len);
         self.head = (self.head + 1) % RX_RING_SIZE;
         self.hw_count -= 1;
@@ -1474,6 +1552,15 @@ const CCIF_SRAM_SIZE: usize = 512;
 pub(crate) unsafe fn ccif_send(channel: CcifChannel, data: &[u8]) -> Result<(), CcciError> {
     if data.len() > CCIF_SRAM_SIZE {
         return Err(CcciError::PayloadTooLarge(data.len()));
+    }
+
+    // Confirm the modem has consumed any previous message on this channel
+    // before overwriting the shared SRAM window (issue #261).
+    // SAFETY: shared memory region at BUSY is mapped and within the CCCI
+    // aperture. Access is synchronized via CCIF doorbell.
+    let busy = unsafe { mmio::read32(ccif_reg::BUSY) };
+    if ccif_channel_busy(busy, channel) {
+        return Err(CcciError::CcifChannelBusy(channel));
     }
 
     // Write data to SRAM window (word-aligned writes).
@@ -2435,6 +2522,23 @@ mod tests {
     }
 
     #[test]
+    fn ccif_channel_busy_detects_target_bit() {
+        let busy = CcifChannel::Sram.mask();
+        assert!(
+            ccif_channel_busy(busy, CcifChannel::Sram),
+            "BUSY bit set for the target channel must report busy"
+        );
+        assert!(
+            !ccif_channel_busy(busy, CcifChannel::RingQ0),
+            "BUSY bit for a different channel must not report busy"
+        );
+        assert!(
+            !ccif_channel_busy(0, CcifChannel::Sram),
+            "a clear BUSY register must never report busy"
+        );
+    }
+
+    #[test]
     fn ccif_parse_multiple_channels() {
         // Simulate SRAM + Exception channels firing
         let raw = CcifChannel::Sram.mask() | CcifChannel::Exception.mask();
@@ -2698,6 +2802,18 @@ mod tests {
 
         gpd.clear_hw_owned();
         assert!(!gpd.is_hw_owned(), "clear_hw_owned works");
+    }
+
+    #[test]
+    fn gpd_recv_len_volatile_reads_current_value() {
+        let mut gpd = CldmaGpd::zeroed();
+        assert_eq!(gpd.recv_len_volatile(), 0, "starts at zero");
+        gpd.recv_len = 42;
+        assert_eq!(
+            gpd.recv_len_volatile(),
+            42,
+            "reflects a direct field write (host build has no concurrent DMA writer)"
+        );
     }
 
     // -- Error display --

--- a/crates/thumos/src/emmc.rs
+++ b/crates/thumos/src/emmc.rs
@@ -246,6 +246,29 @@ const DMA_CFG_STS_ACTIVE: u32 = 1 << 0;
 /// FIFO clear bit  -  write 1 to flush both TX and RX FIFOs.
 const FIFOCS_CLR: u32 = 1 << 0;
 
+/// RX FIFO word-count field shift (bits [23:16] per the MT6739 MSDC
+/// datasheet, as cited in issue #293).
+///
+/// WARNING: the exact bit position is taken from the issue's datasheet
+/// citation, not independently re-derived against the BSP header. The
+/// per-word poll is bounded by POLL_TIMEOUT so a wrong field position
+/// degrades to a DataTimeout (safe), but must be verified before silicon.
+/// TODO(#293)[deliberate-prudent]: confirm FIFOCS RXCNT field position against the MT6739 BSP.
+const FIFOCS_RXCNT_SHIFT: u32 = 16;
+
+/// RX FIFO word-count field mask (8 bits at [23:16]).
+const FIFOCS_RXCNT_MASK: u32 = 0xFF << FIFOCS_RXCNT_SHIFT;
+
+/// True if the MSDC_FIFOCS RX word count is nonzero, i.e. at least one word
+/// is buffered and safe to read FROM MSDC_RXDATA.
+///
+/// WHY: STS_DATBUSY stays SET for the duration of an entire block transfer,
+/// so it cannot signal per-word FIFO readiness during a PIO read; the RX
+/// count field is the per-word-accurate signal (issue #293).
+fn fifo_rx_ready(fifocs: u32) -> bool {
+    fifocs & FIFOCS_RXCNT_MASK != 0
+}
+
 // ---------------------------------------------------------------------------
 // MSDC_PS bit fields
 // ---------------------------------------------------------------------------
@@ -740,11 +763,20 @@ impl MsdcController {
         // PIO: read 128 words (512 bytes) FROM MSDC_RXDATA
         let buf_ptr = buf.as_mut_ptr().cast::<u32>();
         for i in 0..WORDS_PER_SECTOR {
-            // Poll until FIFO has data (check dat busy clears for completion)
-            // SAFETY: SDC_STS is a valid MMIO register at offset 0x3C within the MSDC0 address space. Volatile access is required for hardware registers.
-            if !unsafe { mmio::wait_bits_clear(self.reg(REG_SDC_STS), STS_DATBUSY, POLL_TIMEOUT) } {
-                // NOTE: datbusy stays SET until the full block is transferred,
-                // so we read word-by-word and only check at the end
+            // Poll the RX FIFO word count until at least one word is
+            // buffered, instead of STS_DATBUSY (which cannot signal
+            // per-word readiness -- see fifo_rx_ready, issue #293).
+            let mut ready = false;
+            for _ in 0..POLL_TIMEOUT {
+                // SAFETY: MSDC_FIFOCS is a valid MMIO register at offset 0x14 within the MSDC0 address space. Volatile access is required for hardware registers.
+                let fifocs = unsafe { self.read_reg(REG_MSDC_FIFOCS) };
+                if fifo_rx_ready(fifocs) {
+                    ready = true;
+                    break;
+                }
+            }
+            if !ready {
+                return Err(MsdcError::DataTimeout);
             }
             // SAFETY: MSDC_RXDATA is a valid MMIO register at offset 0x1C within the MSDC0 address space. Volatile access is required for hardware registers.
             let word = unsafe { self.read_reg(REG_MSDC_RXDATA) };
@@ -758,11 +790,11 @@ impl MsdcController {
             return Err(MsdcError::DataTimeout);
         }
 
-        // Clear transfer-complete interrupt
-        // SAFETY: MSDC_INT is a valid MMIO register at offset 0x0C within the MSDC0 address space. Volatile access is required for hardware registers.
-        unsafe { self.write_reg(REG_MSDC_INT, INT_XFER_COMPL) };
-
-        Ok(())
+        // Check INT_ERR_MASK before clearing completion so a hardware error
+        // (e.g. INT_DATCRCERR) coinciding with INT_XFER_COMPL is not
+        // silently discarded (issue #286).
+        // SAFETY: controller register block is mapped per caller contract.
+        unsafe { self.check_and_clear_completion(INT_XFER_COMPL) }
     }
 
     /// Write a single 512-byte sector via PIO.
@@ -810,11 +842,10 @@ impl MsdcController {
             return Err(MsdcError::DataTimeout);
         }
 
-        // Clear transfer-complete interrupt
-        // SAFETY: MSDC_INT is a valid MMIO register at offset 0x0C within the MSDC0 address space. Volatile access is required for hardware registers.
-        unsafe { self.write_reg(REG_MSDC_INT, INT_XFER_COMPL) };
-
-        Ok(())
+        // Check INT_ERR_MASK before clearing completion so a hardware error
+        // coinciding with INT_XFER_COMPL is not silently discarded (issue #286).
+        // SAFETY: controller register block is mapped per caller contract.
+        unsafe { self.check_and_clear_completion(INT_XFER_COMPL) }
     }
 
     // -- DMA transfers --
@@ -881,11 +912,11 @@ impl MsdcController {
             return Err(MsdcError::DataTimeout);
         }
 
-        // Clear completion interrupt
-        // SAFETY: MSDC_INT is a valid MMIO register at offset 0x0C within the MSDC0 address space. Volatile access is required for hardware registers.
-        unsafe { self.write_reg(REG_MSDC_INT, INT_XFER_COMPL | INT_DXFER_DONE) };
-
-        Ok(())
+        // Check INT_ERR_MASK before clearing completion so a hardware error
+        // coinciding with INT_XFER_COMPL/INT_DXFER_DONE is not silently
+        // discarded (issue #286).
+        // SAFETY: controller register block is mapped per caller contract.
+        unsafe { self.check_and_clear_completion(INT_XFER_COMPL | INT_DXFER_DONE) }
     }
 
     /// Write sectors via DMA using a GPD/BD descriptor chain.
@@ -944,11 +975,11 @@ impl MsdcController {
             return Err(MsdcError::DataTimeout);
         }
 
-        // Clear completion interrupt
-        // SAFETY: MSDC_INT is a valid MMIO register at offset 0x0C within the MSDC0 address space. Volatile access is required for hardware registers.
-        unsafe { self.write_reg(REG_MSDC_INT, INT_XFER_COMPL | INT_DXFER_DONE) };
-
-        Ok(())
+        // Check INT_ERR_MASK before clearing completion so a hardware error
+        // coinciding with INT_XFER_COMPL/INT_DXFER_DONE is not silently
+        // discarded (issue #286).
+        // SAFETY: controller register block is mapped per caller contract.
+        unsafe { self.check_and_clear_completion(INT_XFER_COMPL | INT_DXFER_DONE) }
     }
 
     /// Read the 32-bit response FROM SDC_RESP0.
@@ -996,6 +1027,34 @@ impl MsdcController {
     pub(crate) unsafe fn clear_interrupts(&self, bits: u32) {
         // SAFETY: MSDC_INT is a valid MMIO register at offset 0x0C within the MSDC0 address space. Volatile access is required for hardware registers.
         unsafe { self.write_reg(REG_MSDC_INT, bits) };
+    }
+
+    /// Check for hardware error interrupts before clearing a transfer's
+    /// completion bits.
+    ///
+    /// Reads MSDC_INT; if any bit in [`INT_ERR_MASK`] is set, clears every
+    /// observed bit (MSDC_INT is write-1-to-clear) and returns
+    /// [`MsdcError::InterruptError`] carrying the error bits. Otherwise
+    /// clears only `completion_bits` and returns `Ok(())`.
+    ///
+    /// WHY: clearing a completion bit (e.g. INT_XFER_COMPL) without first
+    /// inspecting INT_ERR_MASK silently discards a hardware error that
+    /// coincided with completion (issue #286).
+    ///
+    /// # Safety
+    ///
+    /// The controller register block must be mapped.
+    unsafe fn check_and_clear_completion(&self, completion_bits: u32) -> Result<(), MsdcError> {
+        // SAFETY: MSDC_INT is a valid MMIO register at offset 0x0C within the MSDC0 address space. Volatile access is required for hardware registers.
+        let status = unsafe { self.interrupt_status() };
+        if status & INT_ERR_MASK != 0 {
+            // SAFETY: MSDC_INT is write-1-to-clear; writing the full observed status clears every pending bit, including the error bits just inspected.
+            unsafe { self.clear_interrupts(status) };
+            return Err(MsdcError::InterruptError(status & INT_ERR_MASK));
+        }
+        // SAFETY: MSDC_INT is a valid MMIO register at offset 0x0C within the MSDC0 address space. Volatile access is required for hardware registers.
+        unsafe { self.clear_interrupts(completion_bits) };
+        Ok(())
     }
 
     /// Enable specific interrupt sources.
@@ -1418,6 +1477,29 @@ mod tests {
             STS_CMDBUSY & STS_DATBUSY,
             0,
             "cmdbusy and datbusy do not overlap"
+        );
+    }
+
+    // -- MSDC_FIFOCS RX readiness (issue #293) --
+
+    #[test]
+    fn fifo_rx_ready_false_when_count_field_zero() {
+        assert!(!fifo_rx_ready(0), "zero RX count must not be ready");
+        assert!(
+            !fifo_rx_ready(FIFOCS_CLR),
+            "bits outside the RXCNT field must not signal readiness"
+        );
+    }
+
+    #[test]
+    fn fifo_rx_ready_true_when_count_field_nonzero() {
+        assert!(
+            fifo_rx_ready(1 << FIFOCS_RXCNT_SHIFT),
+            "a single buffered word must signal readiness"
+        );
+        assert!(
+            fifo_rx_ready(0xFF << FIFOCS_RXCNT_SHIFT),
+            "a full RXCNT field must signal readiness"
         );
     }
 }

--- a/crates/thumos/src/usb.rs
+++ b/crates/thumos/src/usb.rs
@@ -17,8 +17,6 @@
 //! `drivers/usb/musb/musb_core.h` and the hardware_info provided in the
 //! dispatch prompt.
 
-use crate::mmio;
-
 // ---------------------------------------------------------------------------
 // Base address
 // ---------------------------------------------------------------------------
@@ -71,6 +69,19 @@ const REG_RXCSR: usize = 0x116;
 const REG_TXMAXP: usize = 0x118;
 /// EPx RX max packet size (16-bit).
 const REG_RXMAXP: usize = 0x11A;
+/// EPx RX byte count for the last received OUT packet (16-bit); valid
+/// when REG_INDEX >= 1. Source: MUSB Programmer's Guide `RxCount`/`COUNT0`
+/// -- may be less than REG_RXMAXP for a short packet (issue #221). Placed
+/// immediately after REG_RXMAXP to follow this driver's banked-register
+/// layout (which already reorders from the raw Mentor Graphics offsets).
+///
+/// WARNING: this offset is inferred from the driver's banked layout, NOT
+/// confirmed against the MT6739 BSP header — the drain is clamped to
+/// EP1_MAX_PKT so a wrong value cannot overrun the ring buffer, but the
+/// exact offset must be verified before trusting short-packet lengths on
+/// real silicon.
+/// TODO(#221)[deliberate-prudent]: confirm REG_RXCOUNT against the MT6739 MUSB BSP header.
+const REG_RXCOUNT: usize = 0x11C;
 
 // ---------------------------------------------------------------------------
 // FIFO registers
@@ -609,6 +620,17 @@ impl UsbIrqStatus {
     }
 }
 
+/// Clamp a raw `RxCount` register value to the endpoint's max packet size.
+///
+/// WHY: `RxCount` reports the number of bytes MUSB placed in the FIFO for
+/// the current OUT packet, which may be less than `max_pkt` for a short
+/// packet. Bounding the result to `max_pkt` also keeps the FIFO drain loop
+/// within the endpoint's configured packet size if the register ever
+/// reports an out-of-range value (issue #221).
+fn clamp_rx_count(raw_count: u16, max_pkt: u16) -> usize {
+    usize::from(raw_count).min(usize::from(max_pkt))
+}
+
 // ---------------------------------------------------------------------------
 // USB controller
 // ---------------------------------------------------------------------------
@@ -777,11 +799,10 @@ impl UsbController {
 
             // Wait for the FIFO to be ready (TxPktRdy cleared by hardware after send).
             // WHY: Timeout prevents infinite spin if the host disconnects mid-transfer.
-            let ready = mmio::wait_bits_clear(
-                self.base + REG_TXCSR,
-                u32::from(TXCSR_TXPKTRDY),
-                100_000,
-            );
+            // WHY: REG_TXCSR is a 16-bit register; mmio::wait_bits_clear performs an
+            // unaligned 32-bit load at this odd half-word offset (issue #227) -- poll
+            // with the 16-bit-aligned accessor instead.
+            let ready = self.wait_bits_clear16(REG_TXCSR, TXCSR_TXPKTRDY, 100_000);
             if !ready {
                 return 0;
             }
@@ -1156,11 +1177,13 @@ impl UsbController {
 
             let fifo = self.base + REG_FIFO_BASE + 4; // EP1 FIFO
 
-            // Drain the entire FIFO (up to EP1_MAX_PKT bytes).
-            for _ in 0..usize::from(EP1_MAX_PKT) {
-                // NOTE: We don't have a RxCount register in this simplified driver.
-                // We drain one full packet worth of bytes and rely on the ring
-                // buffer to absorb whatever arrives.
+            // WHY: RxCount reports the actual number of bytes the host sent
+            // in this OUT packet, which may be less than EP1_MAX_PKT for a
+            // short packet. Draining a fixed 64 bytes regardless of RxCount
+            // read stale FIFO bytes past the valid payload (issue #221).
+            let rx_count = clamp_rx_count(self.read16(REG_RXCOUNT), EP1_MAX_PKT);
+
+            for _ in 0..rx_count {
                 let byte = core::ptr::read_volatile(fifo as *const u8);
                 let next_head = (self.rx_head + 1) % SERIAL_RX_BUF_LEN;
                 if next_head != self.rx_tail {
@@ -1254,6 +1277,28 @@ impl UsbController {
         // SAFETY: caller verifies offset is a valid 2-byte-aligned 16-bit MUSB register within the MUSB address space at 0x1121_0000. Volatile access is required for hardware registers.
         unsafe { core::ptr::write_volatile((self.base + offset) as *mut u16, val) }
     }
+
+    /// Poll a 16-bit MUSB register until the given bits are clear, with a timeout.
+    ///
+    /// Returns `true` if the bits became clear, `false` on timeout. Uses a
+    /// correctly-sized 16-bit access -- unlike `mmio::wait_bits_clear`,
+    /// which performs an unconditional 32-bit load and would straddle
+    /// adjacent register bytes when polling a 16-bit-only MUSB register
+    /// such as REG_TXCSR at an odd half-word offset (issue #227).
+    ///
+    /// # Safety
+    ///
+    /// `offset` must be a valid 16-bit MUSB register, 2-byte aligned.
+    #[inline]
+    unsafe fn wait_bits_clear16(&self, offset: usize, bits: u16, max_iterations: u32) -> bool {
+        for _ in 0..max_iterations {
+            // SAFETY: caller verifies offset is a valid 2-byte-aligned 16-bit MUSB register within the MUSB address space at 0x1121_0000.
+            if unsafe { self.read16(offset) } & bits == 0 {
+                return true;
+            }
+        }
+        false
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1285,7 +1330,38 @@ mod tests {
         assert_eq!(REG_RXCSR, 0x116, "RxCSR OFFSET must be 0x116");
         assert_eq!(REG_TXMAXP, 0x118, "TxMaxP OFFSET must be 0x118");
         assert_eq!(REG_RXMAXP, 0x11A, "RxMaxP OFFSET must be 0x11A");
+        assert_eq!(REG_RXCOUNT, 0x11C, "RxCount OFFSET must be 0x11C");
         assert_eq!(REG_FIFO_BASE, 0x120, "FIFO base OFFSET must be 0x120");
+    }
+
+    // --- RX byte-count clamping (issue #221) ---
+
+    #[test]
+    fn clamp_rx_count_short_packet_uses_actual_count() {
+        assert_eq!(
+            clamp_rx_count(1, EP1_MAX_PKT),
+            1,
+            "a 1-byte OUT packet must drain exactly 1 byte, not a full EP1_MAX_PKT"
+        );
+    }
+
+    #[test]
+    fn clamp_rx_count_full_packet_uses_max_pkt() {
+        assert_eq!(clamp_rx_count(64, EP1_MAX_PKT), 64);
+    }
+
+    #[test]
+    fn clamp_rx_count_zero_length_packet_drains_nothing() {
+        assert_eq!(clamp_rx_count(0, EP1_MAX_PKT), 0);
+    }
+
+    #[test]
+    fn clamp_rx_count_clamps_out_of_range_register_value() {
+        assert_eq!(
+            clamp_rx_count(200, EP1_MAX_PKT),
+            usize::from(EP1_MAX_PKT),
+            "a bogus RxCount above the endpoint max packet size must be clamped"
+        );
     }
 
     // --- Device descriptor serialization ---


### PR DESCRIPTION
## Summary

MMIO register-access fixes across the USB, eMMC, and CCCI-modem drivers. These paths are `#[cfg(target_arch="arm")]` MMIO, so the gate is the **armv7a build + register-semantics review**; the extracted predicate helpers (`clamp_rx_count`, `fifo_rx_ready`, `ccif_channel_busy`, the GPD volatile accessor) are host-tested.

**Fully verified (closed):**
- **#227** — `write_serial` polled the 16-bit `REG_TXCSR` via `mmio::wait_bits_clear`, an unconditional 32-bit load at an odd half-word offset — an unaligned Device-memory access that faults on Cortex-A7 (or reads the adjacent register). Added `wait_bits_clear16` reusing the driver's own `read16`.
- **#286** — all four MSDC completion paths cleared `INT_XFER_COMPL` without first reading `INT_ERR`, losing an error that coincided with completion. A shared `check_and_clear_completion` reads `MSDC_INT`, returns `MsdcError::InterruptError` on any error bit (write-1-to-clear preserves siblings), else clears only the completion bits. (`InterruptError` was dead code before.)
- **#261** (modem) — `ccif_send` wrote the shared CCIF SRAM window without checking the per-channel `BUSY` bit — clobbering an in-flight modem message. It now reads `BUSY` (previously dead code) and returns `CcifChannelBusy`, letting the caller's existing retry path re-send.
- **#262** (modem) — the CLDMA GPD descriptor ring used plain non-volatile, unfenced accesses for the AP↔DMA ownership handoff. The ownership accessors now use volatile loads/stores with a `dmb` barrier (release before publishing HWO, acquire after observing it clear — the standard DMA-descriptor idiom); `poll_rx` reads the modem-written `recv_len` volatile. `dmb_sy` is arm-gated with a host no-op stub (matching mmu.rs) so host tests still build.

**Code landed, issue left open (`Refs`):**
- **#221** (USB EP1 RxCount) and **#293** (eMMC FIFO word-count poll) — the *logic* is correct and host-tested (short-packet clamping / per-word FIFO readiness), but each depends on a **register offset / bit-position that could not be verified against the MT6739 BSP header** in this environment. Both are landed behind clamps/timeouts so a wrong constant is memory-safe (degrades to a bounded drain / `DataTimeout`), and both carry a `TODO(#221)`/`TODO(#293)[deliberate-prudent]` marker. The issues stay **open** pending BSP verification — a genuine external blocker, not a descope.

## Review posture

The two modem-boundary fixes (#261/#262) were reviewed at the orchestrator (Opus) tier. #262's barrier-domain choice (`dmb sy` vs `ish`) and the arm-gating of the asm (an unconditional `dmb` would break the i686 host build) were specifically verified.

## Verification

- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — 1787 passed (+6 helpers)
- `cargo build --release --target armv7a-none-eabi` — compiles (incl. the `dmb sy` asm)
- `kanon lint . --summary` — clean