### PR TITLE
Harden adversarial time sources, seal iterations, IPC-to-kinit (6 issues)

### DIFF
--- a/crates/stegnos/src/keys.rs
+++ b/crates/stegnos/src/keys.rs
@@ -10,7 +10,7 @@ use sha2::Sha256;
 use snafu::Snafu;
 use zeroize::{Zeroize, Zeroizing};
 
-use crate::config::Config;
+use crate::config::{Config, MIN_PBKDF2_ITERATIONS};
 
 const SALT_LEN: usize = 32;
 const KEY_LEN: usize = 32;
@@ -25,6 +25,22 @@ pub(crate) enum Error {
     /// The iteration count passed to key derivation was zero.
     #[snafu(display("iterations must be non-zero"))]
     ZeroIterations {
+        /// Source location.
+        #[snafu(implicit)]
+        location: snafu::Location,
+    },
+
+    /// The persisted iteration count on an unseal attempt was below the
+    /// configured minimum -- indicates a tampered on-device header (#357).
+    #[snafu(display(
+        "stored iteration count {iterations} is below the minimum {min} \
+         (possible tampering)"
+    ))]
+    WeakIterations {
+        /// The rejected, tampered-low iteration count read from the slot.
+        iterations: u32,
+        /// The enforced minimum ([`crate::config::MIN_PBKDF2_ITERATIONS`]).
+        min: u32,
         /// Source location.
         #[snafu(implicit)]
         location: snafu::Location,
@@ -221,9 +237,22 @@ pub(crate) fn seal_key_with_config(
 /// # Errors
 ///
 /// Returns [`Error::KeyUnseal`] if the passphrase is wrong or the slot is corrupted.
-/// Returns [`Error::ZeroIterations`] if the stored iteration count is zero.
+/// Returns [`Error::WeakIterations`] if the stored iteration count is below
+/// [`crate::config::MIN_PBKDF2_ITERATIONS`] -- the seal path always clamps
+/// into range, so a weakened stored value indicates a tampered header (#357).
+/// Returns [`Error::ZeroIterations`] if the stored iteration count is zero
+/// (subsumed by the `WeakIterations` check above; kept for `derive_key`
+/// callers that bypass `unseal_key`).
 /// Returns [`Error::InvalidKey`] if key construction fails.
 pub(crate) fn unseal_key(slot: &KeySlot, passphrase: &[u8]) -> Result<[u8; KEY_LEN]> {
+    if slot.iterations < MIN_PBKDF2_ITERATIONS {
+        return WeakIterationsSnafu {
+            iterations: slot.iterations,
+            min: MIN_PBKDF2_ITERATIONS,
+        }
+        .fail();
+    }
+
     let derived = derive_key(passphrase, &slot.salt, slot.iterations)?;
 
     let opening_key =
@@ -333,6 +362,26 @@ mod tests {
         assert!(
             result.is_err(),
             "unseal with wrong passphrase must return an error"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn unseal_rejects_tampered_low_iteration_slot() -> Result<()> {
+        // #357: an attacker who rewrites the persisted KeySlot header can
+        // set iterations=1, collapsing the PBKDF2 work factor. unseal_key
+        // must reject any stored count below MIN_PBKDF2_ITERATIONS before
+        // ever deriving a key, regardless of whether the passphrase is
+        // otherwise correct.
+        let primary_key = [0x77u8; KEY_LEN];
+        let passphrase = b"correct passphrase";
+        let mut slot = seal_key(&primary_key, passphrase)?;
+        slot.iterations = 1;
+
+        let result = unseal_key(&slot, passphrase);
+        assert!(
+            matches!(result, Err(Error::WeakIterations { iterations: 1, .. })),
+            "tampered slot with iterations=1 must be rejected as WeakIterations"
         );
         Ok(())
     }

--- a/crates/thumos/src/capability.rs
+++ b/crates/thumos/src/capability.rs
@@ -8,8 +8,10 @@
 //!
 //! - kinit (PID 0) holds `Capabilities::ALL` at boot.
 //! - Forked children receive a subset defined by kinit policy. The default
-//!   policy strips MODEM and AUDIT so that generic userspace cannot access
-//!   the baseband or read the audit log.
+//!   policy strips MODEM, AUDIT, and IPC_INIT so that generic userspace
+//!   cannot access the baseband, read the audit log, or message PID 0's
+//!   inbox (#371 -- mirrors the CAP_KILL precedent for protecting PID 0
+//!   as a signal target, #269).
 //! - Syscalls that access sensitive resources call `check(required)` at entry.
 //!   On failure the syscall returns EPERM; on success execution continues.
 //!
@@ -23,6 +25,7 @@
 //! |  3  | CRYPTO    | Kernel CSPRNG, key material access        |
 //! |  4  | RADIO     | WiFi / BT / GPS radio control             |
 //! |  5  | AUDIT     | Reading the kernel audit log              |
+//! |  6  | IPC_INIT  | Sending an IPC message to PID 0 (kinit)   |
 
 /// Capability bitfield type (32-bit, 6 bits used).
 ///
@@ -45,16 +48,23 @@ impl Capabilities {
     pub(crate) const RADIO: u32 = 1 << 4;
     /// Read audit log.
     pub(crate) const AUDIT: u32 = 1 << 5;
+    /// Send an IPC message to PID 0 (kinit). Mirrors the CAP_KILL precedent
+    /// (#269/REQ-09) of protecting PID 0 -- the fault supervisor and
+    /// IPC-trust anchor -- with a dedicated capability rather than leaving
+    /// it reachable by any process holding a generic "can do IPC" bit
+    /// (#371).
+    pub(crate) const IPC_INIT: u32 = 1 << 6;
     /// All capabilities granted (kinit / PID 0).
-    pub(crate) const ALL: u32 = 0x3F;
+    pub(crate) const ALL: u32 = 0x7F;
 
     /// Default capability set for forked children.
     ///
-    /// WHY: strips MODEM and AUDIT from ALL. Generic userspace processes have
-    /// no legitimate need to speak AT commands to the baseband or read the
-    /// audit log. All other capabilities remain available; the policy can be
+    /// WHY: strips MODEM, AUDIT, and IPC_INIT from ALL. Generic userspace
+    /// processes have no legitimate need to speak AT commands to the
+    /// baseband, read the audit log, or message kinit's inbox directly
+    /// (#371). All other capabilities remain available; the policy can be
     /// tightened per-process by kinit before exec.
-    pub(crate) const FORK_DEFAULT: u32 = Self::ALL & !(Self::MODEM | Self::AUDIT);
+    pub(crate) const FORK_DEFAULT: u32 = Self::ALL & !(Self::MODEM | Self::AUDIT | Self::IPC_INIT);
 
     /// Construct a capability set from a raw bitfield.
     #[inline]
@@ -158,6 +168,7 @@ mod tests {
         assert!(caps.contains(Capabilities::CRYPTO),  "kinit must have CRYPTO");
         assert!(caps.contains(Capabilities::RADIO),   "kinit must have RADIO");
         assert!(caps.contains(Capabilities::AUDIT),   "kinit must have AUDIT");
+        assert!(caps.contains(Capabilities::IPC_INIT), "kinit must have IPC_INIT");
         // ALL must equal the union of all individual bits.
         let union =
             Capabilities::MODEM
@@ -165,7 +176,8 @@ mod tests {
             | Capabilities::KILL
             | Capabilities::CRYPTO
             | Capabilities::RADIO
-            | Capabilities::AUDIT;
+            | Capabilities::AUDIT
+            | Capabilities::IPC_INIT;
         assert_eq!(Capabilities::ALL, union, "ALL must equal bitwise-OR of all caps");
     }
 
@@ -182,11 +194,13 @@ mod tests {
             child.bits() & parent.bits(), child.bits(),
             "child capabilities must be a subset of parent capabilities"
         );
-        // MODEM and AUDIT must be stripped.
+        // MODEM, AUDIT, and IPC_INIT must be stripped.
         assert!(!child.contains(Capabilities::MODEM),
             "MODEM must not be inherited by default");
         assert!(!child.contains(Capabilities::AUDIT),
             "AUDIT must not be inherited by default");
+        assert!(!child.contains(Capabilities::IPC_INIT),
+            "IPC_INIT must not be inherited by default (#371)");
         // Remaining caps must be present.
         assert!(child.contains(Capabilities::RAW_NET), "RAW_NET must be inherited");
         assert!(child.contains(Capabilities::KILL),    "KILL must be inherited");
@@ -259,7 +273,7 @@ mod tests {
     // -----------------------------------------------------------------------
     #[test]
     fn all_caps_value() {
-        assert_eq!(Capabilities::ALL, 0x3F, "ALL must equal 0x3F (6 bits)");
+        assert_eq!(Capabilities::ALL, 0x7F, "ALL must equal 0x7F (7 bits, #371 adds IPC_INIT)");
     }
 
     // -----------------------------------------------------------------------
@@ -267,8 +281,8 @@ mod tests {
     // -----------------------------------------------------------------------
     #[test]
     fn fork_default_value() {
-        let expected = Capabilities::ALL & !(Capabilities::MODEM | Capabilities::AUDIT);
+        let expected = Capabilities::ALL & !(Capabilities::MODEM | Capabilities::AUDIT | Capabilities::IPC_INIT);
         assert_eq!(Capabilities::FORK_DEFAULT, expected,
-            "FORK_DEFAULT must equal ALL & !(MODEM | AUDIT)");
+            "FORK_DEFAULT must equal ALL & !(MODEM | AUDIT | IPC_INIT)");
     }
 }

--- a/crates/thumos/src/clock.rs
+++ b/crates/thumos/src/clock.rs
@@ -293,11 +293,38 @@ pub(crate) fn build_ntp_request() -> [u8; NTP_PACKET_SIZE] {
 /// - Bytes 40-43: seconds since NTP epoch (1900-01-01)
 /// - Bytes 44-47: fractional seconds
 ///
-/// Returns the transmit timestamp as Unix epoch seconds, or `None`
-/// if the packet is too short or the timestamp is zero.
+/// Validates packet structure before trusting the timestamp (#367): mode
+/// must be 4 (server response), the Leap Indicator must not be 3
+/// (unsynchronized), and stratum must be in `1..16` (0 = kiss-o'-death,
+/// 16 = unsynchronized). This is structural validation only -- NTP
+/// authentication (NTS) is future work per the module doc.
+///
+/// Returns the transmit timestamp as Unix epoch seconds, or `None` if the
+/// packet is too short, structurally invalid, or the timestamp is zero.
 #[must_use]
 pub(crate) fn parse_ntp_response(packet: &[u8]) -> Option<u64> {
     if packet.len() < NTP_PACKET_SIZE {
+        return None;
+    }
+
+    // Mode (bits [2:0] of byte 0) must be 4 (server response). Rejects
+    // client/broadcast/reserved-mode packets an adversary could replay (#367).
+    if packet[0] & 0x07 != 4 {
+        return None;
+    }
+
+    // Leap Indicator (bits [7:6] of byte 0) of 3 signals the server clock is
+    // unsynchronized ("alarm condition" per RFC 5905 SS7.3) and must be
+    // discarded rather than trusted (#367).
+    if packet[0] >> 6 == 3 {
+        return None;
+    }
+
+    // Stratum (byte 1): 0 is kiss-o'-death (server refusing service, no
+    // valid time attached), 16 is unsynchronized. Valid strata are 1-15;
+    // both boundary conditions must be rejected (#367).
+    let stratum = packet[1];
+    if stratum == 0 || stratum >= 16 {
         return None;
     }
 
@@ -525,6 +552,46 @@ mod tests {
         );
     }
 
+    #[test]
+    fn get_wall_clock_ntp_positive_offset_path() {
+        // #376: the NTP code path (as opposed to GPS) was previously
+        // untested by get_wall_clock -- this exercises it directly.
+        let mut clock = ClockManager::new();
+        let accepted = clock.update_from_ntp(1_700_000_000, 0);
+        assert!(accepted, "NTP must be accepted when no GPS is present");
+
+        let wall = clock.get_wall_clock(5_000); // 5 seconds later
+        assert_eq!(
+            wall,
+            1_700_000_005,
+            "wall clock must be monotonic_secs + ntp offset"
+        );
+    }
+
+    #[test]
+    fn get_wall_clock_ntp_large_negative_offset_wraps_to_huge_timestamp() {
+        // #376: documents the current (unguarded) behavior of the NTP
+        // path. A hostile NTP server supplying a large-negative offset
+        // drives get_wall_clock() to silently wrap to a near-u64::MAX
+        // timestamp via the `as u64` cast rather than erroring or
+        // clamping. This is the exact silent-wraparound surface #376
+        // exists to make visible, as a regression guard: a future
+        // plausibility guard (companion to #367's packet validation)
+        // should make this test's expected value change to a bounded
+        // result, at which point this assertion should be updated
+        // deliberately rather than silently.
+        let mut clock = ClockManager::new();
+        clock.ntp_offset = Some(i64::MIN);
+        clock.ntp_update_tick = 0;
+
+        let wall = clock.get_wall_clock(0);
+        assert_eq!(
+            wall,
+            i64::MIN as u64,
+            "unguarded NTP path must wrap exactly as documented (#376)"
+        );
+    }
+
     // -- NTP packet tests --
 
     #[test]
@@ -545,6 +612,10 @@ mod tests {
     #[test]
     fn parse_ntp_response_extracts_timestamp() {
         let mut packet = [0u8; 48];
+        // LI=0, VN=4, Mode=4 (server response) -- required for the packet to
+        // pass the structural validation added for #367.
+        packet[0] = 0x24;
+        packet[1] = 1; // stratum 1 (primary reference) -- valid, non-zero, <16.
         // Set transmit timestamp at bytes 40-43.
         // NTP epoch value = Unix epoch + NTP_UNIX_OFFSET
         let unix_time: u64 = 1_700_000_000;
@@ -556,6 +627,72 @@ mod tests {
             result,
             Some(unix_time),
             "must extract Unix epoch from NTP timestamp"
+        );
+    }
+
+    #[test]
+    fn parse_ntp_response_rejects_wrong_mode() {
+        // #367: mode bits [2:0] of byte 0 must be 4 (server response).
+        let mut packet = [0u8; 48];
+        packet[0] = 0x03; // LI=0, VN=0, Mode=3 (client, not server)
+        packet[1] = 1;
+        let unix_time: u64 = 1_700_000_000;
+        let ntp_time = (unix_time + NTP_UNIX_OFFSET) as u32;
+        packet[40..44].copy_from_slice(&ntp_time.to_be_bytes());
+        assert_eq!(
+            parse_ntp_response(&packet),
+            None,
+            "non-server mode must be rejected"
+        );
+    }
+
+    #[test]
+    fn parse_ntp_response_rejects_alarm_leap_indicator() {
+        // #367: LI = 3 (bits [7:6] of byte 0) signals an unsynchronized
+        // server clock and must be discarded.
+        let mut packet = [0u8; 48];
+        packet[0] = 0xE4; // LI=3, VN=4, Mode=4
+        packet[1] = 1;
+        let unix_time: u64 = 1_700_000_000;
+        let ntp_time = (unix_time + NTP_UNIX_OFFSET) as u32;
+        packet[40..44].copy_from_slice(&ntp_time.to_be_bytes());
+        assert_eq!(
+            parse_ntp_response(&packet),
+            None,
+            "LI=3 (alarm/unsynchronized) must be rejected"
+        );
+    }
+
+    #[test]
+    fn parse_ntp_response_rejects_kiss_of_death_stratum() {
+        // #367: stratum 0 is kiss-o'-death -- the server is refusing
+        // service and the packet carries no valid time.
+        let mut packet = [0u8; 48];
+        packet[0] = 0x24; // LI=0, VN=4, Mode=4
+        packet[1] = 0; // stratum 0
+        let unix_time: u64 = 1_700_000_000;
+        let ntp_time = (unix_time + NTP_UNIX_OFFSET) as u32;
+        packet[40..44].copy_from_slice(&ntp_time.to_be_bytes());
+        assert_eq!(
+            parse_ntp_response(&packet),
+            None,
+            "stratum 0 (kiss-o'-death) must be rejected"
+        );
+    }
+
+    #[test]
+    fn parse_ntp_response_rejects_unsynchronized_stratum() {
+        // #367: stratum 16 means the server itself is unsynchronized.
+        let mut packet = [0u8; 48];
+        packet[0] = 0x24; // LI=0, VN=4, Mode=4
+        packet[1] = 16; // stratum 16
+        let unix_time: u64 = 1_700_000_000;
+        let ntp_time = (unix_time + NTP_UNIX_OFFSET) as u32;
+        packet[40..44].copy_from_slice(&ntp_time.to_be_bytes());
+        assert_eq!(
+            parse_ntp_response(&packet),
+            None,
+            "stratum 16 (unsynchronized) must be rejected"
         );
     }
 

--- a/crates/thumos/src/heorte.rs
+++ b/crates/thumos/src/heorte.rs
@@ -316,7 +316,10 @@ impl HeorteManager {
 
 /// Decompose Unix epoch seconds into `(hour, minute, year, month, day)`.
 ///
-/// Uses a simplified algorithm sufficient for display purposes.
+/// Uses a closed-form Gregorian calendar calculation (O(1) regardless of
+/// epoch magnitude) sufficient for display purposes. `year` saturates to
+/// `u16::MAX` for dates beyond the display range rather than overflowing
+/// or iterating (#366).
 pub(crate) fn decompose_epoch(epoch: u64) -> (u8, u8, u16, u8, u8) {
     if epoch == 0 {
         return (0, 0, 0, 0, 0);
@@ -326,39 +329,36 @@ pub(crate) fn decompose_epoch(epoch: u64) -> (u8, u8, u16, u8, u8) {
     let hour = (day_secs / SECS_PER_HOUR) as u8;
     let minute = ((day_secs % SECS_PER_HOUR) / SECS_PER_MIN) as u8;
 
-    let mut days = (epoch / SECS_PER_DAY) as u32;
-    let mut year: u16 = 1970;
-    loop {
-        let days_in_year = if is_leap_year(year) { 366 } else { 365 };
-        if days < days_in_year {
-            break;
-        }
-        days -= days_in_year;
-        year += 1;
-    }
-
-    let leap = is_leap_year(year);
-    let month_days: [u32; 12] = [
-        31,
-        if leap { 29 } else { 28 },
-        31, 30, 31, 30, 31, 31, 30, 31, 30, 31,
-    ];
-    let mut month: u8 = 1;
-    for &md in &month_days {
-        if days < md {
-            break;
-        }
-        days -= md;
-        month += 1;
-    }
-
-    let day = (days + 1) as u8;
+    let days = epoch / SECS_PER_DAY;
+    let (year, month, day) = civil_from_days(days);
     (hour, minute, year, month, day)
 }
 
-/// Check if a year is a leap year.
-const fn is_leap_year(year: u16) -> bool {
-    (year.is_multiple_of(4) && !year.is_multiple_of(100)) || year.is_multiple_of(400)
+/// Convert days-since-Unix-epoch to a `(year, month, day)` civil date in
+/// O(1), replacing the year-by-year iteration that made `decompose_epoch`
+/// an O(years) DoS surface for an adversarial epoch -- up to ~11.7M
+/// iterations for a large `days` value (#366).
+///
+/// Closed-form Gregorian calendar algorithm (Howard Hinnant's
+/// `civil_from_days`, <https://howardhinnant.github.io/date_algorithms.html>).
+/// `days` is always non-negative here (`epoch / SECS_PER_DAY`), so the
+/// `i64` intermediate arithmetic never loses range for any `u64` epoch.
+/// `year` saturates to `u16::MAX` rather than overflowing for dates far
+/// beyond the display range.
+fn civil_from_days(days: u64) -> (u16, u8, u8) {
+    let z = (days as i64).saturating_add(719_468);
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097; // [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365; // [0, 399]
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11]
+    let d = doy - (153 * mp + 2) / 5 + 1; // [1, 31]
+    let m = if mp < 10 { mp + 3 } else { mp - 9 }; // [1, 12]
+    let y = if m <= 2 { y + 1 } else { y };
+
+    let year = u16::try_from(y).unwrap_or(u16::MAX);
+    (year, m as u8, d as u8)
 }
 
 /// Format date as "YYYY-MM-DD" into a fixed buffer.
@@ -544,6 +544,19 @@ mod tests {
         // 2026-01-01 00:00:00 UTC = 1767225600
         let (h, m, y, mo, d) = decompose_epoch(1_767_225_600);
         assert_eq!((y, mo, d, h, m), (2026, 1, 1, 0, 0));
+    }
+
+    #[test]
+    fn decompose_epoch_large_value_completes_in_o1() {
+        // #366: an adversarial epoch near u64::MAX previously drove the
+        // year-by-year loop through millions of iterations. The closed-form
+        // civil_from_days() calculation returns in O(1) regardless of
+        // magnitude -- this test would hang under the old implementation
+        // and returns instantly under the fix.
+        let (_, _, year, month, day) = decompose_epoch(u64::MAX / 2);
+        assert_eq!(year, u16::MAX, "year must saturate rather than wrap or panic");
+        assert!((1..=12).contains(&month), "month must stay in valid range");
+        assert!((1..=31).contains(&day), "day must stay in valid range");
     }
 
     #[test]

--- a/crates/thumos/src/ipc.rs
+++ b/crates/thumos/src/ipc.rs
@@ -128,6 +128,14 @@ fn validate_pid(pid: Pid) -> Result<usize, i32> {
 
 /// Send a message to a process. Non-blocking: returns false if inbox full
 /// or the target PID is invalid.
+///
+/// NOTE: this primitive performs no capability/authorization check by
+/// design -- it is also used by trusted kernel-internal callers (e.g.
+/// `process::notify_fault`, which relays a fault report to PID 0 on behalf
+/// of the faulting process). The untrusted-facing authorization gate for
+/// PID 0 as a target lives at the syscall boundary instead: see
+/// `syscall::dispatch`'s `Syscall::Send` arm and
+/// `capability::Capabilities::IPC_INIT` (#371).
 pub(crate) fn send(to: Pid, mut msg: Message) -> bool {
     let idx = match validate_pid(to) {
         Ok(i) => i,

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -2698,4 +2698,121 @@ mod tests {
         }
     }
 
+    /// #371: sys_send (Syscall::Send) targeting PID 0 must be denied when
+    /// the sender lacks CAP_IPC_INIT, and the message must not be
+    /// delivered into kinit's inbox.
+    #[test]
+    fn sys_send_to_pid_zero_denied_without_ipc_init_cap() {
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+
+            let pt0 = mmu::alloc_addr_space().unwrap();
+            procs[0] = Some(Process {
+                pid: 0,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: None,
+                exit_status: 0,
+                page_table_phys: pt0,
+                stack_base: 0,
+                stack_pages: 0,
+                heap_break: DEFAULT_HEAP_BREAK,
+                mappings: [None; MAX_MAPPINGS],
+                signal_state: SignalState::new(),
+                uid: 0,
+                wake_tick: 0,
+                capabilities: crate::capability::Capabilities::ALL,
+            });
+
+            let pt1 = mmu::alloc_addr_space().unwrap();
+            procs[1] = Some(Process {
+                pid: 1,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: Some(0),
+                exit_status: 0,
+                page_table_phys: pt1,
+                stack_base: 0,
+                stack_pages: 0,
+                heap_break: DEFAULT_HEAP_BREAK,
+                mappings: [None; MAX_MAPPINGS],
+                signal_state: SignalState::new(),
+                uid: 1,
+                wake_tick: 0,
+                // Generic fork-default userspace process: no CAP_IPC_INIT.
+                capabilities: crate::capability::Capabilities::FORK_DEFAULT,
+            });
+            CURRENT = 1;
+
+            let ret = crate::syscall::dispatch(crate::syscall::Syscall::Send.as_u32(), 0, 42, 0, 0);
+            assert_eq!(ret, u32::MAX, "send to PID 0 without CAP_IPC_INIT must be denied");
+
+            CURRENT = 0;
+            assert!(
+                crate::ipc::recv().is_none(),
+                "denied send must not deliver a message into PID 0's inbox"
+            );
+        }
+    }
+
+    /// #371: a process explicitly granted CAP_IPC_INIT may message PID 0,
+    /// and the delivered message carries the sender's PID and tag.
+    #[test]
+    fn sys_send_to_pid_zero_allowed_with_ipc_init_cap() {
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+
+            let pt0 = mmu::alloc_addr_space().unwrap();
+            procs[0] = Some(Process {
+                pid: 0,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: None,
+                exit_status: 0,
+                page_table_phys: pt0,
+                stack_base: 0,
+                stack_pages: 0,
+                heap_break: DEFAULT_HEAP_BREAK,
+                mappings: [None; MAX_MAPPINGS],
+                signal_state: SignalState::new(),
+                uid: 0,
+                wake_tick: 0,
+                capabilities: crate::capability::Capabilities::ALL,
+            });
+
+            let pt1 = mmu::alloc_addr_space().unwrap();
+            procs[1] = Some(Process {
+                pid: 1,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: Some(0),
+                exit_status: 0,
+                page_table_phys: pt1,
+                stack_base: 0,
+                stack_pages: 0,
+                heap_break: DEFAULT_HEAP_BREAK,
+                mappings: [None; MAX_MAPPINGS],
+                signal_state: SignalState::new(),
+                uid: 1,
+                wake_tick: 0,
+                capabilities: crate::capability::Capabilities::IPC_INIT,
+            });
+            CURRENT = 1;
+
+            let ret = crate::syscall::dispatch(crate::syscall::Syscall::Send.as_u32(), 0, 42, 0, 0);
+            assert_eq!(ret, 0, "send to PID 0 with CAP_IPC_INIT must succeed");
+
+            CURRENT = 0;
+            let msg = crate::ipc::recv();
+            assert!(msg.is_some(), "allowed send must deliver a message into PID 0's inbox");
+            assert_eq!(
+                msg.map(|m| (m.tag, m.from)),
+                Some((42, 1)),
+                "delivered message must carry the sender's tag and PID"
+            );
+        }
+    }
+
 }

--- a/crates/thumos/src/syscall.rs
+++ b/crates/thumos/src/syscall.rs
@@ -23,6 +23,7 @@
 
 use core::fmt::Write;
 
+use crate::capability;
 use crate::fd;
 use crate::futex;
 use crate::ipc;
@@ -448,6 +449,19 @@ pub(crate) fn dispatch(num: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> 
         }
         Syscall::Send => {
             let Ok(to) = u8::try_from(arg0) else { return EINVAL; };
+            // WHY (#371): PID 0 (kinit) is the fault supervisor and
+            // IPC-trust anchor -- mirrors the #269/CAP_KILL precedent that
+            // protects PID 0 from arbitrary signals. A generic userspace
+            // process must not be able to flood or spoof messages into
+            // kinit's inbox; only a process holding CAP_IPC_INIT may
+            // target PID 0 via this syscall. This check lives at the
+            // syscall boundary only -- kernel-internal delivery to kinit
+            // (process::notify_fault) calls ipc::send() directly and is
+            // unaffected, exactly as sys_kill's belt-and-suspenders check
+            // does not reach deliver_signal_to's internal callers.
+            if to == 0 && capability::check(capability::Capabilities::IPC_INIT).is_err() {
+                return u32::MAX;
+            }
             let tag = arg1;
             let Ok(ptr) = usize::try_from(arg2) else { return EINVAL; };
             let Ok(len) = usize::try_from(arg3) else { return EINVAL; };

--- a/crates/thumos/src/time.rs
+++ b/crates/thumos/src/time.rs
@@ -64,10 +64,46 @@ pub(crate) static mut REALTIME_OFFSET_SECS: u64 = 1_735_603_200;
 // Epoch offset update
 // ---------------------------------------------------------------------------
 
+/// Earliest epoch accepted as a plausible external time-source update.
+///
+/// WHY 2020-01-01: comfortably before this kernel's earliest possible
+/// deployment, so it never rejects a legitimate GPS/NTP/carrier time while
+/// still bounding a hostile modem RTC that reports epoch 0 or another
+/// implausible pre-boot date (#374).
+const MIN_VALID_EPOCH: u64 = 1_577_836_800; // 2020-01-01T00:00:00Z
+
+/// Latest epoch accepted as a plausible external time-source update.
+///
+/// WHY 2100-01-01: generous upper bound -- no legitimate time source should
+/// ever report a date this far out. A hostile modem RTC setting the clock
+/// to year 2500+ would corrupt certificate validity checks and audit-log
+/// ordering (#374).
+const MAX_VALID_EPOCH: u64 = 4_102_444_800; // 2100-01-01T00:00:00Z
+
+/// Compute the new `REALTIME_OFFSET_SECS` value for a candidate wall-clock
+/// update, or `None` if `unix_now_secs` falls outside the plausible epoch
+/// window `[MIN_VALID_EPOCH, MAX_VALID_EPOCH]`.
+///
+/// Pure function (no static access), deliberately kept free of the
+/// `#[cfg(not(test))]` gating that `set_realtime_offset` carries, so the
+/// validation and offset arithmetic are host-testable without the
+/// ARM-only timer read (#374).
+#[must_use]
+fn compute_realtime_offset(unix_now_secs: u64, elapsed_secs: u64) -> Option<u64> {
+    if !(MIN_VALID_EPOCH..=MAX_VALID_EPOCH).contains(&unix_now_secs) {
+        return None;
+    }
+    Some(unix_now_secs.saturating_sub(elapsed_secs))
+}
+
 /// Update the wall-clock boot epoch from an external source (e.g., modem RTC).
 ///
 /// `unix_now_secs` is the current Unix timestamp in seconds. This function
 /// back-calculates the boot epoch by subtracting the elapsed monotonic time.
+/// Rejects `unix_now_secs` outside `[MIN_VALID_EPOCH, MAX_VALID_EPOCH]` and
+/// leaves `REALTIME_OFFSET_SECS` unchanged -- a hostile modem RTC (the
+/// lowest-trust source per the clock hierarchy) must not be able to set the
+/// clock to an implausible date (#374).
 ///
 /// # Safety
 ///
@@ -78,9 +114,12 @@ pub(crate) static mut REALTIME_OFFSET_SECS: u64 = 1_735_603_200;
 #[cfg(not(test))]
 pub unsafe fn set_realtime_offset(unix_now_secs: u64) {
     let elapsed_secs = monotonic_secs();
+    let Some(new_offset) = compute_realtime_offset(unix_now_secs, elapsed_secs) else {
+        return;
+    };
     // SAFETY: see function-level safety doc; caller ensures exclusion.
     unsafe {
-        REALTIME_OFFSET_SECS = unix_now_secs.saturating_sub(elapsed_secs);
+        REALTIME_OFFSET_SECS = new_offset;
     }
 }
 
@@ -352,6 +391,44 @@ mod tests {
         assert!(
             offset >= min_epoch,
             "boot epoch offset must be >= 2025-01-01 (got {offset})"
+        );
+    }
+
+    /// #374: a plausible epoch within the accepted window computes the
+    /// expected offset (unix_now_secs - elapsed_secs).
+    #[test]
+    fn compute_realtime_offset_accepts_plausible_window() {
+        assert_eq!(
+            compute_realtime_offset(MIN_VALID_EPOCH, 0),
+            Some(MIN_VALID_EPOCH),
+            "lower bound must be accepted"
+        );
+        assert_eq!(
+            compute_realtime_offset(MAX_VALID_EPOCH, 100),
+            Some(MAX_VALID_EPOCH - 100),
+            "upper bound must be accepted, offset subtracts elapsed time"
+        );
+    }
+
+    /// #374: epoch 0 (1970, a hostile modem RTC's most common failure
+    /// value) must be rejected -- the offset is left unchanged (None).
+    #[test]
+    fn compute_realtime_offset_rejects_epoch_zero() {
+        assert_eq!(
+            compute_realtime_offset(0, 0),
+            None,
+            "epoch 0 (1970) must be rejected as implausible"
+        );
+    }
+
+    /// #374: a hostile modem RTC reporting year ~2200 must be rejected.
+    #[test]
+    fn compute_realtime_offset_rejects_far_future() {
+        let year_2200_epoch = MAX_VALID_EPOCH + 100 * 365 * 86_400;
+        assert_eq!(
+            compute_realtime_offset(year_2200_epoch, 0),
+            None,
+            "year 2200 must be rejected"
         );
     }
 


### PR DESCRIPTION
## Summary

Time sources (modem RTC, NTP) and the IPC boundary are attacker-influenced on a counter-surveillance device.

- **#366** — `decompose_epoch` used an O(years) loop → an adversarial epoch drove ~11.7M iterations (DoS). Replaced with Howard Hinnant's closed-form `civil_from_days` (O(1); year saturates).
- **#367** — `parse_ntp_response` validated only length + non-zero timestamp. Now checks mode == 4 (server), rejects LI == 3, stratum 0 (kiss-o'-death) / ≥ 16 (unsynchronized).
- **#374** (security) — `set_realtime_offset` accepted an arbitrary modem-RTC epoch. Validation + arithmetic moved to a pure, host-testable `compute_realtime_offset` that rejects outside `[2020, 2100)`, leaving the prior offset untouched.
- **#376** — added coverage for `get_wall_clock`'s NTP path + documented the negative-offset arithmetic as a regression guard.
- **#357** (security) — stegnos `unseal_key` passed the persisted iteration count straight to the KDF; a tampered header with `iterations=1` collapses the PBKDF2 work factor. Now rejects any count below `MIN_PBKDF2_ITERATIONS` with a new `WeakIterations` error.
- **#371** (security) — `sys_send` could target any PID including 0 (kinit). Added `CAP_IPC_INIT` (stripped from `FORK_DEFAULT`), gated on PID-0 sends at the syscall boundary, mirroring CAP_KILL/PID-0 (#269). `ipc::send` is left ungated so kernel-internal fault relay (`notify_fault`) keeps working for unprivileged crashers.

## Closes

Closes #366, #367, #374, #376, #357, #371

## Verification

- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — 1813 passed (+12)
- `cargo test -p stegnos` — 26 passed (+1)
- `cargo clippy --workspace --all-targets -- -D warnings` + `cargo test --doc --workspace` — clean
- `cargo build --release --target armv7a-none-eabi` — compiles
- `kanon lint . --summary` — clean

## Review & follow-ups

#371 (capability model) and #357/#374 (security) reviewed at the orchestrator tier. #371 was designed only after verifying the trust model — the ungated `ipc::send` is intentional (fault relay). Two follow-ups flagged: (1) `screen_home.rs` has a *duplicate* O(years) `decompose_epoch` loop not covered by #366 (same DoS — filing separately); (2) extending IPC-target protection beyond PID 0 to named services (telephony/security daemon) needs a PID→service registry that doesn't exist yet.