### PR TITLE
Cache-flush durability, IMSI neighbor tracking, screen_home DoS + coverage (5 issues)

### DIFF
--- a/crates/sema/src/cell.rs
+++ b/crates/sema/src/cell.rs
@@ -455,7 +455,13 @@ pub(crate) fn detect_imsi_catcher_with_config(
                     reselection_count = reselection_count.saturating_add(1);
                 }
 
+                // #355: a cell the device has actively connected to is a
+                // known handover target for future SuddenTowerChange checks,
+                // the same as one seen via NeighborSeen -- real devices
+                // routinely hand back to a previously-served cell without
+                // the serving cell re-announcing it as a neighbour.
                 seen_tower_ids.insert(tower.id());
+                known_neighbor_ids.insert(tower.id());
                 prev_serving = Some(tower);
             }
 
@@ -634,6 +640,36 @@ mod tests {
                 .iter()
                 .any(|a| matches!(a, ImsiCatcherAlert::SuddenTowerChange { .. })),
             "handover to a previously-announced neighbour should not raise SuddenTowerChange"
+        );
+    }
+
+    #[test]
+    fn imsi_catcher_no_sudden_change_on_handover_back_to_previously_connected_cell() {
+        // #355: Connected(A) must register A as a known neighbour, so a
+        // later HandoverTo(A) -- returning to a cell the device previously
+        // served on, without an intervening NeighborSeen(A) -- must not
+        // raise SuddenTowerChange. Real devices hand back to
+        // previously-served cells during normal mobility.
+        let first_cell = tower(1, -70, CellTechnology::Lte);
+        let second_cell = tower(2, -72, CellTechnology::Lte);
+        let events = [
+            CellEvent::Connected(first_cell.clone()),
+            // Reselection to another serving cell (Connected, not a
+            // HandoverTo -- the latter to a never-known tower would raise
+            // its own SuddenTowerChange and confound this test).
+            CellEvent::Connected(second_cell),
+            // Hand back to first_cell, which was only ever Connected, never
+            // explicitly announced via NeighborSeen. Pre-#355 this raised a
+            // false SuddenTowerChange because Connected did not register the
+            // cell as a known neighbour.
+            CellEvent::HandoverTo(first_cell),
+        ];
+        let alerts = detect_imsi_catcher(&events);
+        assert!(
+            !alerts
+                .iter()
+                .any(|a| matches!(a, ImsiCatcherAlert::SuddenTowerChange { .. })),
+            "handover back to a previously-Connected cell must not raise SuddenTowerChange"
         );
     }
 

