### PR TITLE
SMS prompt guard, FM screen per-frame heap, mmu pool locking (3 issues)

### DIFF
--- a/crates/thumos/src/mmu.rs
+++ b/crates/thumos/src/mmu.rs
@@ -14,6 +14,8 @@
 //! - DACR  (CP15 c3): domain access control
 //! - SCTLR (CP15 c1): system control (bit 0 = MMU enable)
 
+use crate::irq;
+
 /// L1 page table: 4096 entries x 4 bytes = 16 KB.
 /// Must be 16 KB aligned.
 #[repr(C, align(16384))]
@@ -89,8 +91,16 @@ static mut L2_TABLES: [L2Table; L2_POOL_SIZE] = {
 /// Allocation bitmask for L2_TABLES. Bit N = 1 means slot N is in use.
 static mut L2_ALLOC: u64 = 0;
 
+/// WHY (#416): guards every `L2_ALLOC` accessor (`alloc_l2_table`,
+/// `free_l2_table`) -- same defect class as #331/PAGE_LOCK.
+static L2_POOL_LOCK: irq::IrqSpinlock = irq::IrqSpinlock::new();
+
 /// Allocate an L2 page table from the pool. Returns its physical address.
 pub(crate) fn alloc_l2_table() -> Option<usize> {
+    // WHY (#416): serializes with every other L2_ALLOC accessor, including
+    // an IRQ-context caller, so a concurrent or IRQ-interleaved RMW cannot
+    // double-allocate the same pool slot (same defect class as #331).
+    let _g = L2_POOL_LOCK.lock();
     unsafe {
         let alloc = core::ptr::addr_of_mut!(L2_ALLOC);
         let mask = core::ptr::read_volatile(alloc);
@@ -110,6 +120,10 @@ pub(crate) fn alloc_l2_table() -> Option<usize> {
 ///
 /// `phys_addr` must have been returned by `alloc_l2_table` and not yet freed.
 pub unsafe fn free_l2_table(phys_addr: usize) {
+    // WHY (#416): serializes with every other L2_ALLOC accessor (see
+    // alloc_l2_table) so a concurrent alloc/free pair cannot corrupt a torn
+    // bitmask update.
+    let _g = L2_POOL_LOCK.lock();
     unsafe {
         let tables = &*core::ptr::addr_of!(L2_TABLES);
         for (i, table) in tables.iter().enumerate() {
@@ -560,10 +574,19 @@ pub(crate) static mut ADDR_SPACE_ALLOC: u16 = 0;
 #[cfg(not(test))]
 static mut ADDR_SPACE_ALLOC: u16 = 0;
 
+/// WHY (#416): guards every `ADDR_SPACE_ALLOC` accessor (`alloc_addr_space`,
+/// `free_addr_space`) -- same defect class as #331/PAGE_LOCK.
+static ADDR_SPACE_LOCK: irq::IrqSpinlock = irq::IrqSpinlock::new();
+
 /// Allocate a free user L1 page table FROM the pool.
 /// Zeroes the slot before returning its physical address.
 /// Returns None if all 16 slots are occupied.
 pub fn alloc_addr_space() -> Option<usize> {
+    // WHY (#416): serializes with every other ADDR_SPACE_ALLOC accessor,
+    // including an IRQ-context caller, so a concurrent or IRQ-interleaved
+    // RMW cannot double-allocate the same address-space slot (same defect
+    // class as #331).
+    let _g = ADDR_SPACE_LOCK.lock();
     unsafe {
         let alloc = core::ptr::addr_of_mut!(ADDR_SPACE_ALLOC);
         let mask = core::ptr::read_volatile(alloc);
@@ -592,6 +615,10 @@ pub fn alloc_addr_space() -> Option<usize> {
 ///
 /// `phys_addr` must have been returned by `alloc_addr_space` and not yet freed.
 pub unsafe fn free_addr_space(phys_addr: usize) {
+    // WHY (#416): serializes with every other ADDR_SPACE_ALLOC accessor (see
+    // alloc_addr_space) so a concurrent alloc/free pair cannot corrupt a
+    // torn bitmask update.
+    let _g = ADDR_SPACE_LOCK.lock();
     unsafe {
         let tables = &*core::ptr::addr_of!(USER_TABLES);
         for (i, table) in tables.iter().enumerate() {
@@ -896,5 +923,71 @@ mod tests {
                 free_l2_table(addr);
             }
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // #416: IRQ-safe locking for L2_ALLOC / ADDR_SPACE_ALLOC pools
+    // -----------------------------------------------------------------------
+    //
+    // WHY these tests exercise L2_POOL_LOCK/ADDR_SPACE_LOCK directly rather
+    // than going through alloc_l2_table()/alloc_addr_space(): the masking
+    // contract is independent of pool state, so it is testable in isolation
+    // the same way page.rs's #331 PAGE_LOCK tests are (see that file).
+
+    #[test]
+    fn l2_pool_lock_masks_irqs_for_the_critical_section() {
+        // Regression test for #416: L2_ALLOC mutations must run inside an
+        // IRQ-masked critical section shared by every caller -- alloc_l2_table
+        // AND free_l2_table -- or an IRQ-context caller can interleave with a
+        // non-locked in-progress caller and double-allocate the same L2 pool
+        // slot (same defect class as #331). Host-testable via the mock
+        // IRQ-state seam in `irq`.
+        crate::irq::reset_mock();
+        assert!(crate::irq::mock_enabled(), "starts unmasked");
+        let guard = L2_POOL_LOCK.lock();
+        assert!(!crate::irq::mock_enabled(), "L2_POOL_LOCK.lock() must mask IRQ delivery while held");
+        drop(guard);
+        assert!(crate::irq::mock_enabled(), "dropping the guard must restore IRQ delivery");
+    }
+
+    #[test]
+    fn nested_irq_guard_does_not_unmask_while_l2_pool_lock_held() {
+        crate::irq::reset_mock();
+        let outer = L2_POOL_LOCK.lock();
+        assert!(!crate::irq::mock_enabled());
+        let inner = crate::irq::IrqGuard::new();
+        assert!(!crate::irq::mock_enabled());
+        drop(inner);
+        assert!(!crate::irq::mock_enabled(), "inner drop must not unmask while L2_POOL_LOCK is still held");
+        drop(outer);
+        assert!(crate::irq::mock_enabled(), "outer drop restores IRQ delivery");
+    }
+
+    #[test]
+    fn addr_space_lock_masks_irqs_for_the_critical_section() {
+        // Regression test for #416: ADDR_SPACE_ALLOC mutations must run
+        // inside an IRQ-masked critical section shared by every caller --
+        // alloc_addr_space AND free_addr_space -- or an IRQ-context caller
+        // can interleave with a non-locked in-progress caller and
+        // double-allocate the same address-space slot.
+        crate::irq::reset_mock();
+        assert!(crate::irq::mock_enabled(), "starts unmasked");
+        let guard = ADDR_SPACE_LOCK.lock();
+        assert!(!crate::irq::mock_enabled(), "ADDR_SPACE_LOCK.lock() must mask IRQ delivery while held");
+        drop(guard);
+        assert!(crate::irq::mock_enabled(), "dropping the guard must restore IRQ delivery");
+    }
+
+    #[test]
+    fn nested_irq_guard_does_not_unmask_while_addr_space_lock_held() {
+        crate::irq::reset_mock();
+        let outer = ADDR_SPACE_LOCK.lock();
+        assert!(!crate::irq::mock_enabled());
+        let inner = crate::irq::IrqGuard::new();
+        assert!(!crate::irq::mock_enabled());
+        drop(inner);
+        assert!(!crate::irq::mock_enabled(), "inner drop must not unmask while ADDR_SPACE_LOCK is still held");
+        drop(outer);
+        assert!(crate::irq::mock_enabled(), "outer drop restores IRQ delivery");
     }
 }

--- a/crates/thumos/src/screen_fm.rs
+++ b/crates/thumos/src/screen_fm.rs
@@ -20,9 +20,6 @@
     reason = "FM radio screen created in Phase 07 Wave 8, kinit wiring pending"
 )]
 
-extern crate alloc;
-use alloc::string::String;
-
 use crate::fm_radio::{self, FmState};
 use crate::ui::{
     self, color, Key, Screen, ScreenAction,
@@ -129,14 +126,6 @@ impl FmScreen {
         self.volume = volume;
     }
 
-    /// Format the current frequency as a display string.
-    ///
-    /// Returns a string like "98.5" or "107.9".
-    fn format_frequency(&self) -> String {
-        let (mhz, frac) = fm_radio::freq_to_display(self.frequency_khz);
-        alloc::format!("{mhz}.{frac}")
-    }
-
     /// Map RSSI to signal bar count (0-5).
     ///
     /// RSSI ranges from about -100 dBm (no signal) to -30 dBm (strong).
@@ -171,7 +160,10 @@ impl FmScreen {
 
     /// Draw the large frequency display (scaled 2x).
     fn draw_frequency(&self, fb: &mut [u16]) {
-        let freq_str = self.format_frequency();
+        let mut freq_buf = [0u8; 8];
+        let freq_len = format_freq_into(self.frequency_khz, &mut freq_buf);
+        // INVARIANT: format_freq_into only ever writes ASCII digits and '.'.
+        let freq_str = core::str::from_utf8(&freq_buf[..freq_len]).unwrap_or("--.-");
         let w = SCREEN_WIDTH;
 
         // Draw at 2x scale by drawing each character doubled.
@@ -228,7 +220,6 @@ impl FmScreen {
         for i in 0..PRESET_COUNT {
             let slot_x = PADDING_X + (i as u16) * (CHAR_WIDTH * 5 + 4);
             let label_num = (i + 1) as u8;
-            let label_char = (b'0' + label_num) as char;
 
             // Highlight active preset.
             let fg = if self.active_preset == Some(i) {
@@ -237,20 +228,24 @@ impl FmScreen {
                 color::WHITE
             };
 
-            // Slot number.
-            let label = alloc::format!("{label_char}:");
-            ui::draw_str(fb, w, slot_x, PRESET_FREQ_Y, &label, fg, color::BLACK);
+            // Slot number (e.g. "1:").
+            let label_buf = [b'0' + label_num, b':'];
+            // INVARIANT: label_buf is always an ASCII digit followed by ':'.
+            let label = core::str::from_utf8(&label_buf).unwrap_or("?:");
+            ui::draw_str(fb, w, slot_x, PRESET_FREQ_Y, label, fg, color::BLACK);
 
             // Preset frequency (if set).
             if i < self.preset_count as usize && self.presets[i] > 0 {
-                let (mhz, frac) = fm_radio::freq_to_display(self.presets[i]);
-                let freq_text = alloc::format!("{mhz}.{frac}");
+                let mut freq_buf = [0u8; 8];
+                let freq_len = format_freq_into(self.presets[i], &mut freq_buf);
+                // INVARIANT: format_freq_into only ever writes ASCII digits and '.'.
+                let freq_text = core::str::from_utf8(&freq_buf[..freq_len]).unwrap_or("--.-");
                 ui::draw_str(
                     fb,
                     w,
                     slot_x + 2 * CHAR_WIDTH,
                     PRESET_FREQ_Y,
-                    &freq_text,
+                    freq_text,
                     fg,
                     color::BLACK,
                 );
@@ -316,9 +311,15 @@ impl Screen for FmScreen {
                 // Draw signal bars.
                 self.draw_signal_bars(fb);
 
-                // Draw status line.
-                let vol_text = alloc::format!("Vol: {}", self.volume);
-                ui::draw_str(fb, w, PADDING_X, STATUS_Y, &vol_text, color::WHITE, color::BLACK);
+                // Draw status line: "Vol: N" (N is 0-15, one or two digits).
+                let mut vol_buf = [0u8; 10];
+                vol_buf[..5].copy_from_slice(b"Vol: ");
+                let mut vol_digits = [0u8; 3];
+                let digit_len = format_u8_into(self.volume, &mut vol_digits);
+                vol_buf[5..5 + digit_len].copy_from_slice(&vol_digits[..digit_len]);
+                // INVARIANT: vol_buf is always "Vol: " (ASCII) followed by ASCII digits.
+                let vol_text = core::str::from_utf8(&vol_buf[..5 + digit_len]).unwrap_or("Vol: ?");
+                ui::draw_str(fb, w, PADDING_X, STATUS_Y, vol_text, color::WHITE, color::BLACK);
 
                 // Draw seek arrows.
                 let arrows = "<< SEEK >>";
@@ -411,6 +412,61 @@ impl Screen for FmScreen {
 }
 
 // ---------------------------------------------------------------------------
+// Formatting helpers (no_std, no heap allocation)
+// ---------------------------------------------------------------------------
+
+/// Format a frequency in kHz as "MHZ.FRAC" (e.g. "98.5") into a stack buffer.
+///
+/// Returns the number of bytes written. FM broadcast frequencies are always
+/// within `fm_radio`'s tunable band (87.5-108.0 MHz), so mhz is always two
+/// or three digits and one fractional digit always follows; an 8-byte
+/// buffer is always sufficient.
+fn format_freq_into(freq_khz: u32, buf: &mut [u8; 8]) -> usize {
+    let (mhz, frac) = fm_radio::freq_to_display(freq_khz);
+    let mut pos = 0;
+
+    // INVARIANT: fm_radio::tune bounds freq_khz to FM_FREQ_MIN_KHZ..=
+    // FM_FREQ_MAX_KHZ (87_500..=108_000), so mhz is always in 87..=108 and
+    // each extracted digit fits in u8.
+    if mhz >= 100 {
+        buf[pos] = b'0' + (mhz / 100) as u8;
+        pos += 1;
+    }
+    if mhz >= 10 {
+        buf[pos] = b'0' + ((mhz / 10) % 10) as u8;
+        pos += 1;
+    }
+    buf[pos] = b'0' + (mhz % 10) as u8;
+    pos += 1;
+
+    buf[pos] = b'.';
+    pos += 1;
+
+    // INVARIANT: frac = (freq_khz % 1000) / 100 is always a single digit.
+    buf[pos] = b'0' + (frac % 10) as u8;
+    pos += 1;
+
+    pos
+}
+
+/// Format a u8 as decimal digits into a byte buffer. Returns bytes written.
+fn format_u8_into(val: u8, buf: &mut [u8; 3]) -> usize {
+    if val >= 100 {
+        buf[0] = b'0' + val / 100;
+        buf[1] = b'0' + (val / 10) % 10;
+        buf[2] = b'0' + val % 10;
+        3
+    } else if val >= 10 {
+        buf[0] = b'0' + val / 10;
+        buf[1] = b'0' + val % 10;
+        2
+    } else {
+        buf[0] = b'0' + val;
+        1
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -421,18 +477,28 @@ mod tests {
 
     #[test]
     fn frequency_display_formats_correctly() {
-        let mut screen = FmScreen::new();
-        screen.frequency_khz = 98_500;
-        let display = screen.format_frequency();
-        assert_eq!(display, "98.5", "98500 kHz must display as 98.5");
+        let mut buf = [0u8; 8];
 
-        screen.frequency_khz = 107_900;
-        let display = screen.format_frequency();
-        assert_eq!(display, "107.9", "107900 kHz must display as 107.9");
+        let len = format_freq_into(98_500, &mut buf);
+        assert_eq!(
+            core::str::from_utf8(&buf[..len]).unwrap_or(""),
+            "98.5",
+            "98500 kHz must display as 98.5"
+        );
 
-        screen.frequency_khz = 88_000;
-        let display = screen.format_frequency();
-        assert_eq!(display, "88.0", "88000 kHz must display as 88.0");
+        let len = format_freq_into(107_900, &mut buf);
+        assert_eq!(
+            core::str::from_utf8(&buf[..len]).unwrap_or(""),
+            "107.9",
+            "107900 kHz must display as 107.9"
+        );
+
+        let len = format_freq_into(88_000, &mut buf);
+        assert_eq!(
+            core::str::from_utf8(&buf[..len]).unwrap_or(""),
+            "88.0",
+            "88000 kHz must display as 88.0"
+        );
     }
 
     #[test]
@@ -553,6 +619,43 @@ mod tests {
         screen.draw(&mut fb);
         let any_set = fb.iter().any(|&px| px != 0);
         assert!(any_set, "FM screen in Tuned state must render visible content");
+    }
+
+    #[test]
+    fn draw_tuned_with_presets_does_not_panic() {
+        // Exercises the no-alloc preset-frequency formatting path in
+        // draw_presets() (issue #392), not just the empty "---" slots.
+        let mut screen = FmScreen::new();
+        screen.fm_state = FmState::Tuned {
+            frequency_khz: 98_500,
+        };
+        screen.frequency_khz = 98_500;
+        screen.rssi = -60;
+        screen.preset_count = 3;
+        screen.presets[0] = 88_000;
+        screen.presets[1] = 98_500;
+        screen.presets[2] = 107_900;
+        let mut fb = [0u16; CONTENT_PIXELS];
+        screen.draw(&mut fb);
+        let any_set = fb.iter().any(|&px| px != 0);
+        assert!(any_set, "FM screen with presets must render visible content");
+    }
+
+    #[test]
+    fn format_u8_into_covers_one_two_and_three_digit_values() {
+        let mut buf = [0u8; 3];
+
+        let len = format_u8_into(0, &mut buf);
+        assert_eq!(core::str::from_utf8(&buf[..len]).unwrap_or(""), "0");
+
+        let len = format_u8_into(9, &mut buf);
+        assert_eq!(core::str::from_utf8(&buf[..len]).unwrap_or(""), "9");
+
+        let len = format_u8_into(15, &mut buf);
+        assert_eq!(core::str::from_utf8(&buf[..len]).unwrap_or(""), "15");
+
+        let len = format_u8_into(255, &mut buf);
+        assert_eq!(core::str::from_utf8(&buf[..len]).unwrap_or(""), "255");
     }
 
     #[test]

--- a/crates/thumos/src/sms.rs
+++ b/crates/thumos/src/sms.rs
@@ -363,14 +363,20 @@ impl SmsManager {
         transport.send_at(cmd_str).map_err(|_| SmsError::TransportError)?;
 
         // Wait for the '>' prompt, then send PDU + Ctrl-Z.
+        let mut prompt_received = false;
         for _ in 0..16 {
             let n = transport
                 .recv_line(&mut line_buf, 5000)
                 .map_err(|_| SmsError::TransportError)?;
             let line = &line_buf[..n];
             if !line.is_empty() && line[0] == b'>' {
+                prompt_received = true;
                 break;
             }
+        }
+
+        if !prompt_received {
+            return Err(SmsError::TransportError);
         }
 
         // Send the PDU hex followed by Ctrl-Z (0x1A).
@@ -686,6 +692,32 @@ mod tests {
             result,
             Err(SmsError::CmsError(330)),
             "a +CMS ERROR final result on SMS submit must surface the code immediately, not TransportError after exhausting the wait loop"
+        );
+    }
+
+    #[test]
+    fn send_returns_transport_error_when_prompt_never_received() {
+        use crate::telephony_mock::MockModemTransport;
+
+        let mut mock = MockModemTransport::new();
+        mock.queue_ok(); // AT+CMGF=0 -> OK
+        // Never queue a '>' prompt line: 16 non-prompt lines exhaust the
+        // wait loop without ever seeing the modem's data-entry prompt.
+        for _ in 0..16 {
+            mock.queue_response(b"");
+        }
+
+        let result = SmsManager::send(&mut mock, "+15551234567", "Hi");
+
+        assert_eq!(
+            result,
+            Err(SmsError::TransportError),
+            "exhausting the '>' prompt wait loop must return TransportError, not fall through to PDU transmission"
+        );
+        assert_eq!(
+            mock.sent_commands.len(),
+            2,
+            "the PDU must never be transmitted when the '>' prompt was not received; only AT+CMGF=0 and AT+CMGS=<len> may have been sent"
         );
     }
 


### PR DESCRIPTION
The last directly-actionable audit defects.

- **#295** — `SmsManager::send` fell through to PDU transmission when the modem `>` prompt loop exhausted 16 attempts without the prompt — sending a PDU the modem isn't waiting for. Now returns `TransportError` if the prompt never arrives. _(Corrected: the code is in `thumos/sms.rs`, not klesis.)_
- **#392** — the FM screen re-allocated heap Strings via `alloc::format!` every draw (frequency + up to 12 preset labels/frequencies + volume). Replaced with no-alloc stack-buffer formatters mirroring `screen_alarm.rs`; `extern crate alloc` removed.
- **#416** (hardening follow-up filed earlier this session) — mmu.rs's `L2_ALLOC`/`ADDR_SPACE_ALLOC` pool bitmasks used unlocked non-atomic RMW (same class as #331). Each pool now has its own `irq::IrqSpinlock`; one-directional lock order (ADDR_SPACE→L2), no deadlock.

## Closes

Closes #295, #392, #416

## Verification

- kernel nextest 1838→1845 (+7, incl. the IRQ-lock masking tests for both new pool locks)
- armv7a compiles; kanon lint clean