### PR TITLE
GIC EOI ordering, WMT regulator lifecycle, DSI init, audio atomicity (8 issues)

### DIFF
--- a/crates/kelyphos/src/wmt.rs
+++ b/crates/kelyphos/src/wmt.rs
@@ -742,11 +742,20 @@ impl<R: RegisterIo> WmtManager<R> {
         let mut step = PowerOnStep::SpmClockEnable;
         loop {
             self.power_on_step = step;
-            step = step.execute_and_advance_with_poll(
+            step = match step.execute_and_advance_with_poll(
                 &mut self.io,
                 &mut self.clock_type,
                 self.poll_timeout_iters,
-            )?;
+            ) {
+                Ok(next) => next,
+                Err(err) => {
+                    // Roll back the regulator enabled at sequence start
+                    // (#352) — leaving it live across a retry double-enables
+                    // it while CONSYS sits in a partial-reset state.
+                    self.io.pmic_regulator_disable(PmicRegulator::Vcn18);
+                    return Err(err);
+                }
+            };
             if step == PowerOnStep::Done {
                 self.power_on_step = PowerOnStep::Done;
                 break;
@@ -792,6 +801,22 @@ impl<R: RegisterIo> WmtManager<R> {
             .clear_bits32(CONSYS_TOP1_PWR_CTRL_REG, CONSYS_SPM_PWR_ON_S_BIT);
         self.io
             .clear_bits32(CONSYS_TOP1_PWR_CTRL_REG, CONSYS_SPM_PWR_ON_BIT);
+
+        // Disable each active subsystem's regulator before clearing the
+        // bitmask (#349) — after subsystems is zeroed, disable_subsystem()
+        // rejects every subsystem as "already disabled" with no other path
+        // to turn its regulator off.
+        for subsystem in [
+            Subsystem::Bt,
+            Subsystem::Fm,
+            Subsystem::Gps,
+            Subsystem::Wifi,
+        ] {
+            if self.subsystems & subsystem.mask() != 0 {
+                self.io
+                    .pmic_regulator_disable(Self::subsystem_regulator(subsystem));
+            }
+        }
 
         // Disable core regulator last.
         self.io.pmic_regulator_disable(PmicRegulator::Vcn18);
@@ -1189,6 +1214,27 @@ mod tests {
     }
 
     #[test]
+    fn power_on_failure_disables_vcn18_regulator() {
+        let mut io = FakeIo::new();
+        // Remove the ack bit so polling never succeeds (fails at step 3).
+        io.regs.insert(CONSYS_PWR_CONN_ACK_REG, 0x0000_0000);
+        let mut mgr = WmtManager::new(io);
+        let err = mgr
+            .power_on()
+            .expect_err("must fail when ack bit never sets");
+        assert!(
+            matches!(err, WmtError::PowerAckTimeout { step: 3 }),
+            "error must be PowerAckTimeout at step 3, got {err:?}"
+        );
+        let vcn18_bit = 1u8 << u8::from(PmicRegulator::Vcn18);
+        assert_eq!(
+            mgr.io.regulators & vcn18_bit,
+            0,
+            "Vcn18 must be disabled after a failed power_on, not left stranded (#352)"
+        );
+    }
+
+    #[test]
     fn power_on_chip_id_mismatch_returns_error() {
         let mut io = FakeIo::new();
         // Return wrong chip ID so step 15 never matches.
@@ -1394,6 +1440,27 @@ mod tests {
         assert!(
             matches!(err, WmtError::AlreadyPoweredOff),
             "error must be AlreadyPoweredOff, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn power_off_disables_active_subsystem_regulators() {
+        let io = FakeIo::new();
+        let mut mgr = WmtManager::new(io);
+        mgr.power_on().unwrap_or_default();
+        mgr.enable_subsystem(Subsystem::Bt).unwrap_or_default();
+        let bt_bit = 1u8 << u8::from(PmicRegulator::Vcn33Bt);
+        assert!(
+            mgr.io.regulators & bt_bit != 0,
+            "Vcn33Bt must be enabled after enable_subsystem(Bt)"
+        );
+
+        mgr.power_off().unwrap_or_default();
+
+        assert_eq!(
+            mgr.io.regulators & bt_bit,
+            0,
+            "Vcn33Bt regulator must be disabled by power_off, not left orphaned (#349)"
         );
     }
 }

--- a/crates/thumos/src/audio.rs
+++ b/crates/thumos/src/audio.rs
@@ -199,14 +199,19 @@ impl<C: AudioCodecOps> AudioManager<C> {
     ///
     /// ## Lifecycle
     ///
-    /// 1. If this is the first session (refcount 0 -> 1), power on the codec.
-    /// 2. If the session kind is `VoiceCall`, enable mic (ADC + bias).
-    /// 3. Preempt any active session at lower-or-equal priority; if a
-    ///    strictly higher-priority session is active, the new session is
-    ///    inserted paused instead (#386).
-    /// 4. Configure the codec for the requested route — skipped if step 3
-    ///    inserted the new session paused.
-    /// 5. Return the new session's ID.
+    /// 1. If this is the first session (refcount 0 -> 1), power on the
+    ///    codec. Any hardware failure from this step onward rolls back
+    ///    what this call powered on and returns before any session state
+    ///    is mutated (#390) — `open_session` has a single commit point.
+    /// 2. If the session kind is `VoiceCall`, enable mic (ADC + bias);
+    ///    on failure, roll back the ADC if it was already enabled.
+    /// 3. Configure the codec for the requested route, unless a strictly
+    ///    higher-priority session is already active (in which case the
+    ///    new session is inserted paused instead, #386). This is the
+    ///    commit point: no previously-active session is paused before
+    ///    this succeeds.
+    /// 4. Preempt any active session at lower-or-equal priority.
+    /// 5. Push the new session and return its ID.
     ///
     /// ## Preemption rules
     ///
@@ -227,53 +232,87 @@ impl<C: AudioCodecOps> AudioManager<C> {
         kind: SessionKind,
         route: AudioRoute,
     ) -> Result<u32, AudioError> {
-        let id = self.next_id;
-        self.next_id = self.next_id.wrapping_add(1);
-
         let priority = SessionPriority::from_kind(kind);
+        let first_session = self.sessions.is_empty();
 
-        // Power on codec if this is the first session.
-        if self.sessions.is_empty() {
+        // Power on codec if this is the first session. A failure at any
+        // step here must roll the codec back to powered-off (#390) — the
+        // only prior commit was self.codec_powered, which we also revert.
+        if first_session {
             self.codec.power_on()?;
             self.codec_powered = true;
-            self.codec.enable_dac()?;
-            self.codec.set_volume(self.volume)?;
+
+            if let Err(err) = self.codec.enable_dac() {
+                self.codec.power_off().ok();
+                self.codec_powered = false;
+                return Err(err);
+            }
+            if let Err(err) = self.codec.set_volume(self.volume) {
+                self.codec.power_off().ok();
+                self.codec_powered = false;
+                return Err(err);
+            }
         }
 
-        // Enable mic for voice calls.
+        // Enable mic for voice calls. Roll back the ADC if mic bias fails
+        // to enable, so codec.adc_enabled and mgr.is_mic_powered() never
+        // disagree (#390) — an ADC left hot with no mic-powered session
+        // recorded is an unauditable microphone.
         let needs_mic = kind == SessionKind::VoiceCall;
         if needs_mic && !self.mic_powered {
-            self.codec.enable_adc()?;
-            self.codec.enable_mic_bias()?;
+            if let Err(err) = self.codec.enable_adc() {
+                if first_session {
+                    self.codec.power_off().ok();
+                    self.codec_powered = false;
+                }
+                return Err(err);
+            }
+            if let Err(err) = self.codec.enable_mic_bias() {
+                self.codec.disable_adc().ok();
+                if first_session {
+                    self.codec.power_off().ok();
+                    self.codec_powered = false;
+                }
+                return Err(err);
+            }
             self.mic_powered = true;
         }
 
-        // Preempt sessions: pause any active session at lower or equal priority.
-        // Equal priority: most recent wins, so pause previous same-priority.
+        // WHY: a strictly-higher-priority active session is unaffected by
+        // preemption (only <= priority sessions get paused below), so it
+        // is safe to compute this before the preemption loop runs — the
+        // set of higher-priority actives is the same before and after.
+        // The new session must not become active, and must not touch the
+        // codec route, or it silently displaces the higher-priority
+        // session's audio (#386).
+        let blocked_by_higher_priority =
+            self.sessions.iter().any(|s| s.active && s.priority > priority);
+
+        // Commit point: set the codec output route for the new session,
+        // unless a strictly higher-priority session is already active.
+        // No session state is mutated before this succeeds (#390) — a
+        // set_output failure must not permanently strand previously-active
+        // sessions paused with no path to resume them.
+        if !blocked_by_higher_priority {
+            self.codec.set_output(route)?;
+            self.active_route = route;
+        }
+
+        // Every hardware operation has succeeded — pause preempted
+        // sessions and push the new one. Equal priority: most recent
+        // wins, so pause previous same-priority.
         for session in &mut self.sessions {
             if session.active && session.priority <= priority {
                 session.active = false;
             }
         }
 
-        // WHY: the loop above only pauses <= priority sessions, so a
-        // strictly-higher-priority active session survives it by
-        // construction. The new session must not become active, and must
-        // not touch the codec route, or it silently displaces the
-        // higher-priority session's audio (#386).
-        let blocked_by_higher_priority =
-            self.sessions.iter().any(|s| s.active && s.priority > priority);
+        let id = self.next_id;
+        self.next_id = self.next_id.wrapping_add(1);
 
-        // Set the codec output route for the new session, unless a
-        // strictly higher-priority session is already active.
-        if !blocked_by_higher_priority {
-            self.codec.set_output(route)?;
-            self.active_route = route;
-        }
-
-        // Create and store the session. Starts paused if a higher-priority
-        // session is active; it resumes automatically via
-        // resume_highest_priority() when that session closes.
+        // Starts paused if a higher-priority session is active; it
+        // resumes automatically via resume_highest_priority() when that
+        // session closes.
         let session = AudioSession {
             id,
             kind,
@@ -474,6 +513,18 @@ impl<C: AudioCodecOps> AudioManager<C> {
             self.mic_powered = false;
         }
         Ok(())
+    }
+}
+
+impl<C: AudioCodecOps> Drop for AudioManager<C> {
+    /// Backstop against any path that leaves the codec physically powered
+    /// with no session recorded (#390) — a stranded LDO drains power
+    /// indefinitely on a power-constrained device. Best-effort: a failure
+    /// here is not actionable during drop.
+    fn drop(&mut self) {
+        if self.codec_powered {
+            self.codec.power_off().ok();
+        }
     }
 }
 
@@ -983,6 +1034,69 @@ mod tests {
         assert!(
             music.map_or(false, |s| s.active),
             "music must resume once the call closes"
+        );
+    }
+
+    #[test]
+    fn open_session_enable_dac_failure_powers_off_codec() {
+        // WHY: regression test for #390 — a failure partway through the
+        // first-session hardware init sequence must not strand the codec
+        // physically powered with no session recorded.
+        let mut mgr = make_manager();
+        mgr.codec_mut().fail_enable_dac = Some(AudioError::HardwareError);
+
+        let result = mgr.open_session(SessionKind::Music, AudioRoute::Speaker);
+        assert!(result.is_err(), "open_session must fail when enable_dac fails");
+        assert!(
+            !mgr.is_codec_powered(),
+            "codec must be powered off after a failed open_session (#390)"
+        );
+        assert_eq!(mgr.session_count(), 0, "no session must be recorded on failure");
+    }
+
+    #[test]
+    fn open_session_mic_bias_failure_disables_adc() {
+        // WHY: regression test for #390 — enable_mic_bias failing after
+        // enable_adc succeeded must not leave the ADC live with
+        // mgr.is_mic_powered() reporting false (an unobservable hot mic).
+        let mut mgr = make_manager();
+        mgr.codec_mut().fail_enable_mic_bias = Some(AudioError::HardwareError);
+
+        let result = mgr.open_session(SessionKind::VoiceCall, AudioRoute::Earpiece);
+        assert!(result.is_err(), "open_session must fail when enable_mic_bias fails");
+        assert!(
+            !mgr.codec().is_adc_enabled(),
+            "ADC must be rolled back when mic bias enable fails (#390)"
+        );
+        assert!(
+            !mgr.is_mic_powered(),
+            "mic must not be reported powered after a failed open_session"
+        );
+    }
+
+    #[test]
+    fn open_session_set_output_failure_preserves_preempted_sessions() {
+        // WHY: regression test for #390 — a set_output failure during
+        // preemption must not strand previously-active sessions paused
+        // with no way to resume them.
+        let mut mgr = make_manager();
+        let music_id = mgr
+            .open_session(SessionKind::Music, AudioRoute::Speaker)
+            .unwrap_or(0);
+
+        mgr.codec_mut().fail_set_output = Some(AudioError::HardwareError);
+        let result = mgr.open_session(SessionKind::Alarm, AudioRoute::Speaker);
+        assert!(result.is_err(), "open_session must fail when set_output fails");
+
+        let music = mgr.active_sessions().iter().find(|s| s.id == music_id);
+        assert!(
+            music.map_or(false, |s| s.active),
+            "music must remain active when the preempting session's set_output fails (#390)"
+        );
+        assert_eq!(
+            mgr.session_count(),
+            1,
+            "the failed session must not be recorded"
         );
     }
 }

--- a/crates/thumos/src/audio_codec.rs
+++ b/crates/thumos/src/audio_codec.rs
@@ -627,6 +627,14 @@ pub struct MockCodec {
     pub operations: alloc::vec::Vec<alloc::string::String>,
     /// If set, `power_on` returns this error.
     pub fail_power_on: Option<AudioError>,
+    /// If set, `enable_dac` returns this error (#390).
+    pub fail_enable_dac: Option<AudioError>,
+    /// If set, `enable_adc` returns this error (#390).
+    pub fail_enable_adc: Option<AudioError>,
+    /// If set, `enable_mic_bias` returns this error (#390).
+    pub fail_enable_mic_bias: Option<AudioError>,
+    /// If set, `set_output` returns this error (#390).
+    pub fail_set_output: Option<AudioError>,
 }
 
 #[cfg(test)]
@@ -642,6 +650,10 @@ impl MockCodec {
             mic_bias: false,
             operations: alloc::vec::Vec::new(),
             fail_power_on: None,
+            fail_enable_dac: None,
+            fail_enable_adc: None,
+            fail_enable_mic_bias: None,
+            fail_set_output: None,
         }
     }
 }
@@ -672,6 +684,10 @@ impl AudioCodecOps for MockCodec {
         if !self.powered {
             return Err(AudioError::CodecNotPowered);
         }
+        if let Some(err) = self.fail_enable_dac {
+            self.operations.push(alloc::string::String::from("enable_dac:FAIL"));
+            return Err(err);
+        }
         self.dac_enabled = true;
         self.operations.push(alloc::string::String::from("enable_dac"));
         Ok(())
@@ -680,6 +696,10 @@ impl AudioCodecOps for MockCodec {
     fn enable_adc(&mut self) -> Result<(), AudioError> {
         if !self.powered {
             return Err(AudioError::CodecNotPowered);
+        }
+        if let Some(err) = self.fail_enable_adc {
+            self.operations.push(alloc::string::String::from("enable_adc:FAIL"));
+            return Err(err);
         }
         self.adc_enabled = true;
         self.operations.push(alloc::string::String::from("enable_adc"));
@@ -705,6 +725,10 @@ impl AudioCodecOps for MockCodec {
         if !self.dac_enabled {
             return Err(AudioError::DacNotEnabled);
         }
+        if let Some(err) = self.fail_set_output {
+            self.operations.push(alloc::string::String::from("set_output:FAIL"));
+            return Err(err);
+        }
         self.route = route;
         self.operations
             .push(alloc::format!("set_output:{route:?}"));
@@ -725,6 +749,10 @@ impl AudioCodecOps for MockCodec {
     fn enable_mic_bias(&mut self) -> Result<(), AudioError> {
         if !self.powered {
             return Err(AudioError::CodecNotPowered);
+        }
+        if let Some(err) = self.fail_enable_mic_bias {
+            self.operations.push(alloc::string::String::from("enable_mic_bias:FAIL"));
+            return Err(err);
         }
         self.mic_bias = true;
         self.operations.push(alloc::string::String::from("enable_mic_bias"));

--- a/crates/thumos/src/display.rs
+++ b/crates/thumos/src/display.rs
@@ -235,8 +235,12 @@ mod dsi {
     pub(crate) const LD0_HS_TX_EN: u32 = 1 << 0;
 
     // WHY: CMDQ word format for DCS short writes (the only type we use):
-    //   bits [7:0]   = config (0x00 = short write 0-param, 0x05 = short write 1-param,
-    //                          0x39 = long write / generic long)
+    //   bits [7:0]   = config (0x05 = short write 0-param, 0x15 = short write
+    //                          1-param, 0x39 = long write / generic long) —
+    //                          these are the MIPI DSI standard
+    //                          "Processor-Sourced" packet data types
+    //                          (DCS_SHORT_WRITE / _PARAM / DCS_LONG_WRITE),
+    //                          the same values used by upstream mtk-dsi.c (#387).
     //   bits [15:8]  = DCS command byte
     //   bits [23:16] = first data byte (for 1-param short writes)
     //   bits [31:24] = second data byte (unused for short writes, set to 0)
@@ -245,9 +249,9 @@ mod dsi {
     // subsequent data into additional CMDQ slots.
 
     /// CMDQ config: DCS short write, no parameter (data type 0x05).
-    pub(crate) const CMDQ_SHORT_W0: u32 = 0x00;
+    pub(crate) const CMDQ_SHORT_W0: u32 = 0x05;
     /// CMDQ config: DCS short write, 1 parameter (data type 0x15).
-    pub(crate) const CMDQ_SHORT_W1: u32 = 0x05;
+    pub(crate) const CMDQ_SHORT_W1: u32 = 0x15;
     /// CMDQ config: DCS long write (data type 0x39).
     pub(crate) const CMDQ_LONG_W: u32 = 0x39;
 }
@@ -361,10 +365,15 @@ pub(crate) trait LcmControl {
 
     /// Send the panel initialization command sequence via DSI.
     ///
+    /// # Errors
+    ///
+    /// Returns [`DsiTimeout`] if any DCS command in the sequence times out
+    /// (#389); the remainder of the sequence is aborted.
+    ///
     /// # Safety
     ///
     /// DSI0 must be configured and clock lanes active before calling.
-    unsafe fn init(&self);
+    unsafe fn init(&self) -> Result<(), DsiTimeout>;
 
     /// Enter panel sleep mode (MIPI DCS Sleep In).
     ///
@@ -445,10 +454,19 @@ fn delay_ms(_ms: u32) {}
 /// # Safety
 ///
 /// DSI0 registers must be mapped and accessible.
-unsafe fn dsi_wait_idle() {
+/// A DSI command's poll-wait exhausted [`DSI_POLL_TIMEOUT`] without the
+/// engine going idle (#389). The caller must not proceed to overwrite
+/// `START`/CMDQ while a prior transfer may still be in flight.
+pub(crate) struct DsiTimeout;
+
+unsafe fn dsi_wait_idle() -> Result<(), DsiTimeout> {
     // SAFETY: DSI0_START is a valid MMIO register at 0x1400_D000 within the DSI0 address space. Volatile access is required for hardware registers.
     unsafe {
-        mmio::wait_bits_clear(dsi::START, dsi::START_BIT, DSI_POLL_TIMEOUT);
+        if mmio::wait_bits_clear(dsi::START, dsi::START_BIT, DSI_POLL_TIMEOUT) {
+            Ok(())
+        } else {
+            Err(DsiTimeout)
+        }
     }
 }
 
@@ -457,10 +475,10 @@ unsafe fn dsi_wait_idle() {
 /// # Safety
 ///
 /// DSI0 must be configured with clock and data lanes active.
-unsafe fn dcs_write_cmd0(cmd: u8) {
+unsafe fn dcs_write_cmd0(cmd: u8) -> Result<(), DsiTimeout> {
     // SAFETY: DSI0 registers (START, CMDQ_SIZE, CMDQ_DATA) are valid MMIO registers within the DSI0 address space at 0x1400_D000. Volatile access is required for hardware registers.
     unsafe {
-        dsi_wait_idle();
+        dsi_wait_idle()?;
         // Clear start bit before writing command queue
         mmio::write32(dsi::START, 0);
         // One CMDQ entry: short write, 0 params
@@ -471,7 +489,7 @@ unsafe fn dcs_write_cmd0(cmd: u8) {
         );
         // Trigger DSI command
         mmio::write32(dsi::START, dsi::START_BIT);
-        dsi_wait_idle();
+        dsi_wait_idle()
     }
 }
 
@@ -480,10 +498,10 @@ unsafe fn dcs_write_cmd0(cmd: u8) {
 /// # Safety
 ///
 /// DSI0 must be configured with clock and data lanes active.
-unsafe fn dcs_write_cmd1(cmd: u8, data: u8) {
+unsafe fn dcs_write_cmd1(cmd: u8, data: u8) -> Result<(), DsiTimeout> {
     // SAFETY: DSI0 registers (START, CMDQ_SIZE, CMDQ_DATA) are valid MMIO registers within the DSI0 address space at 0x1400_D000. Volatile access is required for hardware registers.
     unsafe {
-        dsi_wait_idle();
+        dsi_wait_idle()?;
         mmio::write32(dsi::START, 0);
         mmio::write32(dsi::CMDQ_SIZE, 1);
         mmio::write32(
@@ -491,7 +509,7 @@ unsafe fn dcs_write_cmd1(cmd: u8, data: u8) {
             dsi::CMDQ_SHORT_W1 | (u32::from(cmd) << 8) | (u32::from(data) << 16),
         );
         mmio::write32(dsi::START, dsi::START_BIT);
-        dsi_wait_idle();
+        dsi_wait_idle()
     }
 }
 
@@ -505,10 +523,10 @@ unsafe fn dcs_write_cmd1(cmd: u8, data: u8) {
 ///
 /// DSI0 must be configured. `data.len()` must be <= 60 bytes
 /// (limited by the 16-entry × 4-byte CMDQ minus header overhead).
-unsafe fn dcs_write_long(cmd: u8, data: &[u8]) {
+unsafe fn dcs_write_long(cmd: u8, data: &[u8]) -> Result<(), DsiTimeout> {
     // SAFETY: DSI0 registers (START, CMDQ_SIZE, CMDQ_DATA) are valid MMIO registers within the DSI0 address space at 0x1400_D000. Volatile access is required for hardware registers.
     unsafe {
-        dsi_wait_idle();
+        dsi_wait_idle()?;
         mmio::write32(dsi::START, 0);
 
         // Total payload length: cmd byte + data bytes
@@ -546,7 +564,24 @@ unsafe fn dcs_write_long(cmd: u8, data: &[u8]) {
         // CMDQ_SIZE = number of 32-bit slots used.
         mmio::write32(dsi::CMDQ_SIZE, slot as u32);
         mmio::write32(dsi::START, dsi::START_BIT);
-        dsi_wait_idle();
+        dsi_wait_idle()
+    }
+}
+
+/// Assert DSI video-mode START.
+///
+/// Must be called after the LCM DCS init sequence has been fully sent
+/// ([`LcmControl::init`]) — asserting video START first can prevent the
+/// panel from receiving DCS init commands (#391).
+///
+/// # Safety
+///
+/// DSI0 must be configured (`DisplayDriver::configure_dsi`) and the LCM
+/// init sequence must have completed.
+unsafe fn dsi_start_video_mode() {
+    // SAFETY: DSI0_START is a valid MMIO register within the DSI0 address space at 0x1400_D000. Volatile access is required for hardware registers.
+    unsafe {
+        mmio::write32(dsi::START, dsi::START_BIT);
     }
 }
 
@@ -593,68 +628,69 @@ impl LcmControl for Gc9306 {
         &self.params
     }
 
-    unsafe fn init(&self) {
+    unsafe fn init(&self) -> Result<(), DsiTimeout> {
         // GC9306 init sequence derived from four independent GPL/Apache
         // driver sources. See docs/GC9306-INIT.md for provenance and
         // per-source gamma differences.
         // SAFETY: DSI0 is configured with clock and data lanes active per caller contract. All DCS commands are routed through dcs_write_* helpers which access valid DSI0 MMIO registers.
         unsafe {
             // Inter register enable (GC-specific page unlock)
-            dcs_write_cmd0(0xFE);
-            dcs_write_cmd0(0xEF);
+            dcs_write_cmd0(0xFE)?;
+            dcs_write_cmd0(0xEF)?;
 
             // Memory access control: MX=1, BGR=1 (direction 0 for AGM M7)
-            dcs_write_cmd1(0x36, 0x48);
+            dcs_write_cmd1(0x36, 0x48)?;
 
             // Pixel format: RGB565, 16-bit
-            dcs_write_cmd1(0x3A, 0x05);
+            dcs_write_cmd1(0x3A, 0x05)?;
 
             // Power control registers
-            dcs_write_long(0xA4, &[0x44, 0x44]); // Power control 7
-            dcs_write_long(0xA5, &[0x42, 0x42]); // Power control 8
-            dcs_write_long(0xAA, &[0x88, 0x88]); // Power control (undocumented)
-            dcs_write_long(0xE8, &[0x11, 0x0B]); // Frame rate control
-            dcs_write_long(0xE3, &[0x01, 0x10]); // Source precharge control
+            dcs_write_long(0xA4, &[0x44, 0x44])?; // Power control 7
+            dcs_write_long(0xA5, &[0x42, 0x42])?; // Power control 8
+            dcs_write_long(0xAA, &[0x88, 0x88])?; // Power control (undocumented)
+            dcs_write_long(0xE8, &[0x11, 0x0B])?; // Frame rate control
+            dcs_write_long(0xE3, &[0x01, 0x10])?; // Source precharge control
 
             // Internal registers
-            dcs_write_cmd1(0xFF, 0x61); // Internal register (undocumented)
-            dcs_write_cmd1(0xAC, 0x00); // LDO enable
-            dcs_write_cmd1(0xAD, 0x33); // VGLO voltage control
-            dcs_write_cmd1(0xAE, 0x2B); // Internal power (undocumented)
-            dcs_write_cmd1(0xAF, 0x55); // DIG_VREFAD_VRDD control
+            dcs_write_cmd1(0xFF, 0x61)?; // Internal register (undocumented)
+            dcs_write_cmd1(0xAC, 0x00)?; // LDO enable
+            dcs_write_cmd1(0xAD, 0x33)?; // VGLO voltage control
+            dcs_write_cmd1(0xAE, 0x2B)?; // Internal power (undocumented)
+            dcs_write_cmd1(0xAF, 0x55)?; // DIG_VREFAD_VRDD control
 
             // VCOM offset voltages
-            dcs_write_long(0xA6, &[0x2A, 0x2A]); // VCOM offset 1
-            dcs_write_long(0xA7, &[0x2B, 0x2B]); // VCOM offset 2
-            dcs_write_long(0xA8, &[0x18, 0x18]); // VCOM offset 3
-            dcs_write_long(0xA9, &[0x2A, 0x2A]); // VCOM offset 4
+            dcs_write_long(0xA6, &[0x2A, 0x2A])?; // VCOM offset 1
+            dcs_write_long(0xA7, &[0x2B, 0x2B])?; // VCOM offset 2
+            dcs_write_long(0xA8, &[0x18, 0x18])?; // VCOM offset 3
+            dcs_write_long(0xA9, &[0x2A, 0x2A])?; // VCOM offset 4
 
             // Column address set: 0-239
-            dcs_write_long(0x2A, &[0x00, 0x00, 0x00, 0xEF]);
+            dcs_write_long(0x2A, &[0x00, 0x00, 0x00, 0xEF])?;
             // Row address set: 0-319
-            dcs_write_long(0x2B, &[0x00, 0x00, 0x01, 0x3F]);
+            dcs_write_long(0x2B, &[0x00, 0x00, 0x01, 0x3F])?;
             // Memory write start
-            dcs_write_cmd0(0x2C);
+            dcs_write_cmd0(0x2C)?;
 
             // Gamma correction (LuatOS/Fibocom values; may need panel tuning)
-            dcs_write_long(0xF0, &[0x02, 0x00, 0x00, 0x1B, 0x1F, 0x0B]); // Positive gamma 1
-            dcs_write_long(0xF1, &[0x01, 0x03, 0x00, 0x28, 0x2B, 0x0E]); // Positive gamma 2
-            dcs_write_long(0xF2, &[0x0B, 0x08, 0x3B, 0x04, 0x03, 0x4C]); // Positive gamma 3
-            dcs_write_long(0xF3, &[0x0E, 0x07, 0x46, 0x04, 0x05, 0x51]); // Positive gamma 4
-            dcs_write_long(0xF4, &[0x08, 0x15, 0x15, 0x1F, 0x22, 0x0F]); // Negative gamma 1
-            dcs_write_long(0xF5, &[0x0B, 0x13, 0x11, 0x1F, 0x21, 0x0F]); // Negative gamma 2
+            dcs_write_long(0xF0, &[0x02, 0x00, 0x00, 0x1B, 0x1F, 0x0B])?; // Positive gamma 1
+            dcs_write_long(0xF1, &[0x01, 0x03, 0x00, 0x28, 0x2B, 0x0E])?; // Positive gamma 2
+            dcs_write_long(0xF2, &[0x0B, 0x08, 0x3B, 0x04, 0x03, 0x4C])?; // Positive gamma 3
+            dcs_write_long(0xF3, &[0x0E, 0x07, 0x46, 0x04, 0x05, 0x51])?; // Positive gamma 4
+            dcs_write_long(0xF4, &[0x08, 0x15, 0x15, 0x1F, 0x22, 0x0F])?; // Negative gamma 1
+            dcs_write_long(0xF5, &[0x0B, 0x13, 0x11, 0x1F, 0x21, 0x0F])?; // Negative gamma 2
 
             // Sleep Out — wait 120 ms for internal voltage stabilization
-            dcs_write_cmd0(0x11);
+            dcs_write_cmd0(0x11)?;
             delay_ms(120);
 
             // Display On — wait 20 ms for display to become active
-            dcs_write_cmd0(0x29);
+            dcs_write_cmd0(0x29)?;
             delay_ms(20);
 
             // Memory write (ready for pixel data)
-            dcs_write_cmd0(0x2C);
+            dcs_write_cmd0(0x2C)?;
         }
+        Ok(())
     }
 
     unsafe fn suspend(&self) {
@@ -662,12 +698,15 @@ impl LcmControl for Gc9306 {
         // Inter register enable must precede power commands.
         // SAFETY: DSI0 is active and panel is in normal operating state per caller contract. All DCS commands are routed through dcs_write_* helpers which access valid DSI0 MMIO registers.
         unsafe {
-            dcs_write_cmd0(0xFE); // Inter register enable 1
-            dcs_write_cmd0(0xEF); // Inter register enable 2
+            // WHY: best-effort teardown — a timed-out DCS command here has
+            // no established recovery path (unlike init, #389); the panel
+            // is being suspended either way.
+            let _ = dcs_write_cmd0(0xFE); // Inter register enable 1
+            let _ = dcs_write_cmd0(0xEF); // Inter register enable 2
             // Display Off first, then Sleep In per MIPI DCS spec
-            dcs_write_cmd0(0x28); // Display Off
+            let _ = dcs_write_cmd0(0x28); // Display Off
             delay_ms(120);
-            dcs_write_cmd0(0x10); // Sleep In (enter minimum power)
+            let _ = dcs_write_cmd0(0x10); // Sleep In (enter minimum power)
         }
     }
 
@@ -675,13 +714,14 @@ impl LcmControl for Gc9306 {
         // GC9306 sleep-out sequence from docs/GC9306-INIT.md.
         // SAFETY: DSI0 is active and panel is in suspended state per caller contract. All DCS commands are routed through dcs_write_* helpers which access valid DSI0 MMIO registers.
         unsafe {
-            dcs_write_cmd0(0xFE); // Inter register enable 1
-            dcs_write_cmd0(0xEF); // Inter register enable 2
+            // WHY: best-effort resume — same rationale as suspend() above.
+            let _ = dcs_write_cmd0(0xFE); // Inter register enable 1
+            let _ = dcs_write_cmd0(0xEF); // Inter register enable 2
             // Sleep Out — wait 120 ms for voltage stabilization
-            dcs_write_cmd0(0x11);
+            let _ = dcs_write_cmd0(0x11);
             delay_ms(120);
             // Display On
-            dcs_write_cmd0(0x29);
+            let _ = dcs_write_cmd0(0x29);
         }
     }
 }
@@ -692,7 +732,9 @@ impl LcmBacklight for Gc9306 {
         // The GC9306 supports this command natively.
         // SAFETY: DSI0 is active and panel is not suspended per caller contract. dcs_write_cmd1 accesses valid DSI0 MMIO registers within the DSI0 address space at 0x1400_D000.
         unsafe {
-            dcs_write_cmd1(0x51, level);
+            // WHY: best-effort — a timed-out backlight write has no
+            // established recovery path from this ()-returning trait method.
+            let _ = dcs_write_cmd1(0x51, level);
         }
     }
 }
@@ -728,6 +770,9 @@ pub enum DisplayState {
     Active,
     /// Panel in sleep mode.
     Suspended,
+    /// A DSI command timed out during initialization; the pipeline is not
+    /// usable (#389).
+    Error,
 }
 
 // ---------------------------------------------------------------------------
@@ -838,10 +883,26 @@ impl<L: LcmDriver> DisplayDriver<L> {
 
         // Step 8: send LCM init commands
         // SAFETY: DSI0 is configured with clock and data lanes active after configure_dsi(). DCS commands access valid DSI0 MMIO registers.
-        unsafe {
-            self.lcm.init();
+        let lcm_init_result = unsafe { self.lcm.init() };
+        if lcm_init_result.is_err() {
+            // WHY: a DSI command timeout during LCM init means the panel
+            // may not have received its DCS init sequence — entering
+            // DisplayState::Error stops the pipeline from proceeding to
+            // configure the mutex and trigger a frame against a
+            // half-initialized (or unresponsive) panel (#389).
+            self.state = DisplayState::Error;
+            return;
         }
         self.state = DisplayState::LcmInitialized;
+
+        // Step 8b: start DSI video mode — must occur AFTER the LCM DCS
+        // init sequence has been fully sent, not before (#391). Asserting
+        // START while the panel is still processing init commands can
+        // prevent those commands from being received correctly.
+        // SAFETY: DSI0_START is a valid MMIO register within the DSI0 address space at 0x1400_D000. Volatile access is required for hardware registers.
+        unsafe {
+            dsi_start_video_mode();
+        }
 
         // Step 9: configure mutex
         // SAFETY: display mutex registers are valid MMIO registers within the DISP_MUTEX address space at 0x1400_1000. Volatile access is required for hardware registers.
@@ -1012,8 +1073,13 @@ impl<L: LcmDriver> DisplayDriver<L> {
             mmio::write32(dsi::PHY_LCCON, dsi::LC_HS_TX_EN);
             mmio::write32(dsi::PHY_LD0CON, dsi::LD0_HS_TX_EN);
 
-            // Start DSI
-            mmio::write32(dsi::START, dsi::START_BIT);
+            // WHY: DSI video-mode START is intentionally NOT asserted here.
+            // Asserting START puts the panel into continuous video clocking
+            // before the LCM has received its DCS init sequence (Sleep Out,
+            // gamma, etc.), which can prevent the panel from receiving
+            // those commands correctly. START is asserted by
+            // dsi_start_video_mode(), called after the LCM init sequence
+            // completes (see DisplayDriver::init) (#391).
         }
         self.state = DisplayState::DsiConfigured;
     }
@@ -1258,6 +1324,49 @@ mod tests {
         );
     }
 
+    // -- DSI CMDQ data-type constants (#387) --
+
+    #[test]
+    fn cmdq_short_w0_matches_mipi_dcs_short_write_no_param() {
+        assert_eq!(
+            dsi::CMDQ_SHORT_W0, 0x05,
+            "CMDQ_SHORT_W0 must equal the MIPI DSI DCS short-write, \
+             0-parameter data type (0x05)"
+        );
+    }
+
+    #[test]
+    fn cmdq_short_w1_matches_mipi_dcs_short_write_one_param() {
+        assert_eq!(
+            dsi::CMDQ_SHORT_W1, 0x15,
+            "CMDQ_SHORT_W1 must equal the MIPI DSI DCS short-write, \
+             1-parameter data type (0x15)"
+        );
+    }
+
+    #[test]
+    fn cmdq_word_low_byte_zero_param_command() {
+        let cmd: u8 = 0x11; // Sleep Out
+        let word = dsi::CMDQ_SHORT_W0 | (u32::from(cmd) << 8);
+        assert_eq!(
+            word & 0xFF,
+            0x05,
+            "packed CMDQ word for a 0-param DCS command must carry data type 0x05 in its low byte"
+        );
+    }
+
+    #[test]
+    fn cmdq_word_low_byte_one_param_command() {
+        let cmd: u8 = 0x36; // Memory Access Control
+        let data: u8 = 0x48;
+        let word = dsi::CMDQ_SHORT_W1 | (u32::from(cmd) << 8) | (u32::from(data) << 16);
+        assert_eq!(
+            word & 0xFF,
+            0x15,
+            "packed CMDQ word for a 1-param DCS command must carry data type 0x15 in its low byte"
+        );
+    }
+
     // -- GC9306 panel parameters --
 
     #[test]
@@ -1306,17 +1415,17 @@ mod tests {
 
     #[test]
     fn cmdq_short_w0_encodes_cmd_byte() {
-        // Short write 0-param: config=0x00, cmd in bits[15:8]
+        // Short write 0-param: config=0x05 (MIPI DCS short write, no param), cmd in bits[15:8]
         let word = dsi::CMDQ_SHORT_W0 | (0x11_u32 << 8);
-        assert_eq!(word & 0xFF, 0x00, "config byte = short write 0-param");
+        assert_eq!(word & 0xFF, 0x05, "config byte = short write 0-param (#387)");
         assert_eq!((word >> 8) & 0xFF, 0x11, "cmd byte = Sleep Out");
     }
 
     #[test]
     fn cmdq_short_w1_encodes_cmd_and_data() {
-        // Short write 1-param: config=0x05, cmd in [15:8], data in [23:16]
+        // Short write 1-param: config=0x15 (MIPI DCS short write, 1 param), cmd in [15:8], data in [23:16]
         let word = dsi::CMDQ_SHORT_W1 | (0x36_u32 << 8) | (0x48_u32 << 16);
-        assert_eq!(word & 0xFF, 0x05, "config byte = short write 1-param");
+        assert_eq!(word & 0xFF, 0x15, "config byte = short write 1-param (#387)");
         assert_eq!((word >> 8) & 0xFF, 0x36, "cmd byte = MADCTL");
         assert_eq!((word >> 16) & 0xFF, 0x48, "data byte = MX|BGR");
     }

--- a/crates/thumos/src/exceptions.rs
+++ b/crates/thumos/src/exceptions.rs
@@ -124,6 +124,14 @@ pub extern "C" fn irq_handler_rust() {
         return;
     }
 
+    // WHY: EOI must be written in the CURRENT execution context, before any
+    // interrupt-specific work below that can abandon this context via
+    // process::switch_to(). GICv2 requires GICC_EOIR to deactivate the
+    // interrupt; skipping it after a scheduler switch leaves the interrupt
+    // permanently active and blocks all further IRQ delivery at every
+    // priority (GICC_PMR = 0xFF) (#341).
+    gic::end_of_interrupt(irq);
+
     if irq == timer::TIMER_IRQ {
         // Timer tick
         // SAFETY: TICK_COUNT is only written from this IRQ handler, which
@@ -191,8 +199,6 @@ pub extern "C" fn irq_handler_rust() {
         let _ = process::check_pending_signal(); // WHY: signal delivery failure is non-actionable in IRQ context; will retry on next tick
 
     }
-
-    gic::end_of_interrupt(irq);
 }
 
 /// Data abort handler  -  print fault info and hang.

--- a/crates/thumos/src/uart.rs
+++ b/crates/thumos/src/uart.rs
@@ -53,7 +53,7 @@ impl Uart {
             while core::ptr::read_volatile(lsr) & LSR_THRE == 0 {}
 
             // Write byte
-            *thr = u32::from(byte);
+            core::ptr::write_volatile(thr, u32::from(byte));
         }
     }
 


### PR DESCRIPTION
The last verifiable-defect cluster — MMIO/interrupt correctness (armv7a-review-verified) plus host-testable regulator/audio state-machine fixes.

- **#341 (HIGH)** — `gic::end_of_interrupt` was the *last* statement in `irq_handler_rust`, after `process::switch_to()` abandons the stack frame, so on a scheduler switch the EOI never ran — and GICv2 requires `GICC_EOIR` to deactivate the interrupt (a missed EOI blocks all further IRQ delivery). EOI now fires right after the spurious check, dominating both switch and idle paths.
- **#349 / #352** — WMT `power_off` orphaned active subsystems' regulators; `power_on` left Vcn18 live on a poll failure. Both now manage the regulator lifecycle correctly (host-tested via `FakeIo`).
- **#362** — UART THR write → `write_volatile`.
- **#389** — `dsi_wait_idle` now returns `Result`; `dcs_write_*` propagate it; `init` returns `Result` and `DisplayDriver::init` enters `DisplayState::Error` instead of driving a mutex + frame against an unresponsive panel.
- **#391** — DSI video-mode START moved to *after* the LCM DCS init sequence.
- **#387** — `CMDQ_SHORT_W0/W1` corrected to the standard MIPI DCS codes 0x05/0x15 (verified against the MIPI spec + Linux `drm_mipi_dsi.h` + the code's own doc comments — **not** BSP-gated, unlike #221/#293). Existing encode tests updated.
- **#390** — audio `open_session` restructured around a single commit point with explicit rollback (host-tested: enable_dac fail powers off, mic_bias fail disables ADC, set_output fail preserves preempted sessions) + a `Drop` backstop.

## Closes

Closes #341, #349, #352, #362, #389, #391, #387, #390

## Verification

- kernel nextest 1820→1838 (+18); kelyphos 61→63 (+2)
- workspace clippy -D warnings + doctests clean; armv7a compiles; kanon lint clean

## Review posture

#341 (interrupt-controller correctness) reviewed at the orchestrator tier: EOI now fires in the pre-switch context, once per acknowledged IRQ; CPSR.I masks reentrancy during the handler, so EOI timing only gates the *next* IRQ. #389/#391 overlap in `display.rs` was reconciled by hand. #387's `M_CRYPTO_ERROR`-vs-`InvalidId` note does not apply here.