### PR TITLE
Kernel low-rollup batch 4: 22 coverage tests (#282 tail, findings 67-95)

### DIFF
--- a/crates/thumos/src/ccci_logger.rs
+++ b/crates/thumos/src/ccci_logger.rs
@@ -1770,6 +1770,40 @@ mod tests {
     }
 
     #[test]
+    fn firewall_apply_mode_preserves_counters_across_transition() {
+        let mut fw = CcciFirewall::new(FirewallMode::Daily);
+
+        // Accumulate counters in Daily mode: ControlTx/SystemTx are
+        // allowlisted (allow), MdLogRx is not (drop).
+        fw.evaluate(CcciChannel::ControlTx as u32);
+        fw.evaluate(CcciChannel::SystemTx as u32);
+        fw.evaluate(CcciChannel::MdLogRx as u32);
+        assert_eq!(fw.allow_count(), 2);
+        assert_eq!(fw.drop_count(), 1);
+
+        // WHY: apply_mode rebuilds mode + allowlist_len only -- drop_count
+        // and allow_count must survive the transition, not reset alongside
+        // the allowlist.
+        fw.apply_mode(FirewallMode::Panic);
+        assert_eq!(fw.mode(), FirewallMode::Panic);
+        assert_eq!(
+            fw.allowlist_len(),
+            0,
+            "Panic must still rebuild an empty allowlist"
+        );
+        assert_eq!(
+            fw.allow_count(),
+            2,
+            "apply_mode must not reset allow_count across a mode transition"
+        );
+        assert_eq!(
+            fw.drop_count(),
+            1,
+            "apply_mode must not reset drop_count across a mode transition"
+        );
+    }
+
+    #[test]
     fn firewall_counters_accumulate() {
         let mut fw = CcciFirewall::new(FirewallMode::Sentinel);
 

--- a/crates/thumos/src/matrix_crypto.rs
+++ b/crates/thumos/src/matrix_crypto.rs
@@ -1595,6 +1595,31 @@ mod tests {
     }
 
     #[test]
+    fn aes256_cbc_corrupted_padding_byte_fails() {
+        setup_test_rng();
+        let key = [0u8; KEY_SIZE];
+        // WHY: a plaintext of exactly one block forces PKCS#7 to append a
+        // full padding block (16 bytes, each valued 0x10).
+        let plaintext = b"exactly16bytes!!";
+        let ciphertext = aes256_cbc_encrypt(&key, plaintext);
+        assert!(ciphertext.is_ok());
+        let mut ciphertext = ciphertext.unwrap_or_default();
+
+        // WHY: CBC decryption computes P[n] = D(C[n]) XOR C[n-1], so
+        // flipping a bit in the last byte of the first ciphertext block
+        // (chained into the final padding block) flips the same bit,
+        // deterministically, in the final block's last decrypted byte --
+        // independent of key. 0x10 (padding length 16) XOR 0x01 = 0x11
+        // (17), which exceeds the 16-byte block size, so PKCS#7 unpadding
+        // must reject it.
+        let flip_index = AES_BLOCK_SIZE + AES_BLOCK_SIZE - 1;
+        ciphertext[flip_index] ^= 0x01;
+
+        let result = aes256_cbc_decrypt(&key, &ciphertext);
+        assert_eq!(result, Err(CryptoError::InvalidPadding));
+    }
+
+    #[test]
     fn aes256_cbc_empty_plaintext_fails() {
         let key = [0u8; KEY_SIZE];
         let result = aes256_cbc_encrypt(&key, b"");
@@ -1607,6 +1632,18 @@ mod tests {
         // Too short for IV + one block.
         let result = aes256_cbc_decrypt(&key, &[0u8; 16]);
         assert_eq!(result, Err(CryptoError::CiphertextTooShort));
+    }
+
+    #[test]
+    fn aes256_cbc_non_block_multiple_length_fails() {
+        let key = [0u8; KEY_SIZE];
+        // WHY: data.len() == 33 clears the CiphertextTooShort floor (IV +
+        // one block = 32) but the ciphertext portion (33 - 16 = 17 bytes)
+        // is not a multiple of AES_BLOCK_SIZE, hitting the
+        // InvalidCiphertextLength guard in cbc_decrypt.
+        let data = [0u8; AES_BLOCK_SIZE * 2 + 1];
+        let result = aes256_cbc_decrypt(&key, &data);
+        assert_eq!(result, Err(CryptoError::InvalidCiphertextLength));
     }
 
     // -- Megolm session tests --

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -1470,6 +1470,53 @@ mod tests {
         }
     }
 
+    /// fork() must NOT let the child inherit a signal that was pending in the
+    /// parent at fork time: signal HANDLERS are inherited but the pending mask
+    /// is cleared (process.rs fork(), `s.pending = 0`), matching POSIX
+    /// fork() semantics.
+    #[test]
+    fn fork_clears_child_pending_signal_mask() {
+        // SAFETY: test-only; reset_all reinitialises global state. Single-threaded
+        // test execution ensures no concurrent access to PROCS or CURRENT.
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            let pt = mmu::alloc_addr_space().unwrap_or_default();
+            let mut parent_signal_state = SignalState::new();
+            parent_signal_state.set_pending(crate::signal::Signal::Sigusr1);
+            procs[0] = Some(Process {
+                pid: 0,
+                state: State::Running,
+                ctx: Context::zero(),
+                parent: None,
+                exit_status: 0,
+                page_table_phys: pt,
+                stack_base: 0,
+                stack_pages: 0,
+                heap_break: DEFAULT_HEAP_BREAK,
+                mappings: [None; MAX_MAPPINGS],
+                signal_state: parent_signal_state,
+                uid: 0,
+                wake_tick: 0,
+                capabilities: crate::capability::Capabilities::ALL,
+            });
+            CURRENT = 0;
+
+            let child_pid = fork().unwrap_or_default();
+
+            let child_pending = get_pending_mask(child_pid);
+            let parent_pending = get_pending_mask(0);
+            assert_eq!(
+                child_pending, 0,
+                "child must start with a clean pending-signal mask even though the parent had SIGUSR1 pending at fork time"
+            );
+            assert_ne!(
+                parent_pending, 0,
+                "fork must not clear the PARENT's own pending-signal mask"
+            );
+        }
+    }
+
     #[test]
     fn fork_strips_privileged_capabilities() {
         // SAFETY: test-only; reset_all reinitialises global state. Single-threaded
@@ -2332,6 +2379,71 @@ mod tests {
                 "process must return to Running after clear_wake_tick"
             );
             assert_eq!(p.wake_tick, 0, "wake_tick must be reset to 0");
+        }
+    }
+
+    /// schedule()'s first pass wakes a Sleeping process once its wake_tick has
+    /// elapsed (`now >= wake_tick`), transitioning it to Ready; a process whose
+    /// wake_tick has NOT yet elapsed must stay Sleeping. exceptions::ticks()
+    /// is only ever written FROM the real timer IRQ handler, so it reads 0 for
+    /// the life of the host test binary -- wake_tick 0 is therefore already due.
+    #[test]
+    fn schedule_wakes_sleeping_process_past_wake_tick() {
+        // SAFETY: test-only; reset_all reinitialises global state. Single-threaded
+        // test execution ensures no concurrent access to PROCS or CURRENT.
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+
+            let pt0 = mmu::alloc_addr_space().unwrap_or_default();
+            procs[0] = Some(Process {
+                pid: 0,
+                state: State::Sleeping,
+                ctx: Context::zero(),
+                parent: None,
+                exit_status: 0,
+                page_table_phys: pt0,
+                stack_base: 0,
+                stack_pages: 0,
+                heap_break: DEFAULT_HEAP_BREAK,
+                mappings: [None; MAX_MAPPINGS],
+                signal_state: SignalState::new(),
+                uid: 0,
+                wake_tick: 0,
+                capabilities: crate::capability::Capabilities::ALL,
+            });
+
+            let pt1 = mmu::alloc_addr_space().unwrap_or_default();
+            procs[1] = Some(Process {
+                pid: 1,
+                state: State::Sleeping,
+                ctx: Context::zero(),
+                parent: Some(0),
+                exit_status: 0,
+                page_table_phys: pt1,
+                stack_base: 0,
+                stack_pages: 0,
+                heap_break: DEFAULT_HEAP_BREAK,
+                mappings: [None; MAX_MAPPINGS],
+                signal_state: SignalState::new(),
+                uid: 0,
+                wake_tick: u64::MAX,
+                capabilities: crate::capability::Capabilities::ALL,
+            });
+            CURRENT = 0;
+
+            schedule();
+
+            assert_eq!(
+                get_state(0),
+                Some(State::Ready),
+                "a Sleeping process whose wake_tick has elapsed must transition to Ready"
+            );
+            assert_eq!(
+                get_state(1),
+                Some(State::Sleeping),
+                "a Sleeping process whose wake_tick has NOT elapsed must remain Sleeping"
+            );
         }
     }
     // -----------------------------------------------------------------------