--- a/crates/thumos/src/block.rs
+++ b/crates/thumos/src/block.rs
@@ -368,7 +368,7 @@ pub(crate) fn write_block(
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use alloc::vec;
 
     use super::*;
@@ -463,9 +463,9 @@ mod tests {
 
     /// A block device mock that returns [`BlockError::IoError`] on reads/writes
     /// to specific sectors, and [`BlockError::DeviceNotReady`] when not initialized.
-    struct FailingBlockDevice {
+    pub(crate) struct FailingBlockDevice {
         /// Whether the device has been "initialized".
-        ready: bool,
+        pub(crate) ready: bool,
         /// Sector that triggers an `IoError` (all others succeed like `MemBlockDevice`).
         fail_sector: u64,
         /// Total sector count.
@@ -475,7 +475,7 @@ mod tests {
     }
 
     impl FailingBlockDevice {
-        fn new(sector_count: u64, fail_sector: u64) -> Self {
+        pub(crate) fn new(sector_count: u64, fail_sector: u64) -> Self {
             let size = sector_count as usize * SECTOR_SIZE;
             Self {
                 ready: false,

--- a/crates/thumos/src/cache.rs
+++ b/crates/thumos/src/cache.rs
@@ -158,19 +158,31 @@ impl BlockCache {
 
     /// Flush all dirty cache entries to the device.
     ///
-    /// After a successful flush, all entries are marked clean (not dirty).
+    /// Every dirty entry is attempted, even after an earlier one fails --
+    /// a single persistently-failing block must not permanently block
+    /// flushing of every entry that sorts after it in the cache (#375).
+    /// Entries that flush successfully are marked clean regardless of
+    /// failures elsewhere in the same pass.
     ///
     /// # Errors
     ///
-    /// Returns [`BlockError`] if any write-back to the device fails. Entries
-    /// that were successfully flushed before the failure are marked clean.
+    /// Returns the first [`BlockError`] encountered, if any. Entries that
+    /// flushed successfully (including ones after the first failure) are
+    /// marked clean; the entry (or entries) that failed remain dirty and
+    /// are retried on the next `flush` call.
     pub(crate) fn flush(&mut self, dev: &mut dyn BlockDevice) -> Result<(), BlockError> {
+        let mut first_err = None;
         for i in 0..self.entries.len() {
-            if self.entries[i].valid && self.entries[i].dirty {
-                self.write_back(dev, i)?;
+            if self.entries[i].valid && self.entries[i].dirty
+                && let Err(e) = self.write_back(dev, i)
+            {
+                first_err.get_or_insert(e);
             }
         }
-        Ok(())
+        match first_err {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
     }
 
     /// Sync all dirty cache entries to the device.
@@ -276,6 +288,7 @@ mod tests {
     use alloc::vec;
 
     use super::*;
+    use crate::block::tests::FailingBlockDevice;
     use crate::block::MemBlockDevice;
 
     /// Helper: create a device large enough for cache testing.
@@ -372,6 +385,50 @@ mod tests {
             !cache.entries[idx].dirty,
             "entry should be clean after flush"
         );
+    }
+
+    #[test]
+    fn flush_continues_past_failing_entry_and_returns_first_error() {
+        // #375: entry 4 (block_num 4) fails write-back. flush() must still
+        // attempt every OTHER dirty entry rather than aborting at the first
+        // failure -- otherwise a single persistently-bad block would
+        // permanently block flushing of every entry ordered after it, since
+        // a retried flush() restarts from index 0 and hits the same
+        // failure every time.
+        let fail_lba = 4 * SECTORS_PER_BLOCK as u64;
+        let mut dev = FailingBlockDevice::new(4096, fail_lba);
+        dev.ready = true;
+        let mut cache = BlockCache::new();
+
+        // Fill 10 dirty entries; blocks 0..10 land in cache slots 0..10 on
+        // an empty cache (same fill-order assumption as the eviction test
+        // below).
+        for i in 0..10u64 {
+            let data = pattern_block((i & 0xFF) as u8);
+            cache.write(&mut dev, i, &data).expect("fill write failed");
+        }
+
+        let result = cache.flush(&mut dev);
+        assert_eq!(
+            result,
+            Err(BlockError::IoError),
+            "flush must surface the write-back error"
+        );
+
+        for i in 0..10u64 {
+            let idx = cache.find_entry(i).expect("block should still be cached");
+            if i == 4 {
+                assert!(
+                    cache.entries[idx].dirty,
+                    "the failing entry must remain dirty"
+                );
+            } else {
+                assert!(
+                    !cache.entries[idx].dirty,
+                    "entry {i} must still be flushed despite entry 4's failure"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/thumos/src/harmostes.rs
+++ b/crates/thumos/src/harmostes.rs
@@ -1541,6 +1541,100 @@ mod tests {
     }
 
     #[test]
+    fn build_encrypted_send_request_produces_megolm_encrypted_request() {
+        // #377: build_encrypted_send_request had zero direct test coverage --
+        // only the underlying build_megolm_request was exercised indirectly
+        // via flush_outbox_attempts_all. Cover the public entry point itself.
+        let mut client = matrix_client_with_test_credentials();
+        let room_id = "!enc-room:matrix.example.com";
+
+        let result = client.build_encrypted_send_request(room_id, "secret message");
+        assert!(result.is_ok(), "encrypted send request build must succeed");
+
+        let (req, txn_id) = result.ok().unwrap_or_else(|| {
+            // Fallback that never executes -- satisfies no-unwrap lint.
+            let r = HttpRequest::new(
+                http_client::HttpMethod::Get,
+                String::new(),
+                String::new(),
+            );
+            (r, 0)
+        });
+
+        assert_eq!(txn_id, TXN_ID_START);
+        assert!(req.path.contains(room_id));
+        assert!(
+            req.path.contains("/send/m.room.encrypted/"),
+            "encrypted send must PUT to the m.room.encrypted path, got {}",
+            req.path
+        );
+
+        let body_bytes = req.body.as_ref().map(|b| b.as_slice()).unwrap_or(&[]);
+        let body_str = core::str::from_utf8(body_bytes).unwrap_or("");
+        assert!(
+            body_str.contains("\"ciphertext\""),
+            "encrypted body must carry a ciphertext field, got {body_str}"
+        );
+        assert!(
+            body_str.contains("m.megolm.v1.aes-sha2"),
+            "encrypted body must declare the Megolm algorithm"
+        );
+        assert!(
+            !body_str.contains("secret message"),
+            "the plaintext body must never appear verbatim in the encrypted request"
+        );
+    }
+
+    #[test]
+    fn build_encrypted_send_request_creates_outbound_session_when_none_exists() {
+        // #377: the first encrypted send for a room must auto-create an
+        // outbound Megolm session; a second send for the same room must
+        // reuse it rather than creating another.
+        let mut client = matrix_client_with_test_credentials();
+        let room_id = "!fresh-room:matrix.example.com";
+
+        assert!(
+            client.crypto().find_outbound_megolm(room_id).is_none(),
+            "no outbound session should exist before the first encrypted send"
+        );
+
+        assert!(client.build_encrypted_send_request(room_id, "first").is_ok());
+        let session_id_after_first = client
+            .crypto()
+            .find_outbound_megolm(room_id)
+            .map(|s| s.session_id);
+        assert!(
+            session_id_after_first.is_some(),
+            "an outbound session must exist after the first encrypted send"
+        );
+
+        assert!(client.build_encrypted_send_request(room_id, "second").is_ok());
+        let session_id_after_second = client
+            .crypto()
+            .find_outbound_megolm(room_id)
+            .map(|s| s.session_id);
+        assert_eq!(
+            session_id_after_first, session_id_after_second,
+            "a second encrypted send for the same room must reuse the existing session"
+        );
+    }
+
+    #[test]
+    fn build_encrypted_send_request_propagates_crypto_failure_without_panicking() {
+        // #377: an empty body drives encrypt_megolm's CryptoError::EmptyPlaintext
+        // path. build_encrypted_send_request must surface it as an Err, not
+        // panic and not silently fall back to plaintext (audit #370).
+        let mut client = matrix_client_with_test_credentials();
+        let room_id = "!empty-body-room:matrix.example.com";
+
+        let result = client.build_encrypted_send_request(room_id, "");
+        assert!(
+            matches!(result, Err(MatrixError::ServerError { .. })),
+            "empty-plaintext crypto failure must surface as MatrixError::ServerError, got {result:?}"
+        );
+    }
+
+    #[test]
     fn should_sync_respects_interval() {
         let mut client = matrix_client_with_test_credentials();
 

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -2698,6 +2698,132 @@ mod tests {
         }
     }
 
+    /// #379 (REQ-09): a process without CAP_KILL may not signal a
+    /// different, non-zero process -- sys_kill must return EPERM and the
+    /// target must be left untouched.
+    #[test]
+    fn sys_kill_cross_process_denied_without_cap_kill() {
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+
+            let pt1 = mmu::alloc_addr_space().unwrap();
+            procs[1] = Some(Process {
+                pid: 1,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: Some(0),
+                exit_status: 0,
+                page_table_phys: pt1,
+                stack_base: 0,
+                stack_pages: 0,
+                heap_break: DEFAULT_HEAP_BREAK,
+                mappings: [None; MAX_MAPPINGS],
+                signal_state: SignalState::new(),
+                uid: 1,
+                wake_tick: 0,
+                // No KILL bit -- mirrors capability::tests::kill_requires_cap_kill's
+                // "process without KILL cap" fixture.
+                capabilities: crate::capability::Capabilities::CRYPTO
+                    | crate::capability::Capabilities::RADIO,
+            });
+
+            let pt2 = mmu::alloc_addr_space().unwrap();
+            procs[2] = Some(Process {
+                pid: 2,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: Some(0),
+                exit_status: 0,
+                page_table_phys: pt2,
+                stack_base: 0,
+                stack_pages: 0,
+                heap_break: DEFAULT_HEAP_BREAK,
+                mappings: [None; MAX_MAPPINGS],
+                signal_state: SignalState::new(),
+                uid: 2,
+                wake_tick: 0,
+                capabilities: crate::capability::Capabilities::FORK_DEFAULT,
+            });
+            CURRENT = 1;
+
+            const EPERM: u32 = 0u32.wrapping_sub(1);
+            let ret = crate::signal::sys_kill(2, crate::signal::Signal::Sigterm as u32);
+            assert_eq!(
+                ret, EPERM,
+                "sys_kill from a process without CAP_KILL targeting a different PID must return EPERM"
+            );
+
+            let procs = &*core::ptr::addr_of!(PROCS);
+            assert_eq!(
+                procs[2].as_ref().map(|p| p.state),
+                Some(State::Running),
+                "the denied kill must not touch the target process's state"
+            );
+        }
+    }
+
+    /// #379 (REQ-09): a process holding CAP_KILL may signal a different,
+    /// non-zero process -- sys_kill succeeds and the default action
+    /// (SIGTERM -> terminate) is applied to the target.
+    #[test]
+    fn sys_kill_cross_process_allowed_with_cap_kill() {
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+
+            let pt1 = mmu::alloc_addr_space().unwrap();
+            procs[1] = Some(Process {
+                pid: 1,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: Some(0),
+                exit_status: 0,
+                page_table_phys: pt1,
+                stack_base: 0,
+                stack_pages: 0,
+                heap_break: DEFAULT_HEAP_BREAK,
+                mappings: [None; MAX_MAPPINGS],
+                signal_state: SignalState::new(),
+                uid: 1,
+                wake_tick: 0,
+                capabilities: crate::capability::Capabilities::KILL,
+            });
+
+            let pt2 = mmu::alloc_addr_space().unwrap();
+            procs[2] = Some(Process {
+                pid: 2,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: Some(0),
+                exit_status: 0,
+                page_table_phys: pt2,
+                stack_base: 0,
+                stack_pages: 0,
+                heap_break: DEFAULT_HEAP_BREAK,
+                mappings: [None; MAX_MAPPINGS],
+                signal_state: SignalState::new(),
+                uid: 2,
+                wake_tick: 0,
+                capabilities: crate::capability::Capabilities::FORK_DEFAULT,
+            });
+            CURRENT = 1;
+
+            let ret = crate::signal::sys_kill(2, crate::signal::Signal::Sigterm as u32);
+            assert_eq!(
+                ret, 0,
+                "sys_kill from a process holding CAP_KILL targeting a different PID must succeed"
+            );
+
+            let procs = &*core::ptr::addr_of!(PROCS);
+            assert_eq!(
+                procs[2].as_ref().map(|p| p.state),
+                Some(State::Dead),
+                "SIGTERM's default action (terminate) must be applied to the target"
+            );
+        }
+    }
+
     /// #371: sys_send (Syscall::Send) targeting PID 0 must be denied when
     /// the sender lacks CAP_IPC_INIT, and the message must not be
     /// delivered into kinit's inbox.

--- a/crates/thumos/src/screen_home.rs
+++ b/crates/thumos/src/screen_home.rs
@@ -12,6 +12,7 @@
 //! accepts a snapshot of the current state to avoid holding references
 //! to kernel globals across the render boundary.
 
+use crate::heorte;
 use crate::ui::{
     self, color, Key, Screen, ScreenAction, ScreenId,
     CHAR_HEIGHT, CONTENT_HEIGHT, SCREEN_WIDTH,
@@ -139,8 +140,10 @@ impl Screen for HomeScreen {
         // Clear content area to black.
         ui::fill_rect(fb, w, h, 0, 0, w, h, color::BLACK);
 
-        // Extract HH:MM and YYYY-MM-DD from epoch seconds.
-        let (hour, minute, year, month, day) = decompose_epoch(self.state.epoch_secs);
+        // Extract HH:MM and YYYY-MM-DD from epoch seconds. #423: delegates
+        // to heorte's O(1) closed-form decomposition rather than keeping a
+        // second year-by-year loop (the DoS #366 already fixed once here).
+        let (hour, minute, year, month, day) = heorte::decompose_epoch(self.state.epoch_secs);
 
         // Large centered time (2x scale).
         let time_buf = format_time(hour, minute);
@@ -196,65 +199,6 @@ impl Screen for HomeScreen {
     fn title(&self) -> &'static str {
         ""
     }
-}
-
-// ---------------------------------------------------------------------------
-// Time/date decomposition
-// ---------------------------------------------------------------------------
-
-/// Decompose Unix epoch seconds into `(hour, minute, year, month, day)`.
-///
-/// Uses a simplified algorithm sufficient for display purposes. Not a
-/// full calendar implementation -- no leap-second handling, approximate
-/// leap-year handling.
-fn decompose_epoch(epoch: u64) -> (u8, u8, u16, u8, u8) {
-    if epoch == 0 {
-        return (0, 0, 0, 0, 0);
-    }
-
-    // Time of day.
-    let day_secs = epoch % 86400;
-    let hour = (day_secs / 3600) as u8;
-    let minute = ((day_secs % 3600) / 60) as u8;
-
-    // Days since Unix epoch.
-    let mut days = (epoch / 86400) as u32;
-
-    // Year calculation (accounting for leap years).
-    let mut year: u16 = 1970;
-    loop {
-        let days_in_year = if is_leap_year(year) { 366 } else { 365 };
-        if days < days_in_year {
-            break;
-        }
-        days -= days_in_year;
-        year += 1;
-    }
-
-    // Month calculation.
-    let leap = is_leap_year(year);
-    let month_days: [u32; 12] = [
-        31,
-        if leap { 29 } else { 28 },
-        31, 30, 31, 30, 31, 31, 30, 31, 30, 31,
-    ];
-    let mut month: u8 = 1;
-    for &md in &month_days {
-        if days < md {
-            break;
-        }
-        days -= md;
-        month += 1;
-    }
-
-    let day = (days + 1) as u8; // 1-indexed
-
-    (hour, minute, year, month, day)
-}
-
-/// Check if a year is a leap year.
-const fn is_leap_year(year: u16) -> bool {
-    (year.is_multiple_of(4) && !year.is_multiple_of(100)) || year.is_multiple_of(400)
 }
 
 // ---------------------------------------------------------------------------
@@ -429,14 +373,14 @@ mod tests {
 
     #[test]
     fn decompose_epoch_zero_returns_zeroes() {
-        let (h, m, y, mo, d) = decompose_epoch(0);
+        let (h, m, y, mo, d) = heorte::decompose_epoch(0);
         assert_eq!((h, m, y, mo, d), (0, 0, 0, 0, 0), "epoch 0 must return all zeros");
     }
 
     #[test]
     fn decompose_epoch_known_date() {
         // 2026-01-01 00:00:00 UTC = 1767225600
-        let (h, m, y, mo, d) = decompose_epoch(1_767_225_600);
+        let (h, m, y, mo, d) = heorte::decompose_epoch(1_767_225_600);
         assert_eq!(y, 2026, "year must be 2026");
         assert_eq!(mo, 1, "month must be January");
         assert_eq!(d, 1, "day must be 1");
@@ -448,9 +392,22 @@ mod tests {
     fn decompose_epoch_with_time() {
         // 2026-01-01 14:30:00 UTC = 1767225600 + 14*3600 + 30*60
         let epoch = 1_767_225_600 + 14 * 3600 + 30 * 60;
-        let (h, m, _y, _mo, _d) = decompose_epoch(epoch);
+        let (h, m, _y, _mo, _d) = heorte::decompose_epoch(epoch);
         assert_eq!(h, 14, "hour must be 14");
         assert_eq!(m, 30, "minute must be 30");
+    }
+
+    #[test]
+    fn decompose_epoch_large_value_completes_in_o1() {
+        // #423: screen_home used to carry its own year-by-year
+        // decompose_epoch/is_leap_year (the same O(years) DoS shape as
+        // #366's heorte copy). Now that draw() delegates to
+        // heorte::decompose_epoch directly, an adversarial epoch near
+        // u64::MAX must resolve in O(1) rather than looping ~11.7M times.
+        let (_h, _m, year, month, day) = heorte::decompose_epoch(u64::MAX / 2);
+        assert_eq!(year, u16::MAX, "year must saturate rather than wrap or panic");
+        assert!((1..=12).contains(&month), "month must stay in valid range");
+        assert!((1..=31).contains(&day), "day must stay in valid range");
     }
 
     #[test]
@@ -487,14 +444,6 @@ mod tests {
     fn format_unread_overflow() {
         let buf = format_unread(200);
         assert_eq!(buf.as_str(), "99+ UNREAD", "overflow must show 99+");
-    }
-
-    #[test]
-    fn is_leap_year_correct() {
-        assert!(is_leap_year(2000), "2000 is a leap year (div by 400)");
-        assert!(!is_leap_year(1900), "1900 is not a leap year (div by 100)");
-        assert!(is_leap_year(2024), "2024 is a leap year (div by 4)");
-        assert!(!is_leap_year(2025), "2025 is not a leap year");
     }
 
     #[test]


### PR DESCRIPTION
- **#375** — `BlockCache::flush` aborted at the first write-back failure via `?`; since it always iterates from 0, a single persistently-failing block would permanently block every later entry from flushing (silent durability hole). `flush` now attempts every dirty entry, marks successes clean, returns the first error; the failing entry stays dirty for retry.
- **#355** — sema's IMSI-catcher added a Connected tower only to `seen_tower_ids`, not `known_neighbor_ids`, so a normal handover back to a previously-served cell falsely raised `SuddenTowerChange`. A connected cell is now a known handover target.
- **#423** — `screen_home.rs` carried its own O(years) `decompose_epoch`/`is_leap_year` (same DoS #366 fixed in heorte) driving the always-visible clock. Deleted both; delegated to the now-O(1) `heorte::decompose_epoch`.
- **#377** — `build_encrypted_send_request` had zero direct coverage. Added tests for the Megolm request shape, session auto-create/reuse, and empty-plaintext crypto-failure propagation.
- **#379** — the cross-process CAP_KILL branch of `sys_kill` was untested. Added capability-denied (EPERM, target untouched) + capability-allowed (SIGTERM terminates) tests.

Closes #375, #377, #379, #355, #423

**Verification:** kernel nextest 1820 (+6); sema 65 (+1); workspace clippy -D warnings + doctests clean; armv7a compiles; kanon lint clean.

_Note: #373 (Matrix ID validation) from the same batch is deferred to its own PR — the From→TryFrom change ripples through 4 files and needs a compiler-driven implementation, not a blind apply._