### PR TITLE
Kernel low-rollup batch 1: 17 findings incl. 4 mislabeled security/correctness bugs (#282)

### DIFF
--- a/crates/thumos/src/ccci.rs
+++ b/crates/thumos/src/ccci.rs
@@ -567,10 +567,6 @@ pub(crate) enum CcciError {
     RingBufferFull,
     /// CCIF channel is still busy with an unconsumed message (issue #261).
     CcifChannelBusy(CcifChannel),
-    /// Modem watchdog timeout.
-    ModemWatchdog(u32),
-    /// Identity response blocked by kernel filter.
-    IdentityFiltered,
     /// Header deserialization failed.
     MalformedHeader,
     /// Packet header length field exceeds the actual buffer size.
@@ -603,8 +599,6 @@ impl fmt::Display for CcciError {
             }
             Self::RingBufferFull => write!(f, "ring buffer full"),
             Self::CcifChannelBusy(channel) => write!(f, "CCIF channel {channel:?} busy"),
-            Self::ModemWatchdog(status) => write!(f, "modem WDT: {status:#010x}"),
-            Self::IdentityFiltered => write!(f, "identity response filtered"),
             Self::MalformedHeader => write!(f, "malformed CCCI header"),
             Self::PacketLengthExceeded {
                 header_length,
@@ -910,6 +904,11 @@ pub(crate) struct RxRing {
     head: usize,
     /// Number of descriptors currently owned by hardware.
     hw_count: usize,
+    /// Active ring length -- may be less than RX_RING_SIZE if fewer buffer
+    /// addresses were supplied to `init_chain` (e.g. a boot-time allocation
+    /// shortfall). `head` must wrap by this, not RX_RING_SIZE, or it walks
+    /// into descriptors HW never chained into the ring (issue #282 finding 4).
+    count: usize,
 }
 
 impl RxRing {
@@ -919,6 +918,7 @@ impl RxRing {
             descriptors: [CldmaGpd::zeroed(); RX_RING_SIZE],
             head: 0,
             hw_count: 0,
+            count: RX_RING_SIZE,
         }
     }
 
@@ -941,6 +941,7 @@ impl RxRing {
         }
         self.head = 0;
         self.hw_count = count;
+        self.count = count;
     }
 
     /// Poll for received data. Returns descriptor index and received length,
@@ -967,7 +968,7 @@ impl RxRing {
         let recv_len = self.descriptors[idx]
             .recv_len_volatile()
             .min(self.descriptors[idx].data_len);
-        self.head = (self.head + 1) % RX_RING_SIZE;
+        self.head = (self.head + 1) % self.count;
         self.hw_count -= 1;
         Some((idx, recv_len))
     }
@@ -1381,6 +1382,47 @@ pub(crate) unsafe fn dispatch_cldma_irq() -> (u32, u32) {
     (tx_status, rx_status)
 }
 
+/// Parse a raw DMA exception status register value into a typed result.
+///
+/// # Errors
+///
+/// Returns [`CcciError::DmaError`] carrying the raw status bits when the
+/// hardware reports a CLDMA DMA exception (source register: `DMA_ERR`,
+/// `PD_BASE + 0x0870`).
+pub(crate) fn parse_dma_error(status: u32) -> Result<(), CcciError> {
+    if status == 0 {
+        Ok(())
+    } else {
+        Err(CcciError::DmaError(status))
+    }
+}
+
+/// Read and acknowledge the CLDMA DMA exception status register.
+///
+/// # Safety
+///
+/// Must be called with CLDMA registers mapped (same preconditions as
+/// [`dispatch_cldma_irq`]).
+///
+/// # Errors
+///
+/// See [`parse_dma_error`].
+pub(crate) unsafe fn read_dma_error() -> Result<(), CcciError> {
+    // SAFETY: shared memory region at DMA_ERR is mapped and within the CCCI
+    // aperture. Access is synchronized via CCIF doorbell.
+    let status = unsafe { mmio::read32(cldma_pd::DMA_ERR) };
+    if status != 0 {
+        // WHY: write the same bits back to acknowledge, the same convention
+        // dispatch_cldma_irq uses for L2TISAR0/L2RISAR0.
+        // SAFETY: shared memory region at DMA_ERR is mapped and within the
+        // CCCI aperture. Access is synchronized via CCIF doorbell.
+        unsafe {
+            mmio::write32(cldma_pd::DMA_ERR, status);
+        }
+    }
+    parse_dma_error(status)
+}
+
 /// Parse raw CLDMA TX interrupt status into typed events.
 pub(crate) fn parse_cldma_tx_status(status: u32) -> [Option<CldmaIrqEvent>; 3] {
     let mut events: [Option<CldmaIrqEvent>; 3] = [None; 3];
@@ -1451,12 +1493,14 @@ pub(crate) unsafe fn dispatch_ccif_irq() -> u32 {
 }
 
 /// Dispatch CCIF channels to typed events.
-pub(crate) fn parse_ccif_channels(raw: u32) -> [Option<CcifChannel>; 8] {
-    let mut result: [Option<CcifChannel>; 8] = [None; 8];
+pub(crate) fn parse_ccif_channels(raw: u32) -> [Option<CcifChannel>; 24] {
+    let mut result: [Option<CcifChannel>; 24] = [None; 24];
     let mut idx = 0;
     for bit in 0..24u8 {
-        if raw & (1u32 << bit) != 0 && idx < 8 {
-            result[idx] = CcifChannel::from_raw(bit);
+        if raw & (1u32 << bit) != 0
+            && let Some(channel) = CcifChannel::from_raw(bit)
+        {
+            result[idx] = Some(channel);
             idx += 1;
         }
     }
@@ -2089,6 +2133,89 @@ impl CcciDriver {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn ccif_parse_channels_beyond_old_eight_slot_cap() {
+        // All 8 RingQ channels plus Sram and Exception -- 10 concurrent
+        // channels, which the old 8-element result array could not hold
+        // without dropping the high-numbered control channels (issue #282
+        // finding 1).
+        let raw = (0..8u8).fold(0u32, |acc, bit| acc | (1 << bit))
+            | CcifChannel::Sram.mask()
+            | CcifChannel::Exception.mask();
+        let parsed = parse_ccif_channels(raw);
+        let active: Vec<CcifChannel> = parsed.iter().flatten().copied().collect();
+        assert_eq!(
+            active.len(),
+            10,
+            "all 10 concurrently active channels must be reported"
+        );
+        assert!(
+            active.contains(&CcifChannel::Sram),
+            "Sram must not be dropped by ring-queue flood"
+        );
+        assert!(
+            active.contains(&CcifChannel::Exception),
+            "Exception must not be dropped by ring-queue flood"
+        );
+    }
+
+    #[test]
+    fn ccif_parse_channels_ignores_reserved_bit_positions() {
+        // Bits 8-14 are reserved/unmapped (from_raw returns None) and must not
+        // consume a result slot.
+        let raw = 0x7F00 | CcifChannel::Exception.mask();
+        let parsed = parse_ccif_channels(raw);
+        let active: Vec<CcifChannel> = parsed.iter().flatten().copied().collect();
+        assert_eq!(active.len(), 1);
+        assert!(active.contains(&CcifChannel::Exception));
+    }
+
+    #[test]
+    fn parse_dma_error_clean_status_is_ok() {
+        assert_eq!(parse_dma_error(0), Ok(()));
+    }
+
+    #[test]
+    fn parse_dma_error_nonzero_status_reports_dma_error() {
+        assert_eq!(
+            parse_dma_error(0x0000_0007),
+            Err(CcciError::DmaError(0x0000_0007))
+        );
+    }
+
+    #[test]
+    fn rx_ring_partial_init_head_wraps_at_count_not_ring_size() {
+        let mut ring = RxRing::new();
+        let base: u32 = 0x4030_0000;
+        // Only 4 buffers supplied for a 16-slot ring (RX_RING_SIZE) -- a
+        // legitimate partial-init scenario. `head` must wrap at `count` (4),
+        // matching the HW descriptor chain init_chain actually built, not at
+        // RX_RING_SIZE (16) -- issue #282 finding 4.
+        let buf_addrs: [u32; 4] =
+            core::array::from_fn(|i| 0x5100_0000 + (u32::try_from(i).unwrap_or_default()) * 0x1000);
+        ring.init_chain(base, &buf_addrs, 2048);
+
+        for i in 0..4usize {
+            ring.descriptors[i].clear_hw_owned();
+            ring.descriptors[i].recv_len = 128;
+        }
+        for i in 0..4usize {
+            let (idx, len) = ring.poll_rx().unwrap_or_default();
+            assert_eq!(idx, i, "descriptor order within the active ring");
+            assert_eq!(len, 128);
+            ring.rearm(idx, buf_addrs[idx], 2048);
+        }
+
+        // After a full cycle, head must wrap back to descriptor 0 (armed,
+        // HW-owned), not land on the never-initialized descriptor 4, which
+        // would fabricate a phantom zero-length completion (data_ptr == 0).
+        assert!(
+            ring.poll_rx().is_none(),
+            "head must wrap within the active `count` descriptors, not fabricate a phantom completion"
+        );
+    }
+
     use alloc::format;
     use alloc::vec::Vec;
 

--- a/crates/thumos/src/ccci_logger.rs
+++ b/crates/thumos/src/ccci_logger.rs
@@ -506,16 +506,20 @@ const MAX_ANOMALIES: usize = 16;
 /// * `now` -- current timestamp in milliseconds
 /// * `window_ms` -- the time window to measure current rates over
 ///
-/// Returns an array of up to [`MAX_ANOMALIES`] anomalies and the count.
+/// Returns an array of up to [`MAX_ANOMALIES`] anomalies, the count, and
+/// whether more anomalies were detected than the array could hold (issue
+/// #282 finding 5 -- the old 2-tuple gave no way to distinguish "exactly
+/// MAX_ANOMALIES occurred" from "more occurred and were dropped").
 #[must_use]
 pub(crate) fn detect_anomalies(
     log: &CcciLogger,
     baseline: &ModemBaseline,
     now: u64,
     window_ms: u64,
-) -> ([Option<CcciAnomaly>; MAX_ANOMALIES], usize) {
+) -> ([Option<CcciAnomaly>; MAX_ANOMALIES], usize, bool) {
     let mut anomalies: [Option<CcciAnomaly>; MAX_ANOMALIES] = [None; MAX_ANOMALIES];
     let mut count = 0;
+    let mut overflowed = false;
 
     let since = now.saturating_sub(window_ms);
 
@@ -536,6 +540,8 @@ pub(crate) fn detect_anomalies(
                     baseline_max: 0,
                 });
                 count += 1;
+            } else {
+                overflowed = true;
             }
             continue;
         }
@@ -556,6 +562,8 @@ pub(crate) fn detect_anomalies(
                     baseline_max: baseline_stats.max_rate,
                 });
                 count += 1;
+            } else {
+                overflowed = true;
             }
         }
 
@@ -585,11 +593,13 @@ pub(crate) fn detect_anomalies(
                     baseline_max: baseline_stats.max_data0,
                 });
                 count += 1;
+            } else {
+                overflowed = true;
             }
         }
     }
 