--- a/crates/thumos/src/secure_boot.rs
+++ b/crates/thumos/src/secure_boot.rs
@@ -520,6 +520,86 @@ mod tests {
         assert!(sig.iter().all(|&b| b == 0xBB), "signature must be all 0xBB");
     }
 
+    /// Test that a genuinely valid combined image (payload + Ed25519
+    /// signature under the embedded boot key) verifies via
+    /// [`verify_combined_image`].
+    #[test]
+    fn combined_image_valid_signature_passes() {
+        use ed25519_dalek::{Signer, SigningKey};
+
+        // NOTE: RFC 8032 section 7.1 Test Vector 1 secret key (seed) -- the
+        // private half of BOOT_PUBLIC_KEY. Cross-verified against the
+        // vendored ed25519-dalek crate's own RFC-8032-derived fixture and by
+        // independently recomputing the derived public key.
+        let seed: [u8; 32] = [
+            0x9d, 0x61, 0xb1, 0x9d, 0xef, 0xfd, 0x5a, 0x60, 0xba, 0x84, 0x4a, 0xf4, 0x92, 0xec,
+            0x2c, 0xc4, 0x44, 0x49, 0xc5, 0x69, 0x7b, 0x32, 0x69, 0x19, 0x70, 0x3b, 0xac, 0x03,
+            0x1c, 0xae, 0x7f, 0x60,
+        ];
+        let signing_key = SigningKey::from_bytes(&seed);
+        assert_eq!(
+            signing_key.verifying_key().to_bytes(),
+            BOOT_PUBLIC_KEY,
+            "seed must derive the embedded boot public key"
+        );
+
+        let payload = [0x5Au8; 16];
+        let signature = signing_key.sign(&payload).to_bytes();
+
+        let mut image = [0u8; 16 + SIGNATURE_LEN];
+        image[..16].copy_from_slice(&payload);
+        image[16..].copy_from_slice(&signature);
+
+        assert_eq!(
+            verify_combined_image(&image),
+            Ok(()),
+            "combined image with a valid boot-key signature must verify"
+        );
+    }
+
+    /// Test that tampering a single payload byte after signing breaks
+    /// [`verify_combined_image`] (the signature no longer covers the
+    /// modified bytes).
+    #[test]
+    fn combined_image_tampered_payload_fails() {
+        use ed25519_dalek::{Signer, SigningKey};
+
+        // NOTE: same RFC 8032 Test Vector 1 seed as
+        // combined_image_valid_signature_passes.
+        let seed: [u8; 32] = [
+            0x9d, 0x61, 0xb1, 0x9d, 0xef, 0xfd, 0x5a, 0x60, 0xba, 0x84, 0x4a, 0xf4, 0x92, 0xec,
+            0x2c, 0xc4, 0x44, 0x49, 0xc5, 0x69, 0x7b, 0x32, 0x69, 0x19, 0x70, 0x3b, 0xac, 0x03,
+            0x1c, 0xae, 0x7f, 0x60,
+        ];
+        let signing_key = SigningKey::from_bytes(&seed);
+
+        let payload = [0x5Au8; 16];
+        let signature = signing_key.sign(&payload).to_bytes();
+
+        let mut image = [0u8; 16 + SIGNATURE_LEN];
+        image[..16].copy_from_slice(&payload);
+        image[16..].copy_from_slice(&signature);
+        image[0] ^= 0x01; // tamper one payload byte after signing
+
+        assert_eq!(
+            verify_combined_image(&image),
+            Err(SecureBootError::InvalidSignature),
+            "tampered payload byte must fail signature verification"
+        );
+    }
+
+    /// Test that an image shorter than MIN_IMAGE_SIZE is rejected by
+    /// [`verify_combined_image`] before any signature verification.
+    #[test]
+    fn combined_image_too_short_fails() {
+        let short = [0u8; 64]; // exactly 64 bytes, need 65+
+        assert_eq!(
+            verify_combined_image(&short),
+            Err(SecureBootError::ImageTooShort),
+            "combined image of exactly 64 bytes must fail (need at least 65)"
+        );
+    }
+
     /// Test Display impl for SecureBootError.
     #[test]
     fn error_display() {

--- a/crates/thumos/src/security_mode.rs
+++ b/crates/thumos/src/security_mode.rs
@@ -1131,6 +1131,34 @@ mod tests {
         assert_eq!(mm.mode(), SecurityMode::Panic);
     }
 
+    #[test]
+    fn panic_abort_window_exact_boundary_ticks() {
+        // WHY: elapsed == PANIC_ABORT_WINDOW_TICKS (1500) sits on the
+        // inclusive edge of `elapsed > PANIC_ABORT_WINDOW_TICKS` -- the
+        // abort must still succeed here.
+        let mut mm = mode_manager_with_test_pin();
+        let mut km = key_manager_with_derived_keys();
+        let mut pm = PowerManager::new();
+
+        mm.activate_panic(1000, PanicActivation::KeyCombo, &mut km, &mut pm)
+            .expect("activate_panic failed");
+        mm.abort_panic(2500, &mut pm)
+            .expect("abort at elapsed == PANIC_ABORT_WINDOW_TICKS must succeed");
+        assert_eq!(mm.mode(), SecurityMode::Daily);
+
+        // WHY: elapsed == PANIC_ABORT_WINDOW_TICKS + 1 (1501) is one tick
+        // past the inclusive edge -- the abort must fail here.
+        let mut mm = mode_manager_with_test_pin();
+        let mut km = key_manager_with_derived_keys();
+        let mut pm = PowerManager::new();
+
+        mm.activate_panic(1000, PanicActivation::KeyCombo, &mut km, &mut pm)
+            .expect("activate_panic failed");
+        let result = mm.abort_panic(2501, &mut pm);
+        assert_eq!(result, Err(ModeTransitionError::AbortWindowExpired));
+        assert_eq!(mm.mode(), SecurityMode::Panic);
+    }
+
     // -----------------------------------------------------------------------
     // Covert Lock toggles RF
     // -----------------------------------------------------------------------
@@ -1424,6 +1452,60 @@ mod tests {
         assert!(!constant_time_eq(&a, &c));
     }
 
+    #[test]
+    fn log_mode_change_records_audit_entry() {
+        let mut log = AuditLog::new();
+        let key = [0xAAu8; KEY_SIZE];
+
+        assert!(log.is_empty(), "audit log must start empty");
+
+        log_mode_change(
+            SecurityMode::Daily,
+            SecurityMode::Sentinel,
+            &mut log,
+            &key,
+            12345,
+        );
+
+        assert_eq!(
+            log.len(),
+            1,
+            "log_mode_change must append exactly one entry"
+        );
+        let (older, newer) = log.recent(1);
+        let entry = if newer.is_empty() {
+            &older[0]
+        } else {
+            &newer[0]
+        };
+        assert_eq!(entry.event_type, AuditEventType::ModeChange);
+        assert_eq!(entry.timestamp, 12345);
+        assert_eq!(entry.detail(), b"Daily->Sentinel");
+    }
+
+    #[test]
+    fn log_panic_trigger_records_audit_entry() {
+        let mut log = AuditLog::new();
+        let key = [0xAAu8; KEY_SIZE];
+
+        log_panic_trigger(PanicActivation::PttTripleClick, &mut log, &key, 99);
+
+        assert_eq!(
+            log.len(),
+            1,
+            "log_panic_trigger must append exactly one entry"
+        );
+        let (older, newer) = log.recent(1);
+        let entry = if newer.is_empty() {
+            &older[0]
+        } else {
+            &newer[0]
+        };
+        assert_eq!(entry.event_type, AuditEventType::PanicTrigger);
+        assert_eq!(entry.timestamp, 99);
+        assert_eq!(entry.detail(), b"PTT triple-click");
+    }
+
     // -----------------------------------------------------------------------
     // Threat response tests (Phase 10 Wave 3)
     // -----------------------------------------------------------------------
@@ -1502,6 +1584,42 @@ mod tests {
             fw.mode(),
             FirewallMode::Daily,
             "firewall must remain in Daily mode"
+        );
+    }
+
+    #[test]
+    fn evaluate_threat_score_equals_threshold_is_critical() {
+        // WHY: the critical branch compares `threat_score >= critical_threshold`,
+        // so the threshold value is inclusive of "critical", and the critical
+        // check must short-circuit ahead of the Sentinel-restrict branch even
+        // while Sentinel mode is active.
+        use crate::ccci_logger::{CcciFirewall, FirewallMode};
+
+        let mut fw = CcciFirewall::new(FirewallMode::Daily);
+        let mut pm = PowerManager::new();
+        pm.apply_mode(crate::power::PowerMode::Full);
+
+        let response = evaluate_threat(
+            SecurityMode::Sentinel,
+            80, // score == threshold
+            80, // threshold
+            &mut fw,
+            &mut pm,
+        );
+
+        assert_eq!(
+            response,
+            ThreatResponse::ModemPowerCut,
+            "score exactly equal to critical_threshold must be classified critical"
+        );
+        assert_eq!(
+            fw.mode(),
+            FirewallMode::Panic,
+            "firewall must switch to Panic, not Sentinel, when the score meets the threshold exactly"
+        );
+        assert!(
+            pm.is_modem_pmic_killed(),
+            "modem must be PMIC-killed at the exact threshold"
         );
     }
 

