### PR TITLE
Bound attacker-controlled input + fix the privacy-purge auth gap (8 issues)

### DIFF
--- a/crates/thumos/src/ekphrasis.rs
+++ b/crates/thumos/src/ekphrasis.rs
@@ -92,6 +92,14 @@ const AUDIO_SAMPLE_RATE_HZ: u32 = 16_000;
 /// Audio channels for STT capture.
 const AUDIO_CHANNELS: u8 = 1;
 
+/// Maximum buffered audio bytes accumulated by `feed_audio` before the
+/// buffer is drained via `take_audio_frame`. At the 16 kHz mono 16-bit STT
+/// capture rate (32 KB/s), 256 KiB is 8 seconds of un-drained audio —
+/// generous headroom for a slow drain cycle on a 1 GB device without
+/// leaving the slab allocator exposed to unbounded growth from a stuck
+/// audio callback (#363).
+const MAX_AUDIO_BUFFER_BYTES: usize = 256 * 1024;
+
 // ---------------------------------------------------------------------------
 // Error types
 // ---------------------------------------------------------------------------
@@ -111,7 +119,8 @@ pub enum EkphrasisError {
     PayloadTooLarge,
     /// The transcription text exceeds the maximum length.
     TextTooLong,
-    /// Audio capture failed (mic power or codec error).
+    /// Audio capture failed: mic power/codec error, or the buffered audio
+    /// reached [`MAX_AUDIO_BUFFER_BYTES`] before being drained (#363).
     AudioCaptureFailed,
     /// The ekphrasis state machine is in an invalid state for the operation.
     InvalidState {
@@ -598,10 +607,15 @@ impl Ekphrasis {
     /// # Errors
     ///
     /// Returns [`EkphrasisError::InvalidState`] if not in `Recording`
-    /// or `Streaming` state.
+    /// or `Streaming` state. Returns [`EkphrasisError::AudioCaptureFailed`]
+    /// if appending `data` would exceed [`MAX_AUDIO_BUFFER_BYTES`] — the
+    /// caller should stop capture (#363).
     pub(crate) fn feed_audio(&mut self, data: &[u8]) -> Result<(), EkphrasisError> {
         match &self.state {
             EkphrasisState::Recording | EkphrasisState::Streaming => {
+                if self.audio_buffer.len().saturating_add(data.len()) > MAX_AUDIO_BUFFER_BYTES {
+                    return Err(EkphrasisError::AudioCaptureFailed);
+                }
                 self.audio_buffer.extend_from_slice(data);
                 Ok(())
             }
@@ -1461,6 +1475,26 @@ Let me know if you need anything else."#;
         let mut ek = Ekphrasis::new("stt.example.lan", 8080);
         let result = ek.feed_audio(&[0x01]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn feed_audio_rejects_beyond_max_buffer() {
+        let mut ek = Ekphrasis::new("stt.example.lan", 8080);
+        ek.set_endpoint_reachable(true);
+        let _ = ek.start_recording();
+
+        // Fill exactly to the cap.
+        let chunk = alloc::vec![0u8; MAX_AUDIO_BUFFER_BYTES];
+        assert!(ek.feed_audio(&chunk).is_ok(), "filling to the cap must succeed");
+        assert_eq!(ek.audio_buffer.len(), MAX_AUDIO_BUFFER_BYTES);
+
+        // One more byte must be rejected, and the buffer must not grow further.
+        let result = ek.feed_audio(&[0x01]);
+        assert_eq!(result, Err(EkphrasisError::AudioCaptureFailed));
+        assert_eq!(
+            ek.audio_buffer.len(), MAX_AUDIO_BUFFER_BYTES,
+            "rejected feed must not grow the buffer past the cap"
+        );
     }
 
     #[test]

--- a/crates/thumos/src/futex.rs
+++ b/crates/thumos/src/futex.rs
@@ -165,6 +165,47 @@ pub fn sys_futex_wake(addr: u32, max_wake: u32) -> u32 {
     woken
 }
 
+/// Free all waiter slots belonging to a process that has died — via normal
+/// exit, SIGKILL, default-action termination, or a fault (#364).
+///
+/// Without this sweep, a process killed while blocked in `sys_futex_wait`
+/// leaves its slot permanently occupied: `sys_futex_wake` only frees a slot
+/// on a matching wake, and a dead process can never be woken by anything.
+/// Call from every path that transitions a PCB to `State::Dead`.
+pub(crate) fn free_waiters_for_pid(pid: u32) {
+    // SAFETY: FUTEX_WAITERS is a static mut; addr_of_mut! avoids an
+    // intermediate reference. Single-core cooperative kernel ensures
+    // exclusive access here.
+    let waiters = unsafe { &mut *core::ptr::addr_of_mut!(FUTEX_WAITERS) };
+    for slot in waiters.iter_mut() {
+        if slot.as_ref().is_some_and(|w| w.pid == pid) {
+            *slot = None;
+        }
+    }
+}
+
+/// Insert a waiter directly, bypassing `sys_futex_wait`'s
+/// `#[cfg(not(test))]`-gated block path (that path requires `crate::process`,
+/// which is not compiled under test). Test-only seam for exercising
+/// process-death cleanup from other modules' test suites.
+#[cfg(test)]
+pub(crate) fn insert_waiter_for_test(addr: u32, pid: u32) {
+    // SAFETY: test-only; nextest gives each test its own process, so this
+    // static starts zeroed and is not shared across tests.
+    let waiters = unsafe { &mut *core::ptr::addr_of_mut!(FUTEX_WAITERS) };
+    if let Some(slot) = waiters.iter_mut().find(|s| s.is_none()) {
+        *slot = Some(FutexWaiter { addr, pid });
+    }
+}
+
+/// Whether any waiter slot currently belongs to `pid`. Test-only.
+#[cfg(test)]
+pub(crate) fn has_waiter_for_pid(pid: u32) -> bool {
+    // SAFETY: test-only; see insert_waiter_for_test.
+    let waiters = unsafe { &*core::ptr::addr_of!(FUTEX_WAITERS) };
+    waiters.iter().any(|s| s.as_ref().is_some_and(|w| w.pid == pid))
+}
+
 /// Dispatch futex syscall.
 ///
 /// # Arguments
@@ -254,5 +295,32 @@ mod tests {
         // FUTEX_WAKE with null addr returns 0 (no waiters at null).
         let result_wake = sys_futex_wake(0, 1);
         assert_eq!(result_wake, 0);
+    }
+
+    #[test]
+    fn free_waiters_for_pid_clears_only_matching_slots() {
+        reset_waiters();
+        // SAFETY: test-only direct write to the private static, mirroring
+        // reset_waiters' own access pattern, to seed waiters without
+        // depending on the #[cfg(not(test))] block path in sys_futex_wait.
+        unsafe {
+            let waiters = &mut *core::ptr::addr_of_mut!(FUTEX_WAITERS);
+            waiters[0] = Some(FutexWaiter { addr: 0x1000, pid: 4 });
+            waiters[1] = Some(FutexWaiter { addr: 0x2000, pid: 7 });
+        }
+
+        free_waiters_for_pid(4);
+
+        // SAFETY: same as above.
+        unsafe {
+            let waiters = &*core::ptr::addr_of!(FUTEX_WAITERS);
+            assert!(waiters[0].is_none(), "dead pid's waiter slot must be freed");
+            assert!(waiters[1].is_some(), "other pids' waiter slots must be untouched");
+            assert_eq!(waiters[1].as_ref().map(|w| w.pid), Some(7));
+            assert!(
+                waiters.iter().any(|s| s.is_none()),
+                "a freed slot must be available for reuse"
+            );
+        }
     }
 }

--- a/crates/thumos/src/harmostes.rs
+++ b/crates/thumos/src/harmostes.rs
@@ -71,6 +71,13 @@ const MAX_ROOMS: usize = 150;
 /// Maximum messages cached per room.
 const MAX_MESSAGES_PER_ROOM: usize = 100;
 
+/// Maximum number of pending messages held in the outbox before
+/// `queue_message`/`send_message` reject further additions (#365). Each
+/// entry holds two heap Strings (room_id + body); bounding count bounds
+/// worst-case outbox memory on a 1 GB device the same way MAX_ROOMS and
+/// MAX_MESSAGES_PER_ROOM already bound room/timeline memory.
+const MAX_OUTBOX_MESSAGES: usize = 256;
+
 /// Transaction ID counter starting value.
 const TXN_ID_START: u32 = 1;
 
@@ -106,6 +113,8 @@ pub enum MatrixError {
     SyncDisabled,
     /// The room list has reached capacity.
     RoomCapacityReached,
+    /// The outbox has reached [`MAX_OUTBOX_MESSAGES`] pending messages (#365).
+    OutboxFull,
 }
 
 impl fmt::Display for MatrixError {
@@ -123,6 +132,7 @@ impl fmt::Display for MatrixError {
             Self::MissingSendResponse => write!(f, "send response missing event_id"),
             Self::SyncDisabled => write!(f, "sync disabled in current security mode"),
             Self::RoomCapacityReached => write!(f, "room capacity reached"),
+            Self::OutboxFull => write!(f, "outbox capacity reached"),
         }
     }
 }
@@ -768,11 +778,17 @@ impl MatrixClient {
     /// # Errors
     ///
     /// Returns [`MatrixError::Http`] if the request cannot be built.
+    /// Returns [`MatrixError::OutboxFull`] if the outbox already holds
+    /// [`MAX_OUTBOX_MESSAGES`] pending messages (#365).
     pub(crate) fn send_message(
         &mut self,
         room_id: &str,
         body: &str,
     ) -> Result<(HttpRequest, u32), MatrixError> {
+        if self.outbox.len() >= MAX_OUTBOX_MESSAGES {
+            return Err(MatrixError::OutboxFull);
+        }
+
         let (req, txn_id) = self.build_send_request(room_id, body)?;
 
         self.outbox.push(PendingMessage {
@@ -796,7 +812,16 @@ impl MatrixClient {
     /// Queue a message for later sending (when offline).
     ///
     /// The message is added to the outbox with the next transaction ID.
-    pub(crate) fn queue_message(&mut self, room_id: &str, body: &str) {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MatrixError::OutboxFull`] if the outbox already holds
+    /// [`MAX_OUTBOX_MESSAGES`] pending messages (#365).
+    pub(crate) fn queue_message(&mut self, room_id: &str, body: &str) -> Result<(), MatrixError> {
+        if self.outbox.len() >= MAX_OUTBOX_MESSAGES {
+            return Err(MatrixError::OutboxFull);
+        }
+
         let txn_id = self.next_txn_id;
         self.next_txn_id = self.next_txn_id.saturating_add(1);
 
@@ -805,6 +830,8 @@ impl MatrixClient {
             body: String::from(body),
             txn_id,
         });
+
+        Ok(())
     }
 
     /// Build encrypted HTTP requests for all pending outbox messages.
@@ -1376,8 +1403,8 @@ mod tests {
     fn outbox_queues_when_offline() {
         let mut client = matrix_client_with_test_credentials();
 
-        client.queue_message("!room1:example.com", "msg1");
-        client.queue_message("!room2:example.com", "msg2");
+        let _ = client.queue_message("!room1:example.com", "msg1");
+        let _ = client.queue_message("!room2:example.com", "msg2");
 
         assert_eq!(client.outbox().len(), 2);
         assert_eq!(client.outbox()[0].room_id, "!room1:example.com");
@@ -1390,12 +1417,46 @@ mod tests {
     }
 
     #[test]
+    fn queue_message_rejects_beyond_outbox_cap() {
+        let mut client = matrix_client_with_test_credentials();
+
+        for _ in 0..MAX_OUTBOX_MESSAGES {
+            assert!(
+                client.queue_message("!room:example.com", "msg").is_ok(),
+                "queueing up to the cap must succeed"
+            );
+        }
+        assert_eq!(client.outbox().len(), MAX_OUTBOX_MESSAGES);
+
+        let result = client.queue_message("!overflow:example.com", "msg");
+        assert_eq!(result, Err(MatrixError::OutboxFull));
+        assert_eq!(
+            client.outbox().len(), MAX_OUTBOX_MESSAGES,
+            "outbox must not grow past the cap"
+        );
+    }
+
+    #[test]
+    fn send_message_rejects_when_outbox_full() {
+        let mut client = matrix_client_with_test_credentials();
+        for _ in 0..MAX_OUTBOX_MESSAGES {
+            assert!(client.queue_message("!room:example.com", "msg").is_ok());
+        }
+
+        let result = client.send_message("!room:example.com", "one more");
+        assert!(
+            matches!(result, Err(MatrixError::OutboxFull)),
+            "send_message must reject when the outbox is already full"
+        );
+    }
+
+    #[test]
     fn flush_outbox_attempts_all() {
         let mut client = matrix_client_with_test_credentials();
 
-        client.queue_message("!room1:example.com", "msg1");
-        client.queue_message("!room2:example.com", "msg2");
-        client.queue_message("!room3:example.com", "msg3");
+        let _ = client.queue_message("!room1:example.com", "msg1");
+        let _ = client.queue_message("!room2:example.com", "msg2");
+        let _ = client.queue_message("!room3:example.com", "msg3");
 
         let results = client.flush_outbox();
 

--- a/crates/thumos/src/heorte.rs
+++ b/crates/thumos/src/heorte.rs
@@ -75,14 +75,32 @@ pub struct CalendarEvent {
     pub all_day: bool,
 }
 
+/// Return the largest prefix length of `bytes` (capped at `max_len`) that
+/// ends on a valid UTF-8 char boundary, so truncating to it never splits a
+/// multi-byte codepoint (#359).
+pub(crate) fn utf8_truncate_len(bytes: &[u8], max_len: usize) -> usize {
+    let mut len = bytes.len().min(max_len);
+    if len == bytes.len() {
+        return len;
+    }
+    // UTF-8 continuation bytes are `10xxxxxx` (0x80..=0xBF); back off from
+    // a mid-codepoint cut to the start of that codepoint.
+    while len > 0 && (bytes[len] & 0xC0) == 0x80 {
+        len -= 1;
+    }
+    len
+}
+
 impl CalendarEvent {
     /// Create a new calendar event.
     ///
-    /// `title_bytes` is truncated to [`MAX_TITLE_LEN`] if longer.
+    /// `title_bytes` is truncated to [`MAX_TITLE_LEN`] if longer, backing
+    /// off to the last full codepoint so truncation never splits one
+    /// (#359).
     #[must_use]
     pub(crate) fn new(id: u32, title_bytes: &[u8], start_epoch: u64, duration_min: u16, all_day: bool) -> Self {
         let mut title = [0u8; MAX_TITLE_LEN];
-        let len = title_bytes.len().min(MAX_TITLE_LEN);
+        let len = utf8_truncate_len(title_bytes, MAX_TITLE_LEN);
         title[..len].copy_from_slice(&title_bytes[..len]);
         Self {
             id,
@@ -462,6 +480,23 @@ mod tests {
         let long_title = [b'A'; 100];
         let event = CalendarEvent::new(1, &long_title, 0, 0, false);
         assert_eq!(event.title_len as usize, MAX_TITLE_LEN, "title must be truncated");
+    }
+
+    #[test]
+    fn event_title_truncation_preserves_valid_utf8_prefix() {
+        // 63 ASCII bytes + a 2-byte codepoint straddling MAX_TITLE_LEN (64):
+        // pre-fix, a byte-count truncation would cut mid-codepoint and
+        // title_str() would silently return "" instead of the 63 valid
+        // 'A' characters (#359).
+        let mut long_title = alloc::vec![b'A'; 63];
+        long_title.extend_from_slice("é".as_bytes());
+        let event = CalendarEvent::new(1, &long_title, 0, 0, false);
+        assert_eq!(
+            event.title_len as usize, 63,
+            "truncation must back off to the last full codepoint, not split it"
+        );
+        assert_eq!(event.title_str().len(), 63);
+        assert!(event.title_str().chars().all(|c| c == 'A'));
     }
 
     #[test]

--- a/crates/thumos/src/heorte_alarm.rs
+++ b/crates/thumos/src/heorte_alarm.rs
@@ -5,7 +5,7 @@
 
 // Items in this module are re-exported from heorte.rs.
 
-use crate::heorte::{SECS_PER_DAY, SECS_PER_HOUR, SECS_PER_MIN};
+use crate::heorte::{utf8_truncate_len, SECS_PER_DAY, SECS_PER_HOUR, SECS_PER_MIN};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -80,7 +80,7 @@ impl Alarm {
         repeat_days: u8,
     ) -> Self {
         let mut label = [0u8; MAX_LABEL_LEN];
-        let len = label_bytes.len().min(MAX_LABEL_LEN);
+        let len = utf8_truncate_len(label_bytes, MAX_LABEL_LEN);
         label[..len].copy_from_slice(&label_bytes[..len]);
         Self {
             id,
@@ -181,6 +181,23 @@ mod tests {
         let alarm = Alarm::new(1, 6, 30, b"Wake up", false, 0);
         let epoch_630 = 23400;
         assert!(!alarm.should_fire(epoch_630), "disabled alarm must not fire");
+    }
+
+    #[test]
+    fn alarm_label_truncation_preserves_valid_utf8_prefix() {
+        // 31 ASCII bytes + a 2-byte codepoint straddling MAX_LABEL_LEN (32):
+        // pre-fix, a byte-count truncation would cut mid-codepoint and
+        // label_str() would silently return "" instead of the 31 valid
+        // 'A' characters (#359).
+        let mut long_label = alloc::vec![b'A'; 31];
+        long_label.extend_from_slice("é".as_bytes());
+        let alarm = Alarm::new(1, 6, 30, &long_label, true, 0);
+        assert_eq!(
+            alarm.label_len as usize, 31,
+            "truncation must back off to the last full codepoint, not split it"
+        );
+        assert_eq!(alarm.label_str().len(), 31);
+        assert!(alarm.label_str().chars().all(|c| c == 'A'));
     }
 
     #[test]

--- a/crates/thumos/src/lock_screen.rs
+++ b/crates/thumos/src/lock_screen.rs
@@ -149,7 +149,7 @@ impl fmt::Display for UnlockResult {
 /// optimizing backend. The lock screen is the duress/coercion surface, so a
 /// timing oracle on PIN/passphrase hashes must not exist.
 #[must_use]
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+pub(crate) fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     // Slice `ct_eq` returns Choice(0) on a length mismatch (lengths here are
     // fixed 32-byte SHA-256 digests, so length is not secret).
     a.ct_eq(b).unwrap_u8() == 1

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -579,6 +579,11 @@ pub(crate) fn exit_cleanup(status: i32) {
                 page::free_page(base + i * page::PAGE_SIZE);
             }
         }
+        // WHY: a self-exiting process cannot itself be blocked in
+        // sys_futex_wait (blocked processes do not run), but sweep
+        // defensively so every Dead-transition path shares the same
+        // invariant (#364).
+        crate::futex::free_waiters_for_pid(u32::from(CURRENT));
     }
 }
 
@@ -1036,6 +1041,11 @@ pub unsafe fn deliver_signal_to(pid: Pid, sig: Signal) -> u32 {
         // SIGKILL always terminates — handler cannot override.
         if sig == Signal::Sigkill {
             proc.state = State::Dead;
+            // WHY: a process killed while blocked in sys_futex_wait would
+            // otherwise leave its waiter slot permanently occupied — nothing
+            // wakes a dead process, and sys_futex_wake only frees a slot on
+            // a matching wake (#364).
+            crate::futex::free_waiters_for_pid(u32::from(pid));
             return 0;
         }
         match proc.signal_state.action(sig) {
@@ -1046,6 +1056,8 @@ pub unsafe fn deliver_signal_to(pid: Pid, sig: Signal) -> u32 {
             SignalAction::Default => match sig.default_action() {
                 crate::signal::DefaultAction::Terminate => {
                     proc.state = State::Dead;
+                    // WHY: see the SIGKILL branch above (#364).
+                    crate::futex::free_waiters_for_pid(u32::from(pid));
                 }
                 crate::signal::DefaultAction::Ignore => {}
             },
@@ -2602,6 +2614,55 @@ mod tests {
 
             let state = get_state(0);
             assert_eq!(state, Some(State::Running), "PID 0 must stay alive");
+        }
+    }
+
+    #[test]
+    fn sigkill_frees_futex_waiter_slots_for_dying_pid() {
+        // SAFETY: test-only; reset_all reinitialises global state. nextest
+        // runs each test in its own process, so FUTEX_WAITERS also starts
+        // zeroed here (#364).
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            let pt = mmu::alloc_addr_space().unwrap();
+            procs[0] = Some(Process {
+                pid: 0,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: None,
+                exit_status: 0,
+                page_table_phys: pt,
+                stack_base: 0,
+                stack_pages: 0,
+                heap_break: DEFAULT_HEAP_BREAK,
+                mappings: [None; MAX_MAPPINGS],
+                signal_state: SignalState::new(),
+                uid: 0,
+                wake_tick: 0,
+                capabilities: crate::capability::Capabilities::ALL,
+            });
+            CURRENT = 0;
+
+            let child_pid = fork().unwrap_or_default();
+
+            // Simulate the child being blocked in sys_futex_wait when
+            // killed — seed a waiter slot for it directly, bypassing the
+            // host-untestable #[cfg(not(test))] block path in
+            // sys_futex_wait.
+            crate::futex::insert_waiter_for_test(0x1000, u32::from(child_pid));
+            assert!(
+                crate::futex::has_waiter_for_pid(u32::from(child_pid)),
+                "waiter must be seeded before the kill"
+            );
+
+            let ret = deliver_signal_to(child_pid, crate::signal::Signal::Sigkill);
+            assert_eq!(ret, 0, "SIGKILL delivery should succeed");
+
+            assert!(
+                !crate::futex::has_waiter_for_pid(u32::from(child_pid)),
+                "SIGKILL must free the dying process's futex waiter slot"
+            );
         }
     }
 

--- a/crates/thumos/src/screen_call.rs
+++ b/crates/thumos/src/screen_call.rs
@@ -182,8 +182,13 @@ impl CallScreen {
     }
 
     /// Return the number as a string slice.
+    ///
+    /// `number_len` is clamped to the buffer length before slicing — it is
+    /// a public field the telephony driver populates directly from raw
+    /// caller-ID data, with no compile-time guarantee it stays in bounds
+    /// (#394).
     fn number_str(&self) -> &str {
-        let len = self.state.number_len as usize;
+        let len = (self.state.number_len as usize).min(self.state.number.len());
         core::str::from_utf8(&self.state.number[..len]).unwrap_or("")
     }
 
@@ -513,6 +518,21 @@ mod tests {
         screen.draw(&mut fb);
         let any_set = fb.iter().any(|&px| px != 0);
         assert!(any_set, "active call screen must render visible content");
+    }
+
+    #[test]
+    fn draw_does_not_panic_on_oversized_number_len() {
+        let mut screen = make_incoming_screen();
+        // Driver/attacker-controlled caller-ID length exceeding the 20-byte
+        // buffer (#394) — number_str() must clamp instead of panicking.
+        screen.state.number_len = 255;
+
+        let mut fb = [0u16; SCREEN_WIDTH as usize * CONTENT_HEIGHT as usize];
+        screen.draw(&mut fb);
+        assert!(
+            fb.iter().any(|&px| px != 0),
+            "screen must still render after clamping an oversized number_len"
+        );
     }
 
     #[test]

--- a/crates/thumos/src/screen_messages.rs
+++ b/crates/thumos/src/screen_messages.rs
@@ -150,6 +150,14 @@ const VISIBLE_ENTRIES: u16 = CONTENT_HEIGHT / ENTRY_HEIGHT;
 /// Maximum characters per line in the full message view (word wrap).
 const CHARS_PER_LINE: usize = (SCREEN_WIDTH as usize) / (CHAR_WIDTH as usize);
 
+/// Maximum message body length (bytes) rendered in the Detail view. Longer
+/// bodies are truncated (char-boundary-safe) before word-wrapping so a
+/// large attacker-controlled body cannot drive an unbounded per-render-tick
+/// allocation in `word_wrap` (#393). 4096 bytes is generous for the
+/// 240x320 display (over 130 wrapped lines at 30 chars/line) while
+/// bounding worst-case allocation on the device's 1 GB RAM.
+const MAX_BODY_DISPLAY_LEN: usize = 4096;
+
 /// Y offset for the title in message detail/compose views.
 const TITLE_Y: u16 = 4;
 
@@ -536,9 +544,13 @@ impl MessagesScreen {
             );
         }
 
-        // Body text with word wrap.
+        // Body text with word wrap. The body is truncated to
+        // MAX_BODY_DISPLAY_LEN (char-boundary-safe) before wrapping so a
+        // multi-megabyte whitespace-free attacker-controlled body cannot
+        // drive an unbounded per-tick allocation in word_wrap (#393).
         let body_y_start = CONTENT_START_Y + CHAR_HEIGHT;
-        let lines = word_wrap(&msg.body, CHARS_PER_LINE);
+        let body_display = truncate_body_for_display(&msg.body);
+        let lines = word_wrap(body_display, CHARS_PER_LINE);
         let max_visible_lines = ((CONTENT_HEIGHT - body_y_start) / CHAR_HEIGHT) as usize;
         let start_line = self.detail_scroll;
         let end_line = (start_line + max_visible_lines).min(lines.len());
@@ -881,6 +893,15 @@ fn split_at_char_boundary(s: &str, pos: usize) -> (&str, &str) {
     (&s[..split_pos], &s[split_pos..])
 }
 
+/// Truncate `body` to at most [`MAX_BODY_DISPLAY_LEN`] bytes (char-boundary
+/// safe) for Detail-view rendering (#393).
+fn truncate_body_for_display(body: &str) -> &str {
+    if body.len() <= MAX_BODY_DISPLAY_LEN {
+        return body;
+    }
+    split_at_char_boundary(body, MAX_BODY_DISPLAY_LEN).0
+}
+
 /// Format a Unix timestamp as a simple display string.
 ///
 /// Produces "HH:MM" for the time portion only (date is omitted for
@@ -947,6 +968,52 @@ mod tests {
             any_set,
             "inbox with messages must render visible pixels"
         );
+    }
+
+    #[test]
+    fn truncate_body_for_display_bounds_huge_body() {
+        let huge_body = "A".repeat(1_000_000);
+        let truncated = truncate_body_for_display(&huge_body);
+        assert!(
+            truncated.len() <= MAX_BODY_DISPLAY_LEN,
+            "display body must be capped at MAX_BODY_DISPLAY_LEN"
+        );
+    }
+
+    #[test]
+    fn truncate_body_for_display_is_char_boundary_safe() {
+        // MAX_BODY_DISPLAY_LEN - 1 ASCII bytes + a 2-byte codepoint
+        // straddling the truncation boundary (#393).
+        let mut body = "A".repeat(MAX_BODY_DISPLAY_LEN - 1);
+        body.push('é');
+        let truncated = truncate_body_for_display(&body);
+        assert!(truncated.len() <= MAX_BODY_DISPLAY_LEN);
+        assert_eq!(
+            truncated.len(), MAX_BODY_DISPLAY_LEN - 1,
+            "the 2-byte char must be dropped, not split"
+        );
+    }
+
+    #[test]
+    fn draw_detail_bounds_word_wrap_allocation_for_huge_body() {
+        let mut screen = MessagesScreen::new();
+        // 1 MB whitespace-free body — worst case for word_wrap's per-line
+        // allocation without the MAX_BODY_DISPLAY_LEN cap (#393).
+        let huge_body = "A".repeat(1_000_000);
+        screen.set_messages(alloc::vec![MessageEntry {
+            sender: String::from("+15551234567"),
+            body: huge_body,
+            timestamp: 0,
+            read: false,
+            transport: MessageTransport::Sms,
+        }]);
+        screen.view = MessageView::Detail;
+
+        let mut fb = [0u16; CONTENT_PIXELS];
+        screen.draw(&mut fb);
+
+        let any_set = fb.iter().any(|&px| px != 0);
+        assert!(any_set, "detail view must still render visible content");
     }
 
     #[test]

--- a/crates/thumos/src/screen_privacy.rs
+++ b/crates/thumos/src/screen_privacy.rs
@@ -23,6 +23,8 @@
     reason = "Privacy dashboard created in Phase 08 Wave 7, kinit wiring pending"
 )]
 
+use crate::lock_screen::constant_time_eq;
+use crate::security::{self, SHA256_DIGEST_LEN};
 use crate::ui::{
     self, color, Key, Screen, ScreenAction, ScreenId,
     CHAR_HEIGHT, CHAR_WIDTH, CONTENT_HEIGHT, SCREEN_WIDTH,
@@ -397,14 +399,19 @@ pub(crate) struct PrivacyScreen {
     purge_state: Option<PurgeConfirmState>,
     /// Total storage usage across all categories (cached).
     total_bytes: u64,
+    /// SHA-256 hash of the configured purge confirmation code (#395). The
+    /// purge dialog requires this exact code, not merely non-empty input.
+    purge_passphrase_hash: [u8; SHA256_DIGEST_LEN],
 }
 
 impl PrivacyScreen {
     /// Create a new privacy dashboard with default category data.
     ///
     /// In production, category sizes would be populated from `lfs.rs`
-    /// inode metadata on screen entry.
-    pub(crate) fn new() -> Self {
+    /// inode metadata on screen entry. `purge_passphrase_hash` is the
+    /// SHA-256 hash of the configured purge confirmation code (#395); the
+    /// purge dialog rejects any input that does not hash-match it.
+    pub(crate) fn new(purge_passphrase_hash: [u8; SHA256_DIGEST_LEN]) -> Self {
         let categories = default_categories();
         let total_bytes = categories.iter().map(|c| c.size_bytes).sum();
         Self {
@@ -414,7 +421,14 @@ impl PrivacyScreen {
             view: PrivacyView::List,
             purge_state: None,
             total_bytes,
+            purge_passphrase_hash,
         }
+    }
+
+    /// Create a privacy dashboard for tests with a known purge code.
+    #[cfg(test)]
+    pub(crate) fn new_for_test(purge_code: &[u8]) -> Self {
+        Self::new(security::sha256(purge_code))
     }
 
     /// Update a category's size (called when refreshing from filesystem).
@@ -739,17 +753,19 @@ impl PrivacyScreen {
     /// Handle key input in the purge confirmation dialog.
     fn handle_purge_key(&mut self, key: Key) -> ScreenAction {
         match key {
-            // Numpad keys for passphrase entry.
-            Key::Num0 => { self.purge_digit(0); ScreenAction::None }
-            Key::Num1 => { self.purge_digit(1); ScreenAction::None }
-            Key::Num2 => { self.purge_digit(2); ScreenAction::None }
-            Key::Num3 => { self.purge_digit(3); ScreenAction::None }
-            Key::Num4 => { self.purge_digit(4); ScreenAction::None }
-            Key::Num5 => { self.purge_digit(5); ScreenAction::None }
-            Key::Num6 => { self.purge_digit(6); ScreenAction::None }
-            Key::Num7 => { self.purge_digit(7); ScreenAction::None }
-            Key::Num8 => { self.purge_digit(8); ScreenAction::None }
-            Key::Num9 => { self.purge_digit(9); ScreenAction::None }
+            // Numpad keys for passphrase entry. Stored as ASCII digit bytes
+            // to match the sha256(entered) convention used for comparison
+            // below (and in lock_screen.rs's PIN/passphrase verification).
+            Key::Num0 => { self.purge_digit(b'0'); ScreenAction::None }
+            Key::Num1 => { self.purge_digit(b'1'); ScreenAction::None }
+            Key::Num2 => { self.purge_digit(b'2'); ScreenAction::None }
+            Key::Num3 => { self.purge_digit(b'3'); ScreenAction::None }
+            Key::Num4 => { self.purge_digit(b'4'); ScreenAction::None }
+            Key::Num5 => { self.purge_digit(b'5'); ScreenAction::None }
+            Key::Num6 => { self.purge_digit(b'6'); ScreenAction::None }
+            Key::Num7 => { self.purge_digit(b'7'); ScreenAction::None }
+            Key::Num8 => { self.purge_digit(b'8'); ScreenAction::None }
+            Key::Num9 => { self.purge_digit(b'9'); ScreenAction::None }
 
             Key::Left => {
                 // Backspace.
@@ -760,9 +776,14 @@ impl PrivacyScreen {
             }
 
             Key::Ok => {
-                // Confirm purge (passphrase would be verified in production).
+                // Confirm purge only when the entered code hash-matches the
+                // configured purge_passphrase_hash (#395) — a bare
+                // non-empty check let a single keypress destroy data with
+                // no real verification.
                 if let Some(state) = &self.purge_state {
-                    if state.passphrase_len > 0 {
+                    let entered = &state.passphrase[..state.passphrase_len];
+                    let hash = security::sha256(entered);
+                    if constant_time_eq(&hash, &self.purge_passphrase_hash) {
                         let idx = state.category_idx;
                         self.execute_purge(idx);
                     }
@@ -914,7 +935,7 @@ mod tests {
 
     #[test]
     fn new_screen_starts_at_list_view() {
-        let screen = PrivacyScreen::new();
+        let screen = PrivacyScreen::new_for_test(b"1234");
         assert_eq!(screen.view, PrivacyView::List);
         assert_eq!(screen.cursor, 0);
         assert_eq!(screen.scroll_offset, 0);
@@ -922,7 +943,7 @@ mod tests {
 
     #[test]
     fn total_bytes_calculated() {
-        let screen = PrivacyScreen::new();
+        let screen = PrivacyScreen::new_for_test(b"1234");
         let expected: u64 = default_categories().iter().map(|c| c.size_bytes).sum();
         assert_eq!(
             screen.total_bytes(), expected,
@@ -932,7 +953,7 @@ mod tests {
 
     #[test]
     fn update_size_recalculates_total() {
-        let mut screen = PrivacyScreen::new();
+        let mut screen = PrivacyScreen::new_for_test(b"1234");
         let old_total = screen.total_bytes();
         screen.update_size(1, 0); // Zero out Messages
         assert!(
@@ -943,7 +964,7 @@ mod tests {
 
     #[test]
     fn cursor_navigation() {
-        let mut screen = PrivacyScreen::new();
+        let mut screen = PrivacyScreen::new_for_test(b"1234");
 
         // Down moves cursor.
         let action = screen.on_key(Key::Down);
@@ -963,7 +984,7 @@ mod tests {
 
     #[test]
     fn cursor_stops_at_bottom() {
-        let mut screen = PrivacyScreen::new();
+        let mut screen = PrivacyScreen::new_for_test(b"1234");
         for _ in 0..CATEGORY_COUNT + 5 {
             screen.on_key(Key::Down);
         }
@@ -975,21 +996,21 @@ mod tests {
 
     #[test]
     fn ok_enters_detail_view() {
-        let mut screen = PrivacyScreen::new();
+        let mut screen = PrivacyScreen::new_for_test(b"1234");
         screen.on_key(Key::Ok);
         assert_eq!(screen.view, PrivacyView::Detail);
     }
 
     #[test]
     fn rsk_exits_from_list() {
-        let mut screen = PrivacyScreen::new();
+        let mut screen = PrivacyScreen::new_for_test(b"1234");
         let action = screen.on_key(Key::Rsk);
         assert_eq!(action, ScreenAction::Back);
     }
 
     #[test]
     fn back_from_detail_returns_to_list() {
-        let mut screen = PrivacyScreen::new();
+        let mut screen = PrivacyScreen::new_for_test(b"1234");
         screen.on_key(Key::Ok); // Enter detail
         assert_eq!(screen.view, PrivacyView::Detail);
 
@@ -999,7 +1020,7 @@ mod tests {
 
     #[test]
     fn purge_flow_for_purgeable_category() {
-        let mut screen = PrivacyScreen::new();
+        let mut screen = PrivacyScreen::new_for_test(b"1234");
         // Navigate to Messages (index 1, purgeable).
         screen.on_key(Key::Down);
         screen.on_key(Key::Ok); // Detail view
@@ -1008,10 +1029,11 @@ mod tests {
         screen.on_key(Key::Lsk); // PURGE
         assert_eq!(screen.view, PrivacyView::PurgeConfirm);
 
-        // Enter a passphrase digit and confirm.
+        // Enter the correct purge code and confirm.
         screen.on_key(Key::Num1);
         screen.on_key(Key::Num2);
         screen.on_key(Key::Num3);
+        screen.on_key(Key::Num4);
         screen.on_key(Key::Ok); // Confirm
 
         // Should be back in list view with zeroed size.
@@ -1023,8 +1045,33 @@ mod tests {
     }
 
     #[test]
+    fn purge_rejected_for_wrong_passphrase() {
+        let mut screen = PrivacyScreen::new_for_test(b"1234");
+        screen.on_key(Key::Down); // Messages
+        screen.on_key(Key::Ok); // Detail
+        screen.on_key(Key::Lsk); // PURGE
+
+        // Enter a non-empty but WRONG code and confirm (#395).
+        let original_size = screen.categories[1].size_bytes;
+        screen.on_key(Key::Num9);
+        screen.on_key(Key::Num9);
+        screen.on_key(Key::Num9);
+        screen.on_key(Key::Num9);
+        screen.on_key(Key::Ok);
+
+        assert_eq!(
+            screen.view, PrivacyView::PurgeConfirm,
+            "purge must not proceed with a wrong code"
+        );
+        assert_eq!(
+            screen.categories[1].size_bytes, original_size,
+            "size must not change when the wrong purge code is entered"
+        );
+    }
+
+    #[test]
     fn purge_rejected_for_protected_category() {
-        let mut screen = PrivacyScreen::new();
+        let mut screen = PrivacyScreen::new_for_test(b"1234");
         // First category (Audit log) is not purgeable.
         screen.on_key(Key::Ok); // Detail view
         assert_eq!(screen.view, PrivacyView::Detail);
@@ -1038,7 +1085,7 @@ mod tests {
 
     #[test]
     fn purge_cancel_returns_to_list() {
-        let mut screen = PrivacyScreen::new();
+        let mut screen = PrivacyScreen::new_for_test(b"1234");
         screen.on_key(Key::Down); // Messages
         screen.on_key(Key::Ok); // Detail
         screen.on_key(Key::Lsk); // PURGE
@@ -1051,7 +1098,7 @@ mod tests {
 
     #[test]
     fn purge_requires_passphrase() {
-        let mut screen = PrivacyScreen::new();
+        let mut screen = PrivacyScreen::new_for_test(b"1234");
         screen.on_key(Key::Down); // Messages
         screen.on_key(Key::Ok); // Detail
         screen.on_key(Key::Lsk); // PURGE
@@ -1073,7 +1120,7 @@ mod tests {
 
     #[test]
     fn passphrase_backspace() {
-        let mut screen = PrivacyScreen::new();
+        let mut screen = PrivacyScreen::new_for_test(b"1234");
         screen.on_key(Key::Down); // Messages
         screen.on_key(Key::Ok); // Detail
         screen.on_key(Key::Lsk); // PURGE
@@ -1088,7 +1135,7 @@ mod tests {
 
     #[test]
     fn softkey_labels_change_by_view() {
-        let mut screen = PrivacyScreen::new();
+        let mut screen = PrivacyScreen::new_for_test(b"1234");
 
         // List view.
         assert_eq!(screen.softkey_left(), "REVIEW");
@@ -1109,7 +1156,7 @@ mod tests {
 
     #[test]
     fn draw_list_does_not_panic() {
-        let screen = PrivacyScreen::new();
+        let screen = PrivacyScreen::new_for_test(b"1234");
         let mut fb = [0u16; SCREEN_WIDTH as usize * CONTENT_HEIGHT as usize];
         screen.draw(&mut fb);
         let any_set = fb.iter().any(|&px| px != 0);
@@ -1118,7 +1165,7 @@ mod tests {
 
     #[test]
     fn draw_detail_does_not_panic() {
-        let mut screen = PrivacyScreen::new();
+        let mut screen = PrivacyScreen::new_for_test(b"1234");
         screen.view = PrivacyView::Detail;
         let mut fb = [0u16; SCREEN_WIDTH as usize * CONTENT_HEIGHT as usize];
         screen.draw(&mut fb);
@@ -1128,7 +1175,7 @@ mod tests {
 
     #[test]
     fn draw_purge_confirm_does_not_panic() {
-        let mut screen = PrivacyScreen::new();
+        let mut screen = PrivacyScreen::new_for_test(b"1234");
         screen.view = PrivacyView::PurgeConfirm;
         screen.purge_state = Some(PurgeConfirmState::new(1));
         let mut fb = [0u16; SCREEN_WIDTH as usize * CONTENT_HEIGHT as usize];
@@ -1139,13 +1186,13 @@ mod tests {
 
     #[test]
     fn title_is_privacy() {
-        let screen = PrivacyScreen::new();
+        let screen = PrivacyScreen::new_for_test(b"1234");
         assert_eq!(screen.title(), "Privacy");
     }
 
     #[test]
     fn purgeable_count_correct() {
-        let screen = PrivacyScreen::new();
+        let screen = PrivacyScreen::new_for_test(b"1234");
         let expected = default_categories().iter().filter(|c| c.purgeable).count();
         assert_eq!(screen.purgeable_count(), expected);
     }
@@ -1167,7 +1214,7 @@ mod tests {
 
     #[test]
     fn update_retention() {
-        let mut screen = PrivacyScreen::new();
+        let mut screen = PrivacyScreen::new_for_test(b"1234");
         screen.update_retention(1, 180);
         assert_eq!(
             screen.categories[1].retention_days, 180,
@@ -1177,7 +1224,7 @@ mod tests {
 
     #[test]
     fn category_accessor() {
-        let screen = PrivacyScreen::new();
+        let screen = PrivacyScreen::new_for_test(b"1234");
         let cat = screen.category(0);
         assert!(cat.is_some());
         assert_eq!(cat.map(|c| c.name), Some("Audit log"));

--- a/crates/thumos/src/screen_threat.rs
+++ b/crates/thumos/src/screen_threat.rs
@@ -283,6 +283,19 @@ pub(crate) struct ThreatMonitor {
     cursor: usize,
 }
 
+/// Truncate `s` to at most `max_bytes`, backing off to the nearest earlier
+/// UTF-8 char boundary so a multi-byte codepoint is never split (#396).
+fn truncate_at_char_boundary(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
 impl ThreatMonitor {
     /// Create a new threat monitor with no alerts and default state.
     pub(crate) fn new() -> Self {
@@ -300,7 +313,15 @@ impl ThreatMonitor {
 
     /// Add a new alert, maintaining newest-first order and the
     /// `MAX_ALERTS` capacity limit.
-    pub(crate) fn push_alert(&mut self, alert: ThreatAlert) {
+    pub(crate) fn push_alert(&mut self, mut alert: ThreatAlert) {
+        // Enforce MAX_DESC_LEN here (not just at render time) so a single
+        // oversized attacker-controlled description cannot inflate ring
+        // buffer memory (#396).
+        if alert.description.len() > MAX_DESC_LEN {
+            alert.description =
+                String::from(truncate_at_char_boundary(&alert.description, MAX_DESC_LEN));
+        }
+
         // Insert at position determined by timestamp (newest first).
         let pos = self.alerts
             .iter()
@@ -461,14 +482,17 @@ impl Screen for ThreatMonitor {
                 let icon_x = PADDING_X + 6 * 8; // after timestamp
                 ui::draw_char(fb, w, icon_x, row_y + 3, icon, alert.severity.color(), bg);
 
-                // Description (truncated to fit).
+                // Description (truncated to fit the row width). draw_str
+                // renders one glyph per `char`, so the cut must be made at
+                // a character boundary, not a raw byte offset (#396) — a
+                // byte-index slice can land mid-codepoint and panic.
                 let desc_x = icon_x + 2 * 8;
                 let max_chars = ((w - desc_x) / 8) as usize;
-                let desc = if alert.description.len() > max_chars {
-                    &alert.description[..max_chars]
-                } else {
-                    &alert.description
-                };
+                let desc = alert
+                    .description
+                    .char_indices()
+                    .nth(max_chars)
+                    .map_or(alert.description.as_str(), |(i, _)| &alert.description[..i]);
                 ui::draw_str(fb, w, desc_x, row_y + 3, desc, fg, bg);
             }
 
@@ -656,6 +680,45 @@ mod tests {
         monitor.draw(&mut fb);
         let any_set = fb.iter().any(|&px| px != 0);
         assert!(any_set, "threat monitor with alerts must render visible content");
+    }
+
+    #[test]
+    fn draw_handles_multibyte_description_at_truncation_boundary() {
+        let mut monitor = ThreatMonitor::new();
+        let mut alert = make_alert(1000, ThreatAlertType::BleTracker, ThreatLevel::Medium);
+        // 20 ASCII chars + a 2-byte codepoint so the render-time truncation
+        // boundary (byte 21 at this screen width) lands mid-codepoint
+        // pre-fix (#396).
+        alert.description = String::from("12345678901234567890é tracker seen nearby");
+        monitor.push_alert(alert);
+
+        let mut fb = [0u16; CONTENT_PIXELS];
+        // Must not panic ("byte index N is not a char boundary").
+        monitor.draw(&mut fb);
+        assert!(
+            fb.iter().any(|&px| px != 0),
+            "threat screen must render the char-boundary-truncated description"
+        );
+    }
+
+    #[test]
+    fn push_alert_truncates_description_to_max_desc_len_on_char_boundary() {
+        let mut monitor = ThreatMonitor::new();
+        let mut alert = make_alert(1000, ThreatAlertType::BleTracker, ThreatLevel::Low);
+        // 47 ASCII chars + a 2-byte codepoint so MAX_DESC_LEN (48) lands
+        // mid-codepoint if truncation is not char-boundary-safe (#396).
+        let mut long_desc = "A".repeat(47);
+        long_desc.push('é');
+        long_desc.push_str(" more text after the cap");
+        alert.description = long_desc;
+        monitor.push_alert(alert);
+
+        let stored = &monitor.alerts[0].description;
+        assert!(stored.len() <= MAX_DESC_LEN, "description must be capped at MAX_DESC_LEN");
+        assert_eq!(
+            stored.as_str(), "A".repeat(47),
+            "truncation must back off to the last full codepoint"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Resource-exhaustion and input-bounds hardening for a counter-surveillance device, plus a **critical missing authorization check** on the data-purge.

- **#395 (CRITICAL)** — the privacy dashboard's data-purge executed on *any* non-empty digit sequence; the entered code was read but never compared to anything ("passphrase would be verified in production"). `PrivacyScreen` now carries a `purge_passphrase_hash` and confirms via SHA-256 + a constant-time compare (reusing `lock_screen`'s, not a fourth copy). Corequisite bug fixed too: digits were stored as raw nibbles, not the ASCII bytes the hash expects, which would have made any comparison silently always-fail.
- **#363** — `feed_audio` grew `audio_buffer` unbounded → capped at 256 KiB (~8 s of PCM), rejects overflow.
- **#364** — futex waiter slots were never freed when a process died blocked in `futex_wait` (nothing wakes a dead process) → table leaked to exhaustion. `free_waiters_for_pid` now runs on every Dead-transition (SIGKILL, default-terminate, `exit_cleanup`).
- **#365** — the Matrix outbox `Vec` grew unbounded → capped at 256; `queue_message`/`send_message` reject when full.
- **#393** — `draw_detail` re-wrapped an unbounded attacker-controlled body every render tick → truncated char-boundary-safe to 4 KiB before `word_wrap`.
- **#394** — `screen_call` sliced a `[u8; 20]` by a public `u8` length with no bound → clamped before slicing.
- **#396** — `screen_threat` byte-sliced the description at a pixel boundary (UTF-8 panic) and never enforced `MAX_DESC_LEN` → char-boundary-safe at render + `push_alert`.
- **#359** — calendar/alarm title/label truncation cut on a raw byte count, silently returning `""` when it split a codepoint → shared `utf8_truncate_len` backs off to the last full codepoint.

## Closes

Closes #363, #364, #365, #393, #394, #396, #359, #395

## Verification

- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — 1801 passed (+14), incl. purge-code-rejection and futex-cleanup-on-kill tests.
- `cargo build --release --target armv7a-none-eabi` — compiles
- `kanon lint . --summary` — clean

## Review & follow-up

#395 (security surface) was reviewed at the orchestrator tier. Flagged follow-up (not blocking): `constant_time_eq` now has 3–4 near-identical copies across `lock_screen`/`security_mode`/`wifi`/`screen_privacy` — worth consolidating to one `subtle`-backed helper. #378 (Timer sub-second) was found to be a duplicate of the merged #342 and closed.