-    (anomalies, count)
+    (anomalies, count, overflowed)
 }
 
 // ---------------------------------------------------------------------------
@@ -843,6 +853,33 @@ pub unsafe fn modem_power_cut() {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn detect_anomalies_reports_overflow_past_max_anomalies() {
+        let mut log = CcciLogger::new();
+        let baseline = build_baseline(&log, 60_000);
+
+        // Traffic on 20 distinct channels (all 'unexpected', none active in
+        // baseline) -- more than MAX_ANOMALIES (16) can hold.
+        for ch in 0..20u32 {
+            log.record(CcciLogEntry {
+                timestamp: 70_000,
+                channel: ch,
+                direction: PacketDirection::Rx,
+                data0: 0,
+                data1: 0,
+                packet_len: 16,
+            });
+        }
+
+        let (_anomalies, count, overflowed) = detect_anomalies(&log, &baseline, 70_000, 60_000);
+        assert_eq!(count, MAX_ANOMALIES, "array fills to capacity");
+        assert!(
+            overflowed,
+            "detect_anomalies must report overflow when more anomalies exist than MAX_ANOMALIES can hold"
+        );
+    }
+
     use alloc::string::ToString;
 
     use super::*;
@@ -1158,7 +1195,7 @@ mod tests {
             packet_len: 16,
         });
 
-        let (anomalies, count) = detect_anomalies(&log, &baseline, 70_000, 60_000);
+        let (anomalies, count, _overflowed) = detect_anomalies(&log, &baseline, 70_000, 60_000);
         let found = anomalies[..count]
             .iter()
             .flatten()
@@ -1224,7 +1261,7 @@ mod tests {
             packet_len: 16,
         });
 