--- a/crates/thumos/src/telephony.rs
+++ b/crates/thumos/src/telephony.rs
@@ -1174,6 +1174,54 @@ mod tests {
         );
     }
 
+    #[test]
+    fn cpin_sim_pin_required_surfaces_sim_not_ready() {
+        let mut mock = MockModemTransport::new();
+        mock.queue_ok(); // Step 1: AT
+        mock.queue_ok(); // Step 2: ATE0
+        mock.queue_ok(); // Step 3: AT+CFUN=1
+        // Step 4: AT+CPIN? -> +CPIN: SIM PIN -- the ordinary PIN-required
+        // case, distinct from the already-covered SIM PUK case.
+        mock.queue_info_ok(b"+CPIN: SIM PIN");
+
+        let mut tel = Telephony::new(mock);
+        let result = tel.initialize();
+        assert_eq!(
+            result,
+            Err(TelephonyError::SimNotReady),
+            "SIM PIN required must surface as SimNotReady"
+        );
+        assert_eq!(
+            tel.modem_state(),
+            ModemState::Error(TelephonyError::SimNotReady)
+        );
+    }
+
+    #[test]
+    fn cpin_cme_error_preserves_code_not_sim_not_ready() {
+        let mut mock = MockModemTransport::new();
+        mock.queue_ok(); // Step 1: AT
+        mock.queue_ok(); // Step 2: ATE0
+        mock.queue_ok(); // Step 3: AT+CFUN=1
+        // Step 4: AT+CPIN? -> +CME ERROR (modem-level failure, not a SIM
+        // PIN/PUK state) -- must preserve the code, not collapse to
+        // SimNotReady (the same class of bug as issue #282 finding 18, but
+        // on the CME rather CMS error path).
+        mock.queue_response(b"+CME ERROR: 10");
+
+        let mut tel = Telephony::new(mock);
+        let result = tel.initialize();
+        assert_eq!(
+            result,
+            Err(TelephonyError::CmeError(10)),
+            "a +CME ERROR on AT+CPIN? must preserve its code, not collapse to SimNotReady"
+        );
+        assert_eq!(
+            tel.modem_state(),
+            ModemState::Error(TelephonyError::CmeError(10))
+        );
+    }
+
     use super::*;
 
     /// Helper: create a mock transport pre-loaded for a full init sequence.
