### PR TITLE
Kernel low-rollup batch 2: 16 findings incl. 4 security fixes (#282)

### DIFF
--- a/crates/thumos/src/ccci_logger.rs
+++ b/crates/thumos/src/ccci_logger.rs
@@ -523,6 +523,33 @@ pub(crate) fn detect_anomalies(
 
     let since = now.saturating_sub(window_ms);
 
+    // WHY: a single pass over the log ring, bucketed per channel, replaces
+    // the old design where the "data0 out of range" check below called
+    // `log.entries()` and walked the FULL ring ONCE PER CHANNEL --
+    // CHANNEL_COUNT full rescans of the same LOG_CAPACITY entries -- to
+    // find the first out-of-range value per channel (issue #282 finding
+    // 12). Semantics are unchanged: this still records the chronologically
+    // FIRST in-window entry whose data0 falls outside the baseline range,
+    // per channel (issue #248).
+    let (older, newer) = log.entries();
+    let mut out_of_range_data0: [Option<u32>; CHANNEL_COUNT] = [None; CHANNEL_COUNT];
+    for entry in older.iter().chain(newer.iter()) {
+        if entry.timestamp < since {
+            continue;
+        }
+        let Ok(ch) = usize::try_from(entry.channel) else {
+            continue;
+        };
+        if ch >= CHANNEL_COUNT || out_of_range_data0[ch].is_some() {
+            continue;
+        }
+        let baseline_stats = &baseline.channels[ch];
+        let d0 = entry.data0;
+        if d0 < baseline_stats.min_data0 || d0 > baseline_stats.max_data0 {
+            out_of_range_data0[ch] = Some(d0);
+        }
+    }
+
     // Per-channel: check for active channels, rate, and data0.
     for ch in 0..CHANNEL_COUNT {
         let ch_u32 = ch as u32;
@@ -567,23 +594,11 @@ pub(crate) fn detect_anomalies(
             }
         }
 
-        // 3. data0 out of range -- check every packet on this channel in
-        // the window; flag on the first one that violates the baseline
-        // range. SECURITY: checking only the most recent packet let an
+        // 3. data0 out of range (computed in the single pass above).
+        // SECURITY: checking only the most recent packet let an
         // adversarial modem smuggle an out-of-range data0 in any packet
         // except the last and evade detection entirely (issue #248).
-        let (older, newer) = log.entries();
-        let mut out_of_range: Option<u32> = None;
-        for entry in older.iter().chain(newer.iter()) {
-            if entry.channel == ch_u32 && entry.timestamp >= since {
-                let d0 = entry.data0;
-                if d0 < baseline_stats.min_data0 || d0 > baseline_stats.max_data0 {
-                    out_of_range = Some(d0);
-                    break;
-                }
-            }
-        }
-        if let Some(d0) = out_of_range {
+        if let Some(d0) = out_of_range_data0[ch] {
             if count < MAX_ANOMALIES {
                 anomalies[count] = Some(CcciAnomaly {
                     timestamp: now,
@@ -1398,6 +1413,65 @@ mod tests {
         assert!(
             found,
             "must detect data0 out of range even when the offending packet is not last in the window"
+        );
+    }
+
+    #[test]
+    fn anomaly_detects_data0_out_of_range_independently_per_channel() {
+        let mut log = CcciLogger::new();
+
+        for d0 in [100u32, 150, 200] {
+            log.record(CcciLogEntry {
+                timestamp: 1000,
+                channel: 4,
+                direction: PacketDirection::Rx,
+                data0: d0,
+                data1: 0,
+                packet_len: 16,
+            });
+        }
+        for d0 in [10u32, 15, 20] {
+            log.record(CcciLogEntry {
+                timestamp: 1000,
+                channel: 5,
+                direction: PacketDirection::Rx,
+                data0: d0,
+                data1: 0,
+                packet_len: 16,
+            });
+        }
+        let baseline = build_baseline(&log, 60_000);
+
+        log.record(CcciLogEntry {
+            timestamp: 70_000,
+            channel: 4,
+            direction: PacketDirection::Rx,
+            data0: 500,
+            data1: 0,
+            packet_len: 16,
+        });
+        log.record(CcciLogEntry {
+            timestamp: 71_000,
+            channel: 5,
+            direction: PacketDirection::Rx,
+            data0: 999,
+            data1: 0,
+            packet_len: 16,
+        });
+
+        let (anomalies, count, _overflowed) = detect_anomalies(&log, &baseline, 71_000, 60_000);
+        let found4 = anomalies[..count]
+            .iter()
+            .flatten()
+            .any(|a| a.channel == 4 && a.kind == AnomalyKind::Data0OutOfRange && a.observed == 500);
+        let found5 = anomalies[..count]
+            .iter()
+            .flatten()
+            .any(|a| a.channel == 5 && a.kind == AnomalyKind::Data0OutOfRange && a.observed == 999);
+        assert!(found4, "channel 4's violation must be detected");
+        assert!(
+            found5,
+            "channel 5's violation must be detected independently of channel 4's"
         );
     }
 

--- a/crates/thumos/src/matrix_crypto.rs
+++ b/crates/thumos/src/matrix_crypto.rs
@@ -69,6 +69,15 @@ const MEGOLM_KEY_MATERIAL_LEN: usize = KEY_SIZE + KEY_SIZE + AES_BLOCK_SIZE;
 /// not read from a stale session counter).
 const MEGOLM_INDEX_LEN: usize = 4;
 
+/// Maximum accepted Megolm wire payload length in bytes (issue #282 finding
+/// 9). `decrypt_megolm` allocates proportional to the ciphertext length
+/// during AES-CBC decrypt; without an explicit cap, a room member who holds
+/// the (shared, group) session key -- and can therefore forge a valid MAC
+/// over an arbitrarily large ciphertext -- can force an oversized
+/// allocation on every device in the room. 64 KiB is generous for any real
+/// text/media-key event on this device's 1 GB RAM budget.
+const MEGOLM_MAX_PAYLOAD_LEN: usize = 65536;
+
 /// Ed25519 signature length in bytes.
 const ED25519_SIGNATURE_LEN: usize = 64;
 
@@ -125,6 +134,10 @@ pub enum CryptoError {
     /// The Megolm message is too short to hold the index prefix + MAC tag
     /// (audit #231/#250).
     MegolmMessageTooShort,
+    /// The Megolm message exceeds [`MEGOLM_MAX_PAYLOAD_LEN`] (issue #282
+    /// finding 9) -- rejected before any allocation proportional to its
+    /// length.
+    MegolmMessageTooLong,
     /// The decrypting Megolm session is bound to a different room than the one
     /// the event arrived in — cross-room session confusion (audit #229).
     RoomIdMismatch,
@@ -177,6 +190,9 @@ impl fmt::Display for CryptoError {
                     f,
                     "Megolm message too short to contain index prefix and MAC"
                 )
+            }
+            Self::MegolmMessageTooLong => {
+                write!(f, "Megolm message exceeds maximum accepted payload length")
             }
             Self::RoomIdMismatch => {
                 write!(
@@ -445,6 +461,25 @@ impl MatrixCrypto {
         Ok(keys)
     }
 
+    /// Remove a one-time key from the local pool after the homeserver
+    /// reports it was claimed by a peer during key exchange.
+    ///
+    /// Without this, `one_time_keys` only ever grows: every key the
+    /// homeserver has already handed to a peer for X3DH stays counted
+    /// against [`MAX_ONE_TIME_KEYS`] forever, permanently deadlocking
+    /// [`generate_one_time_keys`] once the pool fills (issue #282 finding
+    /// 8).
+    ///
+    /// Returns `true` if `key` was present and removed.
+    pub(crate) fn consume_one_time_key(&mut self, key: &[u8; KEY_SIZE]) -> bool {
+        if let Some(idx) = self.one_time_keys.iter().position(|k| k == key) {
+            self.one_time_keys.swap_remove(idx);
+            true
+        } else {
+            false
+        }
+    }
+
     // -----------------------------------------------------------------------
     // Key upload/query API
     // -----------------------------------------------------------------------
@@ -626,11 +661,30 @@ impl MatrixCrypto {
 
     /// Add an inbound Megolm session (received from another device).
     ///
+    /// A session with a `session_id` already present is REPLACED in place
+    /// (matching [`create_outbound_megolm`]'s replace-on-match semantics)
+    /// instead of pushed as a duplicate -- without this, an adversary
+    /// resending the same session_id repeatedly fills all
+    /// [`MAX_MEGOLM_INBOUND`] slots with copies of one session, permanently
+    /// exhausting inbound capacity for every other room/device (issue #282
+    /// finding 16).
+    ///
     /// # Errors
     ///
     /// Returns [`CryptoError::SessionCapacityReached`] if the inbound
-    /// session list is at capacity.
+    /// session list is at capacity and `session.session_id` is not already
+    /// present.
+    ///
+    /// [`create_outbound_megolm`]: Self::create_outbound_megolm
     pub(crate) fn add_inbound_megolm(&mut self, session: MegolmSession) -> Result<(), CryptoError> {
+        if let Some(idx) = self
+            .megolm_inbound
+            .iter()
+            .position(|s| s.session_id == session.session_id)
+        {
+            self.megolm_inbound[idx] = session;
+            return Ok(());
+        }
         if self.megolm_inbound.len() >= MAX_MEGOLM_INBOUND {
             return Err(CryptoError::SessionCapacityReached);
         }
@@ -876,6 +930,12 @@ pub(crate) fn decrypt_megolm(
 
     if payload.len() < MEGOLM_INDEX_LEN + MEGOLM_MAC_LEN {
         return Err(CryptoError::MegolmMessageTooShort);
+    }
+
+    // #282 finding 9: reject an oversized payload BEFORE the MAC check or
+    // any allocation proportional to its length.
+    if payload.len() > MEGOLM_MAX_PAYLOAD_LEN {
+        return Err(CryptoError::MegolmMessageTooLong);
     }
 
     let (body, tag) = payload.split_at(payload.len() - MEGOLM_MAC_LEN);
@@ -1421,6 +1481,41 @@ mod tests {
         assert_eq!(result, Err(CryptoError::KeyCountTooLarge));
     }
 
+    #[test]
+    fn consume_one_time_key_frees_capacity_for_regeneration() {
+        setup_test_rng();
+        let mut crypto = MatrixCrypto::new().expect("test csprng seeded");
+
+        crypto
+            .generate_one_time_keys(MAX_GENERATED_KEYS as u32)
+            .expect("first batch must succeed");
+        crypto
+            .generate_one_time_keys(MAX_GENERATED_KEYS as u32)
+            .expect("second batch must fill the pool to exactly capacity");
+        assert_eq!(crypto.one_time_keys().len(), MAX_ONE_TIME_KEYS);
+
+        assert_eq!(
+            crypto.generate_one_time_keys(1),
+            Err(CryptoError::KeyCapacityReached)
+        );
+
+        let claimed = crypto.one_time_keys()[0];
+        assert!(
+            crypto.consume_one_time_key(&claimed),
+            "a present key must be removed"
+        );
+        assert_eq!(crypto.one_time_keys().len(), MAX_ONE_TIME_KEYS - 1);
+        assert!(
+            crypto.generate_one_time_keys(1).is_ok(),
+            "freeing a slot must unblock regeneration"
+        );
+
+        assert!(
+            !crypto.consume_one_time_key(&claimed),
+            "consuming an already-removed key must return false, not panic"
+        );
+    }
+
     // -- Encrypt/decrypt round-trip tests --
 
     #[test]
@@ -1579,6 +1674,23 @@ mod tests {
             Err(CryptoError::MacVerificationFailed),
             "a flipped ciphertext bit must be rejected by the MAC before decryption"
         );
+    }
+
+    #[test]
+    fn megolm_decrypt_rejects_oversized_payload_before_allocating() {
+        setup_test_rng();
+        let mut crypto = MatrixCrypto::new().expect("test csprng seeded");
+        let room_id = "!oversized:matrix.example.com";
+        let _ = crypto.create_outbound_megolm(room_id);
+        let inbound = crypto
+            .find_outbound_megolm(room_id)
+            .map(Clone::clone)
+            .expect("session exists");
+
+        let mut oversized = Vec::with_capacity(MEGOLM_MAX_PAYLOAD_LEN + 1);
+        oversized.resize(MEGOLM_MAX_PAYLOAD_LEN + 1, 0u8);
+        let result = decrypt_megolm(&inbound, &oversized, room_id);
+        assert_eq!(result, Err(CryptoError::MegolmMessageTooLong));
     }
 
     #[test]
@@ -2018,5 +2130,41 @@ mod tests {
 
         let not_found = crypto.find_inbound_megolm(&[0x00; KEY_SIZE]);
         assert!(not_found.is_none());
+    }
+
+    #[test]
+    fn add_inbound_megolm_duplicate_session_id_replaces_not_duplicates() {
+        setup_test_rng();
+        let mut crypto = MatrixCrypto::new().expect("test csprng seeded");
+
+        let room_a = MatrixRoomId::new("!a:example.com").expect("valid test room id");
+        let room_b = MatrixRoomId::new("!b:example.com").expect("valid test room id");
+
+        for _ in 0..MAX_MEGOLM_INBOUND {
+            let session = MegolmSession {
+                session_id: [0x11; KEY_SIZE],
+                session_key: [0xFF; KEY_SIZE],
+                message_index: 0,
+                room_id: room_a.clone(),
+            };
+            assert!(crypto.add_inbound_megolm(session).is_ok());
+        }
+        assert_eq!(
+            crypto.megolm_inbound().len(),
+            1,
+            "resending the same session_id must replace, not accumulate duplicates"
+        );
+
+        let fresh = MegolmSession {
+            session_id: [0x22; KEY_SIZE],
+            session_key: [0xEE; KEY_SIZE],
+            message_index: 0,
+            room_id: room_b,
+        };
+        assert!(
+            crypto.add_inbound_megolm(fresh).is_ok(),
+            "capacity must still be available for a genuinely new session after duplicate resends"
+        );
+        assert_eq!(crypto.megolm_inbound().len(), 2);
     }
 }

--- a/crates/thumos/src/telephony.rs
+++ b/crates/thumos/src/telephony.rs
@@ -74,6 +74,12 @@ pub enum TelephonyError {
     TransportError,
     /// SIM card not ready or PIN required.
     SimNotReady,
+    /// SIM card requires PUK unlock (too many wrong PIN attempts) -- kept
+    /// distinct from [`Self::SimNotReady`] so a caller does not route to
+    /// the wrong (PIN) unlock flow (issue #282 finding 17). Entering a PIN
+    /// against a PUK-locked SIM burns limited PUK attempts and can
+    /// permanently lock the SIM.
+    SimPukRequired,
     /// Phone number exceeds maximum length.
     NumberTooLong,
 }
@@ -88,6 +94,7 @@ impl core::fmt::Display for TelephonyError {
             Self::InvalidState => write!(f, "invalid telephony state"),
             Self::TransportError => write!(f, "transport error"),
             Self::SimNotReady => write!(f, "SIM not ready"),
+            Self::SimPukRequired => write!(f, "SIM PUK required"),
             Self::NumberTooLong => write!(f, "number too long"),
         }
     }
@@ -325,6 +332,26 @@ pub trait ModemTransport {
 // AT command/response exchange helper
 // ---------------------------------------------------------------------------
 
+/// Maximum informational/blank lines read while waiting for a command's
+/// final result code.
+///
+/// Every AT exchange in this module expects at most one info line before
+/// the final result ([`send_simple`] stores none, [`send_with_info`] stores
+/// one); this cap is generous headroom for stray echo/blank lines, not an
+/// expected-traffic budget. Bounding it (down from 64) shrinks the
+/// worst-case block time a modem pacing junk lines just under `timeout_ms`
+/// can impose on a single command (issue #282 finding 14) -- it narrows,
+/// but does not eliminate, that window; a full fix needs a wall-clock
+/// total budget, which would require threading a clock source into this
+/// currently transport-mock-only, timer-agnostic function.
+const MAX_RESPONSE_LINES: usize = 16;
+
+/// Maximum best-effort drain attempts after a `recv_line` failure.
+///
+/// Bounded the same way [`MAX_RESPONSE_LINES`] is, so a transport that
+/// (incorrectly) always reports a line available cannot loop unboundedly.
+const MAX_DRAIN_LINES: usize = 16;
+
 /// Send an AT command and wait for the final result code.
 ///
 /// Collects informational lines into `info_buf` (up to `info_buf.len()` lines).
@@ -342,8 +369,30 @@ fn send_and_wait<T: ModemTransport>(
 
     // Read lines until we get a final result code.
     // Limit iterations to prevent infinite loop on broken transport.
-    for _ in 0..64 {
-        let n = transport.recv_line(&mut line_buf, timeout_ms)?;
+    for _ in 0..MAX_RESPONSE_LINES {
+        let n = match transport.recv_line(&mut line_buf, timeout_ms) {
+            Ok(n) => n,
+            Err(e) => {
+                // WHY: send_at already committed this command to the modem
+                // -- a recv_line failure here does not mean the modem
+                // won't still emit the final result code a moment later.
+                // Leaving that response unread desyncs the AT channel: the
+                // NEXT send_and_wait call would read the STALE response as
+                // if it belonged to its own command (issue #282 finding
+                // 13). Best-effort non-blocking drain (timeout_ms=0, per
+                // the ModemTransport contract) mops up anything already
+                // sitting in the transport's receive buffer at the moment
+                // of failure; it cannot recover a response that arrives
+                // strictly after this drain.
+                let mut drain_buf = [0u8; MAX_LINE_LEN];
+                for _ in 0..MAX_DRAIN_LINES {
+                    if transport.recv_line(&mut drain_buf, 0).is_err() {
+                        break;
+                    }
+                }
+                return Err(e);
+            }
+        };
         let line = &line_buf[..n];
 
         // Skip blank lines.
@@ -585,12 +634,16 @@ impl<T: ModemTransport> Telephony<T> {
             Ok((AtResponse::Ok, ref info_line, info_len)) if info_len > 0 => {
                 let line = &info_line[..info_len];
                 match parse_cpin_response(line) {
-                    Some(true) => {
+                    Some(SimPinState::Ready) => {
                         // SIM ready, no PIN required.
                     }
-                    Some(false) => {
+                    Some(SimPinState::PinRequired | SimPinState::Other) => {
                         self.modem_state = ModemState::Error(TelephonyError::SimNotReady);
                         return Err(TelephonyError::SimNotReady);
+                    }
+                    Some(SimPinState::PukRequired) => {
+                        self.modem_state = ModemState::Error(TelephonyError::SimPukRequired);
+                        return Err(TelephonyError::SimPukRequired);
                     }
                     None => {
                         self.modem_state = ModemState::Error(TelephonyError::ParseError);
@@ -660,7 +713,10 @@ impl<T: ModemTransport> Telephony<T> {
         self.init_step = 8;
 
         // Step 9: Initial signal strength query.
-        self.update_signal_strength()?;
+        if let Err(e) = self.update_signal_strength() {
+            self.modem_state = ModemState::Error(e);
+            return Err(e);
+        }
         self.init_step = 9;
 
         // Step 10: Seed registration state. AT+CFUN=1 (step 3) only powers
@@ -764,13 +820,19 @@ impl<T: ModemTransport> Telephony<T> {
         }
 
         self.last_signal_poll = current_tick;
-        if self.update_signal_strength().is_ok() {
-            Some(TelephonyEvent::SignalUpdate {
+        match self.update_signal_strength() {
+            Ok(()) => Some(TelephonyEvent::SignalUpdate {
                 bars: self.signal_strength,
                 rssi_dbm: self.signal_dbm,
-            })
-        } else {
-            None
+            }),
+            // WHY: a failed signal poll must be visible (issue #282 finding
+            // 3), not silently swallowed into None (indistinguishable from
+            // "not time to poll yet"). Reuses the existing ModemError event
+            // vocabulary rather than adding new API surface. A single
+            // transient failure does not change modem_state -- Ready and
+            // Registered are owned by initialize()/apply_reg_status, not by
+            // one periodic CSQ query.
+            Err(e) => Some(TelephonyEvent::ModemError(e)),
         }
     }
 
@@ -945,7 +1007,13 @@ impl<T: ModemTransport> Telephony<T> {
                 })
             }
             Urc::Clip { number, number_len } => {
-                // Update the incoming call with caller ID.
+                // Update the incoming call with caller ID -- only if a RING
+                // already transitioned call_state to Incoming. A +CLIP URC
+                // arriving without a prior RING is out-of-order (or forged
+                // -- the modem/network is untrusted per this project's
+                // threat model) and must not synthesize a phantom
+                // IncomingCall event while call_state stays Idle (issue
+                // #282 finding 19).
                 if let CallState::Incoming {
                     number: ref mut n,
                     len: ref mut l,
@@ -953,8 +1021,10 @@ impl<T: ModemTransport> Telephony<T> {
                 {
                     *n = number;
                     *l = number_len;
+                    Some(TelephonyEvent::IncomingCall { number, number_len })
+                } else {
+                    None
                 }
-                Some(TelephonyEvent::IncomingCall { number, number_len })
             }
             Urc::NoCarrier => {
                 self.call_state = CallState::Idle;
@@ -1077,6 +1147,30 @@ mod tests {
             result,
             Err(TelephonyError::CmeError(302)),
             "a +CMS ERROR on AT+CPIN? must preserve its code, not collapse to SimNotReady"
+        );
+    }
+
+    #[test]
+    fn cpin_sim_puk_surfaces_sim_puk_required_not_sim_not_ready() {
+        let mut mock = MockModemTransport::new();
+        mock.queue_ok(); // Step 1: AT
+        mock.queue_ok(); // Step 2: ATE0
+        mock.queue_ok(); // Step 3: AT+CFUN=1
+        // Step 4: AT+CPIN? -> +CPIN: SIM PUK -- must not be conflated with
+        // SIM PIN (issue #282 finding 17): a UI that responds to
+        // SimNotReady with a 4-digit PIN prompt would burn PUK attempts.
+        mock.queue_info_ok(b"+CPIN: SIM PUK");
+
+        let mut tel = Telephony::new(mock);
+        let result = tel.initialize();
+        assert_eq!(
+            result,
+            Err(TelephonyError::SimPukRequired),
+            "SIM PUK must surface as SimPukRequired, not SimNotReady"
+        );
+        assert_eq!(
+            tel.modem_state(),
+            ModemState::Error(TelephonyError::SimPukRequired)
         );
     }
 
@@ -1236,6 +1330,31 @@ mod tests {
     }
 
     #[test]
+    fn poll_signal_surfaces_error_instead_of_silently_discarding_it() {
+        let mock = mock_for_init();
+        let mut tel = Telephony::new(mock);
+        tel.initialize().ok();
+        assert_eq!(tel.modem_state(), ModemState::Registered);
+
+        // AT+CSQ fails -- the failure must be surfaced as a ModemError
+        // event, not silently discarded as if nothing happened (issue #282
+        // finding 3).
+        tel.transport.queue_response(b"ERROR");
+
+        let event = tel.poll_signal(SIGNAL_POLL_INTERVAL_MS);
+        assert_eq!(
+            event,
+            Some(TelephonyEvent::ModemError(TelephonyError::ModemError)),
+            "a failed signal poll must surface as an event, not silently return None"
+        );
+        assert_eq!(
+            tel.modem_state(),
+            ModemState::Registered,
+            "a single transient poll failure must not kill the Ready/Registered state"
+        );
+    }
+
+    #[test]
     fn ring_urc_transitions_to_incoming() {
         let mock = mock_for_init();
         let mut tel = Telephony::new(mock);
@@ -1250,6 +1369,24 @@ mod tests {
         assert!(
             matches!(tel.call_state(), CallState::Incoming { .. }),
             "call state must transition to Incoming on RING"
+        );
+    }
+
+    #[test]
+    fn clip_without_prior_ring_does_not_emit_phantom_incoming_call() {
+        let mock = mock_for_init();
+        let mut tel = Telephony::new(mock);
+        tel.initialize().ok();
+
+        tel.transport.queue_urc(b"+CLIP: \"+15551234567\",145");
+        let event = tel.poll();
+        assert!(
+            event.is_none(),
+            "CLIP without a prior RING must not emit a phantom IncomingCall event"
+        );
+        assert!(
+            matches!(tel.call_state(), CallState::Idle),
+            "call state must remain Idle"
         );
     }
 
@@ -1317,6 +1454,40 @@ mod tests {
             *tel.call_state(),
             CallState::Idle,
             "call state must transition to Idle on NO CARRIER"
+        );
+    }
+
+    #[test]
+    fn send_and_wait_gives_up_after_max_response_lines_not_64() {
+        let mut mock = MockModemTransport::new();
+        for _ in 0..(MAX_RESPONSE_LINES + 4) {
+            mock.queue_response(b"+JUNK: 0");
+        }
+        let mut info_buf = [[0u8; MAX_LINE_LEN]; 1];
+        let result = send_and_wait(&mut mock, "AT", &mut info_buf, 100);
+        assert_eq!(result, Err(TelephonyError::Timeout));
+        assert!(
+            mock.response_lines.len() >= 4,
+            "must give up at MAX_RESPONSE_LINES, leaving unread lines queued"
+        );
+    }
+
+    #[test]
+    fn send_and_wait_drains_stale_response_after_recv_error() {
+        let mut mock = MockModemTransport::new();
+        mock.queue_response(b"OK");
+        mock.fail_next_recv(1);
+
+        let mut info_buf = [[0u8; MAX_LINE_LEN]; 1];
+        let result = send_and_wait(&mut mock, "AT", &mut info_buf, 100);
+        assert_eq!(
+            result,
+            Err(TelephonyError::TransportError),
+            "the injected failure must still surface as an error"
+        );
+        assert!(
+            mock.response_lines.is_empty(),
+            "the stale OK response must be drained, not left for the next exchange"
         );
     }
 
@@ -1479,6 +1650,32 @@ mod tests {
             tel.modem_state(),
             ModemState::Registered,
             "modem must reach Registered state once AT+CREG? confirms it, despite LTE-only rejection"
+        );
+    }
+
+    #[test]
+    fn initialize_records_error_state_on_step_9_signal_query_failure() {
+        let mut mock = MockModemTransport::new();
+        mock.queue_ok(); // AT
+        mock.queue_ok(); // ATE0
+        mock.queue_ok(); // AT+CFUN=1
+        mock.queue_info_ok(b"+CPIN: READY");
+        mock.queue_ok(); // AT+COPS=0,,,7
+        mock.queue_info_ok(b"+COPS: 0,0,\"T-Mobile\"");
+        mock.queue_ok(); // AT+CREG=1
+        mock.queue_ok(); // AT+CLIP=1
+        mock.queue_response(b"ERROR");
+
+        let mut tel = Telephony::new(mock);
+        let result = tel.initialize();
+        assert!(
+            result.is_err(),
+            "a failed signal query must fail initialize()"
+        );
+        assert_eq!(
+            tel.modem_state(),
+            ModemState::Error(TelephonyError::ModemError),
+            "modem_state must record Error, not remain stuck at Initializing"
         );
     }
 

--- a/crates/thumos/src/telephony_mock.rs
+++ b/crates/thumos/src/telephony_mock.rs
@@ -20,6 +20,12 @@ pub(crate) struct MockModemTransport {
     pub urc_lines: Vec<Vec<u8>>,
     /// Whether send_at should succeed.
     pub send_ok: bool,
+    /// Number of upcoming `recv_line` calls that must fail with
+    /// `TransportError` regardless of queued lines, decrementing on each
+    /// call. Simulates a transient failure (e.g. a real-hardware timeout
+    /// that races a response already in flight) independent of whether a
+    /// response is queued -- see `fail_next_recv`.
+    pub inject_recv_failures: usize,
 }
 
 impl MockModemTransport {
@@ -30,7 +36,14 @@ impl MockModemTransport {
             response_lines: Vec::new(),
             urc_lines: Vec::new(),
             send_ok: true,
+            inject_recv_failures: 0,
         }
+    }
+
+    /// Make the next `n` `recv_line` calls fail with `TransportError`,
+    /// regardless of queued response lines.
+    pub(crate) fn fail_next_recv(&mut self, n: usize) {
+        self.inject_recv_failures = n;
     }
 
     /// Queue a response line to be returned by `recv_line`.
@@ -69,6 +82,10 @@ impl ModemTransport for MockModemTransport {
         buf: &mut [u8; MAX_LINE_LEN],
         _timeout_ms: u32,
     ) -> Result<usize, TelephonyError> {
+        if self.inject_recv_failures > 0 {
+            self.inject_recv_failures -= 1;
+            return Err(TelephonyError::TransportError);
+        }
         if let Some(line) = self.response_lines.first() {
             let len = line.len().min(MAX_LINE_LEN);
             buf[..len].copy_from_slice(&line[..len]);

--- a/crates/thumos/src/telephony_parser.rs
+++ b/crates/thumos/src/telephony_parser.rs
@@ -119,18 +119,43 @@ pub(crate) fn parse_clip_response(
     Some(len as u8)
 }
 
+/// SIM card PIN/PUK lock state, parsed from a `+CPIN?` response.
+///
+/// The +CPIN status vocabulary distinguishes many states (3GPP TS 27.007
+/// §8.3); this enum keeps the practically actionable distinction a caller
+/// needs to route to the correct unlock flow -- entering a PUK as if it
+/// were a PIN (or vice versa) burns limited unlock attempts and can
+/// permanently lock the SIM (issue #282 finding 17).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub(crate) enum SimPinState {
+    /// SIM ready, no PIN required.
+    Ready,
+    /// SIM PIN required.
+    PinRequired,
+    /// SIM PUK required (after too many wrong PIN attempts).
+    PukRequired,
+    /// A recognized but distinct lock state (e.g. PH-SIM PIN, PH-NET PUK) --
+    /// not READY, and not a plain SIM PIN/PUK unlock flow.
+    Other,
+}
+
 /// Parse a +CPIN? response line: "+CPIN: <status>"
 ///
-/// Returns true if the SIM is ready (no PIN required).
-pub(crate) fn parse_cpin_response(line: &[u8]) -> Option<bool> {
+/// Distinguishes SIM PIN vs SIM PUK vs other lock states (issue #282
+/// finding 17) -- the old boolean collapsed every non-READY state to a
+/// single "not ready" flag, which cannot tell a caller whether to prompt
+/// for a 4-digit PIN or an 8-digit PUK.
+pub(crate) fn parse_cpin_response(line: &[u8]) -> Option<SimPinState> {
     let rest = strip_prefix(line, b"+CPIN: ")?;
     if rest == b"READY" {
-        Some(true)
+        Some(SimPinState::Ready)
+    } else if starts_with(rest, b"SIM PUK") {
+        Some(SimPinState::PukRequired)
     } else if starts_with(rest, b"SIM PIN") {
-        Some(false)
+        Some(SimPinState::PinRequired)
     } else {
-        // Other states (SIM PUK, etc.) — treat as not ready.
-        Some(false)
+        Some(SimPinState::Other)
     }
 }
 
@@ -287,6 +312,31 @@ mod tests {
         assert_eq!(dbm_to_bars(-110), 1, "-110 dBm must be 1 bar");
         assert_eq!(dbm_to_bars(-111), 0, "-111 dBm must be 0 bars");
         assert_eq!(dbm_to_bars(-999), 0, "unknown signal must be 0 bars");
+    }
+
+    #[test]
+    fn parse_cpin_response_distinguishes_pin_from_puk() {
+        // Distinguishes SIM PIN vs SIM PUK vs READY (issue #282 finding 17)
+        // -- routing a PUK-locked SIM through a PIN-entry UI flow burns
+        // limited PUK attempts and can permanently lock the SIM.
+        assert_eq!(
+            parse_cpin_response(b"+CPIN: READY"),
+            Some(SimPinState::Ready)
+        );
+        assert_eq!(
+            parse_cpin_response(b"+CPIN: SIM PIN"),
+            Some(SimPinState::PinRequired)
+        );
+        assert_eq!(
+            parse_cpin_response(b"+CPIN: SIM PUK"),
+            Some(SimPinState::PukRequired),
+            "SIM PUK must not collapse to the same state as SIM PIN"
+        );
+        assert_eq!(
+            parse_cpin_response(b"+CPIN: PH-NET PIN"),
+            Some(SimPinState::Other)
+        );
+        assert_eq!(parse_cpin_response(b"garbage"), None);
     }
 
     #[test]

--- a/crates/thumos/src/usb.rs
+++ b/crates/thumos/src/usb.rs
@@ -223,6 +223,9 @@ const CDC_REQ_SET_LINE_CODING: u8 = 0x20;
 const CDC_REQ_GET_LINE_CODING: u8 = 0x21;
 /// SET_CONTROL_LINE_STATE: SET DTR/RTS control lines.
 const CDC_REQ_SET_CONTROL_LINE_STATE: u8 = 0x22;
+/// SET_LINE_CODING's fixed payload length (baud[4] + stop[1] + parity[1] +
+/// data bits[1] = 7 bytes) per the CDC ACM spec.
+const LINE_CODING_LEN: u16 = 7;
 
 // ---------------------------------------------------------------------------
 // CDC functional descriptor subtypes (bDescriptorSubtype)
@@ -704,6 +707,16 @@ fn clamp_rx_count(raw_count: u16, max_pkt: u16) -> usize {
     usize::from(raw_count).min(usize::from(max_pkt))
 }
 
+/// True if `w_length` matches SET_LINE_CODING's fixed [`LINE_CODING_LEN`].
+///
+/// SET_LINE_CODING declares a fixed-size (7-byte) payload per the CDC ACM
+/// spec. A request with any other `wLength` did not actually send the
+/// number of bytes `handle_ep0_data_out` unconditionally reads FROM the
+/// FIFO (issue #282 finding 20).
+fn line_coding_length_is_valid(w_length: u16) -> bool {
+    w_length == LINE_CODING_LEN
+}
+
 // ---------------------------------------------------------------------------
 // USB controller
 // ---------------------------------------------------------------------------
@@ -734,6 +747,9 @@ pub(crate) struct UsbController {
     rx_head: usize,
     /// Read index INTO rx_buf.
     rx_tail: usize,
+    /// Count of serial RX bytes dropped because the ring was full -- see
+    /// `rx_dropped_bytes` (issue #282 finding 4).
+    rx_overflow_count: u32,
 }
 
 impl UsbController {
@@ -755,6 +771,7 @@ impl UsbController {
             rx_buf: [0u8; SERIAL_RX_BUF_LEN],
             rx_head: 0,
             rx_tail: 0,
+            rx_overflow_count: 0,
         }
     }
 
@@ -924,6 +941,38 @@ impl UsbController {
             }
         }
         count
+    }
+
+    /// Number of serial RX bytes dropped because the ring buffer was full.
+    ///
+    /// A nonzero count means the host is producing serial data faster than
+    /// [`read_serial`] drains it -- diagnostic-only, does not affect
+    /// transfer correctness of bytes that WERE accepted (issue #282 finding
+    /// 4).
+    ///
+    /// [`read_serial`]: UsbController::read_serial
+    #[must_use]
+    pub(crate) fn rx_dropped_bytes(&self) -> u32 {
+        self.rx_overflow_count
+    }
+
+    /// Push one received byte into the serial RX ring buffer.
+    ///
+    /// Returns `true` if accepted, `false` if the ring was full and the
+    /// byte was dropped. On drop, increments `rx_overflow_count` so a full
+    /// ring no longer discards host bytes with no counter or log (issue
+    /// #282 finding 4) -- see [`rx_dropped_bytes`].
+    ///
+    /// [`rx_dropped_bytes`]: UsbController::rx_dropped_bytes
+    fn ring_push(&mut self, byte: u8) -> bool {
+        let next_head = (self.rx_head + 1) % SERIAL_RX_BUF_LEN;
+        if next_head == self.rx_tail {
+            self.rx_overflow_count = self.rx_overflow_count.saturating_add(1);
+            return false;
+        }
+        self.rx_buf[self.rx_head] = byte;
+        self.rx_head = next_head;
+        true
     }
 
     // -----------------------------------------------------------------------
@@ -1122,7 +1171,23 @@ impl UsbController {
         unsafe {
             match setup.b_request {
                 CDC_REQ_SET_LINE_CODING => {
-                    // Host will send 7 bytes; prepare to receive them.
+                    // WHY: validate the host's declared length before
+                    // transitioning to DataOut -- a request with any
+                    // wLength other than LINE_CODING_LEN is malformed and
+                    // must be rejected rather than silently read as if 7
+                    // valid bytes were present (issue #282 finding 20).
+                    // This does NOT (yet) validate the ACTUAL FIFO receive
+                    // count against wLength -- that needs an EP0
+                    // byte-count register offset this driver has not
+                    // confirmed against the MT6739 MUSB BSP header (same
+                    // class as the already-tracked TODO(#221) for
+                    // REG_RXCOUNT/EP1+).
+                    if !line_coding_length_is_valid(setup.w_length) {
+                        self.ep0_stall();
+                        return;
+                    }
+                    // Host will send LINE_CODING_LEN bytes; prepare to
+                    // receive them.
                     self.ep0_buf_len = 0;
                     self.ep0_buf_pos = 0;
                     self.ep0_state = Ep0State::DataOut;
@@ -1265,12 +1330,9 @@ impl UsbController {
 
             for _ in 0..rx_count {
                 let byte = core::ptr::read_volatile(fifo as *const u8);
-                let next_head = (self.rx_head + 1) % SERIAL_RX_BUF_LEN;
-                if next_head != self.rx_tail {
-                    self.rx_buf[self.rx_head] = byte;
-                    self.rx_head = next_head;
-                }
-                // Ring buffer full: DROP remaining bytes silently.
+                // Ring-full bytes are counted, not silently dropped -- see
+                // ring_push / rx_dropped_bytes (issue #282 finding 4).
+                self.ring_push(byte);
             }
 
             // Clear RxPktRdy to signal we've consumed the packet.
@@ -1630,6 +1692,15 @@ mod tests {
         assert_eq!(pkt.w_length, 7, "SET_LINE_CODING wLength must be 7");
     }
 
+    #[test]
+    fn line_coding_length_validation_accepts_only_seven() {
+        assert!(line_coding_length_is_valid(7));
+        assert!(!line_coding_length_is_valid(0));
+        assert!(!line_coding_length_is_valid(6));
+        assert!(!line_coding_length_is_valid(8));
+        assert!(!line_coding_length_is_valid(64));
+    }
+
     // --- ACM class request handling ---
 
     #[test]
@@ -1738,6 +1809,32 @@ mod tests {
         let n = ctrl.read_serial(&mut buf);
         assert_eq!(n, 3, "must read exactly 3 bytes");
         assert_eq!(&buf[..3], b"ABC", "bytes must match what was written");
+    }
+
+    #[test]
+    fn ring_push_drops_and_counts_overflow_when_ring_is_full() {
+        let mut ctrl = UsbController::new();
+        // SERIAL_RX_BUF_LEN - 1 slots occupied is "full" for a
+        // head==tail-means-empty ring.
+        ctrl.rx_head = SERIAL_RX_BUF_LEN - 1;
+        ctrl.rx_tail = 0;
+        assert_eq!(ctrl.rx_dropped_bytes(), 0, "no drops yet");
+
+        let accepted = ctrl.ring_push(b'X');
+        assert!(!accepted, "ring at capacity must reject the push");
+        assert_eq!(
+            ctrl.rx_dropped_bytes(),
+            1,
+            "a dropped byte must be counted, not silently discarded (issue #282 finding 4)"
+        );
+    }
+
+    #[test]
+    fn ring_push_accepts_when_space_available() {
+        let mut ctrl = UsbController::new();
+        let accepted = ctrl.ring_push(b'Y');
+        assert!(accepted, "ring with free space must accept the push");
+        assert_eq!(ctrl.rx_dropped_bytes(), 0, "an accepted push is not a drop");
     }
 
     // --- write_serial gate: not configured ---

--- a/crates/thumos/src/wifi.rs
+++ b/crates/thumos/src/wifi.rs
@@ -681,30 +681,32 @@ pub(crate) fn eapol_encode(frame: &EapolFrame) -> Vec<u8> {
         .map_or_else(|| frame.raw_body.clone(), eapol_encode_key_frame);
 
     // WHY: body length is capped at u16::MAX to match the 2-byte length field
-    // in the EAPOL header. Frames exceeding this are malformed; truncation is
-    // the least-bad option in a no_std context without Result overhead.
-    let body_len = if body.len() > u16::MAX as usize {
-        u16::MAX
-    } else {
-        body.len() as u16
-    };
-    let mut out = Vec::with_capacity(EAPOL_HEADER_LEN + body.len());
+    // in the EAPOL header. Frames exceeding this are malformed; truncating
+    // the body is the least-bad option in a no_std context without Result
+    // overhead -- but the truncation must apply to the BYTES WRITTEN, not
+    // just the length field, or the declared length and the actual frame
+    // body diverge (issue #282 finding 5: the old code capped only
+    // `body_len` and then unconditionally wrote the full untruncated
+    // `body`, corrupting any frame whose body exceeded u16::MAX).
+    let body_len = u16::try_from(body.len()).unwrap_or(u16::MAX);
+    let truncated_body = &body[..usize::from(body_len)];
+
+    let mut out = Vec::with_capacity(EAPOL_HEADER_LEN + truncated_body.len());
     out.push(frame.version);
     out.push(frame.packet_type.to_byte());
     out.extend_from_slice(&body_len.to_be_bytes());
-    out.extend_from_slice(&body);
+    out.extend_from_slice(truncated_body);
     out
 }
 
 /// Encode an EAPOL-Key frame body.
 fn eapol_encode_key_frame(kf: &EapolKeyFrame) -> Vec<u8> {
-    // WHY: same u16::MAX cap as eapol_encode for the key_data_length field.
-    let key_data_len = if kf.key_data.len() > u16::MAX as usize {
-        u16::MAX
-    } else {
-        kf.key_data.len() as u16
-    };
-    let mut out = Vec::with_capacity(EAPOL_KEY_FIXED_LEN + kf.key_data.len());
+    // WHY: same u16::MAX cap and WRITTEN-bytes truncation fix as
+    // eapol_encode, applied to the key_data_length field (issue #282
+    // finding 5).
+    let key_data_len = u16::try_from(kf.key_data.len()).unwrap_or(u16::MAX);
+    let truncated_key_data = &kf.key_data[..usize::from(key_data_len)];
+    let mut out = Vec::with_capacity(EAPOL_KEY_FIXED_LEN + truncated_key_data.len());
 
     out.push(kf.descriptor_type);
     out.extend_from_slice(&kf.key_info.0.to_be_bytes());
@@ -716,7 +718,7 @@ fn eapol_encode_key_frame(kf: &EapolKeyFrame) -> Vec<u8> {
     out.extend_from_slice(&[0u8; 8]); // reserved
     out.extend_from_slice(&kf.mic);
     out.extend_from_slice(&key_data_len.to_be_bytes());
-    out.extend_from_slice(&kf.key_data);
+    out.extend_from_slice(truncated_key_data);
     out
 }
 
@@ -1396,6 +1398,25 @@ mod tests {
             parsed.as_ref().and_then(|f| f.key_frame.as_ref()),
             Some(&kf),
             "key frame must survive encode/parse roundtrip"
+        );
+    }
+
+    #[test]
+    fn eapol_encode_truncates_body_bytes_to_match_declared_length_field() {
+        let oversized_len = usize::from(u16::MAX) + 100;
+        let frame = EapolFrame {
+            version: 2,
+            packet_type: EapolType::Start,
+            key_frame: None,
+            raw_body: vec![0xAB; oversized_len],
+        };
+        let encoded = eapol_encode(&frame);
+        let declared_len = u16::from_be_bytes([encoded[2], encoded[3]]);
+        assert_eq!(declared_len, u16::MAX, "length field must be capped");
+        assert_eq!(
+            encoded.len(),
+            EAPOL_HEADER_LEN + usize::from(u16::MAX),
+            "encoded frame length must match the declared length field, not the untruncated body"
         );
     }
 


### PR DESCRIPTION
Second batch of the kernel low-severity rollup (#282). **6 batch-2 findings were duplicate citations already fixed by batch-1 (#433)** — verified stale. **2 are architectural** (per-process CWD tracking; USB RX-ring interrupt/reader sync) and flagged for the operator rather than patched fragilely.

## Security-relevant
- **matrix_crypto capacity exhaustion** — `add_inbound_megolm` accepted duplicate session IDs; an adversary resending one `session_id` filled all 128 inbound slots, starving every other room. Now replaces in place on match.
- **matrix_crypto uncapped allocation** — `decrypt_megolm` allocated `ciphertext.len()` from a room member's payload with no bound. Now rejects >64 KiB before the MAC check / any length-proportional alloc.
- **SIM PIN/PUK confusion** — `parse_cpin_response` collapsed PIN/PUK/other into one flag; prompting for a PIN against a PUK-locked SIM burns limited PUK attempts and can permanently brick it. Now `SimPinState{Ready,PinRequired,PukRequired,Other}` + `SimPukRequired`.
- **wifi EAPOL frame corruption** — `eapol_encode` capped the declared length field but wrote the full untruncated body. Now truncates written bytes to match.

## Correctness / diagnostics
telephony: poll_signal surfaces errors (was silent None); step-9 init records Error not stuck-Initializing; no phantom IncomingCall on CLIP-without-RING; send_and_wait drains stale response on recv error + caps at 16 lines. usb: EP1 overflow byte counter; EP0 SET_LINE_CODING wLength validation. ccci_logger: single-pass anomaly scan (was up to 22 rescans). matrix_crypto: consume_one_time_key drains the OTK pool.

## Verification
- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — **1876 passed** (15 new)
- `cargo build --release --target armv7a-none-eabi` — clean
- `kanon lint` — clean

Partially addresses #282 (findings 19-42: 16 fixed + 6 stale-already-fixed; 2 architectural remain). ~53 findings continue in later batches.

_Security-surface fixes (Megolm dedup/cap, PIN/PUK, EAPOL) reviewed at T0/Opus._