-        let (anomalies, count) = detect_anomalies(&log, &baseline, 70_000, 60_000);
+        let (anomalies, count, _overflowed) = detect_anomalies(&log, &baseline, 70_000, 60_000);
         assert!(count > 0, "must detect unexpected channel");
 
         let found = anomalies[..count]
@@ -1264,7 +1301,7 @@ mod tests {
             });
         }
 
-        let (anomalies, count) = detect_anomalies(&log, &baseline, 63_000, 60_000);
+        let (anomalies, count, _overflowed) = detect_anomalies(&log, &baseline, 63_000, 60_000);
         let found = anomalies[..count]
             .iter()
             .flatten()
@@ -1299,7 +1336,7 @@ mod tests {
             packet_len: 16,
         });
 
-        let (anomalies, count) = detect_anomalies(&log, &baseline, 70_000, 60_000);
+        let (anomalies, count, _overflowed) = detect_anomalies(&log, &baseline, 70_000, 60_000);
         let found = anomalies[..count]
             .iter()
             .flatten()
@@ -1353,7 +1390,7 @@ mod tests {
             packet_len: 16,
         });
 
-        let (anomalies, count) = detect_anomalies(&log, &baseline, 72_000, 60_000);
+        let (anomalies, count, _overflowed) = detect_anomalies(&log, &baseline, 72_000, 60_000);
         let found = anomalies[..count]
             .iter()
             .flatten()
@@ -1393,7 +1430,7 @@ mod tests {
             });
         }
 
-        let (_, count) = detect_anomalies(&log, &baseline, 10_000, 60_000);
+        let (_, count, _overflowed) = detect_anomalies(&log, &baseline, 10_000, 60_000);
         assert_eq!(count, 0, "no anomalies for normal traffic");
     }
 

--- a/crates/thumos/src/fd.rs
+++ b/crates/thumos/src/fd.rs
@@ -43,6 +43,20 @@ pub(crate) const EINVAL: u32 = 0u32.wrapping_sub(22);
 pub(crate) const EFAULT: u32 = 0u32.wrapping_sub(14);
 /// Is a directory.
 pub(crate) const EISDIR: u32 = 0u32.wrapping_sub(21);
+/// Not a directory.
+pub(crate) const ENOTDIR: u32 = 0u32.wrapping_sub(20);
+/// Entry already exists.
+pub(crate) const EEXIST: u32 = 0u32.wrapping_sub(17);
+/// Directory not empty.
+pub(crate) const ENOTEMPTY: u32 = 0u32.wrapping_sub(39);
+/// No space left on device.
+pub(crate) const ENOSPC: u32 = 0u32.wrapping_sub(28);
+/// I/O error.
+pub(crate) const EIO: u32 = 0u32.wrapping_sub(5);
+/// Permission denied.
+pub(crate) const EACCES: u32 = 0u32.wrapping_sub(13);
+/// Too many links.
+pub(crate) const EMLINK: u32 = 0u32.wrapping_sub(31);
 /// Inappropriate ioctl for device.
 pub(crate) const ENOTTY: u32 = 0u32.wrapping_sub(25);
 