@@ -1355,6 +1403,35 @@ mod tests {
     }
 
     #[test]
+    fn poll_signal_emits_signal_update_when_interval_has_elapsed() {
+        let mock = mock_for_init();
+        let mut tel = Telephony::new(mock);
+        tel.initialize().ok();
+        assert_eq!(tel.modem_state(), ModemState::Registered);
+
+        // RSSI 20 => -113 + (20*2) = -73 dBm (3 bars), distinct from init's
+        // "+CSQ: 18,99" (-77 dBm) so the assertion proves this poll's fresh
+        // data was used, not stale init-time state.
+        tel.transport.queue_info_ok(b"+CSQ: 20,1");
+        let commands_before = tel.transport.sent_commands.len();
+
+        let event = tel.poll_signal(SIGNAL_POLL_INTERVAL_MS);
+        assert_eq!(
+            event,
+            Some(TelephonyEvent::SignalUpdate {
+                bars: 3,
+                rssi_dbm: -73,
+            }),
+            "an elapsed-interval poll_signal must emit SignalUpdate with the freshly queried data"
+        );
+        assert_eq!(
+            tel.transport.sent_commands.len(),
+            commands_before + 1,
+            "poll_signal must issue AT+CSQ when the interval has elapsed"
+        );
+    }
+
+    #[test]
     fn ring_urc_transitions_to_incoming() {
         let mock = mock_for_init();
         let mut tel = Telephony::new(mock);
@@ -1369,6 +1446,42 @@ mod tests {
         assert!(
             matches!(tel.call_state(), CallState::Incoming { .. }),
             "call state must transition to Incoming on RING"
+        );
+    }
+
+    #[test]
+    fn poll_signal_returns_none_and_does_not_repoll_before_interval_elapsed() {
+        let mock = mock_for_init();
+        let mut tel = Telephony::new(mock);
+        tel.initialize().ok();
+
+        // First elapsed-interval poll succeeds and advances last_signal_poll.
+        tel.transport.queue_info_ok(b"+CSQ: 20,1");
+        let first = tel.poll_signal(SIGNAL_POLL_INTERVAL_MS);
+        assert!(
+            first.is_some(),
+            "sanity: first elapsed-interval poll must succeed"
+        );
+
+        let commands_before = tel.transport.sent_commands.len();
+        let dbm_before = tel.signal_dbm();
+
+        // A second call before another full interval has elapsed must be
+        // throttled: no AT+CSQ reissued, no event emitted, no state mutated.
+        let second = tel.poll_signal(SIGNAL_POLL_INTERVAL_MS + 1);
+        assert_eq!(
+            second, None,
+            "poll_signal must return None when called before the interval has elapsed again"
+        );
+        assert_eq!(
+            tel.transport.sent_commands.len(),
+            commands_before,
+            "a throttled poll_signal call must not re-issue AT+CSQ"
+        );
+        assert_eq!(
+            tel.signal_dbm(),
+            dbm_before,
+            "a throttled poll_signal call must not mutate signal state"
         );
     }
 
@@ -1388,6 +1501,45 @@ mod tests {
             matches!(tel.call_state(), CallState::Idle),
             "call state must remain Idle"
         );
+    }
+
+    #[test]
+    fn ring_then_clip_populates_caller_id_on_incoming_call() {
+        let mock = mock_for_init();
+        let mut tel = Telephony::new(mock);
+        tel.initialize().ok();
+
+        tel.transport.queue_urc(b"RING");
+        tel.poll();
+        assert!(
+            matches!(tel.call_state(), CallState::Incoming { .. }),
+            "RING must transition call state to Incoming before CLIP arrives"
+        );
+
+        tel.transport.queue_urc(b"+CLIP: \"+15551234567\",145");
+        let event = tel.poll();
+
+        let expected_number = b"+15551234567";
+        match tel.call_state() {
+            CallState::Incoming { number, len } => {
+                assert_eq!(
+                    &number[..usize::from(*len)],
+                    expected_number,
+                    "CLIP after a prior RING must populate the incoming call's caller ID"
+                );
+            }
+            other => panic!("expected Incoming state with caller ID, got: {other}"),
+        }
+        match event {
+            Some(TelephonyEvent::IncomingCall { number, number_len }) => {
+                assert_eq!(
+                    &number[..usize::from(number_len)],
+                    expected_number,
+                    "CLIP after RING must emit an IncomingCall event carrying the caller ID"
+                );
+            }
+            other => panic!("expected IncomingCall event with caller ID, got: {other:?}"),
+        }
     }
 
     #[test]
