### PR TITLE
Low-severity rollup across 9 workspace crates (real fixes + coverage)

### DIFF
--- a/crates/asphaleia/src/dns.rs
+++ b/crates/asphaleia/src/dns.rs
@@ -82,12 +82,18 @@ impl DnsBlocklist {
     /// the blocklist.
     ///
     /// `data` must be the DNS message payload (not the IP/UDP framing).
-    /// Returns `true` if the query should be blocked.
+    /// Returns `true` if the query should be blocked, including when the
+    /// message cannot be decoded (non-UTF-8 label, compression pointer,
+    /// truncated, malformed QDCOUNT) — this matches the crate's
+    /// parse-failure-denies default (see `filter.rs`).
     #[must_use]
     pub(crate) fn blocks_dns_payload(&self, data: &[u8]) -> bool {
+        // WHY: fail CLOSED. An undecodable query must not bypass the
+        // blocklist — a malicious app could otherwise evade domain
+        // blocking with a deliberately malformed query.
         extract_query_domain(data)
             .as_deref()
-            .is_some_and(|d| self.is_blocked(d))
+            .is_none_or(|d| self.is_blocked(d))
     }
 }
 
@@ -249,6 +255,19 @@ mod tests {
     }
 
     #[test]
+    fn rejects_compression_pointer_in_qname() {
+        let mut msg = make_dns_query("example.com");
+        // Overwrite the first QNAME label-length byte with a compression
+        // pointer (top two bits SET) — the anti-spoof guard must reject it.
+        msg[DNS_HEADER_LEN] = 0xC0;
+        assert_eq!(
+            extract_query_domain(&msg),
+            None,
+            "QNAME starting with a compression pointer must return None"
+        );
+    }
+
+    #[test]
     fn blocklist_exact_match_blocks_domain() {
         let bl = DnsBlocklist::with_surveillance_defaults();
         assert!(
@@ -327,6 +346,27 @@ mod tests {
         assert!(
             !bl.blocks_dns_payload(&msg),
             "example.com DNS query must not be blocked"
+        );
+    }
+
+    #[test]
+    fn blocks_dns_payload_fails_closed_on_non_utf8_label() {
+        let bl = DnsBlocklist::with_surveillance_defaults();
+        let mut msg = vec![
+            0x12, 0x34, // ID
+            0x01, 0x00, // QR=0, OPCODE=0, RD=1
+            0x00, 0x01, // QDCOUNT = 1
+            0x00, 0x00, // ANCOUNT = 0
+            0x00, 0x00, // NSCOUNT = 0
+            0x00, 0x00, // ARCOUNT = 0
+        ];
+        msg.push(3); // label length
+        msg.extend_from_slice(&[0xFF, 0xFE, 0xFD]); // invalid UTF-8 label bytes
+        msg.push(0x00); // root label
+        msg.extend_from_slice(&[0x00, 0x01, 0x00, 0x01]); // QTYPE/QCLASS
+        assert!(
+            bl.blocks_dns_payload(&msg),
+            "an undecodable query (non-UTF-8 label) must fail closed, not bypass the blocklist"
         );
     }
 }

--- a/crates/asphaleia/src/filter.rs
+++ b/crates/asphaleia/src/filter.rs
@@ -53,19 +53,19 @@ impl Filter {
         &mut self.ruleset
     }
 
-    /// Evaluate a raw IPv4 packet and return the action to take.
+    /// Evaluate a raw IPv4 packet in the given `direction` and return the
+    /// action to take.
     ///
-    /// All packets from the modem are treated as inbound (`Direction::In`).
     /// Packets that fail to parse are denied (fail-closed).
-    pub(crate) fn evaluate(&mut self, packet: &[u8]) -> Action {
-        let action = self.classify(packet);
+    pub(crate) fn evaluate(&mut self, packet: &[u8], direction: Direction) -> Action {
+        let action = self.classify(packet, direction);
         self.record(action);
         action
     }
 
     // Private helpers
 
-    fn classify(&self, packet: &[u8]) -> Action {
+    fn classify(&self, packet: &[u8], direction: Direction) -> Action {
         let Ok(ip) = IpHeader::parse(packet) else {
             return Action::Deny;
         };
@@ -103,7 +103,7 @@ impl Filter {
         };
 
         let info = PacketInfo {
-            direction: Direction::In,
+            direction,
             protocol,
             src_addr: ip.src_addr,
             dst_addr: ip.dst_addr,
@@ -200,11 +200,36 @@ mod tests {
     }
 
     #[test]
+    fn evaluate_honors_direction_parameter_for_outbound_rules() {
+        let mut f = Filter::new();
+        f.ruleset_mut().add_rule(Rule {
+            direction: Direction::Out,
+            protocol: Protocol::Tcp,
+            src_addr: AddressMatch::any(),
+            dst_addr: AddressMatch::any(),
+            src_port: PortMatch::Any,
+            dst_port: PortMatch::Single(443),
+            action: Action::Allow,
+        });
+        let pkt = make_ip_tcp([10, 0, 0, 1], [1, 2, 3, 4], 54321, 443);
+        assert_eq!(
+            f.evaluate(&pkt, Direction::Out),
+            Action::Allow,
+            "outbound-only rule must match when the packet is evaluated as Direction::Out"
+        );
+        assert_eq!(
+            f.evaluate(&pkt, Direction::In),
+            Action::Deny,
+            "the same outbound-only rule must not match when evaluated as Direction::In"
+        );
+    }
+
+    #[test]
     fn empty_filter_denies_all_packets() {
         let mut f = Filter::new();
         let pkt = make_ip_tcp([1, 2, 3, 4], [10, 0, 0, 1], 54321, 80);
         assert_eq!(
-            f.evaluate(&pkt),
+            f.evaluate(&pkt, Direction::In),
             Action::Deny,
             "empty filter must deny all packets"
         );
@@ -224,7 +249,7 @@ mod tests {
         });
         let pkt = make_ip_tcp([1, 2, 3, 4], [10, 0, 0, 1], 54321, 80);
         assert_eq!(
-            f.evaluate(&pkt),
+            f.evaluate(&pkt, Direction::In),
             Action::Allow,
             "matching allow rule must permit packet to port 80"
         );
@@ -244,7 +269,7 @@ mod tests {
         });
         let garbage = [0xFFu8; 5];
         assert_eq!(
-            f.evaluate(&garbage),
+            f.evaluate(&garbage, Direction::In),
             Action::Deny,
             "unparseable packet must be denied even with allow-all rule"
         );
@@ -266,9 +291,9 @@ mod tests {
         let allowed = make_ip_tcp([10, 0, 0, 2], [10, 0, 0, 1], 1234, 443);
         let denied = make_ip_tcp([10, 0, 0, 3], [10, 0, 0, 1], 1234, 443);
 
-        f.evaluate(&allowed);
-        f.evaluate(&allowed);
-        f.evaluate(&denied);
+        f.evaluate(&allowed, Direction::In);
+        f.evaluate(&allowed, Direction::In);
+        f.evaluate(&denied, Direction::In);
 
         assert_eq!(f.packets_allowed, 2, "two allowed packets must be counted");
         assert_eq!(f.packets_denied, 1, "one denied packet must be counted");
@@ -292,7 +317,7 @@ mod tests {
         });
 
         let pkt = make_ip_tcp([1, 2, 3, 4], [10, 0, 0, 1], 12345, 80);
-        f.evaluate(&pkt);
+        f.evaluate(&pkt, Direction::In);
 
         assert_eq!(
             f.packets_denied, 1,
@@ -326,7 +351,7 @@ mod tests {
         let dns_payload = make_dns_query_bytes("app-measurement.com");
         let pkt = make_ip_udp([10, 0, 0, 2], [8, 8, 8, 8], 54321, DNS_PORT, &dns_payload);
         assert_eq!(
-            f.evaluate(&pkt),
+            f.evaluate(&pkt, Direction::In),
             Action::Deny,
             "DNS query for app-measurement.com must be denied by blocklist"
         );
@@ -349,7 +374,7 @@ mod tests {
         let dns_payload = make_dns_query_bytes("example.com");
         let pkt = make_ip_udp([10, 0, 0, 2], [8, 8, 8, 8], 54321, DNS_PORT, &dns_payload);
         assert_eq!(
-            f.evaluate(&pkt),
+            f.evaluate(&pkt, Direction::In),
             Action::Allow,
             "DNS query for example.com must pass the blocklist"
         );

--- a/crates/kelyphos/src/transport.rs
+++ b/crates/kelyphos/src/transport.rs
@@ -798,4 +798,96 @@ mod tests {
             "a max-size frame must be reassembled at full length, never silently truncated"
         );
     }
+
+    #[test]
+    fn rx_parser_assembles_back_to_back_frames() {
+        // WHY: the RX parser resets to WaitSof immediately after every
+        // completed frame (match or mismatch), so a second frame arriving
+        // with no gap after the first must not be lost or merged into the
+        // first frame's tail.
+        let frame_a = make_frame(0, b"first");
+        let frame_b = make_frame(1, b"second");
+        let mut encoded_a = [0u8; TX_FRAME_MAX_ENCODED];
+        let mut encoded_b = [0u8; TX_FRAME_MAX_ENCODED];
+        let len_a = frame_a.encode(&mut encoded_a);
+        let len_b = frame_b.encode(&mut encoded_b);
+
+        let mut t = StpTransport::new();
+        let mut completed: Vec<Vec<u8>> = Vec::new();
+        for &byte in encoded_a
+            .iter()
+            .take(len_a)
+            .chain(encoded_b.iter().take(len_b))
+        {
+            if let Some(raw) = t.receive_byte(byte) {
+                completed.push(raw.to_vec());
+            }
+        }
+
+        assert_eq!(
+            completed.len(),
+            2,
+            "both back-to-back frames must be surfaced as complete, got {completed:?}"
+        );
+        assert_eq!(
+            completed[0].len(),
+            len_a,
+            "first frame length must match its own encoding, not bleed into the second"
+        );
+        assert_eq!(
+            completed[1].len(),
+            len_b,
+            "second frame length must match its own encoding"
+        );
+        assert_eq!(
+            t.crc_errors(),
+            0,
+            "two intact back-to-back frames must not register any CRC errors"
+        );
+    }
+
+    #[test]
+    fn rx_parser_resyncs_after_truncated_frame_precedes_valid_frame() {
+        // WHY: simulates a truncated/corrupted transmission  -  an SOF
+        // followed by an all-zero header (decodes to a zero-length payload)
+        // and a garbage CRC, mirroring a dropped/re-established UART link.
+        // The bogus mini-frame is fully consumed and rejected without
+        // wedging the state machine, so the parser must resynchronize
+        // cleanly on the SOF of the frame that follows.
+        let truncated_then_garbage = [0x80u8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+
+        let frame = make_frame(2, b"resynced");
+        let mut encoded = [0u8; TX_FRAME_MAX_ENCODED];
+        let len = frame.encode(&mut encoded);
+
+        let mut t = StpTransport::new();
+        for &byte in &truncated_then_garbage {
+            let _ = t.receive_byte(byte);
+        }
+        let crc_errors_before_valid_frame = t.crc_errors();
+
+        let mut complete = None;
+        for &byte in encoded.iter().take(len) {
+            if let Some(raw) = t.receive_byte(byte) {
+                complete = Some(raw.to_vec());
+            }
+        }
+
+        let raw = complete.unwrap_or_default();
+        assert_eq!(
+            raw.first().copied(),
+            Some(0x80),
+            "the valid frame following the truncated/garbage prefix must start with SOF"
+        );
+        assert_eq!(
+            raw.len(),
+            len,
+            "the valid frame following the truncated/garbage prefix must be fully reassembled"
+        );
+        assert_eq!(
+            t.crc_errors(),
+            crc_errors_before_valid_frame,
+            "the valid frame itself must not register a new CRC error"
+        );
+    }
 }

--- a/crates/kelyphos/src/wmt.rs
+++ b/crates/kelyphos/src/wmt.rs
@@ -199,6 +199,16 @@ pub(crate) enum WmtError {
         /// Human-readable current state ("enabled" or "disabled").
         state: &'static str,
     },
+
+    /// `enable_subsystem` called before CONSYS completed power-on  -  the RF
+    /// regulator would be enabled onto an unpowered/partially-reset CONSYS.
+    #[snafu(display(
+        "CONSYS is not powered on; call power_on before enabling subsystem {subsystem:?}"
+    ))]
+    ConsysNotPoweredOn {
+        /// Subsystem the caller attempted to enable.
+        subsystem: Subsystem,
+    },
 }
 
 // ── Domain types ──────────────────────────────────────────────────────────────
@@ -829,9 +839,13 @@ impl<R: RegisterIo> WmtManager<R> {
     /// Enable a radio subsystem.
     ///
     /// Turns on the appropriate PMIC regulator for the subsystem and records
-    /// it as active. CONSYS must already be powered on.
+    /// it as active. CONSYS must already be powered on  -  returns
+    /// [`WmtError::ConsysNotPoweredOn`] otherwise.
     #[must_use = "subsystem enable failure must be handled"]
     pub(crate) fn enable_subsystem(&mut self, subsystem: Subsystem) -> Result<(), WmtError> {
+        if self.power != PowerState::On {
+            return Err(WmtError::ConsysNotPoweredOn { subsystem });
+        }
         if self.subsystems & subsystem.mask() != 0 {
             return Err(WmtError::SubsystemStateConflict {
                 subsystem,
@@ -1270,6 +1284,28 @@ mod tests {
     }
 
     // ── subsystem enable/disable ──────────────────────────────────────────────
+
+    #[test]
+    fn enable_subsystem_before_power_on_returns_error() {
+        let io = FakeIo::new();
+        let mut mgr = WmtManager::new(io);
+        let err = mgr
+            .enable_subsystem(Subsystem::Bt)
+            .expect_err("enabling a subsystem before power_on must fail");
+        assert!(
+            matches!(
+                err,
+                WmtError::ConsysNotPoweredOn {
+                    subsystem: Subsystem::Bt
+                }
+            ),
+            "error must be ConsysNotPoweredOn, got {err:?}"
+        );
+        assert_eq!(
+            mgr.io.regulators, 0,
+            "the regulator must not be touched when CONSYS is not powered on"
+        );
+    }
 
     #[test]
     fn enable_subsystem_bt_succeeds() {

--- a/crates/klesis/src/at.rs
+++ b/crates/klesis/src/at.rs
@@ -8,7 +8,7 @@ use nom::Parser;
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until, take_while1};
 use nom::character::complete::{char, digit1};
-use nom::combinator::{map, map_res, opt, value};
+use nom::combinator::{map, map_res, opt, value, verify};
 use nom::sequence::{delimited, preceded};
 
 use crate::error::{Error, Result};
@@ -128,12 +128,15 @@ impl From<u8> for SignalStrength {
         } else {
             -113 + (i16::from(rssi) * 2)
         };
-        let bars = match dbm {
-            ..=-100 => 0,
-            -99..=-85 => 1,
-            -84..=-70 => 2,
-            -69..=-55 => 3,
-            _ => 4,
+        // NOTE: thresholds mirror the kernel's telephony_parser::dbm_to_bars
+        // (the canonical 3GPP-derived dBm mapping) so klesis and the kernel
+        // never disagree on how many bars a given dBm value reports.
+        let bars: u8 = match dbm {
+            d if d >= -70 => 4,
+            d if d >= -85 => 3,
+            d if d >= -100 => 2,
+            d if d >= -110 => 1,
+            _ => 0,
         };
         Self {
             rssi_raw: rssi,
@@ -216,11 +219,26 @@ pub(crate) fn parse_ring(input: &str) -> IResult<&str, Urc> {
     value(Urc::Ring, tag("RING")).parse(input)
 }
 
+/// Maximum length accepted for a `+CMTI` storage-location name.
+///
+/// SECURITY: `storage` is a modem-controlled field; without a bound,
+/// `take_until` allocates a `String` proportional to whatever a
+/// malicious/malfunctioning modem sends before the next `"`. Real storage
+/// identifiers (`"SM"`, `"ME"`, `"MT"`, `"SR"`) are 2-3 chars; this stays
+/// generous while removing the unbounded allocation.
+const MAX_CMTI_STORAGE_LEN: usize = 16;
+
 /// Parse a +CMTI URC: +CMTI: "<storage>",<index>
 pub(crate) fn parse_cmti(input: &str) -> IResult<&str, Urc> {
     let (input, _) = tag("+CMTI: ").parse(input)?;
-    let (input, storage) =
-        delimited(char('"'), map(take_until("\""), String::from), char('"')).parse(input)?;
+    let (input, storage) = delimited(
+        char('"'),
+        verify(map(take_until("\""), String::from), |s: &String| {
+            s.len() <= MAX_CMTI_STORAGE_LEN
+        }),
+        char('"'),
+    )
+    .parse(input)?;
     let (input, _) = char(',').parse(input)?;
     let (input, index) = map_res(digit1, str::parse::<u16>).parse(input)?;
     Ok((input, Urc::Cmti { storage, index }))
@@ -346,6 +364,16 @@ mod tests {
     }
 
     #[test]
+    fn parse_final_result_bare_error() {
+        let (_, resp) = parse_final_result("ERROR").unwrap_or_default();
+        assert_eq!(
+            resp,
+            Response::Error,
+            "bare 'ERROR' must parse to Response::Error"
+        );
+    }
+
+    #[test]
     fn parse_cme_error() {
         let (_, resp) = parse_final_result("+CME ERROR: 10").unwrap_or_default();
         assert_eq!(
@@ -379,7 +407,18 @@ mod tests {
             sig.dbm, -77,
             "RSSI 18 must convert to -77 dBm per AT+CSQ formula"
         );
-        assert_eq!(sig.bars, 2, "RSSI 18 (-77 dBm) must be 2 bars");
+        assert_eq!(sig.bars, 3, "RSSI 18 (-77 dBm) must be 3 bars");
+    }
+
+    #[test]
+    fn signal_strength_bars_match_telephony_parser_thresholds() {
+        // WHY: locks bar thresholds to the kernel's telephony_parser::dbm_to_bars
+        // boundary values so a future edit on either side cannot silently
+        // diverge again.
+        // rssi=21 -> dbm = -113 + 21*2 = -71 dBm (just below -70)
+        assert_eq!(SignalStrength::from(21u8).bars, 3, "-71 dBm must be 3 bars");
+        // rssi=22 -> dbm = -113 + 22*2 = -69 dBm (at/above -70)
+        assert_eq!(SignalStrength::from(22u8).bars, 4, "-69 dBm must be 4 bars");
     }
 
     #[test]
@@ -436,6 +475,17 @@ mod tests {
                 index: 3,
             },
             "CMTI URC must parse storage and index correctly"
+        );
+    }
+
+    #[test]
+    fn parse_cmti_rejects_oversized_storage() {
+        let long_storage = "X".repeat(MAX_CMTI_STORAGE_LEN + 1);
+        let input = format!("+CMTI: \"{long_storage}\",3");
+        let result = parse_cmti(&input);
+        assert!(
+            result.is_err(),
+            "storage field longer than MAX_CMTI_STORAGE_LEN must be rejected"
         );
     }
 

--- a/crates/klesis/src/ccci.rs
+++ b/crates/klesis/src/ccci.rs
@@ -279,11 +279,23 @@ impl CcciMessage {
     /// # Errors
     ///
     /// Returns [`crate::error::Error::Parse`] when `buf` is shorter than
-    /// [`HEADER_SIZE`].
+    /// [`HEADER_SIZE`], or when the payload exceeds [`CCCI_MTU`].
     pub(crate) fn from_bytes(buf: &[u8]) -> Result<Self> {
         let header = CcciHeader::from_bytes(buf)?;
-        let payload = buf.get(HEADER_SIZE..).unwrap_or(&[]).to_vec();
-        Ok(Self { header, payload })
+        let payload = buf.get(HEADER_SIZE..).unwrap_or(&[]);
+        ensure!(
+            payload.len() <= CCCI_MTU,
+            ParseSnafu {
+                message: format!(
+                    "CCCI payload {} bytes exceeds MTU {CCCI_MTU}",
+                    payload.len()
+                ),
+            }
+        );
+        Ok(Self {
+            header,
+            payload: payload.to_vec(),
+        })
     }
 }
 
@@ -341,6 +353,19 @@ mod tests {
         let msg = CcciMessage::new(hdr, payload);
         let decoded = CcciMessage::from_bytes(&msg.to_bytes()).unwrap_or_default();
         assert_eq!(msg, decoded, "message roundtrip must be lossless");
+    }
+
+    #[test]
+    fn message_from_bytes_rejects_oversized_payload() {
+        // WHY: CCCI_MTU bounds a modem-controlled payload against a
+        // malicious/malfunctioning modem sending far more than the hardware
+        // MTU allows.
+        let buf = vec![0u8; HEADER_SIZE + CCCI_MTU + 1];
+        let result = CcciMessage::from_bytes(&buf);
+        assert!(
+            result.is_err(),
+            "a payload larger than CCCI_MTU must be rejected"
+        );
     }
 
     #[test]

--- a/crates/klesis/src/cldma.rs
+++ b/crates/klesis/src/cldma.rs
@@ -155,12 +155,19 @@ impl TxQueue {
 
     /// Remove and return the oldest descriptor from the ring.
     ///
-    /// Returns `None` when the ring is empty.
+    /// Returns `None` when the ring is empty, or when the oldest descriptor
+    /// is still hardware-owned (the DMA engine has not cleared `HWO` yet --
+    /// nothing is ready to reclaim).
     pub(crate) fn dequeue(&mut self) -> Option<Gpd> {
         if self.is_empty() {
             return None;
         }
         let gpd = self.ring[self.tail];
+        if gpd.is_hw_owned() {
+            // WARNING: DMA has not cleared HWO; the descriptor is still
+            // hardware-owned and must not be reclaimed yet.
+            return None;
+        }
         self.tail = (self.tail + 1) % self.capacity;
         self.len -= 1;
         Some(gpd)
@@ -293,7 +300,7 @@ mod tests {
         assert!(q.is_empty(), "new queue must be empty");
 
         let gpd = Gpd {
-            flags: GPD_FLAG_HWO,
+            flags: 0,
             data_len: 20,
             ..Gpd::default()
         };
@@ -303,6 +310,27 @@ mod tests {
         let out = q.dequeue().unwrap_or_default();
         assert_eq!(out, gpd, "dequeued descriptor must equal enqueued one");
         assert!(q.is_empty(), "queue must be empty after dequeue");
+    }
+
+    #[test]
+    fn tx_queue_dequeue_blocks_while_hw_owned() {
+        let mut q = TxQueue::new(4);
+        let gpd = Gpd {
+            flags: GPD_FLAG_HWO,
+            data_len: 20,
+            ..Gpd::default()
+        };
+        q.enqueue(gpd).unwrap_or_default();
+
+        assert!(
+            q.dequeue().is_none(),
+            "dequeue must not reclaim a descriptor while the DMA engine still owns it"
+        );
+        assert_eq!(
+            q.len(),
+            1,
+            "queue length must be unchanged when HWO blocks reclaim"
+        );
     }
 
     #[test]

--- a/crates/klesis/src/gsm7.rs
+++ b/crates/klesis/src/gsm7.rs
@@ -179,6 +179,13 @@ pub(crate) fn decode(data: &[u8], num_chars: usize) -> Result<String> {
         }
         chars_produced += 1;
     }
+    if pending_ext {
+        return Err(crate::error::Error::PduDecode {
+            offset: data.len(),
+            message: "GSM-7 data ends with a dangling ESC septet (truncated extension char)"
+                .to_owned(),
+        });
+    }
     Ok(out)
 }
 
@@ -222,6 +229,20 @@ mod tests {
         assert!(
             decoded.is_empty(),
             "decoding zero septets must produce empty string"
+        );
+    }
+
+    #[test]
+    fn decode_rejects_trailing_esc_without_extension_code() {
+        // WHY: a lone ESC (0x1B) as the final septet has no following
+        // extension code; decode must error rather than silently drop it
+        // and undercount the output.
+        let encoded = encode("{").unwrap_or_default(); // ESC (0x1B) + ext code
+        // Decode only the first septet (the ESC), starving the extension code.
+        let result = decode(&encoded, 1);
+        assert!(
+            result.is_err(),
+            "a dangling ESC septet at the end of input must be rejected"
         );
     }
 

--- a/crates/klesis/src/pdu.rs
+++ b/crates/klesis/src/pdu.rs
@@ -83,7 +83,13 @@ pub(crate) struct SmsSubmit {
 /// `len_digits` is the number of significant digits (FROM the TP-OA/TP-DA
 /// length octet). `type_byte` is the type-of-address octet. `bcd` is the
 /// packed BCD byte slice (`ceil(len_digits` / 2) bytes).
-fn decode_bcd_address(len_digits: u8, type_byte: u8, bcd: &[u8]) -> Address {
+///
+/// # Errors
+///
+/// Returns [`crate::error::Error::PduDecode`] when a digit nibble falls
+/// outside the valid BCD digit range 0-9 (excluding the 0xF odd-length
+/// filler nibble).
+fn decode_bcd_address(len_digits: u8, type_byte: u8, bcd: &[u8]) -> Result<Address> {
     let type_of_address = match type_byte {
         0x91 => AddressType::International,
         0x81 => AddressType::National,
@@ -103,19 +109,31 @@ fn decode_bcd_address(len_digits: u8, type_byte: u8, bcd: &[u8]) -> Address {
         // Low nibble always present when we have a BCD byte.
         let lo_digit_index = idx * 2;
         if lo_digit_index < digit_count {
+            if lo > 9 {
+                return Err(crate::error::Error::PduDecode {
+                    offset: idx,
+                    message: format!("invalid BCD nibble in originating address: 0x{lo:X}"),
+                });
+            }
             number.push(char::from(b'0' + lo));
         }
         // High nibble may be a filler 0xF for odd-digit numbers.
         let hi_digit_index = idx * 2 + 1;
         if hi_digit_index < digit_count && hi != 0x0F {
+            if hi > 9 {
+                return Err(crate::error::Error::PduDecode {
+                    offset: idx,
+                    message: format!("invalid BCD nibble in originating address: 0x{hi:X}"),
+                });
+            }
             number.push(char::from(b'0' + hi));
         }
     }
 
-    Address {
+    Ok(Address {
         number,
         type_of_address,
-    }
+    })
 }
 
 /// Encode an [`Address`] INTO the PDU wire format.
@@ -323,6 +341,16 @@ const WAP_PUSH_PORT_OMA_CP: u16 = 2948;
 /// Alternative WAP Push destination port used by some implementations.
 const WAP_PUSH_PORT_ALT: u16 = 49999;
 
+/// Maximum accepted hex-string length for a single SMS-DELIVER PDU.
+///
+/// SECURITY: `pdu_hex` originates from modem-controlled storage (`AT+CMGR`
+/// response) and is otherwise unbounded before reaching `hex_decode`.
+/// 3GPP TS 23.040 keeps a single SMS-DELIVER TPDU well under 200 octets
+/// (SMSC prefix + header + address + 140-byte max user data); this cap is
+/// generous headroom against a malicious/malfunctioning modem flooding
+/// `decode_deliver` with an oversized hex string.
+const MAX_PDU_HEX_LEN: usize = 1024;
+
 /// UDH Information Element Identifier for application port addressing (16-bit).
 /// 3GPP TS 23.040 § 9.2.3.24.4.
 const UDH_IEI_APP_PORT_16BIT: u8 = 0x05;
@@ -431,6 +459,14 @@ const fn gsm7_udh_septets(udh_octets: usize) -> usize {
     reason = "udl/udhl/udhi/oa are canonical 3GPP TS 23.040 SMS field abbreviations; renaming would break spec fidelity"
 )]
 pub(crate) fn decode_deliver(pdu_hex: &str) -> Result<SmsDeliver> {
+    if pdu_hex.len() > MAX_PDU_HEX_LEN {
+        return Err(crate::error::Error::InvalidHex {
+            message: format!(
+                "PDU hex string exceeds maximum length ({MAX_PDU_HEX_LEN} chars, got {})",
+                pdu_hex.len()
+            ),
+        });
+    }
     let raw = hex_decode(pdu_hex)?;
     let mut cur = Cursor::new(&raw);
 
@@ -454,7 +490,7 @@ pub(crate) fn decode_deliver(pdu_hex: &str) -> Result<SmsDeliver> {
     let oa_type = cur.read_byte()?;
     let oa_bcd_bytes = usize::from(oa_len_digits.div_ceil(2));
     let oa_bcd = cur.read_slice(oa_bcd_bytes)?;
-    let sender = decode_bcd_address(oa_len_digits, oa_type, oa_bcd);
+    let sender = decode_bcd_address(oa_len_digits, oa_type, oa_bcd)?;
 
     // PID: check for silent SMS / SIM toolkit attack.
     let pid = cur.read_byte()?;
@@ -568,7 +604,17 @@ pub(crate) fn encode_submit(msg: &SmsSubmit) -> Result<String> {
 
 fn dcs_to_encoding(dcs: u8, offset: usize) -> Result<DataEncoding> {
     // NOTE: per 3GPP TS 23.038 § 4, bits 3-2 of DCS (for general GROUP 0x0X)
-    // indicate the character SET: 00=GSM7, 01=8-bit data, 10=UCS-2.
+    // indicate the character SET: 00=GSM7, 01=8-bit data, 10=UCS-2. Bit 5
+    // (0x20) is the compression flag; this decoder does not implement
+    // GSM-7 compression, so a set compression bit must be rejected rather
+    // than silently decoded as uncompressed GSM-7.
+    const DCS_COMPRESSED_BIT: u8 = 0x20;
+    if dcs & DCS_COMPRESSED_BIT != 0 {
+        return Err(crate::error::Error::PduDecode {
+            offset,
+            message: format!("compressed GSM-7 DCS not supported (DCS=0x{dcs:02X})"),
+        });
+    }
     let class_bits = (dcs >> 2) & 0x03;
     match class_bits {
         0b00 => Ok(DataEncoding::Gsm7Bit),
@@ -603,10 +649,19 @@ fn decode_user_data(cur: &mut Cursor<'_>, udl: usize, encoding: DataEncoding) ->
                     pair.first().copied().unwrap_or_default(),
                     pair.get(1).copied().unwrap_or_default(),
                 ]);
-                // WHY: SMS UCS-2 is BMP-only; surrogate pairs are technically
-                // possible but rare and outside our current scope.
-                let ch =
-                    char::from_u32(u32::from(code_unit)).unwrap_or(char::REPLACEMENT_CHARACTER);
+                // WHY: SMS UCS-2 is BMP-only; a lone surrogate code unit
+                // (0xD800-0xDFFF) has no valid Unicode scalar value. Reject
+                // it rather than silently substituting U+FFFD, which would
+                // return Ok(SmsDeliver) with garbled text and hide the
+                // malformed-input signal from the caller.
+                let ch = char::from_u32(u32::from(code_unit)).ok_or_else(|| {
+                    crate::error::Error::PduDecode {
+                        offset: cur.pos,
+                        message: format!(
+                            "UCS-2 user data contains lone surrogate 0x{code_unit:04X}"
+                        ),
+                    }
+                })?;
                 s.push(ch);
             }
             s
@@ -716,7 +771,8 @@ mod tests {
             "second byte must be type-of-address 0x91 (international)"
         );
         // Decode back: len_digits=10, type=0x91, bcd = encoded[2..]
-        let decoded = decode_bcd_address(encoded[0], encoded[1], &encoded[2..]);
+        let decoded = decode_bcd_address(encoded[0], encoded[1], &encoded[2..])
+            .expect("decode must succeed for valid BCD digits");
         assert_eq!(
             decoded.number, "+1234567890",
             "decoded number must match original"
@@ -740,7 +796,8 @@ mod tests {
             11,
             "first byte must be digit count (11)"
         );
-        let decoded = decode_bcd_address(encoded[0], encoded[1], &encoded[2..]);
+        let decoded = decode_bcd_address(encoded[0], encoded[1], &encoded[2..])
+            .expect("decode must succeed for valid BCD digits");
         assert_eq!(
             decoded.number, "+12345678901",
             "decoded number must match 11-digit original including trailing filler nibble"
@@ -757,6 +814,18 @@ mod tests {
         assert!(
             result.is_err(),
             "a non-digit byte ('*') in the address must be rejected, not silently corrupted"
+        );
+    }
+
+    #[test]
+    fn decode_bcd_address_rejects_invalid_nibble() {
+        // Nibble 0xA is not a valid decimal BCD digit (only 0-9 and the
+        // 0xF odd-length filler are legal in a phone-number digit field).
+        let bcd = [0x1A]; // lo=0xA (invalid), hi=1
+        let result = decode_bcd_address(2, 0x91, &bcd);
+        assert!(
+            result.is_err(),
+            "an invalid BCD nibble must be rejected, not silently turned into a non-digit char"
         );
     }
 
@@ -795,6 +864,22 @@ mod tests {
         assert_eq!(
             sms.user_data.text, "Hello",
             "GSM-7 packed bytes must decode to 'Hello'"
+        );
+    }
+
+    #[test]
+    fn decode_scts_negative_timezone() {
+        // WHY: the known-PDU vector above only exercises a zero-offset
+        // timezone byte; this covers the negative-offset branch (sign bit
+        // set) that decode_scts's tz parsing never gets to run otherwise.
+        let scts: [u8; 7] = [
+            0x32, 0x10, 0x51, 0x21, 0x03, 0x00, // 2023-01-15 12:30:00
+            0x0A, // tz: 20 quarters (5h), sign bit set -> negative
+        ];
+        let ts = decode_scts(scts);
+        assert_eq!(
+            ts, "2023-01-15 12:30:00-05:00",
+            "negative timezone byte must produce a '-05:00' offset, got: {ts}"
         );
     }
 
@@ -874,6 +959,20 @@ mod tests {
         );
     }
 
+    #[test]
+    fn decode_deliver_ucs2_rejects_lone_surrogate() {
+        // WHY: a lone UCS-2 surrogate code unit (0xD800-0xDFFF) has no valid
+        // Unicode scalar value; decode must reject it instead of silently
+        // substituting U+FFFD and returning Ok with garbled text.
+        // PDU: DCS=0x08 (UCS-2), UDL=2 bytes, UD=0xD800 (lone high surrogate).
+        let pdu = "00000A91214365870900083210512103000002D800";
+        let result = decode_deliver(pdu);
+        assert!(
+            result.is_err(),
+            "a lone UCS-2 surrogate code unit must be rejected, not replaced with U+FFFD"
+        );
+    }
+
     // ── Edge cases ────────────────────────────────────────────────────────────
 
     #[test]
@@ -950,11 +1049,38 @@ mod tests {
     }
 
     #[test]
+    fn decode_deliver_rejects_oversized_hex() {
+        // WHY: MAX_PDU_HEX_LEN bounds a modem-controlled PDU hex string
+        // against a malicious/malfunctioning modem sending far more than
+        // any real SMS-DELIVER TPDU could require.
+        let oversized = "AA".repeat(600); // 1200 hex chars > MAX_PDU_HEX_LEN
+        let result = decode_deliver(&oversized);
+        assert!(
+            result.is_err(),
+            "a PDU hex string longer than MAX_PDU_HEX_LEN must be rejected"
+        );
+    }
+
+    #[test]
     fn hex_decode_invalid_char_returns_error() {
         let result = hex_decode("GG");
         assert!(
             result.is_err(),
             "non-hex character 'G' must return an error"
+        );
+    }
+
+    // ── DCS classification ───────────────────────────────────────────────────
+
+    #[test]
+    fn dcs_to_encoding_rejects_8bit_data_class() {
+        // class_bits = 0b01 (8-bit data) is not implemented; must be
+        // rejected rather than silently misclassified.
+        let dcs = 0b0000_0100u8; // bits 3-2 = 01, compression bit clear
+        let result = dcs_to_encoding(dcs, 0);
+        assert!(
+            result.is_err(),
+            "DCS class 0b01 (8-bit data) must be rejected"
         );
     }
 
@@ -1197,5 +1323,18 @@ mod tests {
         assert!(is_wap_push_port(49999), "port 49999 must be WAP Push");
         assert!(!is_wap_push_port(80), "port 80 must not be WAP Push");
         assert!(!is_wap_push_port(0), "port 0 must not be WAP Push");
+    }
+
+    #[test]
+    fn dcs_to_encoding_rejects_compressed_gsm7() {
+        // Bit 5 (0x20) set = compressed GSM-7, which this decoder does not
+        // implement; must be rejected rather than silently treated as
+        // uncompressed GSM-7.
+        let dcs = 0b0010_0000u8; // compression bit set, class_bits = 00
+        let result = dcs_to_encoding(dcs, 0);
+        assert!(
+            result.is_err(),
+            "compressed GSM-7 DCS must be rejected, not misclassified as uncompressed"
+        );
     }
 }

--- a/crates/klesis/src/transport.rs
+++ b/crates/klesis/src/transport.rs
@@ -134,18 +134,24 @@ impl<T: ModemTransport> AtSession<T> {
         }
     }
 
-    /// Block until the next unsolicited result code (URC) arrives.
+    /// Poll for the next unsolicited result code (URC).
     ///
     /// Reads lines FROM the transport and attempts to parse each one as a
-    /// known URC. Non-URC lines (blank lines, unrecognised text) are skipped.
+    /// known URC. Non-URC lines (blank lines, unrecognised text) are
+    /// skipped. This does NOT block waiting for bytes to arrive: a
+    /// transport that currently has no data (`recv` returning `0`)
+    /// surfaces immediately as [`crate::error::Error::NotReady`] -- callers
+    /// running a scheduler/poll loop must retry the call, not assume it
+    /// parks until a URC shows up.
     ///
     /// # Errors
     ///
-    /// - [`crate::error::Error::Ccci`] / [`crate::error::Error::NotReady`]
-    ///   on transport failure.
+    /// - [`crate::error::Error::NotReady`] when the transport currently has
+    ///   no data available (transient; retry).
+    /// - [`crate::error::Error::Ccci`] on a hard transport failure.
     /// - [`crate::error::Error::Parse`] on malformed line data.
-    /// - [`crate::error::Error::UnexpectedResponse`] when the transport
-    ///   returns only empty data with no URC.
+    /// - [`crate::error::Error::UnexpectedResponse`] when `MAX_ATTEMPTS`
+    ///   unmatched lines are read without finding a URC.
     pub(crate) fn wait_urc(&mut self) -> Result<Urc> {
         // Limit iterations so callers are not surprised by silent loops during
         // tests; real drivers would add a deadline here.
@@ -352,6 +358,39 @@ mod tests {
                 ci: None,
             },
             "URC must be Creg(RegisteredHome)"
+        );
+    }
+
+    #[test]
+    fn wait_urc_detects_cmti() {
+        let transport = MockTransport::with_response(b"+CMTI: \"SM\",3\r\n");
+        let mut session = AtSession::new(transport);
+        let urc = session.wait_urc().unwrap_or_default();
+        assert_eq!(
+            urc,
+            Urc::Cmti {
+                storage: "SM".to_owned(),
+                index: 3,
+            },
+            "URC must be Cmti(SM,3)"
+        );
+    }
+
+    #[test]
+    fn wait_urc_exhausts_max_attempts() {
+        // WHY: MAX_ATTEMPTS bounds wait_urc against a modem that never
+        // emits a recognised URC line, mirroring send_command's
+        // MAX_INFO_LINES guard.
+        let mut data = Vec::new();
+        for _ in 0..1024 {
+            data.extend_from_slice(b"\r\n");
+        }
+        let transport = MockTransport::with_response(&data);
+        let mut session = AtSession::new(transport);
+        let result = session.wait_urc();
+        assert!(
+            result.is_err(),
+            "wait_urc must error after MAX_ATTEMPTS unmatched lines, not loop forever"
         );
     }
 

--- a/crates/krypta/src/error.rs
+++ b/crates/krypta/src/error.rs
@@ -11,8 +11,10 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[non_exhaustive]
 pub enum Error {
     /// Key generation failed.
-    #[snafu(display("key generation failed"))]
+    #[snafu(display("key generation failed at {location}: {source}"))]
     KeyGeneration {
+        /// Underlying OS RNG failure.
+        source: getrandom::Error,
         /// Source location.
         #[snafu(implicit)]
         location: snafu::Location,

--- a/crates/krypta/src/identity.rs
+++ b/crates/krypta/src/identity.rs
@@ -1,6 +1,7 @@
 //! Ed25519 identity key pairs for signing and authentication.
 
 use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
+use snafu::ResultExt as _;
 use x25519_dalek::StaticSecret;
 
 use crate::error::{InvalidKeySnafu, InvalidSignatureSnafu, KeyGenerationSnafu, Result};
@@ -84,7 +85,7 @@ impl IdentityKeyPair {
     /// Returns [`Error::KeyGeneration`] if key generation or parsing fails.
     pub(crate) fn generate() -> Result<Self> {
         let mut private_key_bytes = [0u8; PRIVATE_KEY_LEN];
-        getrandom::fill(&mut private_key_bytes).map_err(|_| KeyGenerationSnafu.build())?;
+        getrandom::fill(&mut private_key_bytes).context(KeyGenerationSnafu)?;
         let key_pair = SigningKey::from_bytes(&private_key_bytes);
         let public_key_bytes = key_pair.verifying_key().to_bytes();
         Ok(Self {

--- a/crates/krypta/src/ratchet.rs
+++ b/crates/krypta/src/ratchet.rs
@@ -276,6 +276,39 @@ mod tests {
     }
 
     #[test]
+    fn decrypt_does_not_mutate_state_on_auth_failure() -> Result<()> {
+        // An in-order message (gap == 0) that fails authentication must leave
+        // the receive chain key, counter, and skipped-key cache untouched —
+        // only a successfully authenticated message may advance state.
+        let root = root_key(0xDD);
+        let mut send = RatchetState::new(root);
+        let mut recv = RatchetState::new(root);
+        let mut msg = encrypt(&mut send, b"in-order message")?;
+        if let Some(byte) = msg.ciphertext.first_mut() {
+            *byte ^= 0xFF;
+        }
+        let counter_before = recv.counter;
+        let chain_key_before = recv.chain_key;
+        assert!(
+            decrypt(&mut recv, &msg).is_err(),
+            "tampered in-order message must fail authentication"
+        );
+        assert_eq!(
+            recv.counter, counter_before,
+            "a failed in-order decrypt must not advance the receive counter"
+        );
+        assert_eq!(
+            recv.chain_key, chain_key_before,
+            "a failed in-order decrypt must not roll the receive chain key"
+        );
+        assert!(
+            recv.skipped.is_empty(),
+            "a failed in-order decrypt must not populate the skipped-key cache"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn ratchet_advances_for_multiple_messages() -> Result<()> {
         let root = root_key(0x33);
         let mut send_state = RatchetState::new(root);

--- a/crates/krypta/src/session.rs
+++ b/crates/krypta/src/session.rs
@@ -177,6 +177,20 @@ mod tests {
     }
 
     #[test]
+    fn full_send_receive_flow_bob_to_alice() -> Result<()> {
+        let (mut alice, mut bob) = make_sessions()?;
+        let plaintext = b"hello FROM bob";
+        let encrypted = bob.encrypt_message(plaintext)?;
+        let decrypted = alice.decrypt_message(&encrypted)?;
+        assert_eq!(
+            decrypted.as_slice(),
+            plaintext,
+            "alice must recover bob's plaintext"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn full_send_receive_multiple_messages() -> Result<()> {
         let (mut alice, mut bob) = make_sessions()?;
         let messages: &[&[u8]] = &[b"first", b"second", b"third"];

--- a/crates/krypta/src/x3dh.rs
+++ b/crates/krypta/src/x3dh.rs
@@ -2,6 +2,7 @@
 
 use hkdf::Hkdf;
 use sha2::Sha256;
+use snafu::ResultExt as _;
 use x25519_dalek::{PublicKey, StaticSecret};
 
 use crate::error::{KeyAgreementSnafu, KeyDerivationSnafu, KeyGenerationSnafu, Result};
@@ -195,7 +196,8 @@ pub(crate) fn initiate_session(
 ///
 /// Returns [`Error::InvalidKey`] if the initiator's identity key is not a valid
 /// Ed25519 point.
-/// Returns [`Error::KeyAgreement`] if DH fails.
+/// Returns [`Error::KeyAgreement`] if DH fails, or if exactly one side offers a
+/// one-time pre-key.
 /// Returns [`Error::KeyDerivation`] if HKDF fails.
 pub(crate) fn respond_session(
     bundle: OwnedBundle,
@@ -218,12 +220,18 @@ pub(crate) fn respond_session(
     ikm.extend_from_slice(&leg_ephemeral_identity);
     ikm.extend_from_slice(&leg_ephemeral_prekey);
 
-    // Optional one-time pre-key leg: DH(EK_A2, OPK_B).
-    if let (Some(otpk_priv), Some(ek2_pub)) =
-        (bundle.one_time_prekey_private, msg.one_time_ephemeral_key)
-    {
-        let leg_one_time = agree(&otpk_priv, &ek2_pub)?;
-        ikm.extend_from_slice(&leg_one_time);
+    // Optional one-time pre-key leg: DH(EK_A2, OPK_B). WHY: presence must
+    // match on both sides — a bundle/message OTP mismatch (e.g. a MITM
+    // stripping the ephemeral in transit) must fail loudly rather than
+    // silently falling back to the 3-leg secret, which would only surface
+    // downstream as an undiagnosable decrypt failure.
+    match (bundle.one_time_prekey_private, msg.one_time_ephemeral_key) {
+        (Some(otpk_priv), Some(ek2_pub)) => {
+            let leg_one_time = agree(&otpk_priv, &ek2_pub)?;
+            ikm.extend_from_slice(&leg_one_time);
+        }
+        (None, None) => {}
+        (Some(_), None) | (None, Some(_)) => return Err(KeyAgreementSnafu.build()),
     }
 
     derive_keys(&ikm)
@@ -232,7 +240,7 @@ pub(crate) fn respond_session(
 /// Generates a fresh X25519 key pair, returning `(private_key, public_key_bytes)`.
 fn generate_x25519() -> Result<(StaticSecret, [u8; X25519_KEY_LEN])> {
     let mut private_bytes = [0u8; X25519_KEY_LEN];
-    getrandom::fill(&mut private_bytes).map_err(|_| KeyGenerationSnafu.build())?;
+    getrandom::fill(&mut private_bytes).context(KeyGenerationSnafu)?;
     let priv_key = StaticSecret::from(private_bytes);
     let pub_bytes = PublicKey::from(&priv_key).to_bytes();
     Ok((priv_key, pub_bytes))
@@ -425,6 +433,28 @@ mod tests {
         assert_eq!(
             alice_secret.raw, bob_secret.raw,
             "3-leg X3DH (no one-time pre-key) must still agree"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn respond_rejects_missing_one_time_prekey_in_message() -> Result<()> {
+        // Attack model: a MITM strips the optional OTP ephemeral from the
+        // initiator message in transit while the responder's bundle still
+        // holds the matching private key. The mismatch must be a hard error,
+        // not a silent fallback to the 3-leg secret.
+        let alice = IdentityKeyPair::generate()?;
+        let bob = IdentityKeyPair::generate()?;
+        let bob_bundle = create_bundle(&bob)?;
+        let pub_bundle = bob_bundle.public_bundle.clone();
+
+        let (_, _, mut init_msg) = initiate_session(&alice, &pub_bundle)?;
+        init_msg.one_time_ephemeral_key = None;
+
+        let err = respond_session(bob_bundle, &init_msg);
+        assert!(
+            matches!(err, Err(crate::error::Error::KeyAgreement { .. })),
+            "a one-time pre-key present in the bundle but stripped from the message must be rejected"
         );
         Ok(())
     }

--- a/crates/leipsanon/src/engine.rs
+++ b/crates/leipsanon/src/engine.rs
@@ -541,4 +541,36 @@ mod tests {
         assert_eq!(result.actions_failed, 0, "empty-file wipe must not fail");
         assert_eq!(result.bytes_wiped, 0, "an empty file wipes zero bytes");
     }
+
+    #[test]
+    fn missing_wipe_target_counts_as_completed_with_zero_bytes() {
+        // WHY: locks in the documented `execute` contract (see its doc
+        // comment) that a wipe target absent FROM the filesystem is treated
+        // as a benign no-op — not a failure, and counted as completed with
+        // zero bytes wiped — rather than surfacing as an I/O error.
+        let missing = std::env::temp_dir().join(format!(
+            "leipsanon_missing_wipe_target_{}_{}",
+            std::process::id(),
+            TEMP_FILE_COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        let plan = vec![WipeAction {
+            path: missing,
+            method: WipeMethod::Zero,
+            priority: 1,
+        }];
+        let mut engine = WipeEngine::new(false);
+        let result = engine.execute(&plan);
+        assert_eq!(
+            result.actions_completed, 1,
+            "a missing wipe target must still be counted as completed"
+        );
+        assert_eq!(
+            result.actions_failed, 0,
+            "a missing wipe target must not be counted as a failure"
+        );
+        assert_eq!(
+            result.bytes_wiped, 0,
+            "a missing wipe target has nothing to write, so zero bytes are wiped"
+        );
+    }
 }

--- a/crates/leipsanon/src/memory.rs
+++ b/crates/leipsanon/src/memory.rs
@@ -16,8 +16,8 @@ use zeroize::Zeroize as _;
 #[non_exhaustive]
 pub(crate) enum MemoryError {
     /// The system random number generator failed to produce bytes.
-    #[snafu(display("failed to generate random bytes"))]
-    RandomGeneration,
+    #[snafu(display("failed to generate random bytes: {source}"))]
+    RandomGeneration { source: getrandom::Error },
 }
 
 // ----- Functions ------------------------------------------------------------
@@ -36,7 +36,7 @@ pub(crate) fn secure_zero(buf: &mut [u8]) {
 ///
 /// Returns [`MemoryError::RandomGeneration`] if the system RNG fails.
 pub(crate) fn secure_random_fill(buf: &mut [u8]) -> Result<(), MemoryError> {
-    getrandom::fill(buf).map_err(|_| MemoryError::RandomGeneration)
+    getrandom::fill(buf).map_err(|source| MemoryError::RandomGeneration { source })
 }
 
 // ----- Types ----------------------------------------------------------------
@@ -147,6 +147,26 @@ mod tests {
             "empty buffer must remain empty after secure_random_fill"
         );
         Ok(())
+    }
+
+    #[test]
+    fn random_generation_error_reports_source_detail() {
+        // WHY: the underlying getrandom::Error carries a diagnosable OS
+        // error code / description; MemoryError::RandomGeneration must embed
+        // it (via `source`) rather than discard it, so an operator can tell
+        // WHY the panic-wipe RNG failed instead of a bare generic message.
+        let err = MemoryError::RandomGeneration {
+            source: getrandom::Error::UNSUPPORTED,
+        };
+        let message = err.to_string();
+        assert!(
+            message.contains("failed to generate random bytes"),
+            "error message must retain the constant prefix"
+        );
+        assert!(
+            message.len() > "failed to generate random bytes".len(),
+            "error message must include the embedded source detail, not just the generic prefix"
+        );
     }
 
     #[test]

--- a/crates/leipsanon/src/targets.rs
+++ b/crates/leipsanon/src/targets.rs
@@ -264,4 +264,28 @@ mod tests {
             "key actions in Everything plan must retain priority 1"
         );
     }
+
+    #[test]
+    fn plan_priorities_are_ascending_for_every_level() {
+        // WHY: `plan`'s doc comment (see above) contracts the returned list
+        // is ordered by ascending priority; WipeEngine::execute relies on
+        // this to wipe keys before anything else. The contract was
+        // previously unverified — a future level that pushed actions out of
+        // priority order would silently break it.
+        let levels = [
+            WipeLevel::Keys,
+            WipeLevel::Contacts,
+            WipeLevel::Messages,
+            WipeLevel::UserData,
+            WipeLevel::Everything,
+        ];
+        for level in levels {
+            let p = plan(level);
+            let priorities: Vec<u8> = p.iter().map(|a| a.priority).collect();
+            assert!(
+                priorities.is_sorted(),
+                "plan({level:?}) must be ordered by ascending priority, got {priorities:?}"
+            );
+        }
+    }
 }

--- a/crates/metaxu/src/client.rs
+++ b/crates/metaxu/src/client.rs
@@ -111,4 +111,39 @@ mod tests {
             })
         ));
     }
+
+    struct MismatchedResponseRuntime;
+
+    impl BridgeTransport for MismatchedResponseRuntime {
+        fn exchange(&mut self, request_frame: &[u8]) -> Result<Vec<u8>> {
+            let _request = decode_request(request_frame)?;
+            let response = TaskResponse::accepted(Ulid::from_bytes([99; 16]), DeviceAction::None);
+            encode_response(&response)
+        }
+    }
+
+    #[test]
+    fn client_reports_response_request_mismatch() {
+        let request_id = Ulid::from_bytes([3; 16]);
+        let request = TaskRequest::SendSms {
+            request_id,
+            identity: identity_ref(),
+            grants: vec![CapabilityGrant::new(
+                Capability::SmsSend,
+                "policy",
+                "grant-sms-2",
+            )],
+            to: "+15550001111".into(),
+            body: "mismatch test".into(),
+        };
+
+        let mut client = BridgeClient::new(MismatchedResponseRuntime);
+        let result = client.submit(&request);
+
+        assert!(matches!(
+            result,
+            Err(crate::Error::ResponseRequestMismatch { response_id, .. })
+                if response_id == Ulid::from_bytes([99; 16])
+        ));
+    }
 }

--- a/crates/metaxu/src/lib.rs
+++ b/crates/metaxu/src/lib.rs
@@ -117,7 +117,7 @@ mod tests {
 
     use super::{
         Capability, CapabilityGrant, DeviceIdentityRef, Error, IdentityKind, TaskRequest,
-        decode_request, encode_request,
+        decode_request, decode_response, encode_request,
     };
 
     #[test]
@@ -138,5 +138,19 @@ mod tests {
 
         assert_eq!(decoded, request);
         Ok(())
+    }
+
+    #[test]
+    fn decode_request_rejects_malformed_bytes() {
+        let result = decode_request(&[]);
+
+        assert!(matches!(result, Err(Error::Decode { .. })));
+    }
+
+    #[test]
+    fn decode_response_rejects_malformed_bytes() {
+        let result = decode_response(&[]);
+
+        assert!(matches!(result, Err(Error::Decode { .. })));
     }
 }

--- a/crates/metaxu/src/protocol.rs
+++ b/crates/metaxu/src/protocol.rs
@@ -375,3 +375,58 @@ pub(crate) fn encode_response(response: &TaskResponse) -> Result<Vec<u8>> {
 pub(crate) fn decode_response(bytes: &[u8]) -> Result<TaskResponse> {
     postcard::from_bytes(bytes).context(crate::error::DecodeSnafu)
 }
+
+#[cfg(test)]
+mod tests {
+    use ulid::Ulid;
+
+    use super::{
+        AudioMode, Capability, CapabilityGrant, DeviceIdentityRef, IdentityKind, TaskRequest,
+        decode_request, encode_request,
+    };
+
+    fn identity_ref() -> DeviceIdentityRef {
+        DeviceIdentityRef::new(IdentityKind::Device, "device-ref", [4; 32])
+    }
+
+    #[test]
+    fn place_call_round_trips() {
+        let request = TaskRequest::PlaceCall {
+            request_id: Ulid::from_bytes([5; 16]),
+            identity: identity_ref(),
+            grants: vec![CapabilityGrant::new(
+                Capability::CallDial,
+                "policy",
+                "grant-call",
+            )],
+            to: "+15559876543".into(),
+        };
+
+        let round_tripped = encode_request(&request)
+            .ok()
+            .and_then(|bytes| decode_request(&bytes).ok());
+
+        assert_eq!(round_tripped, Some(request));
+    }
+
+    #[test]
+    fn audio_session_round_trips() {
+        let request = TaskRequest::AudioSession {
+            request_id: Ulid::from_bytes([6; 16]),
+            identity: identity_ref(),
+            grants: vec![CapabilityGrant::new(
+                Capability::AudioCapture,
+                "policy",
+                "grant-audio",
+            )],
+            mode: AudioMode::Capture,
+            max_duration_ms: 30_000,
+        };
+
+        let round_tripped = encode_request(&request)
+            .ok()
+            .and_then(|bytes| decode_request(&bytes).ok());
+
+        assert_eq!(round_tripped, Some(request));
+    }
+}

--- a/crates/pteron/src/hci.rs
+++ b/crates/pteron/src/hci.rs
@@ -440,8 +440,14 @@ pub(crate) fn decode_event(data: &[u8]) -> Result<HciEvent> {
     }
 
     let event_code = data.get(1).copied().unwrap_or_default();
-    // params start at byte 3 (after H4 type, event code, param_length)
+    let param_length = usize::from(data.get(2).copied().unwrap_or_default());
+    // WHY: params must be bounded to the declared param_length, not every
+    // trailing byte in `data` — otherwise bytes past the real event boundary
+    // would be folded into params (e.g. CommandComplete's return_params).
     let params = data.get(3..).unwrap_or(&[]);
+    let params = params.get(..param_length).ok_or(Error::MalformedEvent {
+        detail: "event: param_length exceeds available bytes",
+    })?;
 
     match event_code {
         EVT_COMMAND_COMPLETE => decode_command_complete(params),
@@ -788,6 +794,35 @@ mod tests {
             "should decode as CommandComplete with num_packets=1, opcode=0x0C03"
         );
         Ok(())
+    }
+
+    #[test]
+    fn decode_command_complete_ignores_trailing_bytes_past_param_length() -> Result<()> {
+        // H4=0x04, evt=0x0E, param_len=4 (num_packets + opcode + 1-byte status),
+        // followed by 2 extra trailing bytes that are not part of this event and
+        // must not leak into return_params.
+        let data = [0x04, 0x0E, 0x04, 0x01, 0x03, 0x0C, 0x00, 0xAA, 0xBB];
+        let evt = decode_event(&data)?;
+        let HciEvent::CommandComplete { return_params, .. } = evt else {
+            unreachable!("expected CommandComplete variant");
+        };
+        assert_eq!(
+            return_params,
+            vec![0x00],
+            "return_params must be bounded to the declared param_length, excluding trailing bytes"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn decode_rejects_param_length_exceeding_available_bytes() {
+        // H4=0x04, evt=0x0E, param_len declares 10 bytes but only 4 follow.
+        let data = [0x04, 0x0E, 0x0A, 0x01, 0x03, 0x0C, 0x00];
+        let result = decode_event(&data);
+        assert!(
+            matches!(result, Err(Error::MalformedEvent { .. })),
+            "a param_length exceeding the actual buffer must be rejected, not silently truncated"
+        );
     }
 
     #[test]

--- a/crates/pteron/src/transport.rs
+++ b/crates/pteron/src/transport.rs
@@ -35,10 +35,13 @@ const STP_DELIMITER_LEN: usize = 2;
 const STP_FUNC_BT: u8 = 0;
 
 /// RX/TX ring buffer capacity mandated by hardware (DRIVER-INTERFACES.md §4.1).
+///
+/// WHY: also the effective STP payload ceiling this driver enforces on both
+/// encode and decode — the STP protocol's own 12-bit length field allows up
+/// to 4095 bytes, but a frame larger than `RING_BUF_SIZE` could never be
+/// received into (or held by) this driver's own ring buffers, so encode and
+/// decode share this tighter bound instead of the raw protocol maximum.
 pub(crate) const RING_BUF_SIZE: usize = 2048;
-
-/// Maximum HCI payload in a single STP frame (12-bit length field).
-const STP_MAX_PAYLOAD: usize = 0xFFF;
 
 /// Default address-rotation interval: 15 minutes in seconds, matching BLE spec
 /// recommendation.
@@ -284,13 +287,13 @@ impl RingBuffer {
 /// # Errors
 ///
 /// Returns [`Error::BufferOverflow`] if `out` is too short for the encoded frame.
-/// Returns [`Error::PayloadTooLarge`] if `payload` exceeds the 12-bit STP length
-/// field maximum.
+/// Returns [`Error::PayloadTooLarge`] if `payload` exceeds [`RING_BUF_SIZE`],
+/// matching the bound [`stp_decode`] enforces on the receive side.
 pub(crate) fn stp_encode(seq: u8, payload: &[u8], out: &mut [u8]) -> Result<usize> {
-    if payload.len() > STP_MAX_PAYLOAD {
+    if payload.len() > RING_BUF_SIZE {
         return Err(Error::PayloadTooLarge {
             length: payload.len(),
-            limit: STP_MAX_PAYLOAD,
+            limit: RING_BUF_SIZE,
         });
     }
     let total = STP_DELIMITER_LEN + STP_HEADER_LEN + payload.len();
@@ -303,7 +306,7 @@ pub(crate) fn stp_encode(seq: u8, payload: &[u8], out: &mut [u8]) -> Result<usiz
 
     let plen = u16::try_from(payload.len()).map_err(|_| Error::PayloadTooLarge {
         length: payload.len(),
-        limit: STP_MAX_PAYLOAD,
+        limit: RING_BUF_SIZE,
     })?;
     let [plen_lo, plen_hi_raw] = plen.to_le_bytes();
     let seq4 = seq & 0x0F;
@@ -693,7 +696,11 @@ impl BtHciTransport {
     pub(crate) const fn tick_seconds(&mut self, secs: u64) -> bool {
         self.secs_since_rotation = self.secs_since_rotation.saturating_add(secs);
         if self.secs_since_rotation >= self.rotation_interval_secs {
-            self.secs_since_rotation = 0;
+            // WARNING: subtract (not reset to 0) so a tick spanning more than
+            // one rotation interval keeps the overrun instead of discarding
+            // it, which would otherwise extend the BLE address-correlation
+            // window past the configured interval.
+            self.secs_since_rotation -= self.rotation_interval_secs;
             return true;
         }
         false
@@ -861,6 +868,23 @@ mod tests {
         );
     }
 
+    #[test]
+    fn stp_encode_rejects_payload_larger_than_ring_buffer() {
+        // WHY: RING_BUF_SIZE + 1 fits the STP protocol's 12-bit length field
+        // (max 4095) but stp_decode could never accept it back; encode and
+        // decode must share the same bound.
+        let payload = vec![0u8; RING_BUF_SIZE + 1];
+        let mut buf = vec![0u8; RING_BUF_SIZE + STP_HEADER_LEN + STP_DELIMITER_LEN + 16];
+        let result = stp_encode(0, &payload, &mut buf);
+        let Err(Error::PayloadTooLarge { limit, .. }) = result else {
+            unreachable!("expected PayloadTooLarge for a payload exceeding RING_BUF_SIZE");
+        };
+        assert_eq!(
+            limit, RING_BUF_SIZE,
+            "encode's payload limit must match decode's RING_BUF_SIZE bound"
+        );
+    }
+
     // ── Reset state machine ──
 
     #[test]
@@ -931,6 +955,30 @@ mod tests {
             transport.rx.peek_at(3),
             Some(0x00),
             "fourth byte must be 0x00 (hw_code)"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn reset_state3_advances_even_when_rx_injection_fails() -> Result<()> {
+        let mut transport = BtHciTransport::new();
+        // WHY: fill the RX ring to capacity so the Hardware Error event
+        // injection at state 3 has no room to land, exercising the
+        // documented best-effort-injection failure path.
+        let filler = vec![0u8; RING_BUF_SIZE - 1];
+        assert!(
+            transport.rx.push(&filler),
+            "filler must fit exactly at capacity - 1"
+        );
+
+        transport.advance_reset()?;
+        transport.advance_reset()?;
+        let s3 = transport.advance_reset()?;
+
+        assert_eq!(
+            s3,
+            RstFlag::ResetCompleteEventDelivered,
+            "reset state machine must still advance even when best-effort RX injection fails"
         );
         Ok(())
     }
@@ -1027,6 +1075,23 @@ mod tests {
         assert!(
             !result,
             "rotation counter must reset to 0 after triggering; second early tick must not rotate"
+        );
+    }
+
+    #[test]
+    fn tick_seconds_preserves_overrun_on_large_tick() {
+        let mut transport = BtHciTransport::new();
+        let interval = transport.rotation_interval_secs();
+        let overrun = 47;
+        let due = transport.tick_seconds(interval + overrun);
+        assert!(
+            due,
+            "a tick spanning more than the interval must signal rotation due"
+        );
+        assert_eq!(
+            transport.secs_since_rotation(),
+            overrun,
+            "the overrun beyond the interval must be preserved, not discarded"
         );
     }
 

--- a/crates/stegnos/src/cipher.rs
+++ b/crates/stegnos/src/cipher.rs
@@ -83,6 +83,12 @@ pub(crate) fn encrypt_block(
 ///
 /// Returns [`Error::InvalidKeyLength`] if `key` is not 64 bytes.
 /// Returns [`Error::InvalidBlockSize`] if either buffer is not 4096 bytes.
+///
+/// # Note
+///
+/// XTS provides confidentiality only, not authentication. A mismatched
+/// `block_number` does not produce an error — it silently yields incorrect
+/// plaintext. Callers needing integrity must authenticate at a higher layer.
 pub(crate) fn decrypt_block(
     key: &[u8; XTS_KEY_LEN],
     block_number: u64,
@@ -198,6 +204,26 @@ mod tests {
         assert_ne!(
             plaintext, ciphertext,
             "encrypted block must differ FROM the plaintext"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn decrypt_with_wrong_block_number_does_not_error() -> super::Result<()> {
+        let key = sample_xts_key();
+        let plaintext = sample_plaintext();
+        let mut ciphertext = [0u8; BLOCK_SIZE];
+        let mut recovered = [0u8; BLOCK_SIZE];
+
+        encrypt_block(&key, 5, &plaintext, &mut ciphertext)?;
+        // WHY: XTS provides no authentication — decrypting with the wrong
+        // tweak succeeds and silently yields incorrect plaintext, it does
+        // not surface as an Err.
+        decrypt_block(&key, 6, &ciphertext, &mut recovered)?;
+
+        assert_ne!(
+            plaintext, recovered,
+            "decrypting with the wrong block_number must not recover the original plaintext"
         );
         Ok(())
     }

--- a/crates/stegnos/src/erase.rs
+++ b/crates/stegnos/src/erase.rs
@@ -58,7 +58,7 @@ pub(crate) struct WipePath {
 /// specified method to each path.
 #[must_use]
 pub(crate) fn wipe_plan(target: WipeTarget) -> Vec<WipePath> {
-    match target {
+    let mut plan = match target {
         WipeTarget::Keys => key_paths(),
 
         WipeTarget::Contacts => vec![WipePath {
@@ -121,7 +121,12 @@ pub(crate) fn wipe_plan(target: WipeTarget) -> Vec<WipePath> {
             ]);
             plan
         }
-    }
+    };
+
+    // INVARIANT: callers execute in priority order; sort defensively instead
+    // of relying on match-arm construction order alone.
+    plan.sort_by_key(|path| path.priority);
+    plan
 }
 
 /// Key material paths, always wiped first (highest priority).
@@ -213,5 +218,25 @@ mod tests {
         assert!(has_keys, "AllUserData plan must include key paths");
         assert!(has_contacts, "AllUserData plan must include contacts path");
         assert!(has_messages, "AllUserData plan must include messages path");
+    }
+
+    #[test]
+    fn wipe_plan_is_sorted_by_priority() {
+        for target in [
+            WipeTarget::Keys,
+            WipeTarget::Contacts,
+            WipeTarget::Messages,
+            WipeTarget::AllUserData,
+            WipeTarget::Everything,
+        ] {
+            let plan = wipe_plan(target);
+            let priorities: Vec<u8> = plan.iter().map(|p| p.priority).collect();
+            let mut sorted = priorities.clone();
+            sorted.sort_unstable();
+            assert_eq!(
+                priorities, sorted,
+                "wipe_plan({target:?}) must be sorted ascending by priority"
+            );
+        }
     }
 }

--- a/crates/topos/src/nmea.rs
+++ b/crates/topos/src/nmea.rs
@@ -287,6 +287,18 @@ mod tests {
     }
 
     #[test]
+    fn parse_gga_returns_error_when_too_few_fields() {
+        let body = "GPGGA,092750.000,5321.6802,N";
+        let checksum = compute_checksum(body);
+        let sentence = format!("${body}*{checksum:02X}");
+        let result = parse_gga(&sentence);
+        assert!(
+            matches!(result, Err(Error::Parse { .. })),
+            "GGA sentence with fewer than 10 fields must return Error::Parse"
+        );
+    }
+
+    #[test]
     fn parse_rmc_extracts_position_speed_and_course() {
         let sentence = "$GPRMC,092750.000,A,5321.6802,N,00630.3372,W,0.02,31.66,280511,,,A*43";
         let fix = parse_rmc(sentence).expect("valid RMC sentence should parse");
@@ -310,6 +322,18 @@ mod tests {
         assert!(
             parse_rmc(sentence).is_err(),
             "RMC with status V (void) must return an error"
+        );
+    }
+
+    #[test]
+    fn parse_rmc_returns_error_when_too_few_fields() {
+        let body = "GPRMC,092750.000,A,5321.6802,N";
+        let checksum = compute_checksum(body);
+        let sentence = format!("${body}*{checksum:02X}");
+        let result = parse_rmc(&sentence);
+        assert!(
+            matches!(result, Err(Error::Parse { .. })),
+            "RMC sentence with fewer than 10 fields must return Error::Parse"
         );
     }
 


### PR DESCRIPTION
Addresses the batched low/info audit findings for the workspace crates — a mix of genuine small defects and untested error/edge paths.

**Real fixes (highlights):**
- **asphaleia** — `blocks_dns_payload` failed *open* on an undecodable query (non-UTF-8 label bypassed the blocklist) → now fails closed; `Filter` hardcoded `Direction::In`, so every outbound rule was **dead code** → `evaluate` now takes the direction.
- **klesis** — realigned dbm→bars thresholds to the kernel's canonical mapping; dangling ESC septet / compressed-GSM-7 DCS / lone UCS-2 surrogate / invalid BCD nibbles now rejected; CCCI payload MTU-bounded; PDU-hex + CMTI length-capped; CLDMA dequeue no longer reclaims a HW-owned descriptor.
- **krypta** — getrandom error source preserved; X3DH respond hard-errors on a one-side-only OTP (MITM strip) instead of silent fallback.
- **kelyphos** — `enable_subsystem` rejects when CONSYS isn't powered on.
- **pteron** — HCI `decode_event` bounds params to `param_length`; STP encode/decode share one bound; BLE rotation preserves tick overrun.
- **leipsanon/stegnos** — getrandom source preserved; wipe-plan priority now sorted + verified; XTS no-auth documented.

Plus focused tests for previously-uncovered error/edge paths across all 9 crates.

## Closes

Closes #278, #279, #283, #380, #381, #383

## Verification

- `cargo test --workspace` — 0 failures (26 suites)
- `cargo clippy --workspace --all-targets -- -D warnings` + doctests + `cargo fmt --all --check` — clean
- `kanon lint` — clean

## Partial umbrellas (left open, commented)

#280 (leipsanon), #281 (metaxu), #382 (pteron) had 2–3 findings each that are genuinely too large for a low-sev patch (wipe I/O cancellation architecture, an IRK/RPA crypto primitive, or a `Box<dyn Error>` that conflicts with the kanon concrete-error standard). Their addressable findings landed here; the deferred ones are commented on each with rationale.