@@ -568,7 +582,16 @@ pub(crate) fn sys_open(path_ptr: u32, path_len: u32, flags: u32) -> u32 {
 
     let (mount_idx, inode_id) = match vfs::resolve_path(mt, path) {
         Ok(r) => r,
-        Err(_) => return ENOENT,
+        Err(VfsError::NotFound) => return ENOENT,
+        Err(VfsError::NotADirectory) => return ENOTDIR,
+        Err(VfsError::IsADirectory) => return EISDIR,
+        Err(VfsError::AlreadyExists) => return EEXIST,
+        Err(VfsError::NotEmpty) => return ENOTEMPTY,
+        Err(VfsError::InvalidPath) => return EINVAL,
+        Err(VfsError::NoSpace) => return ENOSPC,
+        Err(VfsError::IoError | VfsError::RequiresMut) => return EIO,
+        Err(VfsError::PermissionDenied) => return EACCES,
+        Err(VfsError::TooManyLinks) => return EMLINK,
     };
 
     let fd = FileDescriptor::from_vfs(mount_idx as u8, inode_id, flags);
@@ -919,24 +942,42 @@ pub(crate) fn sys_lseek(fd: u32, offset: u32, whence: u32) -> u32 {
 
     // WHY: offset is treated as signed (i32) for SEEK_CUR and SEEK_END.
     let offset_signed = offset as i32;
-    let file_size = entry.size() as i32;
 
-    let new_pos: i32 = match whence {
-        SEEK_SET => offset_signed,
+    // WHY: entry.offset/file_size are inherently non-negative `usize`
+    // quantities; the old blind `as i32` reinterpreted a legitimate value
+    // >= 2^31 as negative mid-calculation, corrupting SEEK_CUR/SEEK_END
+    // (issue #282 finding 7). Widen via try_from (not `as`) into i64 so
+    // the arithmetic itself cannot silently wrap; unwrap_or(i64::MAX) is a
+    // panic-free fallback for a conversion that cannot fail on this
+    // 32-bit target (usize/u32 always fits i64).
+    let file_size = i64::try_from(entry.size()).unwrap_or(i64::MAX);
+
+    let new_pos: i64 = match whence {
+        SEEK_SET => i64::from(offset_signed),
         SEEK_CUR => {
-            let current = entry.offset as i32;
-            current.saturating_add(offset_signed)
+            let current = i64::try_from(entry.offset).unwrap_or(i64::MAX);
+            current.saturating_add(i64::from(offset_signed))
         }
-        SEEK_END => file_size.saturating_add(offset_signed),
+        SEEK_END => file_size.saturating_add(i64::from(offset_signed)),
         _ => return EINVAL,
     };
 
-    if new_pos < 0 {
+    // The syscall ABI reports the result in r0 as a signed i32 (0 =
+    // success); the representable non-error domain is 0..=i32::MAX.
+    const MAX_REPRESENTABLE_POS: i64 = 0x7FFF_FFFF;
+    if new_pos < 0 || new_pos > MAX_REPRESENTABLE_POS {
         return EINVAL;
     }
 
-    entry.offset = new_pos as usize;
-    new_pos as u32
+    let Ok(new_pos_u32) = u32::try_from(new_pos) else {
+        return EINVAL;
+    };
+    let Ok(new_pos_usize) = usize::try_from(new_pos) else {
+        return EINVAL;
+    };
+
+    entry.offset = new_pos_usize;
+    new_pos_u32
 }
 
 /// SYS_dup: duplicate a file descriptor.
@@ -1361,6 +1402,50 @@ fn split_parent_name(path: &str) -> Option<(&str, &str)> {
 
 #[cfg(test)]
 mod tests {
+
+    #[cfg(target_pointer_width = "32")]
+    #[test]
+    fn sys_open_returns_enotdir_not_enoent_for_path_through_a_file() {
+        // SAFETY: test-only.
+        unsafe {
+            setup_test_vfs();
+        }
+        // "/test.txt" is a regular file; walking a further component through
+        // it must surface ENOTDIR (issue #282 finding 6), not the generic
+        // ENOENT the old blanket `Err(_) => ENOENT` mapping returned.
+        let path = b"/test.txt/foo";
+        let result = sys_open(path.as_ptr() as u32, path.len() as u32, 0);
+        assert_eq!(
+            result, ENOTDIR,
+            "path through a non-directory component must return ENOTDIR"
+        );
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    #[test]
+    fn lseek_seek_cur_large_offset_no_i32_wraparound() {
+        // SAFETY: test-only.
+        unsafe {
+            setup_test_vfs();
+        }
+        // A descriptor whose current position sits exactly at the i32 domain
+        // boundary (2^31) -- `as i32` reinterprets this as i32::MIN, which
+        // previously made a legitimate SEEK_CUR result look negative and
+        // return EINVAL (issue #282 finding 7).
+        let mut fd_entry = FileDescriptor::from_vfs(0, 0, 0);
+        fd_entry.offset = 0x8000_0000; // 2^31
+        let table = unsafe { &mut *core::ptr::addr_of_mut!(FD_TABLE) };
+        let fd = table.alloc(fd_entry).expect("fd alloc must succeed");
+
+        // Seek back by exactly 2^31 (raw bit pattern 0x8000_0000 == -2^31 when
+        // reinterpreted as i32) -- the true result is position 0.
+        let new_pos = sys_lseek(fd as u32, 0x8000_0000, SEEK_CUR);
+        assert_eq!(
+            new_pos, 0,
+            "SEEK_CUR must not misreport a valid position as EINVAL from i32 truncation"
+        );
+    }
+
     use super::*;
     use crate::vfs::InodeType;
 

--- a/crates/thumos/src/ipc.rs
+++ b/crates/thumos/src/ipc.rs
@@ -126,8 +126,19 @@ fn validate_pid(pid: Pid) -> Result<usize, i32> {
     Ok(idx)
 }
 
-/// Send a message to a process. Non-blocking: returns false if inbox full
-/// or the target PID is invalid.
+/// Reasons [`send`] can fail to deliver a message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum IpcSendError {
+    /// `to` does not name a live process.
+    InvalidTarget,
+    /// The target's inbox is at capacity.
+    InboxFull,
+}
+
+/// Send a message to a process.
+///
+/// Non-blocking: fails immediately rather than blocking if the target's
+/// inbox is full.
 ///
 /// NOTE: this primitive performs no capability/authorization check by
 /// design -- it is also used by trusted kernel-internal callers (e.g.
@@ -136,18 +147,28 @@ fn validate_pid(pid: Pid) -> Result<usize, i32> {
 /// PID 0 as a target lives at the syscall boundary instead: see
 /// `syscall::dispatch`'s `Syscall::Send` arm and
 /// `capability::Capabilities::IPC_INIT` (#371).
-pub(crate) fn send(to: Pid, mut msg: Message) -> bool {
-    let idx = match validate_pid(to) {
-        Ok(i) => i,
-        Err(_) => return false,
-    };
+///
+/// # Errors
+///
+/// Returns [`IpcSendError::InvalidTarget`] if `to` does not name a live
+/// process, or [`IpcSendError::InboxFull`] if the target's inbox is at
+/// capacity. These were previously conflated into a single `bool` (issue
+/// #282 finding 14), discarding the distinction `validate_pid` already
+/// computes internally.
+pub(crate) fn send(to: Pid, mut msg: Message) -> Result<(), IpcSendError> {
+    let idx = validate_pid(to).map_err(|_| IpcSendError::InvalidTarget)?;
     msg.from = process::current_pid();
     // SAFETY: INBOXES is a static array indexed by PID. addr_of_mut! avoids
     // creating an intermediate reference to the static mut. Single-core kernel
     // with interrupts disabled at call sites ensures exclusive access.
-    unsafe {
+    let delivered = unsafe {
         let inboxes = &mut *core::ptr::addr_of_mut!(INBOXES);
         inboxes[idx].push(msg)
+    };
+    if delivered {
+        Ok(())
+    } else {
+        Err(IpcSendError::InboxFull)
     }
 }
 
@@ -187,6 +208,24 @@ pub(crate) fn has_messages() -> bool {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn send_reports_invalid_target_distinctly() {
+        let msg = Message::new(1, b"x");
+        assert_eq!(
+            send(MAX_INBOX_PROCS as u8, msg),
+            Err(IpcSendError::InvalidTarget)
+        );
+    }
+
+    #[test]
+    fn send_reports_inbox_full_distinctly_from_invalid_target() {
+        for _ in 0..INBOX_SIZE {
+            assert_eq!(send(1, Message::new(1, b"x")), Ok(()));
+        }
+        assert_eq!(send(1, Message::new(1, b"x")), Err(IpcSendError::InboxFull));
+    }
+
     use super::*;
 
     #[test]

--- a/crates/thumos/src/matrix_crypto.rs
+++ b/crates/thumos/src/matrix_crypto.rs
@@ -134,6 +134,10 @@ pub enum CryptoError {
     /// The room id supplied for session creation is not a well-formed Matrix
     /// room identifier (#373).
     InvalidRoomId(crate::matrix_ids::MatrixIdError),
+    /// The Megolm session's message_index has reached u32::MAX; encrypting
+    /// further would reuse a (key, IV) pair (issue #282 finding 9). The
+    /// session must be rotated.
+    MegolmIndexExhausted,
 }
 
 impl From<csprng::CsprngError> for CryptoError {
@@ -184,6 +188,12 @@ impl fmt::Display for CryptoError {
                 write!(f, "device key failed Ed25519 self-signature verification")
             }
             Self::InvalidRoomId(e) => write!(f, "invalid room identifier: {e}"),
+            Self::MegolmIndexExhausted => {
+                write!(
+                    f,
+                    "Megolm session message index exhausted -- rotate the session"
+                )
+            }
         }
     }
 }
@@ -519,11 +529,20 @@ impl MatrixCrypto {
                     let key_str = key_val.as_str().ok_or(CryptoError::InvalidKeyResponse)?;
 
                     if key_name.starts_with("ed25519:") {
+                        // WHY: a key that fails base64 decode is fail-closed
+                        // excluded (found_ed stays false), not substituted
+                        // with a zero/partial key -- the `found_ed &&
+                        // found_curve` gate below then drops the whole
+                        // device, the same disposition as a failed
+                        // self-signature check (#230). Deliberate: an
+                        // unparseable key from the homeserver is untrusted,
+                        // not merely absent (issue #282 finding 8).
                         if let Some(decoded) = decode_base64_key(key_str) {
                             ed25519 = decoded;
                             found_ed = true;
                         }
                     } else if key_name.starts_with("curve25519:") {
+                        // WHY: see the ed25519 branch above -- same policy.
                         if let Some(decoded) = decode_base64_key(key_str) {
                             curve25519 = decoded;
                             found_curve = true;
@@ -797,6 +816,17 @@ pub(crate) fn encrypt_megolm(
     }
 
     let index = session.message_index;
+    // WHY: message_index is the HKDF derivation input for this message's
+    // (AES key, HMAC key, IV) -- see derive_megolm_message_keys. Reject
+    // BEFORE deriving/encrypting once no fresh index remains: the old
+    // `saturating_add` let message_index sit at u32::MAX forever, so every
+    // later call re-derived and reused the SAME (key, IV) pair, breaking
+    // AES-CBC's IND-CPA guarantee (issue #282 finding 9). The session must
+    // be rotated (a fresh create_outbound_megolm) instead.
+    let next_index = index
+        .checked_add(1)
+        .ok_or(CryptoError::MegolmIndexExhausted)?;
+
     let keys = derive_megolm_message_keys(&session.session_key, index)?;
     let ciphertext = cbc_encrypt(&keys.aes_key, &keys.iv, plaintext);
 
@@ -812,7 +842,7 @@ pub(crate) fn encrypt_megolm(
     payload.extend_from_slice(&body);
     payload.extend_from_slice(&tag[..MEGOLM_MAC_LEN]);
 
-    session.message_index = index.saturating_add(1);
+    session.message_index = next_index;
     Ok(payload)
 }
 
@@ -1303,6 +1333,26 @@ fn push_usize(s: &mut String, mut val: usize) {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn encrypt_megolm_refuses_to_reuse_index_at_saturation() {
+        setup_test_rng();
+        let mut session = MegolmSession {
+            session_id: [0u8; KEY_SIZE],
+            session_key: [1u8; KEY_SIZE],
+            message_index: u32::MAX,
+            room_id: MatrixRoomId::new("!test:matrix.example.com").expect("valid test room id"),
+        };
+
+        let result = encrypt_megolm(&mut session, b"one message too many");
+        assert_eq!(result, Err(CryptoError::MegolmIndexExhausted));
+        assert_eq!(
+            session.message_index,
+            u32::MAX,
+            "index must not be mutated on refusal"
+        );
+    }
+
     use super::*;
 
     /// Seed the kernel CSPRNG for deterministic test output.

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -546,7 +546,7 @@ pub(crate) fn notify_fault(faulting_pid: Pid, kind: FaultKind) {
         // to faulting_pid so the message arrives with the correct sender identity.
         let saved = CURRENT;
         CURRENT = faulting_pid;
-        let sent = ipc::send(0, msg);
+        let sent = ipc::send(0, msg).is_ok();
         CURRENT = saved;
         sent
     };

--- a/crates/thumos/src/security_mode.rs
+++ b/crates/thumos/src/security_mode.rs
@@ -222,6 +222,11 @@ pub enum ModeTransitionError {
     AbortWindowExpired,
     /// Already in the requested mode.
     AlreadyInMode,
+    /// Panic abort requested while not currently in Panic mode -- the
+    /// opposite condition from `AlreadyInMode` (which means "transition
+    /// target == current mode"), previously conflated with it (issue #282
+    /// finding 11).
+    NotInPanic,
 }
 
 impl fmt::Display for ModeTransitionError {
@@ -232,6 +237,7 @@ impl fmt::Display for ModeTransitionError {
             Self::PanicIsTerminal => write!(f, "cannot transition out of Panic mode"),
             Self::AbortWindowExpired => write!(f, "panic abort window has expired"),
             Self::AlreadyInMode => write!(f, "already in the requested mode"),
+            Self::NotInPanic => write!(f, "not currently in Panic mode"),
         }
     }
 }
@@ -458,14 +464,14 @@ impl ModeManager {
     ///
     /// Returns [`ModeTransitionError::AbortWindowExpired`] if the abort
     /// window has closed.
-    /// Returns [`ModeTransitionError::AlreadyInMode`] if not in Panic.
+    /// Returns [`ModeTransitionError::NotInPanic`] if not currently in Panic mode.
     pub(crate) fn abort_panic(
         &mut self,
         current_tick: u64,
         power_manager: &mut PowerManager,
     ) -> Result<(), ModeTransitionError> {
         if self.mode != SecurityMode::Panic {
-            return Err(ModeTransitionError::AlreadyInMode);
+            return Err(ModeTransitionError::NotInPanic);
         }
 
         let Some(initiated) = self.panic_initiated_tick else {
@@ -658,13 +664,19 @@ pub(crate) fn log_mode_change(
             offset += 1;
         }
     }
-    let _ = audit_log.log_event(
-        AuditEventType::ModeChange,
-        0,
-        &detail[..offset],
-        timestamp,
-        audit_key,
-    );
+    // WHY: an audit-log write failure (e.g. capacity, missing key) must
+    // never block the mode transition itself -- the transition has already
+    // committed by the time this logs. Best-effort discard via `.ok()`,
+    // not `let _ =` (kanon standard; issue #282 finding 12).
+    audit_log
+        .log_event(
+            AuditEventType::ModeChange,
+            0,
+            &detail[..offset],
+            timestamp,
+            audit_key,
+        )
+        .ok();
 }
 
 /// Log a panic trigger event to the audit log.
@@ -681,13 +693,17 @@ pub(crate) fn log_panic_trigger(
         PanicActivation::PttTripleClick => b"PTT triple-click",
         PanicActivation::DuressPin => b"duress PIN",
     };
-    let _ = audit_log.log_event(
-        AuditEventType::PanicTrigger,
-        0,
-        detail,
-        timestamp,
-        audit_key,
-    );
+    // WHY: see log_mode_change -- audit-log failure must not block the
+    // panic-trigger critical path (issue #282 finding 12).
+    audit_log
+        .log_event(
+            AuditEventType::PanicTrigger,
+            0,
+            detail,
+            timestamp,
+            audit_key,
+        )
+        .ok();
 }
 
 /// Return the string name of a security mode for audit detail fields.
@@ -1276,7 +1292,7 @@ mod tests {
         let mut pm = PowerManager::new();
 
         let result = mm.abort_panic(0, &mut pm);
-        assert_eq!(result, Err(ModeTransitionError::AlreadyInMode));
+        assert_eq!(result, Err(ModeTransitionError::NotInPanic));
     }
 
     #[test]

--- a/crates/thumos/src/syscall.rs
+++ b/crates/thumos/src/syscall.rs
@@ -53,6 +53,14 @@ pub(crate) const EFAULT: u32 = 0u32.wrapping_sub(14);
 /// Total number of defined syscalls.
 pub(crate) const SYSCALL_COUNT: usize = 46;
 
+/// Operation not permitted (two's complement -1, matches Linux EPERM).
+const EPERM: u32 = 0u32.wrapping_sub(1);
+/// No such process (two's complement -3, matches Linux ESRCH).
+const ESRCH: u32 = 0u32.wrapping_sub(3);
+/// Resource temporarily unavailable (two's complement -11, matches Linux
+/// EAGAIN).
+const EAGAIN: u32 = 0u32.wrapping_sub(11);
+
 /// Syscall numbers grouped by kernel domain.
 ///
 /// Numbers 0-9 are legacy assignments FROM the initial kernel bring-up.
@@ -461,7 +469,7 @@ pub(crate) fn dispatch(num: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> 
             // unaffected, exactly as sys_kill's belt-and-suspenders check
             // does not reach deliver_signal_to's internal callers.
             if to == 0 && capability::check(capability::Capabilities::IPC_INIT).is_err() {
-                return u32::MAX;
+                return EPERM;
             }
             let tag = arg1;
             let Ok(ptr) = usize::try_from(arg2) else {
@@ -482,11 +490,15 @@ pub(crate) fn dispatch(num: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> 
                 &[]
             };
             let msg = ipc::Message::new(tag, payload);
-            if ipc::send(to, msg) { 0 } else { u32::MAX }
+            match ipc::send(to, msg) {
+                Ok(()) => 0,
+                Err(ipc::IpcSendError::InvalidTarget) => ESRCH,
+                Err(ipc::IpcSendError::InboxFull) => EAGAIN,
+            }
         }
         Syscall::Recv => match ipc::recv() {
             Some(msg) => u32::from(msg.from),
-            None => u32::MAX,
+            None => EAGAIN,
         },
 
         // ---- Process management ----
@@ -684,6 +696,8 @@ fn sys_write_dispatch(fd: u32, buf_ptr: u32, count: u32) -> u32 {
 
 /// No such file or directory (two's complement -2, matches Linux ENOENT).
 const ENOENT: u32 = 0u32.wrapping_sub(2);
+/// Exec format error (two's complement -8, matches Linux ENOEXEC).
+const ENOEXEC: u32 = 0u32.wrapping_sub(8);
 
 /// execve(path_ptr, argv_ptr, _envp_ptr): replace the current process image.
 ///
@@ -764,7 +778,19 @@ fn sys_execve(path_ptr: u32, argv_ptr: u32, _envp_ptr: u32) -> u32 {
     // --- Step 3: parse and validate ELF ---
     let loaded = match crate::elf::load(elf_data) {
         Ok(l) => l,
-        Err(_) => return EINVAL,
+        // WHY: format/architecture failures -> ENOEXEC (matches Linux's
+        // execve(2) convention: 'not in a recognized format, wrong
+        // architecture, or some other format error'); OOM -> ENOMEM (issue
+        // #282 finding 15 -- the old blanket `Err(_) => EINVAL` never
+        // returned ENOEXEC at all).
+        Err(crate::elf::ElfError::OutOfMemory) => return ENOMEM,
+        Err(
+            crate::elf::ElfError::BadMagic
+            | crate::elf::ElfError::Not32Bit
+            | crate::elf::ElfError::NotLittleEndian
+            | crate::elf::ElfError::NotArm
+            | crate::elf::ElfError::InvalidSegment,
+        ) => return ENOEXEC,
     };
     let entry_point = loaded.entry;
 
@@ -1124,14 +1150,24 @@ fn sys_mmap(arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> u32 {
     for i in 0..page_count {
         let vaddr = candidate + i * page::PAGE_SIZE;
         let Some(phys) = page::alloc_page() else {
-            // OOM: roll back
+            // OOM: roll back previously mapped pages, freeing their
+            // physical frames (not just unmapping) -- the old rollback
+            // only unmapped, permanently leaking every already-mapped
+            // frame (issue #282 finding 13, same class as #226/#328).
             for j in 0..i {
                 let rollback_vaddr = candidate + j * page::PAGE_SIZE;
                 // SAFETY: pt is the current process's valid L1 table and
-                // rollback_vaddr is page-aligned within the mmap candidate region.
-                // These pages were successfully mapped in earlier iterations.
+                // rollback_vaddr is page-aligned within the mmap candidate
+                // region. These pages were successfully mapped in earlier
+                // iterations, so read_l2_phys before unmap_page recovers
+                // the frame to return to the allocator.
                 unsafe {
+                    let rollback_phys = mmu::read_l2_phys(pt, rollback_vaddr);
                     mmu::unmap_page(pt, rollback_vaddr);
+                    mmu::flush_tlb_page(rollback_vaddr);
+                    if let Some(rollback_phys) = rollback_phys {
+                        page::free_page(rollback_phys);
+                    }
                 }
             }
             return MAP_FAILED;
@@ -1146,13 +1182,21 @@ fn sys_mmap(arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> u32 {
             unsafe {
                 page::free_page(phys);
             }
-            // Roll back previous mappings
+            // Roll back previous mappings, freeing their physical frames
+            // too (issue #282 finding 13).
             for j in 0..i {
                 let rollback_vaddr = candidate + j * page::PAGE_SIZE;
                 // SAFETY: pt is the current process's valid L1 table and
-                // rollback_vaddr was successfully mapped in earlier iterations.
+                // rollback_vaddr was successfully mapped in earlier
+                // iterations, so read_l2_phys before unmap_page recovers
+                // the frame to return to the allocator.
                 unsafe {
+                    let rollback_phys = mmu::read_l2_phys(pt, rollback_vaddr);
                     mmu::unmap_page(pt, rollback_vaddr);
+                    mmu::flush_tlb_page(rollback_vaddr);
+                    if let Some(rollback_phys) = rollback_phys {
+                        page::free_page(rollback_phys);
+                    }
                 }
             }
             return MAP_FAILED;
@@ -1166,13 +1210,21 @@ fn sys_mmap(arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> u32 {
         prot: prot_flags,
     };
     if process::add_mapping(mapping).is_none() {
-        // Mapping table full -- roll back
+        // Mapping table full -- roll back, freeing every physical frame
+        // mapped above (issue #282 finding 13).
         for i in 0..page_count {
             let vaddr = candidate + i * page::PAGE_SIZE;
             // SAFETY: pt is the current process's valid L1 table and vaddr
-            // is page-aligned within the region just successfully mapped.
+            // is page-aligned within the region just successfully mapped,
+            // so read_l2_phys before unmap_page recovers the frame to
+            // return to the allocator.
             unsafe {
+                let rollback_phys = mmu::read_l2_phys(pt, vaddr);
                 mmu::unmap_page(pt, vaddr);
+                mmu::flush_tlb_page(vaddr);
+                if let Some(rollback_phys) = rollback_phys {
+                    page::free_page(rollback_phys);
+                }
             }
         }
         return MAP_FAILED;
@@ -1255,6 +1307,82 @@ fn sys_mprotect(arg0: u32, arg1: u32, arg2: u32) -> u32 {
 
 #[cfg(test)]
 mod tests {
+
+    /// #282 finding 13: an OOM partway through sys_mmap's page allocation must
+    /// roll back exactly the pages it mapped before failing, freeing their
+    /// physical frames -- not just unmapping them (same class as #226).
+    #[test]
+    fn mmap_oom_rollback_frees_mapped_pages() {
+        unsafe {
+            setup_mm();
+        }
+
+        // Shrink the free pool to exactly 2 pages so a 4-page mmap OOMs after
+        // mapping the first 2.
+        unsafe {
+            crate::page::init(
+                0x4000_0000,
+                0x4000_0000 + 6 * crate::page::PAGE_SIZE,
+                0x4000_0000 + 4 * crate::page::PAGE_SIZE,
+            );
+        }
+        let free_before = page::free_count();
+        assert_eq!(free_before, 2, "test setup must yield exactly 2 free pages");
+
+        const MAP_PAGES: u32 = 4;
+        let flags_and_fd: u32 = MAP_ANONYMOUS | (0xFFFF << 16);
+        let prot = mmu::prot::PROT_READ | mmu::prot::PROT_WRITE;
+        let length = MAP_PAGES * u32::try_from(crate::page::PAGE_SIZE).unwrap_or_default();
+
+        let addr = sys_mmap(0, length, prot, flags_and_fd);
+        assert_eq!(
+            addr, MAP_FAILED,
+            "mmap must fail when it cannot satisfy the full length"
+        );
+
+        let free_after = page::free_count();
+        assert_eq!(
+            free_after, free_before,
+            "OOM rollback must return exactly the pages mapped before the failure, leaving free-count unchanged (issue #282 finding 13)"
+        );
+    }
+
+    #[test]
+    fn recv_returns_eagain_not_sentinel_when_inbox_empty() {
+        let result = dispatch(Syscall::Recv.as_u32(), 0, 0, 0, 0);
+        assert_eq!(
+            result, EAGAIN,
+            "an empty inbox must report EAGAIN, not the old untyped u32::MAX sentinel"
+        );
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    #[test]
+    fn execve_returns_enoexec_for_bad_elf_magic() {
+        unsafe {
+            process::reset_for_test();
+
+            // Not a valid ELF file at all (bad magic) -- elf::load rejects this
+            // at validate() with ElfError::BadMagic, which sys_execve must
+            // surface as ENOEXEC (issue #282 finding 15), not the generic
+            // EINVAL it previously returned for every ELF load failure.
+            let garbage = [0u8; 52];
+
+            let mut fs = crate::ramfs::RamFs::new();
+            fs.add("bin", &garbage);
+            fd::init_ramfs(fs);
+
+            static mut PATH: [u8; 5] = *b"/bin\0";
+            let path_ptr = core::ptr::addr_of!(PATH) as *const u8 as u32;
+
+            let result = sys_execve(path_ptr, 0, 0);
+            assert_eq!(
+                result, ENOEXEC,
+                "execve must return ENOEXEC (not EINVAL) for a malformed ELF"
+            );
+        }
+    }
+
     use super::*;
 
     // ---- Legacy syscall number preservation ----

--- a/crates/thumos/src/telephony.rs
+++ b/crates/thumos/src/telephony.rs
@@ -443,6 +443,23 @@ pub struct Telephony<T: ModemTransport> {
     init_step: u8,
 }
 
+/// Classify a simple OK/ERROR AT command result into a `TelephonyError`,
+/// preserving the modem's own CME/CMS error code and the transport's own
+/// error type instead of collapsing everything to one generic value
+/// (issue #282 findings 16/17).
+fn classify_simple_result(
+    result: Result<AtResponse, TelephonyError>,
+) -> Result<(), TelephonyError> {
+    match result {
+        Ok(AtResponse::Ok) => Ok(()),
+        Ok(AtResponse::CmeError(code) | AtResponse::CmsError(code)) => {
+            Err(TelephonyError::CmeError(code))
+        }
+        Ok(AtResponse::Error) => Err(TelephonyError::ModemError),
+        Err(e) => Err(e),
+    }
+}
+
 impl<T: ModemTransport> Telephony<T> {
     /// Create a new telephony subsystem with the given transport.
     #[must_use]
@@ -540,28 +557,25 @@ impl<T: ModemTransport> Telephony<T> {
 
         // Step 1: Verify modem responds.
         let result = send_simple(&mut self.transport, "AT", 5000);
-        match result {
-            Ok(AtResponse::Ok) => {}
-            Ok(AtResponse::Error | AtResponse::CmeError(_) | AtResponse::CmsError(_)) | Err(_) => {
-                self.modem_state = ModemState::Error(TelephonyError::Timeout);
-                return Err(TelephonyError::Timeout);
-            }
+        if let Err(e) = classify_simple_result(result) {
+            self.modem_state = ModemState::Error(e);
+            return Err(e);
         }
         self.init_step = 1;
 
         // Step 2: Disable echo.
         let result = send_simple(&mut self.transport, "ATE0", 2000);
-        if !matches!(result, Ok(AtResponse::Ok)) {
-            self.modem_state = ModemState::Error(TelephonyError::ModemError);
-            return Err(TelephonyError::ModemError);
+        if let Err(e) = classify_simple_result(result) {
+            self.modem_state = ModemState::Error(e);
+            return Err(e);
         }
         self.init_step = 2;
 
         // Step 3: Full functionality mode.
         let result = send_simple(&mut self.transport, "AT+CFUN=1", 5000);
-        if !matches!(result, Ok(AtResponse::Ok)) {
-            self.modem_state = ModemState::Error(TelephonyError::ModemError);
-            return Err(TelephonyError::ModemError);
+        if let Err(e) = classify_simple_result(result) {
+            self.modem_state = ModemState::Error(e);
+            return Err(e);
         }
         self.init_step = 3;
 
@@ -584,13 +598,29 @@ impl<T: ModemTransport> Telephony<T> {
                     }
                 }
             }
+            Ok((AtResponse::Ok, _, _)) => {
+                // OK with no info line -- the modem accepted the command but
+                // sent no +CPIN status; a malformed/unparseable response, not
+                // evidence the SIM specifically needs a PIN (issue #282
+                // finding 18).
+                self.modem_state = ModemState::Error(TelephonyError::ParseError);
+                return Err(TelephonyError::ParseError);
+            }
             Ok((AtResponse::CmeError(code), _, _)) => {
                 self.modem_state = ModemState::Error(TelephonyError::CmeError(code));
                 return Err(TelephonyError::CmeError(code));
             }
-            _ => {
-                self.modem_state = ModemState::Error(TelephonyError::SimNotReady);
-                return Err(TelephonyError::SimNotReady);
+            Ok((AtResponse::CmsError(code), _, _)) => {
+                self.modem_state = ModemState::Error(TelephonyError::CmeError(code));
+                return Err(TelephonyError::CmeError(code));
+            }
+            Ok((AtResponse::Error, _, _)) => {
+                self.modem_state = ModemState::Error(TelephonyError::ModemError);
+                return Err(TelephonyError::ModemError);
+            }
+            Err(e) => {
+                self.modem_state = ModemState::Error(e);
+                return Err(e);
             }
         }
         self.init_step = 4;
@@ -1007,6 +1037,49 @@ impl ModemTransport for CcciModemTransport {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn classify_simple_result_preserves_cme_cms_code_and_transport_error() {
+        assert_eq!(classify_simple_result(Ok(AtResponse::Ok)), Ok(()));
+        assert_eq!(
+            classify_simple_result(Ok(AtResponse::Error)),
+            Err(TelephonyError::ModemError)
+        );
+        assert_eq!(
+            classify_simple_result(Ok(AtResponse::CmeError(42))),
+            Err(TelephonyError::CmeError(42))
+        );
+        assert_eq!(
+            classify_simple_result(Ok(AtResponse::CmsError(7))),
+            Err(TelephonyError::CmeError(7))
+        );
+        assert_eq!(
+            classify_simple_result(Err(TelephonyError::TransportError)),
+            Err(TelephonyError::TransportError),
+            "a genuine transport error must not be relabeled as Timeout"
+        );
+    }
+
+    #[test]
+    fn cpin_cms_error_preserves_code_not_sim_not_ready() {
+        let mut mock = MockModemTransport::new();
+        mock.queue_ok(); // Step 1: AT
+        mock.queue_ok(); // Step 2: ATE0
+        mock.queue_ok(); // Step 3: AT+CFUN=1
+        // Step 4: AT+CPIN? -> +CMS ERROR (SMS-storage-class failure, not a SIM
+        // PIN state) -- the old wildcard `_ =>` arm mapped this to
+        // SimNotReady, discarding the code (issue #282 finding 18).
+        mock.queue_response(b"+CMS ERROR: 302");
+
+        let mut tel = Telephony::new(mock);
+        let result = tel.initialize();
+        assert_eq!(
+            result,
+            Err(TelephonyError::CmeError(302)),
+            "a +CMS ERROR on AT+CPIN? must preserve its code, not collapse to SimNotReady"
+        );
+    }
+
     use super::*;
 
     /// Helper: create a mock transport pre-loaded for a full init sequence.


### PR DESCRIPTION
First batch of the kernel low-severity rollup (#282, 95 findings). Each verified at HEAD; several "low" findings were genuine **security/correctness bugs**.

## Real bugs (mislabeled low)
- **sys_mmap physical-frame leak** — all 3 OOM/failure rollback paths unmapped pages without `page::free_page`, permanently leaking every already-mapped frame (same class as #226/#328, which sys_mmap had missed). Now recovers each frame via `read_l2_phys`+`free_page`.
- **Megolm key/IV reuse (IND-CPA break)** — `encrypt_megolm` used `saturating_add`, pinning `message_index` at `u32::MAX` and re-deriving the *same* AES-CBC (key, IV) for every subsequent message. Now rejects via `checked_add` + `MegolmIndexExhausted` (session must rotate). Dormant today (no prod caller) but would activate the moment Megolm-send is wired.
- **sys_lseek i32 truncation** — `offset`/`file_size` narrowed to i32, going negative for legitimate positions ≥ 2³¹ and corrupting SEEK_CUR/SEEK_END. Now i64 via `try_from` + explicit domain check.

## Error-mapping / diagnostic conflations
sys_open (VfsError→ENOTDIR/EIO/… not blanket ENOENT), sys_send/recv (ESRCH/EAGAIN/EPERM via `ipc::send → Result<(), IpcSendError>`), sys_execve (ENOEXEC/ENOMEM not EINVAL), telephony init/CPIN (shared `classify_simple_result` preserves CME/CMS + transport error), security_mode (NotInPanic vs AlreadyInMode; `.ok()` on audit discards).

## CCCI robustness
parse_ccif_channels ([;8]→[;24], skip reserved bits), dead `CcciError` variant removal + `parse_dma_error`, RxRing partial-init phantom-completion fix, detect_anomalies overflow flag.

The ed25519 cofactor finding was **stale** (already `verify_strict`) — no change.

## Verification
- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — **1861 passed** (16 new), 1 skipped
- `cargo build --release --target armv7a-none-eabi` — clean
- `kanon lint` — clean

Partially addresses #282 (17 of 95); remaining findings continue in subsequent batches.

_Security-surface fixes (Megolm, mmap, ipc) reviewed at T0/Opus per model-tiering._