@@ -1676,6 +1828,65 @@ mod tests {
             tel.modem_state(),
             ModemState::Error(TelephonyError::ModemError),
             "modem_state must record Error, not remain stuck at Initializing"
+        );
+    }
+
+    #[test]
+    fn initialize_fails_fast_on_early_step_at_command_errors() {
+        // Step 1: AT -> ERROR must abort before any later step is attempted.
+        let mut mock = MockModemTransport::new();
+        mock.queue_response(b"ERROR");
+        let mut tel = Telephony::new(mock);
+        let result = tel.initialize();
+        assert_eq!(
+            result,
+            Err(TelephonyError::ModemError),
+            "step 1 AT failure must fail initialize()"
+        );
+        assert_eq!(
+            tel.modem_state(),
+            ModemState::Error(TelephonyError::ModemError),
+            "modem_state must record Error on step 1 failure"
+        );
+        assert_eq!(
+            tel.transport.sent_commands.len(),
+            1,
+            "a step 1 failure must abort before step 2 (ATE0) is sent"
+        );
+
+        // Step 2: ATE0 -> ERROR must abort before step 3 is attempted.
+        let mut mock = MockModemTransport::new();
+        mock.queue_ok(); // Step 1: AT
+        mock.queue_response(b"ERROR"); // Step 2: ATE0
+        let mut tel = Telephony::new(mock);
+        let result = tel.initialize();
+        assert_eq!(
+            result,
+            Err(TelephonyError::ModemError),
+            "step 2 ATE0 failure must fail initialize()"
+        );
+        assert_eq!(
+            tel.transport.sent_commands.len(),
+            2,
+            "a step 2 failure must abort before step 3 (AT+CFUN=1) is sent"
+        );
+
+        // Step 3: AT+CFUN=1 -> ERROR must abort before step 4 is attempted.
+        let mut mock = MockModemTransport::new();
+        mock.queue_ok(); // Step 1: AT
+        mock.queue_ok(); // Step 2: ATE0
+        mock.queue_response(b"ERROR"); // Step 3: AT+CFUN=1
+        let mut tel = Telephony::new(mock);
+        let result = tel.initialize();
+        assert_eq!(
+            result,
+            Err(TelephonyError::ModemError),
+            "step 3 AT+CFUN=1 failure must fail initialize()"
+        );
+        assert_eq!(
+            tel.transport.sent_commands.len(),
+            3,
+            "a step 3 failure must abort before step 4 (AT+CPIN?) is sent"
         );
     }
 

--- a/crates/thumos/src/telephony_parser.rs
+++ b/crates/thumos/src/telephony_parser.rs
@@ -355,6 +355,30 @@ mod tests {
     }
 
     #[test]
