### PR TITLE
Validate typed Matrix identifier format at construction (#373)

### DIFF
--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -126,6 +126,9 @@ MANIFEST/no-license:fuzz/Cargo.toml
 MANIFEST/no-msrv:fuzz/Cargo.toml
 MANIFEST/no-deny-toml:fuzz/Cargo.toml
 MANIFEST/no-rustfmt:fuzz/Cargo.toml
+# WHY: fuzz/corpus/ holds binary fuzzer-input samples (raw protocol bytes),
+# which are intentionally not valid UTF-8 and cannot be canonical-clean-linted.
+WORKTREE/canonical-clean:fuzz/corpus/**
 
 # =============================================================================
 # crates/thumos/ — bare-metal kernel binary, excluded from workspace

--- a/crates/thumos/src/harmostes.rs
+++ b/crates/thumos/src/harmostes.rs
@@ -115,6 +115,8 @@ pub enum MatrixError {
     RoomCapacityReached,
     /// The outbox has reached [`MAX_OUTBOX_MESSAGES`] pending messages (#365).
     OutboxFull,
+    /// A Matrix identifier (room/event) failed format validation (#373).
+    InvalidId(crate::matrix_ids::MatrixIdError),
 }
 
 impl fmt::Display for MatrixError {
@@ -133,7 +135,14 @@ impl fmt::Display for MatrixError {
             Self::SyncDisabled => write!(f, "sync disabled in current security mode"),
             Self::RoomCapacityReached => write!(f, "room capacity reached"),
             Self::OutboxFull => write!(f, "outbox capacity reached"),
+            Self::InvalidId(e) => write!(f, "invalid Matrix identifier: {e}"),
         }
+    }
+}
+
+impl From<crate::matrix_ids::MatrixIdError> for MatrixError {
+    fn from(e: crate::matrix_ids::MatrixIdError) -> Self {
+        Self::InvalidId(e)
     }
 }
 
@@ -168,6 +177,13 @@ pub struct SyncResult {
     /// because an over-capacity room cannot be persisted regardless, so
     /// there is nothing a retry could recover.
     pub rooms_over_capacity: u32,
+    /// Number of rooms whose events were dropped because the room-id JSON key
+    /// failed identifier validation (#373). Non-zero means an adversarial or
+    /// buggy homeserver sent a malformed room key; that room's events are
+    /// skipped (they could never be stored), but the sync token still advances
+    /// safely — mirroring the `rooms_over_capacity` rationale (#358), because
+    /// aborting the batch would permanently wedge sync on the bad key.
+    pub rooms_malformed: u32,
     /// The next batch token (opaque, stored for incremental sync).
     pub next_batch: String,
 }
@@ -176,10 +192,11 @@ impl fmt::Display for SyncResult {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "SyncResult({} messages, {} rooms updated, {} over capacity)",
+            "SyncResult({} messages, {} rooms updated, {} over capacity, {} malformed)",
             self.new_messages.len(),
             self.rooms_updated,
             self.rooms_over_capacity,
+            self.rooms_malformed,
         )
     }
 }
@@ -236,15 +253,19 @@ pub struct Room {
 
 impl Room {
     /// Create a new room with the given ID and display name.
-    #[must_use]
-    fn new(room_id: String, display_name: String, is_dm: bool) -> Self {
-        Self {
-            room_id: room_id.into(),
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MatrixError::InvalidId`] if `room_id` is not a well-formed
+    /// Matrix room identifier (#373).
+    fn new(room_id: &str, display_name: String, is_dm: bool) -> Result<Self, MatrixError> {
+        Ok(Self {
+            room_id: MatrixRoomId::new(room_id)?,
             display_name,
             is_dm,
             messages: Vec::new(),
             unread_count: 0,
-        }
+        })
     }
 
     /// Add a message to this room's cache, evicting the oldest if at capacity.
@@ -571,6 +592,7 @@ impl MatrixClient {
             new_messages: Vec::new(),
             rooms_updated: 0,
             rooms_over_capacity: 0,
+            rooms_malformed: 0,
             next_batch: String::from(next_batch),
         };
 
@@ -610,6 +632,14 @@ impl MatrixClient {
                     result.rooms_over_capacity = result.rooms_over_capacity.saturating_add(1);
                     continue;
                 }
+                // WHY(#373): a malformed room-id JSON key cannot be stored
+                // (validation rejects it). The sync token was already advanced,
+                // so propagating the Err would permanently wedge sync on this
+                // key — skip and count, exactly like the over-capacity path.
+                Err(MatrixError::InvalidId(_)) => {
+                    result.rooms_malformed = result.rooms_malformed.saturating_add(1);
+                    continue;
+                }
                 Err(e) => return Err(e),
             };
 
@@ -619,7 +649,9 @@ impl MatrixClient {
                 let msg = parse_timeline_event(event, room_id, &self.crypto);
                 if let Some(msg) = msg {
                     let incoming = IncomingMessage {
-                        room_id: String::from(room_id.as_str()).into(),
+                        // WHY(#373): reuse the already-validated room id stored
+                        // on the room, avoiding a redundant fallible re-parse.
+                        room_id: self.rooms[room_idx].room_id.clone(),
                         event_id: msg.event_id.clone(),
                         sender: msg.sender.clone(),
                         body: msg.body.clone(),
@@ -811,10 +843,14 @@ impl MatrixClient {
             return Err(MatrixError::OutboxFull);
         }
 
+        // WHY(#373): validate before build_send_request, which interpolates
+        // room_id into the HTTP request path — a CRLF-bearing id would be a
+        // header/path injection.
+        let validated_room = MatrixRoomId::new(room_id)?;
         let (req, txn_id) = self.build_send_request(room_id, body)?;
 
         self.outbox.push(PendingMessage {
-            room_id: String::from(room_id).into(),
+            room_id: validated_room,
             body: String::from(body),
             txn_id,
         });
@@ -844,11 +880,14 @@ impl MatrixClient {
             return Err(MatrixError::OutboxFull);
         }
 
+        // WHY(#373): reject a malformed room id before it can be sent from the
+        // outbox (build_send_request interpolates it into the HTTP path).
+        let validated_room = MatrixRoomId::new(room_id)?;
         let txn_id = self.next_txn_id;
         self.next_txn_id = self.next_txn_id.saturating_add(1);
 
         self.outbox.push(PendingMessage {
-            room_id: String::from(room_id).into(),
+            room_id: validated_room,
             body: String::from(body),
             txn_id,
         });
@@ -922,11 +961,8 @@ impl MatrixClient {
             if self.rooms.len() >= MAX_ROOMS {
                 return Err(MatrixError::RoomCapacityReached);
             }
-            self.rooms.push(Room::new(
-                String::from(room_id),
-                String::from(room_id), // Display name defaults to room ID.
-                false,
-            ));
+            self.rooms
+                .push(Room::new(room_id, String::from(room_id), false)?);
         }
 
         Ok(())
@@ -961,11 +997,7 @@ impl MatrixClient {
         if self.rooms.len() >= MAX_ROOMS {
             return Err(MatrixError::RoomCapacityReached);
         }
-        self.rooms.push(Room::new(
-            String::from(room_id),
-            String::from(room_id),
-            false,
-        ));
+        self.rooms.push(Room::new(room_id, String::from(room_id), false)?);
         Ok(self.rooms.len() - 1)
     }
 }
@@ -1127,7 +1159,9 @@ fn parse_timeline_event(
     };
 
     Some(MatrixMessage {
-        event_id: String::from(event_id).into(),
+        // WHY(#373): a malformed event id skips this event rather than
+        // aborting the whole sync (parse_timeline_event returns Option).
+        event_id: MatrixEventId::new(event_id).ok()?,
         sender: String::from(sender),
         body,
         timestamp: if timestamp >= 0 {
@@ -1948,11 +1982,8 @@ mod tests {
 
     #[test]
     fn message_cache_evicts_oldest() {
-        let mut room = Room::new(
-            String::from("!evict:example.com"),
-            String::from("Test Room"),
-            false,
-        );
+        let mut room = Room::new("!evict:example.com", String::from("Test Room"), false)
+            .expect("valid test room id");
 
         // Fill to capacity.
         for i in 0..MAX_MESSAGES_PER_ROOM {
@@ -1960,7 +1991,7 @@ mod tests {
                 event_id: {
                     let mut id = String::from("$msg");
                     push_u32(&mut id, i as u32);
-                    id.into()
+                    MatrixEventId::new(&id).expect("valid test event id")
                 },
                 sender: String::from("@test:example.com"),
                 body: String::from("msg"),
@@ -1972,7 +2003,7 @@ mod tests {
 
         // Add one more — oldest should be evicted.
         room.add_message(MatrixMessage {
-            event_id: String::from("$new").into(),
+            event_id: MatrixEventId::new("$new").expect("valid test event id"),
             sender: String::from("@test:example.com"),
             body: String::from("newest"),
             timestamp: MAX_MESSAGES_PER_ROOM as u64,

--- a/crates/thumos/src/matrix_crypto.rs
+++ b/crates/thumos/src/matrix_crypto.rs
@@ -131,6 +131,9 @@ pub enum CryptoError {
     /// A homeserver-supplied device key failed Ed25519 self-signature
     /// verification (audit #230).
     UntrustedDeviceKey,
+    /// The room id supplied for session creation is not a well-formed Matrix
+    /// room identifier (#373).
+    InvalidRoomId(crate::matrix_ids::MatrixIdError),
 }
 
 impl From<csprng::CsprngError> for CryptoError {
@@ -171,6 +174,7 @@ impl fmt::Display for CryptoError {
             Self::UntrustedDeviceKey => {
                 write!(f, "device key failed Ed25519 self-signature verification")
             }
+            Self::InvalidRoomId(e) => write!(f, "invalid room identifier: {e}"),
         }
     }
 }
@@ -548,12 +552,18 @@ impl MatrixCrypto {
     ///
     /// # Errors
     ///
+    /// Returns [`CryptoError::InvalidRoomId`] if `room_id` is not a well-formed
+    /// Matrix room identifier (#373).
     /// Returns [`CryptoError::SessionCapacityReached`] if the outbound
     /// session list is at capacity and no existing session was replaced.
     pub(crate) fn create_outbound_megolm(
         &mut self,
         room_id: &str,
     ) -> Result<&MegolmSession, CryptoError> {
+        // WHY(#373): validate the room id before spending entropy or storing a
+        // session keyed on it.
+        let validated_room = MatrixRoomId::new(room_id).map_err(CryptoError::InvalidRoomId)?;
+
         // Generate fresh session key and ID.
         let mut session_key = [0u8; KEY_SIZE];
         csprng::kernel_random_bytes(&mut session_key)?;
@@ -564,7 +574,7 @@ impl MatrixCrypto {
             session_id,
             session_key,
             message_index: 0,
-            room_id: String::from(room_id).into(),
+            room_id: validated_room,
         };
 
         // Replace existing session for this room, or add new one.
@@ -1454,7 +1464,7 @@ mod tests {
                 session_id: [0u8; KEY_SIZE],
                 session_key: [0u8; KEY_SIZE],
                 message_index: 0,
-                room_id: String::new().into(),
+                room_id: MatrixRoomId::new("!fallback:test").expect("valid test room id"),
             });
 
         // Get mutable reference to the outbound session.
@@ -1909,7 +1919,7 @@ mod tests {
             session_id: [0x42; KEY_SIZE],
             session_key: [0xFF; KEY_SIZE],
             message_index: 0,
-            room_id: String::from("!room:example.com").into(),
+            room_id: MatrixRoomId::new("!room:example.com").expect("valid test room id"),
         };
 
         let result = crypto.add_inbound_megolm(session);

--- a/crates/thumos/src/matrix_ids.rs
+++ b/crates/thumos/src/matrix_ids.rs
@@ -6,29 +6,116 @@ use core::{fmt, ops::Deref};
 
 use alloc::string::String;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// Maximum length (bytes) accepted for any typed Matrix identifier.
+///
+/// WHY: bounds worst-case memory for an identifier parsed from an
+/// adversarial homeserver response or USB provisioning stream; the Matrix
+/// spec sets no hard ceiling but no legitimate user/room/event/device ID
+/// approaches this size (#373).
+const MAX_ID_LEN: usize = 255;
+
+/// Errors returned when constructing a typed Matrix identifier from an
+/// untrusted string (#373).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum MatrixIdError {
+    /// The value is missing the sigil this identifier type requires.
+    MissingSigil {
+        /// The sigil character this identifier type requires.
+        expected: char,
+    },
+    /// The value contains a CR, LF, or NUL byte (header/path injection risk).
+    ForbiddenByte,
+    /// The value exceeds `MAX_ID_LEN` bytes.
+    TooLong,
+    /// The value is empty.
+    Empty,
+}
+
+impl fmt::Display for MatrixIdError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingSigil { expected } => write!(f, "missing required sigil '{expected}'"),
+            Self::ForbiddenByte => write!(f, "contains a forbidden CR/LF/NUL byte"),
+            Self::TooLong => write!(f, "exceeds maximum identifier length"),
+            Self::Empty => write!(f, "identifier is empty"),
+        }
+    }
+}
+
+/// Validate a candidate Matrix identifier string.
+///
+/// `sigil` is `Some(c)` when the identifier type requires a leading sigil
+/// (`@` user, `!` room, `$` event); `None` for device IDs, which the Matrix
+/// spec does not sigil-prefix (#373).
+fn validate_matrix_id(value: &str, sigil: Option<char>) -> Result<(), MatrixIdError> {
+    if value.is_empty() {
+        return Err(MatrixIdError::Empty);
+    }
+    if value.len() > MAX_ID_LEN {
+        return Err(MatrixIdError::TooLong);
+    }
+    if value.bytes().any(|b| b == b'\r' || b == b'\n' || b == 0) {
+        return Err(MatrixIdError::ForbiddenByte);
+    }
+    if let Some(expected) = sigil
+        && !value.starts_with(expected)
+    {
+        return Err(MatrixIdError::MissingSigil { expected });
+    }
+    Ok(())
+}
 
 macro_rules! matrix_id {
-    ($name:ident) => {
-        #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    ($name:ident, $sigil:expr) => {
+        #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
         #[must_use]
         pub struct $name(String);
 
         impl $name {
+            /// Construct a validated `$name` from an untrusted string.
+            ///
+            /// # Errors
+            ///
+            /// Returns [`MatrixIdError`] if `value` is empty, exceeds the
+            /// maximum identifier length, contains a CR/LF/NUL byte, or is
+            /// missing the required sigil (#373).
+            pub(crate) fn new(value: &str) -> Result<Self, MatrixIdError> {
+                validate_matrix_id(value, $sigil)?;
+                Ok(Self(String::from(value)))
+            }
+
             pub(crate) fn as_str(&self) -> &str {
                 &self.0
             }
         }
 
-        impl From<String> for $name {
-            fn from(value: String) -> Self {
-                Self(value)
+        impl TryFrom<String> for $name {
+            type Error = MatrixIdError;
+
+            fn try_from(value: String) -> Result<Self, MatrixIdError> {
+                validate_matrix_id(&value, $sigil)?;
+                Ok(Self(value))
             }
         }
 
-        impl From<&str> for $name {
-            fn from(value: &str) -> Self {
-                Self(String::from(value))
+        impl TryFrom<&str> for $name {
+            type Error = MatrixIdError;
+
+            fn try_from(value: &str) -> Result<Self, MatrixIdError> {
+                Self::new(value)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let s = String::deserialize(deserializer)?;
+                Self::new(&s).map_err(serde::de::Error::custom)
             }
         }
 
@@ -54,7 +141,118 @@ macro_rules! matrix_id {
     };
 }
 
-matrix_id!(MatrixDeviceId);
-matrix_id!(MatrixEventId);
-matrix_id!(MatrixRoomId);
-matrix_id!(MatrixUserId);
+matrix_id!(MatrixDeviceId, None);
+matrix_id!(MatrixEventId, Some('$'));
+matrix_id!(MatrixRoomId, Some('!'));
+matrix_id!(MatrixUserId, Some('@'));
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_id_requires_at_sigil() {
+        assert!(MatrixUserId::new("@foo:bar").is_ok());
+        assert!(matches!(
+            MatrixUserId::new("foo:bar"),
+            Err(MatrixIdError::MissingSigil { expected: '@' })
+        ));
+    }
+
+    #[test]
+    fn room_id_requires_bang_sigil() {
+        assert!(MatrixRoomId::new("!room:bar").is_ok());
+        assert!(matches!(
+            MatrixRoomId::new("room:bar"),
+            Err(MatrixIdError::MissingSigil { expected: '!' })
+        ));
+    }
+
+    #[test]
+    fn event_id_requires_dollar_sigil() {
+        assert!(MatrixEventId::new("$event123").is_ok());
+        assert!(matches!(
+            MatrixEventId::new("event123"),
+            Err(MatrixIdError::MissingSigil { expected: '$' })
+        ));
+    }
+
+    #[test]
+    fn device_id_has_no_sigil_requirement() {
+        assert!(MatrixDeviceId::new("THUMOSDEV01").is_ok());
+        assert!(MatrixDeviceId::new("@notasigil").is_ok());
+    }
+
+    #[test]
+    fn crlf_injection_is_rejected() {
+        // #373: a malicious homeserver embedding CRLF in a user ID must not
+        // produce a valid typed identifier -- downstream HTTP path/header
+        // construction would otherwise be injectable.
+        let malicious = "@foo:bar\r\nX-Injected: evil";
+        assert!(matches!(
+            MatrixUserId::new(malicious),
+            Err(MatrixIdError::ForbiddenByte)
+        ));
+    }
+
+    #[test]
+    fn embedded_nul_is_rejected() {
+        let malicious = "@foo:bar\u{0}evil";
+        assert!(matches!(
+            MatrixUserId::new(malicious),
+            Err(MatrixIdError::ForbiddenByte)
+        ));
+    }
+
+    #[test]
+    fn empty_id_is_rejected() {
+        assert!(matches!(MatrixUserId::new(""), Err(MatrixIdError::Empty)));
+    }
+
+    #[test]
+    fn oversized_id_is_rejected() {
+        let mut long = String::from("@");
+        for _ in 0..MAX_ID_LEN {
+            long.push('a');
+        }
+        assert!(matches!(
+            MatrixUserId::new(&long),
+            Err(MatrixIdError::TooLong)
+        ));
+    }
+
+    #[test]
+    fn try_from_str_matches_new() {
+        assert_eq!(
+            MatrixUserId::try_from("@foo:bar"),
+            MatrixUserId::new("@foo:bar")
+        );
+        assert!(MatrixUserId::try_from("bad").is_err());
+    }
+
+    #[test]
+    fn postcard_deserialize_rejects_injected_crlf() {
+        // #373: ProvisionBundle.user_id: MatrixUserId is deserialized
+        // straight off the USB provisioning wire format (postcard) -- an
+        // adversarial provisioner must not be able to smuggle a
+        // CRLF-bearing value into a typed identifier this way.
+        let malicious = "@foo:bar\r\nX-Injected: evil";
+        let encoded = postcard::to_allocvec(&malicious).unwrap_or_default();
+        let result: Result<MatrixUserId, _> = postcard::from_bytes(&encoded);
+        assert!(
+            result.is_err(),
+            "postcard deserialization of a CRLF-injected user ID must fail"
+        );
+    }
+
+    #[test]
+    fn postcard_deserialize_accepts_well_formed_id() {
+        let valid = "@foo:bar";
+        let encoded = postcard::to_allocvec(&valid).unwrap_or_default();
+        let result: Result<MatrixUserId, _> = postcard::from_bytes(&encoded);
+        assert_eq!(
+            result.ok().map(|id| String::from(id.as_str())),
+            Some(String::from(valid))
+        );
+    }
+}

--- a/crates/thumos/src/nous.rs
+++ b/crates/thumos/src/nous.rs
@@ -266,6 +266,8 @@ pub enum NousError {
         /// The entity's current preset level.
         current: &'static str,
     },
+    /// The entity's Matrix user id failed format validation (#373).
+    InvalidMatrixId(crate::matrix_ids::MatrixIdError),
 }
 
 impl fmt::Display for NousError {
@@ -291,6 +293,7 @@ impl fmt::Display for NousError {
                     "{entity} requires {required} capability, has {current}"
                 )
             }
+            Self::InvalidMatrixId(e) => write!(f, "invalid Matrix user id: {e}"),
         }
     }
 }
@@ -319,6 +322,8 @@ impl NousEntity {
     /// # Errors
     ///
     /// Returns [`NousError::NameTooLong`] if `name` exceeds [`MAX_NAME_LEN`].
+    /// Returns [`NousError::InvalidMatrixId`] if `matrix_id` is not a
+    /// well-formed Matrix user identifier (#373).
     pub(crate) fn new(
         name: &str,
         matrix_id: String,
@@ -337,7 +342,9 @@ impl NousEntity {
         Ok(Self {
             name: name_buf,
             name_len: name_bytes.len() as u8,
-            matrix_id: matrix_id.into(),
+            // WHY(#373): validate the Matrix user id rather than trusting the
+            // caller; a malformed id surfaces as NousError::InvalidMatrixId.
+            matrix_id: MatrixUserId::new(&matrix_id).map_err(NousError::InvalidMatrixId)?,
             capability_preset: preset,
         })
     }
@@ -397,62 +404,45 @@ impl Eq for NousEntity {}
 // ---------------------------------------------------------------------------
 
 /// Create the default Syn entity (primary general-purpose assistant).
-pub(crate) fn default_syn() -> NousEntity {
-    // Syn is always valid — name is 3 bytes, well under MAX_NAME_LEN.
+///
+/// # Errors
+///
+/// Returns [`NousError`] if the trusted default identifiers ever fail
+/// validation — unreachable for the compile-time constants below, but the
+/// fallible signature keeps the no-panic contract without an infallible
+/// identifier constructor (#373).
+pub(crate) fn default_syn() -> Result<NousEntity, NousError> {
     NousEntity::new(
         "Syn",
         String::from("@syn:thumos.lan"),
         CapabilityPreset::Advisor,
     )
-    .unwrap_or_else(|_| {
-        // This path is unreachable for "Syn" but satisfies no-panic contract.
-        let mut name = [0u8; MAX_NAME_LEN];
-        name[0] = b'?';
-        NousEntity {
-            name,
-            name_len: 1,
-            matrix_id: String::from("@syn:thumos.lan").into(),
-            capability_preset: CapabilityPreset::Off,
-        }
-    })
 }
 
 /// Create the default Phrouros entity (security/field operations).
-pub(crate) fn default_phrouros() -> NousEntity {
+///
+/// # Errors
+///
+/// See [`default_syn`].
+pub(crate) fn default_phrouros() -> Result<NousEntity, NousError> {
     NousEntity::new(
         "Phrouros",
         String::from("@phrouros:thumos.lan"),
         CapabilityPreset::Observer,
     )
-    .unwrap_or_else(|_| {
-        let mut name = [0u8; MAX_NAME_LEN];
-        name[0] = b'?';
-        NousEntity {
-            name,
-            name_len: 1,
-            matrix_id: String::from("@phrouros:thumos.lan").into(),
-            capability_preset: CapabilityPreset::Off,
-        }
-    })
 }
 
 /// Create the default Paideia entity (learning/research).
-pub(crate) fn default_paideia() -> NousEntity {
+///
+/// # Errors
+///
+/// See [`default_syn`].
+pub(crate) fn default_paideia() -> Result<NousEntity, NousError> {
     NousEntity::new(
         "Paideia",
         String::from("@paideia:thumos.lan"),
         CapabilityPreset::Assistant,
     )
-    .unwrap_or_else(|_| {
-        let mut name = [0u8; MAX_NAME_LEN];
-        name[0] = b'?';
-        NousEntity {
-            name,
-            name_len: 1,
-            matrix_id: String::from("@paideia:thumos.lan").into(),
-            capability_preset: CapabilityPreset::Off,
-        }
-    })
 }
 
 // ---------------------------------------------------------------------------
@@ -477,11 +467,14 @@ impl NousManager {
     /// Syn is the default active entity (index 0).
     #[must_use]
     pub(crate) fn new() -> Self {
-        let entities = alloc::vec![
-            default_syn(),
-            default_phrouros(),
-            default_paideia(),
-        ];
+        // WHY(#373): the defaults are trusted compile-time constants that
+        // always validate; `flatten` keeps each successfully-built entity and
+        // drops the unreachable error case, preserving the no-panic contract
+        // without an infallible identifier constructor.
+        let entities = [default_syn(), default_phrouros(), default_paideia()]
+            .into_iter()
+            .flatten()
+            .collect();
         Self {
             entities,
             active_entity: 0,
@@ -912,7 +905,7 @@ mod tests {
 
     #[test]
     fn entity_display() {
-        let entity = default_syn();
+        let entity = default_syn().expect("default syn valid");
         let display = alloc::format!("{entity}");
         assert!(display.contains("Syn"), "display must contain name");
         assert!(
@@ -927,11 +920,11 @@ mod tests {
 
     #[test]
     fn entity_equality() {
-        let a = default_syn();
-        let b = default_syn();
+        let a = default_syn().expect("default syn valid");
+        let b = default_syn().expect("default syn valid");
         assert_eq!(a, b, "identical entities must be equal");
 
-        let c = default_phrouros();
+        let c = default_phrouros().expect("default phrouros valid");
         assert_ne!(a, c, "different entities must not be equal");
     }
 
@@ -939,18 +932,18 @@ mod tests {
 
     #[test]
     fn default_entities_valid() {
-        let syn = default_syn();
+        let syn = default_syn().expect("default syn valid");
         assert_eq!(syn.name_str(), "Syn");
         assert_eq!(syn.capability_preset, CapabilityPreset::Advisor);
         assert!(syn.can_propose());
         assert!(syn.can_auto_execute());
 
-        let phrouros = default_phrouros();
+        let phrouros = default_phrouros().expect("default phrouros valid");
         assert_eq!(phrouros.name_str(), "Phrouros");
         assert_eq!(phrouros.capability_preset, CapabilityPreset::Observer);
         assert!(!phrouros.can_propose());
 
-        let paideia = default_paideia();
+        let paideia = default_paideia().expect("default paideia valid");
         assert_eq!(paideia.name_str(), "Paideia");
         assert_eq!(paideia.capability_preset, CapabilityPreset::Assistant);
         assert!(paideia.can_propose());

--- a/crates/thumos/src/provision.rs
+++ b/crates/thumos/src/provision.rs
@@ -547,8 +547,8 @@ mod tests {
     /// Create a test bundle with deterministic data.
     fn provision_bundle_with_cross_signing() -> ProvisionBundle {
         ProvisionBundle {
-            user_id: String::from("@cody:matrix.example.com").into(),
-            device_id: String::from("THMSTESTDEV01").into(),
+            user_id: MatrixUserId::new("@cody:matrix.example.com").expect("valid test user id"),
+            device_id: MatrixDeviceId::new("THMSTESTDEV01").expect("valid test device id"),
             access_token: String::from("syt_test_provision_token_1234"),
             homeserver: String::from("matrix.example.com"),
             ed25519_key: [0xAA; 32],
@@ -560,8 +560,8 @@ mod tests {
     /// Create a test bundle without cross-signing key.
     fn provision_bundle_without_cross_signing() -> ProvisionBundle {
         ProvisionBundle {
-            user_id: String::from("@test:example.org").into(),
-            device_id: String::from("DEVNOCSIGN").into(),
+            user_id: MatrixUserId::new("@test:example.org").expect("valid test user id"),
+            device_id: MatrixDeviceId::new("DEVNOCSIGN").expect("valid test device id"),
             access_token: String::from("syt_no_cross_sign"),
             homeserver: String::from("example.org"),
             ed25519_key: [0x11; 32],


### PR DESCRIPTION
Typed Matrix IDs accepted any byte sequence via infallible `From` — including CR/LF/NUL, which reach HTTP request paths/headers (injection) and are decoded straight off the **untrusted homeserver sync stream** and the **USB provisioning wire format**.

`matrix_ids.rs`: `From` → fallible `TryFrom` + a validating `Deserialize`. Each ID validates: non-empty, ≤255 bytes, no CR/LF/NUL (injection guard), required sigil (`@`/`!`/`$`; device IDs unsigiled).

Threaded through: harmostes (validate room_id before HTTP-path interpolation; sync loop **skips+counts** a malformed room-id key via new `SyncResult::rooms_malformed` rather than wedging sync on one bad homeserver key; malformed event_id skips that event), matrix_crypto (validate before spending entropy), provision (**zero prod changes** — validates via `Deserialize`, so a malformed id fails postcard decode behind the Ed25519 sig), nous (infallible `new` via dropping the unreachable error on trusted defaults — no bypass, no panic).

Design: untrusted bulk sync-loop = skip-and-count; direct-action = propagate.

Closes #373

**Verification:** kernel nextest 1820→1831 (+11); armv7a compiles; kanon lint clean.

**Review posture:** this security surface (untrusted homeserver + USB ID validation, CRLF/NUL guard) was reviewed at the orchestrator tier — the skip-vs-propagate split and the CR/LF/NUL rejection verified. One flagged minor: a malformed room_id on the encrypted-send path surfaces as `M_CRYPTO_ERROR` not `InvalidId` — still fail-closed, id never reaches path interpolation. Also bundles a pre-existing fuzz-corpus lint-ignore fix (binary inputs, not UTF-8).