### PR TITLE
Kernel low-rollup batch 3: 7 fixes (5 security) + 12 coverage tests (#282)

### DIFF
--- a/crates/thumos/src/ccci.rs
+++ b/crates/thumos/src/ccci.rs
@@ -2397,6 +2397,38 @@ mod tests {
     }
 
     #[test]
+    fn tx_ring_reclaim_stops_at_first_hw_owned_descriptor() {
+        let mut ring = TxRing::new();
+        ring.init_chain(0x4020_0000);
+
+        for i in 0..4 {
+            ring.submit(
+                0x5000_0000 + (u32::try_from(i).unwrap_or_default()) * 0x1000,
+                64,
+            )
+            .unwrap_or_default();
+        }
+
+        // INVARIANT: tail (descriptor 0) remains HW-owned while descriptors
+        // 1-3 complete out of order. reclaim() must stop at the first
+        // HW-owned descriptor and must not skip ahead to reclaim 1-3.
+        ring.descriptors[1].clear_hw_owned();
+        ring.descriptors[2].clear_hw_owned();
+        ring.descriptors[3].clear_hw_owned();
+
+        let reclaimed = ring.reclaim();
+        assert_eq!(
+            reclaimed, 0,
+            "reclaim must stop at the first HW-owned descriptor, not skip past it"
+        );
+        assert_eq!(
+            ring.free_count(),
+            TX_RING_SIZE - 4,
+            "descriptors 1-3 stay unreclaimed because tail (0) is still HW-owned"
+        );
+    }
+
+    #[test]
     fn rx_ring_init_and_poll() {
         let mut ring = RxRing::new();
         let base: u32 = 0x4030_0000;
@@ -2445,6 +2477,29 @@ mod tests {
         assert_eq!(
             len, buf_size,
             "recv_len must be clamped to the descriptor's data_len (buffer capacity)"
+        );
+    }
+
+    #[test]
+    fn rx_ring_poll_returns_none_when_hw_count_reaches_zero() {
+        let mut ring = RxRing::new();
+        let base: u32 = 0x4030_0000;
+        let buf_addrs: [u32; 2] = [0x5100_0000, 0x5100_1000];
+        ring.init_chain(base, &buf_addrs, 512);
+
+        // Drain both descriptors without rearming -- hw_count reaches 0.
+        ring.descriptors[0].clear_hw_owned();
+        ring.descriptors[1].clear_hw_owned();
+        assert!(ring.poll_rx().is_some(), "first descriptor is ready");
+        assert!(ring.poll_rx().is_some(), "second descriptor is ready");
+
+        // INVARIANT: hw_count == 0 now, and the descriptor at `head` was
+        // drained (not rearmed), so it is NOT HW-owned. Without the
+        // hw_count == 0 early-exit, poll_rx would incorrectly re-yield the
+        // already-drained descriptor instead of reporting no data ready.
+        assert!(
+            ring.poll_rx().is_none(),
+            "hw_count == 0 must short-circuit to None, not re-read a drained descriptor"
         );
     }
 
@@ -2796,6 +2851,51 @@ mod tests {
     }
 
     #[test]
+    fn audit_ring_get_after_wrap_spans_multiple_indices() {
+        // WHY: audit_ring_overflow only asserts get(0) (the oldest entry)
+        // after a wrap. The actual_idx modular-arithmetic path in get() is
+        // reused at every logical index, but a regression there would only
+        // surface away from index 0 -- verify several indices spanning the
+        // point where actual_idx itself wraps back to 0.
+        let mut ring = AuditRing::new();
+
+        // 74 writes = one full wrap (64) + 10 more. write_idx == 10.
+        for i in 0..(AUDIT_RING_CAPACITY + 10) {
+            ring.record(AuditEntry::new(
+                u64::try_from(i).unwrap_or_default(),
+                AuditEventKind::ModemTx,
+                0,
+                &[u8::try_from(i).unwrap_or_default()],
+            ));
+        }
+
+        // Oldest (actual_idx == write_idx == 10, global entry 10).
+        assert_eq!(
+            ring.get(0).expect("entry should exist").timestamp,
+            10,
+            "logical index 0 must resolve to the oldest surviving entry"
+        );
+        // Just before the internal actual_idx wraps back to 0 (actual_idx == 63).
+        assert_eq!(
+            ring.get(53).expect("entry should exist").timestamp,
+            63,
+            "logical index 53 must resolve to actual_idx 63, the last slot before internal wrap"
+        );
+        // Just after the internal actual_idx wraps back to 0.
+        assert_eq!(
+            ring.get(54).expect("entry should exist").timestamp,
+            64,
+            "logical index 54 must resolve to actual_idx 0, the first slot after internal wrap"
+        );
+        // Newest (actual_idx == write_idx - 1 == 9, global entry 73).
+        assert_eq!(
+            ring.get(63).expect("entry should exist").timestamp,
+            73,
+            "logical index 63 (count - 1) must resolve to the newest entry"
+        );
+    }
+
+    #[test]
     fn audit_ring_payload_truncation() {
         let mut ring = AuditRing::new();
         let long_data = [0xAB; 128];
@@ -2939,6 +3039,40 @@ mod tests {
         );
     }
 
+    #[test]
+    fn process_rx_control_message_passes_identity_filter() {
+        let mut driver = CcciDriver::new();
+        // WHY: control messages carry CCCI_MAGIC in data0, not a payload
+        // length -- validate_packet's is_control() skip must let this
+        // reach the identity filter as a normal RX event rather than being
+        // misrouted as an oversized data packet or rejected outright.
+        let hdr = CcciHeader::new_control(1, 7);
+        let payload = b"ctrl";
+
+        let result = driver.process_modem_rx(&hdr, payload, 1000);
+        assert_eq!(
+            result,
+            Ok(true),
+            "control message must pass through, not be rejected"
+        );
+        assert_eq!(
+            driver.malformed_packet_count(),
+            0,
+            "control message must not be misrouted as an oversized data packet"
+        );
+
+        let entry = driver.audit().get(0).expect("audit entry should exist");
+        assert_eq!(
+            entry.kind,
+            AuditEventKind::ModemRx,
+            "control message must be logged as ModemRx, not dropped or misrouted"
+        );
+        assert_eq!(
+            entry.channel, 1,
+            "channel must be preserved for the control message"
+        );
+    }
+
     // -- GPD descriptor flags --
 
     #[test]
@@ -3007,6 +3141,25 @@ mod tests {
         assert!(
             validate_packet(&hdr, 16).is_ok(),
             "control message must pass even though data0 >> buffer_len"
+        );
+    }
+
+    #[test]
+    fn validate_packet_control_message_offset_out_of_bounds() {
+        // Control messages skip the data0 length check (data0 carries
+        // CCCI_MAGIC, not a length), but data1 is still used as an offset
+        // on some channels and must remain bounds-checked even when the
+        // header is a control message.
+        let mut hdr = CcciHeader::new_control(5, 0);
+        hdr.data1 = 500;
+        let result = validate_packet(&hdr, 64);
+        assert_eq!(
+            result,
+            Err(CcciError::OffsetOutOfBounds {
+                offset: 500,
+                buffer_len: 64,
+            }),
+            "control message with OOB data1 must still be rejected"
         );
     }
 

--- a/crates/thumos/src/ccci_logger.rs
+++ b/crates/thumos/src/ccci_logger.rs
@@ -346,10 +346,13 @@ impl fmt::Display for ModemBaseline {
 ///
 /// SECURITY: the entire window is adversary-controlled modem traffic (the
 /// MT6739 modem is untrusted per the threat model). `data0` accumulation is
-/// clamped to `CCCI_MTU` (except the `CCCI_MAGIC` control sentinel) so a
-/// modem that floods the 60-second boot window with `data0` spanning
-/// `[0, u32::MAX]` cannot fully defeat later `Data0OutOfRange` anomaly
-/// detection by establishing a maximally permissive baseline.
+/// clamped to `CCCI_MTU`, and control-sentinel packets (`data0 ==
+/// CCCI_MAGIC`) are excluded from the fold entirely -- `validate_packet`
+/// does not restrict which channel may carry the sentinel, so a modem that
+/// floods the 60-second boot window with `data0` spanning `[0, u32::MAX]`,
+/// including magic-sentinel packets on data channels, cannot fully defeat
+/// later `Data0OutOfRange` anomaly detection by establishing a maximally
+/// permissive baseline.
 ///
 /// # Arguments
 ///
@@ -367,6 +370,7 @@ pub(crate) fn build_baseline(log: &CcciLogger, window_end_ms: u64) -> ModemBasel
 
     // Per-channel accumulators.
     let mut packet_counts = [0u32; CHANNEL_COUNT];
+    let mut data0_initialized = [false; CHANNEL_COUNT];
 
     let (older, newer) = log.entries();
     for entry in older.iter().chain(newer.iter()) {
@@ -380,27 +384,19 @@ pub(crate) fn build_baseline(log: &CcciLogger, window_end_ms: u64) -> ModemBasel
 
         let stats = &mut baseline.channels[ch];
         let count = &mut packet_counts[ch];
+        let d0_seen = &mut data0_initialized[ch];
 
         // SECURITY: clamp data0 accumulation to the CCCI MTU ceiling so a
         // baseline built entirely from adversarial boot-window traffic
         // (data0 spanning the full u32 range) cannot fully defeat later
-        // Data0OutOfRange anomaly detection. The control-message sentinel
-        // (CCCI_MAGIC) is a known exact value, not attacker-influenced
-        // range data -- validate_packet already treats it specially -- so
-        // it passes through unclamped.
-        let clamped_data0 = if entry.data0 == CCCI_MAGIC {
-            entry.data0
-        } else {
-            entry.data0.min(CCCI_MTU as u32)
-        };
+        // Data0OutOfRange anomaly detection.
+        let clamped_data0 = entry.data0.min(CCCI_MTU as u32);
 
         if !stats.active {
             // First packet on this channel: initialize min/max.
             stats.active = true;
             stats.min_size = entry.packet_len;
             stats.max_size = entry.packet_len;
-            stats.min_data0 = clamped_data0;
-            stats.max_data0 = clamped_data0;
         } else {
             if entry.packet_len < stats.min_size {
                 stats.min_size = entry.packet_len;
@@ -408,11 +404,28 @@ pub(crate) fn build_baseline(log: &CcciLogger, window_end_ms: u64) -> ModemBasel
             if entry.packet_len > stats.max_size {
                 stats.max_size = entry.packet_len;
             }
-            if clamped_data0 < stats.min_data0 {
+        }
+
+        // SECURITY: control-plane sentinel packets (data0 == CCCI_MAGIC) are
+        // excluded from data0 range folding entirely. validate_packet does
+        // not restrict which channel may carry the sentinel (it only skips
+        // the length check for control packets), so an adversarial modem
+        // can send a magic-sentinel packet on ANY channel. Letting it set
+        // min/max data0 -- even unclamped -- would poison that channel's
+        // baseline max to u32::MAX, permanently defeating the upper-bound
+        // Data0OutOfRange check (issue #282 finding 1).
+        if entry.data0 != CCCI_MAGIC {
+            if !*d0_seen {
+                *d0_seen = true;
                 stats.min_data0 = clamped_data0;
-            }
-            if clamped_data0 > stats.max_data0 {
                 stats.max_data0 = clamped_data0;
+            } else {
+                if clamped_data0 < stats.min_data0 {
+                    stats.min_data0 = clamped_data0;
+                }
+                if clamped_data0 > stats.max_data0 {
+                    stats.max_data0 = clamped_data0;
+                }
             }
         }
 
@@ -1024,6 +1037,64 @@ mod tests {
     }
 
     #[test]
+    fn logger_entries_split_across_wrap_boundary() {
+        let mut log = CcciLogger::new();
+        // Overfill by 10 so the ring buffer wraps: head lands at physical
+        // index 10, forcing entries() to split its result across the wrap
+        // boundary rather than returning one contiguous slice.
+        for i in 0..(LOG_CAPACITY + 10) {
+            log.record(CcciLogEntry {
+                timestamp: i as u64,
+                channel: 0,
+                direction: PacketDirection::Rx,
+                data0: 0,
+                data1: 0,
+                packet_len: 16,
+            });
+        }
+
+        let (older, newer) = log.entries();
+        assert!(
+            !older.is_empty(),
+            "wrapped buffer must have a non-empty older slice"
+        );
+        assert!(
+            !newer.is_empty(),
+            "wrapped buffer must have a non-empty newer slice"
+        );
+        assert_eq!(
+            older.len() + newer.len(),
+            LOG_CAPACITY,
+            "split slices cover the full live count"
+        );
+        assert_eq!(
+            older.len(),
+            LOG_CAPACITY - 10,
+            "older slice runs from head to the physical end"
+        );
+        assert_eq!(
+            newer.len(),
+            10,
+            "newer slice runs from physical start to head"
+        );
+
+        assert_eq!(older[0].timestamp, 10, "oldest live entry after wrap");
+        assert_eq!(
+            newer[newer.len() - 1].timestamp,
+            137,
+            "newest live entry after wrap"
+        );
+
+        let all: alloc::vec::Vec<&CcciLogEntry> = older.iter().chain(newer.iter()).collect();
+        for i in 1..all.len() {
+            assert!(
+                all[i].timestamp >= all[i - 1].timestamp,
+                "entries must remain chronological across the wrap split"
+            );
+        }
+    }
+
+    #[test]
     fn logger_get_out_of_range() {
         let log = CcciLogger::new();
         assert!(log.get(0).is_none(), "empty logger returns None");
@@ -1169,7 +1240,7 @@ mod tests {
     }
 
     #[test]
-    fn baseline_preserves_control_message_magic() {
+    fn baseline_excludes_control_message_magic_from_data0_range() {
         let mut log = CcciLogger::new();
         log.record(CcciLogEntry {
             timestamp: 1000,
@@ -1181,9 +1252,17 @@ mod tests {
         });
 
         let baseline = build_baseline(&log, 60_000);
+        assert!(
+            baseline.channels[0].active,
+            "channel must still be marked active from the control packet"
+        );
         assert_eq!(
-            baseline.channels[0].max_data0, CCCI_MAGIC,
-            "the control-message sentinel must pass through unclamped"
+            baseline.channels[0].max_data0, 0,
+            "a lone control-sentinel packet must not fold data0 into the baseline range"
+        );
+        assert_eq!(
+            baseline.channels[0].min_data0, 0,
+            "a lone control-sentinel packet must not fold data0 into the baseline range"
         );
     }
 
@@ -1222,6 +1301,60 @@ mod tests {
     }
 
     #[test]
+    fn anomaly_still_fires_after_control_magic_poisoning_attempt() {
+        let mut log = CcciLogger::new();
+        // Legitimate data-channel traffic during the baseline window.
+        log.record(CcciLogEntry {
+            timestamp: 1000,
+            channel: 5,
+            direction: PacketDirection::Rx,
+            data0: 100,
+            data1: 0,
+            packet_len: 16,
+        });
+        // Adversarial modem injects a control-sentinel packet on the SAME
+        // data channel during the baseline window. validate_packet does not
+        // restrict which channel may carry data0 == CCCI_MAGIC, so this is
+        // reachable from the modem boundary. If folded into the baseline,
+        // this would set max_data0 to u32::MAX and permanently defeat the
+        // Data0OutOfRange upper bound for channel 5.
+        log.record(CcciLogEntry {
+            timestamp: 1500,
+            channel: 5,
+            direction: PacketDirection::Rx,
+            data0: CCCI_MAGIC,
+            data1: 0,
+            packet_len: 16,
+        });
+        let baseline = build_baseline(&log, 60_000);
+        assert_eq!(
+            baseline.channels[5].max_data0, 100,
+            "the control-sentinel packet must not widen the data0 baseline range"
+        );
+
+        // Live traffic with a data0 far outside the legitimate [100, 100]
+        // range established above.
+        log.record(CcciLogEntry {
+            timestamp: 70_000,
+            channel: 5,
+            direction: PacketDirection::Rx,
+            data0: 50_000,
+            data1: 0,
+            packet_len: 16,
+        });
+
+        let (anomalies, count, _overflowed) = detect_anomalies(&log, &baseline, 70_000, 60_000);
+        let found = anomalies[..count]
+            .iter()
+            .flatten()
+            .any(|a| a.channel == 5 && a.kind == AnomalyKind::Data0OutOfRange);
+        assert!(
+            found,
+            "anomaly detection must still fire after a control-sentinel poisoning attempt on a data channel"
+        );
+    }
+
+    #[test]
     fn baseline_respects_window() {
         let mut log = CcciLogger::new();
         // Packet outside window.
@@ -1245,6 +1378,55 @@ mod tests {
         let baseline = build_baseline(&log, 60_000);
         assert!(!baseline.channels[0].active, "ch0 is outside window");
         assert!(baseline.channels[1].active, "ch1 is inside window");
+    }
+
+    #[test]
+    fn build_baseline_rejects_out_of_range_channel() {
+        let mut log = CcciLogger::new();
+        // Channel value the ring buffer itself does not validate (that
+        // happens upstream in ccci::validate_packet); build_baseline must
+        // defensively bound-check it rather than panicking or writing past
+        // `baseline.channels`.
+        log.record(CcciLogEntry {
+            timestamp: 1000,
+            channel: 255,
+            direction: PacketDirection::Rx,
+            data0: 100,
+            data1: 0,
+            packet_len: 16,
+        });
+        log.record(CcciLogEntry {
+            timestamp: 2000,
+            channel: u32::MAX,
+            direction: PacketDirection::Rx,
+            data0: 100,
+            data1: 0,
+            packet_len: 16,
+        });
+        // In-range channel to confirm the scan continues normally past the
+        // rejected entries.
+        log.record(CcciLogEntry {
+            timestamp: 3000,
+            channel: 3,
+            direction: PacketDirection::Rx,
+            data0: 50,
+            data1: 0,
+            packet_len: 16,
+        });
+
+        let baseline = build_baseline(&log, 60_000);
+        assert!(
+            baseline
+                .channels
+                .iter()
+                .enumerate()
+                .all(|(ch, stats)| ch == 3 || !stats.active),
+            "out-of-range channel entries must not activate any in-array channel"
+        );
+        assert!(
+            baseline.channels[3].active,
+            "the in-range entry must still be folded in"
+        );
     }
 
     #[test]

--- a/crates/thumos/src/fd.rs
+++ b/crates/thumos/src/fd.rs
@@ -1446,6 +1446,36 @@ mod tests {
         );
     }
 
+    #[cfg(target_pointer_width = "32")]
+    #[test]
+    fn lseek_seek_cur_negative_result_rejected_with_einval() {
+        // SAFETY: test-only.
+        unsafe {
+            setup_test_vfs();
+        }
+        // Seeking further back than the current position with SEEK_CUR
+        // would land at a negative file position -- must be rejected with
+        // EINVAL, not wrap or silently succeed (issue #282 finding 12).
+        let mut fd_entry = FileDescriptor::from_vfs(0, 0, 0);
+        fd_entry.offset = 100;
+        let table = unsafe { &mut *core::ptr::addr_of_mut!(FD_TABLE) };
+        let fd = table.alloc(fd_entry).expect("fd alloc must succeed");
+
+        let negative_offset = 0u32.wrapping_sub(200); // -200 two's complement
+        let result = sys_lseek(fd as u32, negative_offset, SEEK_CUR);
+        assert_eq!(
+            result, EINVAL,
+            "SEEK_CUR producing a negative file position must return EINVAL"
+        );
+
+        // A rejected seek must not mutate the stored offset.
+        let unchanged = sys_lseek(fd as u32, 0, SEEK_CUR);
+        assert_eq!(
+            unchanged, 100,
+            "a rejected SEEK_CUR must not mutate the stored file offset"
+        );
+    }
+
     use super::*;
     use crate::vfs::InodeType;
 
@@ -1937,6 +1967,26 @@ mod tests {
         assert_eq!(result, 0);
         assert_eq!(buf[0], b'/');
         assert_eq!(buf[1], 0);
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    #[test]
+    fn getcwd_buffer_too_small_returns_einval() {
+        // SAFETY: test-only.
+        unsafe {
+            setup_test_vfs();
+        }
+        // The root cwd ("/") needs 2 bytes (1 char + NUL terminator); a
+        // 1-byte buffer must be rejected, not truncated or overflowed
+        // (issue #282 finding 14).
+        static mut BUF: [u8; 1] = [0u8; 1];
+        // SAFETY: test-only static; single-threaded per test.
+        let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUF) };
+        let result = sys_getcwd(buf.as_mut_ptr() as u32, 1);
+        assert_eq!(
+            result, EINVAL,
+            "a buffer too small for cwd + NUL must return EINVAL"
+        );
     }
 
     // -- New VFS-specific tests --

--- a/crates/thumos/src/json_mini.rs
+++ b/crates/thumos/src/json_mini.rs
@@ -198,7 +198,11 @@ impl fmt::Display for JsonValue {
             Self::Null => write!(f, "null"),
             Self::Bool(b) => write!(f, "{b}"),
             Self::Number(n) => write!(f, "{n}"),
-            Self::String(s) => write!(f, "\"{s}\""),
+            Self::String(s) => {
+                let mut escaped = String::new();
+                escape_string_into(&mut escaped, s);
+                write!(f, "\"{escaped}\"")
+            }
             Self::Array(a) => {
                 write!(f, "[")?;
                 for (i, v) in a.iter().enumerate() {
@@ -215,7 +219,9 @@ impl fmt::Display for JsonValue {
                     if i > 0 {
                         write!(f, ",")?;
                     }
-                    write!(f, "\"{k}\":{v}")?;
+                    let mut escaped_key = String::new();
+                    escape_string_into(&mut escaped_key, k);
+                    write!(f, "\"{escaped_key}\":{v}")?;
                 }
                 write!(f, "}}")
             }
@@ -1144,6 +1150,16 @@ mod tests {
     }
 
     #[test]
+    fn parse_string_unicode_escape_lone_surrogate_substitutes_replacement_char() {
+        // \uD800 is a lone high surrogate -- not a valid standalone Unicode
+        // scalar value, and this parser does not implement surrogate-pair
+        // handling (BMP only, per module docs). char::from_u32 rejects it,
+        // and the documented fallback is U+FFFD REPLACEMENT CHARACTER.
+        let val = JsonParser::parse(b"\"\\uD800\"");
+        assert_eq!(val, Ok(JsonValue::String(String::from("\u{FFFD}"))));
+    }
+
+    #[test]
     fn parse_empty_string() {
         let val = JsonParser::parse(b"\"\"");
         assert_eq!(val, Ok(JsonValue::String(String::new())));
@@ -1497,6 +1513,28 @@ mod tests {
         );
     }
 
+    #[test]
+    fn parse_exceeds_max_depth_rejected() {
+        // Build JSON nested one level beyond MAX_DEPTH so the parser must
+        // reject it with TooDeep rather than recursing past the guard
+        // (stack overflow risk on deeply/maliciously nested input).
+        let depth = MAX_DEPTH + 1;
+        let mut json = alloc::vec![b'['; depth];
+        json.extend(alloc::vec![b']'; depth]);
+        let val = JsonParser::parse(&json);
+        assert_eq!(val, Err(JsonError::TooDeep));
+    }
+
+    #[test]
+    fn parse_at_max_depth_accepted() {
+        // Nesting exactly MAX_DEPTH levels must still succeed -- the guard
+        // is `depth > MAX_DEPTH`, not `>=`.
+        let mut json = alloc::vec![b'['; MAX_DEPTH];
+        json.extend(alloc::vec![b']'; MAX_DEPTH]);
+        let val = JsonParser::parse(&json);
+        assert!(val.is_ok(), "exactly MAX_DEPTH nesting must be accepted");
+    }
+
     // ===== Display impls =====
 
     #[test]
@@ -1530,6 +1568,43 @@ mod tests {
         assert_eq!(
             JsonValue::String(String::from("hello")).to_string(),
             "\"hello\""
+        );
+    }
+
+    #[test]
+    fn json_value_display_string_escapes_special_chars() {
+        let value = JsonValue::String(String::from("a\"b\\c\td\ne"));
+        let display = value.to_string();
+        assert_eq!(
+            display, "\"a\\\"b\\\\c\\td\\ne\"",
+            "quote, backslash, and control chars must be escaped in Display output"
+        );
+
+        // The escaped Display output must itself be valid, round-trippable
+        // JSON -- an unescaped embedded '"' would terminate the string
+        // literal early (log/output injection), and raw control bytes
+        // produce non-conformant JSON.
+        let reparsed = JsonParser::parse(display.as_bytes());
+        assert_eq!(
+            reparsed,
+            Ok(value),
+            "escaped Display output must round-trip through the parser"
+        );
+    }
+
+    #[test]
+    fn json_value_display_object_escapes_key() {
+        let value = JsonValue::Object(alloc::vec![(String::from("a\"b"), JsonValue::Null)]);
+        let display = value.to_string();
+        assert_eq!(
+            display, "{\"a\\\"b\":null}",
+            "object keys must be escaped in Display output too"
+        );
+        let reparsed = JsonParser::parse(display.as_bytes());
+        assert_eq!(
+            reparsed,
+            Ok(value),
+            "escaped key must round-trip through the parser"
         );
     }
 

--- a/crates/thumos/src/matrix_crypto.rs
+++ b/crates/thumos/src/matrix_crypto.rs
@@ -2111,6 +2111,29 @@ mod tests {
     }
 
     #[test]
+    fn create_outbound_megolm_at_capacity_returns_session_capacity_reached() {
+        setup_test_rng();
+        let mut crypto = MatrixCrypto::new().expect("test csprng seeded");
+
+        for i in 0..MAX_MEGOLM_OUTBOUND {
+            let room = alloc::format!("!room{i}:example.com");
+            assert!(
+                crypto.create_outbound_megolm(&room).is_ok(),
+                "filling the outbound pool to capacity must succeed"
+            );
+        }
+        assert_eq!(crypto.megolm_outbound.len(), MAX_MEGOLM_OUTBOUND);
+
+        let overflow_room = alloc::format!("!room{MAX_MEGOLM_OUTBOUND}:example.com");
+        assert_eq!(
+            crypto.create_outbound_megolm(&overflow_room),
+            Err(CryptoError::SessionCapacityReached),
+            "a genuinely new room past capacity must be rejected, not silently evict"
+        );
+        assert_eq!(crypto.megolm_outbound.len(), MAX_MEGOLM_OUTBOUND);
+    }
+
+    #[test]
     fn inbound_megolm_session_lookup() {
         setup_test_rng();
         let mut crypto = MatrixCrypto::new().expect("test csprng seeded");
@@ -2166,5 +2189,40 @@ mod tests {
             "capacity must still be available for a genuinely new session after duplicate resends"
         );
         assert_eq!(crypto.megolm_inbound().len(), 2);
+    }
+
+    #[test]
+    fn add_inbound_megolm_at_capacity_returns_session_capacity_reached() {
+        setup_test_rng();
+        let mut crypto = MatrixCrypto::new().expect("test csprng seeded");
+        let room = MatrixRoomId::new("!room:example.com").expect("valid test room id");
+
+        for i in 0..MAX_MEGOLM_INBOUND {
+            let session_id_byte = u8::try_from(i).expect("MAX_MEGOLM_INBOUND fits in u8 range");
+            let session = MegolmSession {
+                session_id: [session_id_byte; KEY_SIZE],
+                session_key: [0xFF; KEY_SIZE],
+                message_index: 0,
+                room_id: room.clone(),
+            };
+            assert!(
+                crypto.add_inbound_megolm(session).is_ok(),
+                "filling the inbound pool to capacity must succeed"
+            );
+        }
+        assert_eq!(crypto.megolm_inbound().len(), MAX_MEGOLM_INBOUND);
+
+        let overflow = MegolmSession {
+            session_id: [0xAA; KEY_SIZE],
+            session_key: [0xBB; KEY_SIZE],
+            message_index: 0,
+            room_id: room,
+        };
+        assert_eq!(
+            crypto.add_inbound_megolm(overflow),
+            Err(CryptoError::SessionCapacityReached),
+            "a genuinely new session_id past capacity must be rejected, not silently evict"
+        );
+        assert_eq!(crypto.megolm_inbound().len(), MAX_MEGOLM_INBOUND);
     }
 }

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -931,14 +931,19 @@ pub(crate) fn current_mappings() -> [Option<VmMapping>; MAX_MAPPINGS] {
 }
 
 /// Get the current process's UID.
-/// Returns 0 (root) if the current process is not found (should not happen).
-pub(crate) fn current_uid() -> u32 {
+///
+/// Returns `None` if the current process's PCB slot is absent -- this must
+/// never silently resolve to UID 0 (root): a missing PCB is a scheduler
+/// invariant violation, and treating it as root would grant full privilege
+/// to whatever code path hit the gap (fail-open privilege escalation,
+/// issue #282, process.rs).
+pub(crate) fn current_uid() -> Option<u32> {
     // SAFETY: current process PCB pointer is valid; set by the scheduler on
     // context switch. Read-only access via addr_of!; no mutation occurs here.
     unsafe {
         let procs = &*core::ptr::addr_of!(PROCS);
         let cur = usize::from(CURRENT);
-        procs[cur].as_ref().map_or(0, |p| p.uid)
+        procs[cur].as_ref().map(|p| p.uid)
     }
 }
 
@@ -2224,7 +2229,26 @@ mod tests {
                 capabilities: crate::capability::Capabilities::ALL,
             });
             CURRENT = 0;
-            assert_eq!(current_uid(), 0, "kinit (PID 0) must have UID 0");
+            assert_eq!(current_uid(), Some(0), "kinit (PID 0) must have UID 0");
+        }
+    }
+
+    /// A missing PCB slot must fail closed: `current_uid` must never
+    /// resolve an absent process to UID 0 (root), since every caller of
+    /// `current_uid` would then treat a scheduler-invariant gap as full
+    /// privilege (issue #282, process.rs).
+    #[test]
+    fn getuid_returns_none_when_pcb_absent_never_zero() {
+        // SAFETY: test-only; reset_all reinitialises global state and
+        // leaves every PROCS slot empty.
+        unsafe {
+            reset_all();
+            CURRENT = 0;
+            assert_eq!(
+                current_uid(),
+                None,
+                "an absent PCB must fail closed with None, never fall back to UID 0"
+            );
         }
     }
 

--- a/crates/thumos/src/security_mode.rs
+++ b/crates/thumos/src/security_mode.rs
@@ -227,6 +227,12 @@ pub enum ModeTransitionError {
     /// target == current mode"), previously conflated with it (issue #282
     /// finding 11).
     NotInPanic,
+    /// Sentinel exit was attempted before a real PIN was provisioned
+    /// (`pin_hash` is `None`) -- distinct from `PinMismatch` so an
+    /// unprovisioned manager fails closed instead of silently accepting or
+    /// permanently masquerading as a wrong-PIN lockout (issue #282,
+    /// security_mode.rs).
+    NotProvisioned,
 }
 
 impl fmt::Display for ModeTransitionError {
@@ -238,6 +244,7 @@ impl fmt::Display for ModeTransitionError {
             Self::AbortWindowExpired => write!(f, "panic abort window has expired"),
             Self::AlreadyInMode => write!(f, "already in the requested mode"),
             Self::NotInPanic => write!(f, "not currently in Panic mode"),
+            Self::NotProvisioned => write!(f, "Sentinel exit PIN not yet provisioned"),
         }
     }
 }
@@ -292,7 +299,15 @@ pub(crate) struct ModeManager {
     last_panic_event: Option<PanicEvent>,
     /// PBKDF2-HMAC-SHA256 derived value for Sentinel exit PIN verification
     /// (RFC 8018, salted + iterated — see [`ModeManager::exit_sentinel`]).
-    pin_hash: [u8; 32],
+    ///
+    /// `None` means this manager has never been provisioned with a real
+    /// PIN. Tracked as an explicit state rather than storing an all-zero
+    /// placeholder: a PBKDF2-HMAC-SHA256 output colliding with all-zero is
+    /// cryptographically negligible, so an all-zero `pin_hash` would be
+    /// indistinguishable from "unprovisioned" yet would silently behave as
+    /// if provisioned -- permanently failing every future PIN check
+    /// (issue #282, security_mode.rs).
+    pin_hash: Option<[u8; 32]>,
 }
 
 impl ModeManager {
@@ -308,7 +323,7 @@ impl ModeManager {
             panic_initiated_tick: None,
             pre_panic_mode: SecurityMode::Daily,
             last_panic_event: None,
-            pin_hash,
+            pin_hash: Some(pin_hash),
         }
     }
 
@@ -371,6 +386,8 @@ impl ModeManager {
     /// # Errors
     ///
     /// Returns [`ModeTransitionError::PinRequired`] if `pin` is empty.
+    /// Returns [`ModeTransitionError::NotProvisioned`] if no PIN has ever
+    /// been set for this manager.
     /// Returns [`ModeTransitionError::PinMismatch`] if the PIN is wrong.
     /// Returns [`ModeTransitionError::PanicIsTerminal`] if in Panic.
     /// Returns [`ModeTransitionError::AlreadyInMode`] if already in Daily.
@@ -388,6 +405,14 @@ impl ModeManager {
         if pin.is_empty() {
             return Err(ModeTransitionError::PinRequired);
         }
+        // WHY: an unprovisioned manager (Default::default(), or any
+        // constructor path that never received a real PIN derivation) must
+        // fail closed and distinguishably from a wrong-PIN guess -- never
+        // silently accept, and never present as a permanent PinMismatch
+        // that looks like an ordinary typo (issue #282, security_mode.rs).
+        let Some(stored_hash) = self.pin_hash else {
+            return Err(ModeTransitionError::NotProvisioned);
+        };
 
         // WHY: PBKDF2-HMAC-SHA256 (RFC 8018) replaces the prior single-round
         // unsalted SHA-256 hash — a 4-6 digit PIN has only 1e4-1e6
@@ -406,7 +431,7 @@ impl ModeManager {
             &mut derived_pin,
         )
         .is_ok();
-        if !derive_ok || !constant_time_eq(&derived_pin, &self.pin_hash) {
+        if !derive_ok || !constant_time_eq(&derived_pin, &stored_hash) {
             return Err(ModeTransitionError::PinMismatch);
         }
 
@@ -599,7 +624,20 @@ impl ModeManager {
 
 impl Default for ModeManager {
     fn default() -> Self {
-        Self::new([0u8; 32])
+        // INVARIANT: default-constructed managers are explicitly
+        // unprovisioned (`pin_hash: None`), not a `Some([0u8; 32])`
+        // placeholder -- the latter would silently look provisioned and
+        // permanently fail every future Sentinel-exit PIN check, since a
+        // real PBKDF2-HMAC-SHA256 derivation colliding with all-zero is
+        // cryptographically negligible (issue #282, security_mode.rs).
+        Self {
+            mode: SecurityMode::Daily,
+            covert_lock: false,
+            panic_initiated_tick: None,
+            pre_panic_mode: SecurityMode::Daily,
+            last_panic_event: None,
+            pin_hash: None,
+        }
     }
 }
 
@@ -872,6 +910,32 @@ mod tests {
         assert_eq!(mm.mode(), SecurityMode::Daily);
         assert!(!mm.covert_lock());
         assert!(mm.last_panic_event().is_none());
+    }
+
+    /// A `Default`-constructed manager has never been provisioned with a
+    /// real PIN; Sentinel exit must fail closed (`NotProvisioned`), not
+    /// silently accept any input and not masquerade as an ordinary
+    /// wrong-PIN `PinMismatch` (issue #282, security_mode.rs).
+    #[test]
+    fn default_mode_manager_is_unprovisioned_and_cannot_exit_sentinel() {
+        let mut mm = ModeManager::default();
+        let mut km = key_manager_with_derived_keys();
+        let mut pm = PowerManager::new();
+
+        mm.enter_sentinel(&mut km, &mut pm)
+            .expect("enter_sentinel failed");
+
+        let result = mm.exit_sentinel(b"123456", &mut pm);
+        assert_eq!(
+            result,
+            Err(ModeTransitionError::NotProvisioned),
+            "an unprovisioned manager must reject Sentinel exit distinctly from a wrong PIN"
+        );
+        assert_eq!(
+            mm.mode(),
+            SecurityMode::Sentinel,
+            "a rejected exit must not change mode"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/thumos/src/syscall.rs
+++ b/crates/thumos/src/syscall.rs
@@ -527,7 +527,10 @@ pub(crate) fn dispatch(num: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> 
         }
         Syscall::Execve => sys_execve(arg0, arg1, arg2),
         Syscall::Kill => signal::sys_kill(arg0, arg1),
-        Syscall::Getuid => process::current_uid(),
+        Syscall::Getuid => match process::current_uid() {
+            Some(uid) => uid,
+            None => ESRCH,
+        },
 
         // ---- Memory management ----
         Syscall::Brk => sys_brk(arg0),

--- a/crates/thumos/src/wifi.rs
+++ b/crates/thumos/src/wifi.rs
@@ -71,6 +71,13 @@ pub enum WifiError {
         /// The invalid type byte.
         value: u8,
     },
+    /// EAPOL-Key frame descriptor type is not RSN (0x02). A non-RSN or
+    /// malformed descriptor must never be parsed and trusted as a WPA2
+    /// handshake frame.
+    UnknownKeyDescriptorType {
+        /// The unexpected descriptor type byte.
+        value: u8,
+    },
     /// No scan results matched the configured network.
     NetworkNotFound,
     /// The WiFi hardware is not initialized.
@@ -88,6 +95,9 @@ impl core::fmt::Display for WifiError {
             }
             Self::UnknownEapolType { value } => {
                 write!(f, "unknown EAPOL type: 0x{value:02x}")
+            }
+            Self::UnknownKeyDescriptorType { value } => {
+                write!(f, "unknown EAPOL-Key descriptor type: 0x{value:02x}")
             }
             Self::NetworkNotFound => write!(f, "network not found"),
             Self::NotInitialized => write!(f, "WiFi not initialized"),
@@ -573,8 +583,9 @@ pub struct EapolFrame {
 /// # Errors
 ///
 /// Returns [`WifiError::FrameTooShort`] when the slice cannot satisfy the
-/// declared packet length, and [`WifiError::UnknownEapolType`] for
-/// unrecognised packet type bytes.
+/// declared packet length, [`WifiError::UnknownEapolType`] for
+/// unrecognised packet type bytes, and [`WifiError::UnknownKeyDescriptorType`]
+/// when an EAPOL-Key frame's descriptor type is not RSN (0x02).
 #[must_use]
 pub(crate) fn eapol_parse(data: &[u8]) -> Result<EapolFrame, WifiError> {
     if data.len() < EAPOL_HEADER_LEN {
@@ -626,6 +637,11 @@ fn eapol_parse_key_frame(body: &[u8]) -> Result<EapolKeyFrame, WifiError> {
     }
 
     let descriptor_type = body[0];
+    if descriptor_type != DESCRIPTOR_TYPE_RSN {
+        return Err(WifiError::UnknownKeyDescriptorType {
+            value: descriptor_type,
+        });
+    }
     let key_info = KeyInfo(u16::from_be_bytes([body[1], body[2]]));
     let key_length = u16::from_be_bytes([body[3], body[4]]);
 
@@ -753,24 +769,31 @@ pub enum HandshakeState {
 ///
 /// Tracks handshake progression and stores transient cryptographic material
 /// (nonces, derived keys) for the duration of the handshake.
+///
+/// NOTE: fields are private (audit #282 batch 3). The only sanctioned way
+/// to advance `state` or populate `ptk` is through [`Self::process_message`],
+/// [`Self::msg2_sent`], and [`Self::complete`] -- direct field mutation
+/// from outside this module would bypass MIC verification and the
+/// replay-counter check, e.g. jumping straight to `SendMsg4` without ever
+/// validating Message 3.
 #[derive(Debug, Clone)]
 pub struct WpaHandshake {
     /// Current handshake state.
-    pub state: HandshakeState,
+    state: HandshakeState,
     /// Authenticator nonce (received in Message 1).
-    pub anonce: [u8; NONCE_LEN],
+    anonce: [u8; NONCE_LEN],
     /// Supplicant nonce (generated locally).
-    pub snonce: [u8; NONCE_LEN],
+    snonce: [u8; NONCE_LEN],
     /// Derived Pairwise Transient Key (populated after Message 1 processing).
-    pub ptk: Option<Ptk>,
+    ptk: Option<Ptk>,
     /// Replay counter from the most recent authenticator message.
-    pub replay_counter: u64,
+    replay_counter: u64,
     /// EAPOL protocol version (IEEE 802.1X-2020 §11.3.1) of the most
     /// recently received frame. Msg3 MIC reconstruction and the Msg2/Msg4
     /// responses echo this value instead of hardcoding version 2 (audit
     /// #259) — a version-1 AP (802.1X-2001, common on embedded/enterprise
     /// gear) otherwise fails every MIC check.
-    pub eapol_version: u8,
+    eapol_version: u8,
 }
 
 impl WpaHandshake {
@@ -918,6 +941,12 @@ impl WpaHandshake {
             HandshakeState::SendMsg2 => {
                 // Message 2: supplicant sends SNonce, mic=true, ack=false
                 // Key info: version=2 (AES), pairwise, MIC
+                // Fail closed (#282 batch 3): a missing PTK means no MIC can
+                // be computed -- never emit a frame with a zeroed, spoofable
+                // MIC.
+                let Some(ref ptk) = self.ptk else {
+                    return None;
+                };
                 let key_info = KeyInfo(0x010a); // version=2, pairwise, MIC
                 let mut kf = EapolKeyFrame {
                     descriptor_type: DESCRIPTOR_TYPE_RSN,
@@ -930,16 +959,13 @@ impl WpaHandshake {
                     mic: [0u8; MIC_LEN],
                     key_data: Vec::new(),
                 };
-                // Compute MIC over the frame with zeroed MIC field.
-                if let Some(ref ptk) = self.ptk {
-                    let frame_for_mic = EapolFrame {
-                        version: self.eapol_version,
-                        packet_type: EapolType::Key,
-                        key_frame: Some(kf.clone()),
-                        raw_body: Vec::new(),
-                    };
-                    kf.mic = compute_mic(&ptk.kck, &eapol_encode(&frame_for_mic));
-                }
+                let frame_for_mic = EapolFrame {
+                    version: self.eapol_version,
+                    packet_type: EapolType::Key,
+                    key_frame: Some(kf.clone()),
+                    raw_body: Vec::new(),
+                };
+                kf.mic = compute_mic(&ptk.kck, &eapol_encode(&frame_for_mic));
                 Some(EapolFrame {
                     version: self.eapol_version,
                     packet_type: EapolType::Key,
@@ -949,6 +975,12 @@ impl WpaHandshake {
             }
             HandshakeState::SendMsg4 => {
                 // Message 4: supplicant sends final ACK, mic=true, secure=true
+                // Fail closed (#282 batch 3): a missing PTK means no MIC can
+                // be computed -- never emit a frame with a zeroed, spoofable
+                // MIC.
+                let Some(ref ptk) = self.ptk else {
+                    return None;
+                };
                 let key_info = KeyInfo(0x030a); // version=2, pairwise, MIC, secure
                 let mut kf = EapolKeyFrame {
                     descriptor_type: DESCRIPTOR_TYPE_RSN,
@@ -961,16 +993,13 @@ impl WpaHandshake {
                     mic: [0u8; MIC_LEN],
                     key_data: Vec::new(),
                 };
-                // Compute MIC over the frame with zeroed MIC field.
-                if let Some(ref ptk) = self.ptk {
-                    let frame_for_mic = EapolFrame {
-                        version: self.eapol_version,
-                        packet_type: EapolType::Key,
-                        key_frame: Some(kf.clone()),
-                        raw_body: Vec::new(),
-                    };
-                    kf.mic = compute_mic(&ptk.kck, &eapol_encode(&frame_for_mic));
-                }
+                let frame_for_mic = EapolFrame {
+                    version: self.eapol_version,
+                    packet_type: EapolType::Key,
+                    key_frame: Some(kf.clone()),
+                    raw_body: Vec::new(),
+                };
+                kf.mic = compute_mic(&ptk.kck, &eapol_encode(&frame_for_mic));
                 Some(EapolFrame {
                     version: self.eapol_version,
                     packet_type: EapolType::Key,
@@ -1402,6 +1431,38 @@ mod tests {
     }
 
     #[test]
+    fn eapol_key_frame_rejects_non_rsn_descriptor_type() {
+        let kf = EapolKeyFrame {
+            descriptor_type: 0xFE, // WPA legacy descriptor, not RSN
+            key_info: KeyInfo(0x008a),
+            key_length: 16,
+            replay_counter: 1,
+            nonce: [0xaa; NONCE_LEN],
+            iv: [0u8; IV_LEN],
+            rsc: 0,
+            mic: [0u8; MIC_LEN],
+            key_data: Vec::new(),
+        };
+        let frame = EapolFrame {
+            version: 2,
+            packet_type: EapolType::Key,
+            key_frame: Some(kf),
+            raw_body: Vec::new(),
+        };
+        let encoded = eapol_encode(&frame);
+        let result = eapol_parse(&encoded);
+        match result {
+            Err(WifiError::UnknownKeyDescriptorType { value }) => {
+                assert_eq!(
+                    value, 0xFE,
+                    "error must report the offending descriptor type"
+                );
+            }
+            _ => panic!("must return UnknownKeyDescriptorType for a non-RSN descriptor"),
+        }
+    }
+
+    #[test]
     fn eapol_encode_truncates_body_bytes_to_match_declared_length_field() {
         let oversized_len = usize::from(u16::MAX) + 100;
         let frame = EapolFrame {
@@ -1586,8 +1647,10 @@ mod tests {
             key_data: Vec::new(),
         };
         hs.process_message(&msg1, &pmk, &own_mac, &ap_mac);
-        // Drive to AwaitMsg3 directly (state is `pub`); independent of
-        // whether audit #260's msg2_sent() transition has landed.
+        // NOTE: `state` is module-private, not pub (audit #282 batch 3);
+        // this write is legal only because `tests` is a submodule of `wifi`.
+        // Drive to AwaitMsg3 directly, independent of whether audit #260's
+        // msg2_sent() transition has landed.
         hs.state = HandshakeState::AwaitMsg3;
 
         // Group-key frame masquerading as Msg3: ack, mic, install set,
@@ -1733,14 +1796,39 @@ mod tests {
     }
 
     #[test]
+    fn build_response_fails_closed_without_ptk() {
+        let mut hs = WpaHandshake::new();
+
+        // Driver misuse: reach SendMsg2/SendMsg4 without ever deriving a
+        // PTK. `state` is module-private but settable here because `tests`
+        // is a submodule of `wifi` -- see
+        // handshake_fails_closed_when_awaiting_msg3_without_ptk for the
+        // equivalent process_message-side guard (audit #282 batch 3).
+        hs.state = HandshakeState::SendMsg2;
+        assert!(hs.ptk.is_none(), "PTK must be None on this path");
+        assert!(
+            hs.build_response().is_none(),
+            "SendMsg2 with ptk == None must not emit a zero-MIC frame"
+        );
+
+        hs.state = HandshakeState::SendMsg4;
+        assert!(
+            hs.build_response().is_none(),
+            "SendMsg4 with ptk == None must not emit a zero-MIC frame"
+        );
+    }
+
+    #[test]
     fn handshake_fails_closed_when_awaiting_msg3_without_ptk() {
         let mut hs = WpaHandshake::new();
         let pmk = [0u8; PMK_LEN];
         let own_mac = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
         let ap_mac = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55];
 
+        // NOTE: `state` is module-private, not pub (audit #282 batch 3);
+        // this write is legal only because `tests` is a submodule of `wifi`.
         // Driver misuse: reach AwaitMsg3 without ever processing Message 1,
-        // so `ptk` is still None (`state` is `pub`, per audit #274/#260).
+        // so `ptk` is still None.
         hs.state = HandshakeState::AwaitMsg3;
         assert!(hs.ptk.is_none(), "PTK must be None on this path");
 


### PR DESCRIPTION
Third batch of the kernel low-severity rollup (#282, findings 43-66). **3 stale** (fixed by earlier batches); **2 too-large** (Matrix one-time-key claim-consumption is Phase-09 wiring scope — the `consume_one_time_key` primitive exists but no `/keys/claim` round-trip calls it yet).

## Security fixes
- **current_uid fail-open→root** — returned UID 0 (root) when the current PCB slot was absent. Now `Option<u32>`; Getuid maps `None → ESRCH`.
- **wifi zero-MIC** — `build_response` emitted an all-zero (spoofable) MIC when `ptk` was None. Now fails closed.
- **wifi descriptor validation** — `eapol_parse` never checked the EAPOL-Key descriptor_type; a non-RSN frame was processed with RSN MIC logic. Now rejected.
- **wifi encapsulation** — `WpaHandshake` security-critical fields were `pub` (could jump to SendMsg4 without validating msg3). Now private.
- **CCCI baseline poisoning** — a control-sentinel packet (`data0=CCCI_MAGIC`) on a data channel folded `u32::MAX` into that channel's data0 baseline, permanently defeating `Data0OutOfRange`. Now excluded from the fold.
- **JSON injection** — `JsonValue::Display` emitted strings/keys unescaped (embedded quote terminates the literal early). Now escaped.
- **Sentinel permanent lockout** — `ModeManager::default()` stored an all-zero `pin_hash` indistinguishable from a never-matchable hash, locking Sentinel exit forever. Now `Option`; unprovisioned = distinct `NotProvisioned` error.

## Coverage (12 tests)
AuditRing wrapped get(), process_modem_rx control message, validate_packet OOB data1, TxRing reclaim early-stop, RxRing hw_count==0, CcciLogger wrapped entries(), build_baseline OOR channel, JSON surrogate + MAX_DEPTH boundary, Megolm session-capacity limits, sys_lseek negative SEEK_CUR, sys_getcwd small buffer.

## Verification
- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — **1897 passed** (21 new)
- `cargo build --release --target armv7a-none-eabi` — clean · `kanon lint` — clean

Partially addresses #282 (findings 43-66: 19 done + 3 stale; 2 Phase-09-blocked). ~29 findings remain (67-95).

_Security fixes (uid/MIC/baseline/lockout) reviewed at T0/Opus._