+    fn parse_creg_response_extracts_stat_ignoring_trailing_fields() {
+        assert_eq!(
+            parse_creg_response(b"+CREG: 5"),
+            Some(RegStatus::RegisteredRoaming),
+            "stat=5 must parse as RegisteredRoaming"
+        );
+        assert_eq!(
+            parse_creg_response(b"+CREG: 2,\"1FFE\",\"CE12\""),
+            Some(RegStatus::Searching),
+            "stat must be extracted from the leading field even with trailing lac/ci fields present"
+        );
+        assert_eq!(
+            parse_creg_response(b"+CREG: 9"),
+            Some(RegStatus::Unknown),
+            "an unrecognized stat code must map to RegStatus::Unknown rather than None"
+        );
+        assert_eq!(
+            parse_creg_response(b"+CSQ: 1"),
+            None,
+            "a line without the +CREG prefix must not parse"
+        );
+    }
+
+    #[test]
     fn parse_cops_response_extracts_operator() {
         let line = b"+COPS: 0,0,\"T-Mobile\"";
         let mut name = [0u8; MAX_OPERATOR_LEN];
@@ -438,6 +462,57 @@ mod tests {
         assert_eq!(
             len, None,
             "a caller ID containing AT-command bytes outside the dial charset must be rejected, not stored"
+        );
+    }
+
+    #[test]
+    fn parse_urc_dispatches_line_to_matching_urc_variant() {
+        assert_eq!(
+            parse_urc(b"RING"),
+            Some(Urc::Ring),
+            "RING must dispatch to Urc::Ring"
+        );
+        assert_eq!(
+            parse_urc(b"NO CARRIER"),
+            Some(Urc::NoCarrier),
+            "NO CARRIER must dispatch to Urc::NoCarrier"
+        );
+        assert_eq!(
+            parse_urc(b"BUSY"),
+            Some(Urc::Busy),
+            "BUSY must dispatch to Urc::Busy"
+        );
+        assert_eq!(
+            parse_urc(b"+CSQ: 18,99"),
+            Some(Urc::Csq { rssi: 18, ber: 99 }),
+            "+CSQ line must dispatch to Urc::Csq carrying the parsed rssi/ber"
+        );
+        assert_eq!(
+            parse_urc(b"+CREG: 1"),
+            Some(Urc::Creg {
+                stat: RegStatus::RegisteredHome
+            }),
+            "+CREG line must dispatch to Urc::Creg carrying the parsed stat"
+        );
+        let mut number = [0u8; MAX_NUMBER_LEN];
+        number[..12].copy_from_slice(b"+15551234567");
+        assert_eq!(
+            parse_urc(b"+CLIP: \"+15551234567\",145"),
+            Some(Urc::Clip {
+                number,
+                number_len: 12
+            }),
+            "+CLIP line must dispatch to Urc::Clip carrying the parsed number"
+        );
+        assert_eq!(
+            parse_urc(b"+CLIP: \"AT+CFUN=0\",145"),
+            None,
+            "a +CLIP line whose number fails charset validation must dispatch to None, not a partial Urc::Clip"
+        );
+        assert_eq!(
+            parse_urc(b"+CGATT: 1"),
+            None,
+            "a line matching no known URC prefix must dispatch to None"
         );
     }
 }

--- a/crates/thumos/src/usb.rs
+++ b/crates/thumos/src/usb.rs
@@ -1837,6 +1837,51 @@ mod tests {
         assert_eq!(ctrl.rx_dropped_bytes(), 0, "an accepted push is not a drop");
     }
 
+    #[test]
+    fn ring_push_and_read_wrap_indices_around_buffer_end() {
+        let mut ctrl = UsbController::new();
+        // WHY: position the (empty) ring two slots from the buffer end so the
+        // third push crosses SERIAL_RX_BUF_LEN - 1 and must wrap rx_head back
+        // to 0 rather than index past the end of rx_buf.
+        ctrl.rx_head = SERIAL_RX_BUF_LEN - 2;
+        ctrl.rx_tail = SERIAL_RX_BUF_LEN - 2;
+
+        assert!(
+            ctrl.ring_push(b'A'),
+            "push into a non-full ring must be accepted"
+        );
+        assert!(
+            ctrl.ring_push(b'B'),
+            "push into a non-full ring must be accepted"
+        );
+        assert!(
+            ctrl.ring_push(b'C'),
+            "push that crosses the buffer end must still be accepted"
+        );
+
+        assert_eq!(
+            ctrl.rx_head, 1,
+            "write index must wrap around the buffer end, not overflow past SERIAL_RX_BUF_LEN"
+        );
+        assert_eq!(ctrl.rx_buf[SERIAL_RX_BUF_LEN - 2], b'A');
+        assert_eq!(ctrl.rx_buf[SERIAL_RX_BUF_LEN - 1], b'B');
+        assert_eq!(
+            ctrl.rx_buf[0], b'C',
+            "the byte written after wraparound must land at index 0, not overrun the buffer"
+        );
+
+        let mut buf = [0u8; 3];
+        let n = ctrl.read_serial(&mut buf);
+        assert_eq!(
+            n, 3,
+            "read_serial must drain all 3 bytes across the wrap boundary"
+        );
+        assert_eq!(
+            &buf, b"ABC",
+            "bytes read across the wrap must come back in write order"
+        );
+    }
+
     // --- write_serial gate: not configured ---
 
     #[test]

--- a/crates/thumos/src/wifi.rs
+++ b/crates/thumos/src/wifi.rs
@@ -1384,6 +1384,19 @@ mod tests {
     }
 
     #[test]
+    fn eapol_parse_rejects_unknown_packet_type() {
+        // NOTE: version=2, type=0x04 (undefined EAPOL type byte), length=0.
+        let data = [0x02, 0x04, 0x00, 0x00];
+        let result = eapol_parse(&data);
+        match result {
+            Err(WifiError::UnknownEapolType { value }) => {
+                assert_eq!(value, 0x04, "error must report the offending type byte");
+            }
+            _ => panic!("must return UnknownEapolType for an unrecognised packet type byte"),
+        }
+    }
+
+    #[test]
     fn eapol_frame_parse_short_returns_error() {
         // Only 3 bytes: too short for EAPOL header
         let data = [0x02, 0x01, 0x00];
@@ -1395,6 +1408,27 @@ mod tests {
                 assert_eq!(have, 3, "have must be 3");
             }
             _ => panic!("must return FrameTooShort variant"),
+        }
+    }
+
+    #[test]
+    fn eapol_parse_rejects_declared_body_length_exceeding_buffer() {
+        // NOTE: version=2, type=Start(0x01), declared body length=10, but
+        // only 2 bytes of body actually follow the header.
+        let data = [0x02, 0x01, 0x00, 0x0a, 0xAB, 0xCD];
+        let result = eapol_parse(&data);
+        match result {
+            Err(WifiError::FrameTooShort { need, have }) => {
+                assert_eq!(
+                    need,
+                    EAPOL_HEADER_LEN + 10,
+                    "need must be header length plus the declared body length"
+                );
+                assert_eq!(have, 6, "have must be the actual buffer length");
+            }
+            _ => {
+                panic!("must return FrameTooShort when the declared body length exceeds the buffer")
+            }
         }
     }
 
@@ -1459,6 +1493,54 @@ mod tests {
                 );
             }
             _ => panic!("must return UnknownKeyDescriptorType for a non-RSN descriptor"),
+        }
+    }
+
+    #[test]
+    fn eapol_parse_key_frame_rejects_key_data_length_exceeding_buffer() {
+        let kf = EapolKeyFrame {
+            descriptor_type: DESCRIPTOR_TYPE_RSN,
+            key_info: KeyInfo(0x008a),
+            key_length: 16,
+            replay_counter: 1,
+            nonce: [0xaa; NONCE_LEN],
+            iv: [0u8; IV_LEN],
+            rsc: 0,
+            mic: [0u8; MIC_LEN],
+            key_data: vec![0x01, 0x02, 0x03],
+        };
+        let frame = EapolFrame {
+            version: 2,
+            packet_type: EapolType::Key,
+            key_frame: Some(kf),
+            raw_body: Vec::new(),
+        };
+        let mut encoded = eapol_encode(&frame);
+
+        // WHY: corrupt key_data_length to claim more bytes than actually
+        // follow it, without touching the outer EAPOL body_len field or
+        // the buffer length -- the last two bytes of the fixed key-frame
+        // portion, at offset EAPOL_HEADER_LEN + EAPOL_KEY_FIXED_LEN - 2.
+        let key_data_len_offset = EAPOL_HEADER_LEN + EAPOL_KEY_FIXED_LEN - 2;
+        encoded[key_data_len_offset..key_data_len_offset + 2].copy_from_slice(&50u16.to_be_bytes());
+
+        let result = eapol_parse(&encoded);
+        match result {
+            Err(WifiError::FrameTooShort { need, have }) => {
+                assert_eq!(
+                    need,
+                    EAPOL_KEY_FIXED_LEN + 50,
+                    "need must reflect the corrupted key_data_length"
+                );
+                assert_eq!(
+                    have,
+                    EAPOL_KEY_FIXED_LEN + 3,
+                    "have must be the actual key-frame body length"
+                );
+            }
+            _ => {
+                panic!("must return FrameTooShort when key_data_length exceeds the remaining body")
+            }
         }
     }
 
@@ -1819,6 +1901,81 @@ mod tests {
     }
 
     #[test]
+    fn handshake_builds_msg4_response_and_completes_after_valid_msg3() {
+        setup_csprng();
+        let mut hs = WpaHandshake::new();
+        let pmk = [0u8; PMK_LEN];
+        let own_mac = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
+        let ap_mac = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55];
+
+        let msg1 = EapolKeyFrame {
+            descriptor_type: DESCRIPTOR_TYPE_RSN,
+            key_info: KeyInfo(0x008a),
+            key_length: 16,
+            replay_counter: 1,
+            nonce: [0xaa; NONCE_LEN],
+            iv: [0u8; IV_LEN],
+            rsc: 0,
+            mic: [0u8; MIC_LEN],
+            key_data: Vec::new(),
+        };
+        hs.process_message(&msg1, &pmk, &own_mac, &ap_mac);
+        hs.msg2_sent();
+
+        let mut msg3 = EapolKeyFrame {
+            descriptor_type: DESCRIPTOR_TYPE_RSN,
+            key_info: KeyInfo(0x01ca),
+            key_length: 16,
+            replay_counter: 2,
+            nonce: [0xaa; NONCE_LEN],
+            iv: [0u8; IV_LEN],
+            rsc: 0,
+            mic: [0u8; MIC_LEN],
+            key_data: Vec::new(),
+        };
+        if let Some(ptk) = hs.ptk.clone() {
+            let zeroed_frame = EapolFrame {
+                version: 2,
+                packet_type: EapolType::Key,
+                key_frame: Some(msg3.clone()),
+                raw_body: Vec::new(),
+            };
+            msg3.mic = compute_mic(&ptk.kck, &eapol_encode(&zeroed_frame));
+        }
+
+        let state = hs.process_message(&msg3, &pmk, &own_mac, &ap_mac);
+        assert_eq!(
+            state,
+            HandshakeState::SendMsg4,
+            "Message 3 with a valid MIC must yield SendMsg4"
+        );
+
+        let response = hs.build_response();
+        assert!(
+            response.is_some(),
+            "SendMsg4 with a derived PTK must produce a Message 4 response"
+        );
+        let kf = response.and_then(|f| f.key_frame);
+        assert!(kf.is_some(), "Message 4 response must carry a key frame");
+        if let Some(kf) = kf {
+            assert!(kf.key_info.secure(), "Message 4 must set the secure bit");
+            assert!(kf.key_info.mic(), "Message 4 must set the MIC bit");
+            assert!(!kf.key_info.install(), "Message 4 must not set install");
+            assert_ne!(
+                kf.mic, [0u8; MIC_LEN],
+                "Message 4 MIC must be computed, not zeroed"
+            );
+        }
+
+        hs.complete();
+        assert_eq!(
+            hs.state,
+            HandshakeState::Complete,
+            "complete() must transition SendMsg4 -> Complete"
+        );
+    }
+
+    #[test]
     fn handshake_fails_closed_when_awaiting_msg3_without_ptk() {
         let mut hs = WpaHandshake::new();
         let pmk = [0u8; PMK_LEN];
@@ -1915,6 +2072,53 @@ mod tests {
         assert_ne!(ptk.kck, [0u8; KCK_LEN], "KCK must not be zero");
         assert_ne!(ptk.kek, [0u8; KEK_LEN], "KEK must not be zero");
         assert_ne!(ptk.tk, [0u8; TK_LEN], "TK must not be zero");
+    }
+
+    #[test]
+    fn derive_ptk_normalizes_reversed_aa_spa_and_nonce_order() {
+        let pmk = derive_pmk(b"password", b"TestSSID");
+        let low_mac = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06];
+        let high_mac = [0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F];
+        let low_nonce = [0xAAu8; 32];
+        let high_nonce = [0xBBu8; 32];
+
+        // NOTE: canonical order (aa <= spa, anonce <= snonce) exercises the
+        // already-sorted `if` branches.
+        let sorted = derive_ptk(&pmk, &low_nonce, &high_nonce, &low_mac, &high_mac);
+        // NOTE: reversed order (aa > spa, anonce > snonce) forces both
+        // `else` branches to swap back to the canonical min-first order.
+        let swapped = derive_ptk(&pmk, &high_nonce, &low_nonce, &high_mac, &low_mac);
+
+        assert_eq!(
+            sorted, swapped,
+            "PTK must be identical regardless of AA/SPA and ANonce/SNonce argument order"
+        );
+
+        // WHY: cross-check against PRF-384 computed directly over the
+        // canonical min(AA,SPA) || max(AA,SPA) || min(ANonce,SNonce) ||
+        // max(ANonce,SNonce) concatenation, confirming the swapped call
+        // normalized to that order rather than merely being self-consistent.
+        let mut data = [0u8; 76];
+        data[0..6].copy_from_slice(&low_mac);
+        data[6..12].copy_from_slice(&high_mac);
+        data[12..44].copy_from_slice(&low_nonce);
+        data[44..76].copy_from_slice(&high_nonce);
+        let expected = prf_384(&pmk, b"Pairwise key expansion", &data);
+        assert_eq!(
+            &expected[0..16],
+            &swapped.kck,
+            "swapped-order KCK must match the canonical PRF-384 output"
+        );
+        assert_eq!(
+            &expected[16..32],
+            &swapped.kek,
+            "swapped-order KEK must match the canonical PRF-384 output"
+        );
+        assert_eq!(
+            &expected[32..48],
+            &swapped.tk,
+            "swapped-order TK must match the canonical PRF-384 output"
+        );
     }
 
     /// IEEE Std 802.11i-2004, Table H.13 / Table H.15 (Annex H.7.1,


### PR DESCRIPTION
Final #282 batch — all previously-untested paths. **7 stale** (already covered); **1 fabricated finding** (`scalar_is_canonical` — no such function; the kernel delegates all Ed25519 to `verify_strict`).

## Notable coverage
- **secure_boot verify_combined_image** — valid / tampered-payload / too-short, using the RFC-8032 test-vector-1 seed (private half of the embedded `BOOT_PUBLIC_KEY`) for a genuine positive fixture; the test self-asserts the seed derives `BOOT_PUBLIC_KEY`.
- **wifi** — `derive_ptk` ordering else-branches (cross-checked vs. a hand-built canonical PRF-384); `eapol_parse` UnknownEapolType / body-too-long / key_data overrun; full SendMsg4 → `build_response` → `complete()`.
- **matrix_crypto** — `aes256_cbc` InvalidCiphertextLength + InvalidPadding (via deterministic CBC malleability).
- **process** — fork clears child pending-signal mask; `schedule()` Sleeping→Ready.
- **security_mode** — panic abort window exact boundaries (1500 pass / 1501 fail); audit-log fns; `evaluate_threat` threshold precedence.
- **telephony** — init steps 1-3 fail-fast; SIM-PIN vs CME CPIN arms; poll_signal emit/throttle; RING-then-CLIP caller ID; parse_urc/parse_creg.
- usb ring wraparound; ccci_logger firewall counter preservation.

## Verification
- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — **1923 passed** (26 new)
- `cargo build --release --target armv7a-none-eabi` — clean · `kanon lint` — clean

Completes #282's coverage findings. With this, all 95 findings are fixed (batches 1-3) or covered/confirmed-stale; the 3-4 genuinely-architectural remnants (per-process CWD, USB ring interrupt-sync, Matrix OTK claim-wiring) are being split into their own tracked issues.