### PR TITLE
Wave-2 low-rollup batch 1: 17 fixes across 9 modules (#314)

### DIFF
--- a/crates/thumos/src/bluetooth.rs
+++ b/crates/thumos/src/bluetooth.rs
@@ -48,6 +48,9 @@ const WMT_BT_CHANNEL: u8 = 0x01;
 /// H4 UART packet type: command (host -> controller).
 const H4_COMMAND_TYPE: u8 = 0x01;
 
+/// H4 UART packet type: ACL data (bidirectional; L2CAP/profile payload).
+const H4_ACL_DATA_TYPE: u8 = 0x02;
+
 /// OGF: Controller & Baseband commands.
 const OGF_CONTROLLER_BASEBAND: u16 = 0x03;
 
@@ -295,6 +298,38 @@ pub(crate) fn hci_le_scan_enable(enable: bool, filter_duplicates: bool) -> [u8; 
 }
 
 // ---------------------------------------------------------------------------
+// ACL data encoding (L2CAP/profile payload -- distinct from the HCI command
+// path above)
+// ---------------------------------------------------------------------------
+
+/// Encode an HCI ACL Data packet into an H4-framed buffer.
+///
+/// Format: `[0x02, handle_flags_lo, handle_flags_hi, len_lo, len_hi, payload...]`.
+/// `PB` flag is fixed to `0b10` (first packet, auto-flushable) and `BC` flag to
+/// `0b00` (point-to-point) -- the only combination a host emits for outbound
+/// L2CAP data (Bluetooth Core Spec v5.4 Vol 4 Part E section 5.4.2).
+///
+/// Profile-layer payload (AVDTP signaling, SBC media) belongs on this path,
+/// never the HCI command path (`hci_reset`, `hci_set_random_address`, ...) --
+/// the controller decodes command-typed bytes as an opcode, not a payload.
+#[must_use]
+pub(crate) fn hci_acl_data(handle: u16, payload: &[u8]) -> Vec<u8> {
+    const PB_FIRST_AUTO_FLUSHABLE: u16 = 0b10 << 12;
+    let handle_flags = (handle & 0x0FFF) | PB_FIRST_AUTO_FLUSHABLE;
+    let hf = handle_flags.to_le_bytes();
+    let len = u16::try_from(payload.len()).unwrap_or(u16::MAX);
+    let lv = len.to_le_bytes();
+    let mut out = Vec::with_capacity(5 + payload.len());
+    out.push(H4_ACL_DATA_TYPE);
+    out.push(hf[0]);
+    out.push(hf[1]);
+    out.push(lv[0]);
+    out.push(lv[1]);
+    out.extend_from_slice(payload);
+    out
+}
+
+// ---------------------------------------------------------------------------
 // LE Privacy: non-resolvable private address generation
 // ---------------------------------------------------------------------------
 
@@ -339,6 +374,13 @@ pub(crate) trait BtHwOps {
     /// Send an HCI command via WMT STP transport.
     fn send_command(&mut self, data: &[u8]) -> Result<(), BtError>;
 
+    /// Send HCI ACL data (L2CAP/profile payload) via WMT STP transport.
+    ///
+    /// Distinct from `send_command`: this path carries profile-layer bytes
+    /// (AVDTP signaling, SBC media) framed as HCI ACL Data packets, never as
+    /// HCI commands.
+    fn send_acl_data(&mut self, data: &[u8]) -> Result<(), BtError>;
+
     /// Receive an HCI event from the controller, if available.
     fn recv_event(&mut self) -> Option<Vec<u8>>;
 
@@ -374,6 +416,12 @@ impl BtHw {
 #[cfg(not(test))]
 impl BtHwOps for BtHw {
     fn send_command(&mut self, _data: &[u8]) -> Result<(), BtError> {
+        // TODO(#129)[deliberate-prudent]: implement WMT STP frame TX for BT channel.
+        // Data is framed with WMT_BT_CHANNEL and written to CONSYS MMIO.
+        Err(BtError::NotInitialized)
+    }
+
+    fn send_acl_data(&mut self, _data: &[u8]) -> Result<(), BtError> {
         // TODO(#129)[deliberate-prudent]: implement WMT STP frame TX for BT channel.
         // Data is framed with WMT_BT_CHANNEL and written to CONSYS MMIO.
         Err(BtError::NotInitialized)
@@ -473,14 +521,16 @@ impl<H: BtHwOps> BtAdapter<H> {
             return Err(e);
         }
 
-        // Set the initial random address.
-        self.random_address = generate_random_address();
-        self.address_set_at = current_tick_ms;
-        let addr_cmd = hci_set_random_address(&self.random_address);
+        // Set the initial random address. Commit only after the HCI write
+        // succeeds (mirrors maybe_rotate_address's commit-on-success below).
+        let new_address = generate_random_address();
+        let addr_cmd = hci_set_random_address(&new_address);
         if let Err(e) = self.hw.send_command(&addr_cmd) {
             self.state = BtState::Error(e);
             return Err(e);
         }
+        self.random_address = new_address;
+        self.address_set_at = current_tick_ms;
 
         self.state = BtState::Ready;
         Ok(())
@@ -607,6 +657,8 @@ impl<H: BtHwOps> BtAdapter<H> {
 pub struct MockBtHw {
     /// Commands sent via `send_command`.
     pub sent_commands: Vec<Vec<u8>>,
+    /// ACL data sent via `send_acl_data`.
+    pub sent_acl_data: Vec<Vec<u8>>,
     /// Whether power_on succeeds.
     pub power_on_ok: bool,
     /// Whether send_command succeeds.
@@ -625,6 +677,7 @@ impl MockBtHw {
     pub fn new() -> Self {
         Self {
             sent_commands: Vec::new(),
+            sent_acl_data: Vec::new(),
             power_on_ok: true,
             send_ok: true,
             send_calls: 0,
@@ -644,6 +697,14 @@ impl BtHwOps for MockBtHw {
             return Err(BtError::HardwareTimeout);
         }
         self.sent_commands.push(data.to_vec());
+        Ok(())
+    }
+
+    fn send_acl_data(&mut self, data: &[u8]) -> Result<(), BtError> {
+        if !self.send_ok {
+            return Err(BtError::HardwareTimeout);
+        }
+        self.sent_acl_data.push(data.to_vec());
         Ok(())
     }
 
@@ -751,6 +812,28 @@ mod tests {
         let cmd = hci_le_scan_enable(false, false);
         assert_eq!(cmd[4], 0x00, "enable must be 0");
         assert_eq!(cmd[5], 0x00, "filter_duplicates must be 0");
+    }
+
+    #[test]
+    fn hci_acl_data_uses_acl_type_not_command_type() {
+        let payload = [0xAA, 0xBB, 0xCC];
+        let frame = hci_acl_data(0x0042, &payload);
+        assert_eq!(
+            frame[0], 0x02,
+            "ACL data must use H4 type 0x02, distinct from command type 0x01"
+        );
+        // Handle 0x0042 with PB=0b10, BC=0b00 -> 0x2042 LE.
+        assert_eq!(
+            &frame[1..3],
+            &0x2042u16.to_le_bytes(),
+            "handle/flags field must encode handle + PB=10/BC=00"
+        );
+        assert_eq!(
+            &frame[3..5],
+            &3u16.to_le_bytes(),
+            "data total length must equal the payload length"
+        );
+        assert_eq!(&frame[5..], &payload, "payload must be appended verbatim");
     }
 
     #[test]
@@ -986,6 +1069,26 @@ mod tests {
             adapter.state(),
             BtState::Error(BtError::HardwareTimeout),
             "adapter must be in Error state after HCI command failure"
+        );
+    }
+
+    #[test]
+    fn init_failed_addr_set_leaves_random_address_uncommitted() {
+        let mut hw = MockBtHw::new();
+        hw.fail_after_calls = Some(1); // HCI Reset succeeds; Set Random Address fails
+        let mut adapter = BtAdapter::new(hw);
+        let original_addr = *adapter.random_address();
+
+        let result = adapter.init(12_345);
+        assert_eq!(
+            result,
+            Err(BtError::HardwareTimeout),
+            "init must fail when the Set Random Address command fails"
+        );
+        assert_eq!(
+            *adapter.random_address(),
+            original_addr,
+            "random_address must not be committed unless the HCI write succeeds"
         );
     }
 }

--- a/crates/thumos/src/bt_audio.rs
+++ b/crates/thumos/src/bt_audio.rs
@@ -40,7 +40,7 @@ use crate::avdtp::{
     AVDTP_MAX_TRANSACTION_LABEL, AVDTP_SIGNAL_DISCOVER, AVDTP_SIGNAL_GET_CAPABILITIES,
     AVDTP_SIGNAL_OPEN, AVDTP_SIGNAL_SET_CONFIGURATION, AVDTP_SIGNAL_START, AvdtpMessage,
 };
-use crate::bluetooth::{BtError, BtHwOps};
+use crate::bluetooth::{BtError, BtHwOps, hci_acl_data};
 use crate::sbc::{
     SBC_FREQ_44100, SBC_FREQ_48000, SBC_MAX_FRAME_SIZE, SbcEncoder, SbcFrameHeader, StubSbcEncoder,
 };
@@ -212,7 +212,19 @@ impl<H: BtHwOps> A2dpProfile<H> {
     ///
     /// Must be called before `connect()`. Only 44100 and 48000 Hz are
     /// supported; other values default to 44100.
-    pub(crate) fn configure(&mut self, sample_rate: u32, channels: u8) {
+    ///
+    /// # Errors
+    ///
+    /// - [`BtAudioError::InvalidState`] -- not in Disconnected state. Changing
+    ///   SBC parameters once signaling has started would silently diverge the
+    ///   local encoder from the format already negotiated with the peer via
+    ///   `SetConfiguration`.
+    #[must_use]
+    pub(crate) fn configure(&mut self, sample_rate: u32, channels: u8) -> Result<(), BtAudioError> {
+        if self.state != A2dpState::Disconnected {
+            return Err(BtAudioError::InvalidState);
+        }
+
         self.sample_rate = if sample_rate == 48000 { 48000 } else { 44100 };
         self.channels = if channels >= 2 { 2 } else { 1 };
 
@@ -230,6 +242,7 @@ impl<H: BtHwOps> A2dpProfile<H> {
             }
         };
         self.encoder = StubSbcEncoder::new(header);
+        Ok(())
     }
 
     /// Initiate A2DP connection to the configured peer.
@@ -283,7 +296,7 @@ impl<H: BtHwOps> A2dpProfile<H> {
     /// - [`BtAudioError::HciError`] -- HCI send failed.
     #[must_use]
     pub(crate) fn advance_signaling(&mut self, signal: u8) -> Result<(), BtAudioError> {
-        if self.state != A2dpState::Connecting {
+        if !matches!(self.state, A2dpState::Connecting | A2dpState::Connected) {
             return Err(BtAudioError::InvalidState);
         }
 
@@ -313,10 +326,13 @@ impl<H: BtHwOps> A2dpProfile<H> {
                 self.hw.send_command(&msg).map_err(BtAudioError::from)?;
             }
             AVDTP_SIGNAL_OPEN => {
-                // Received Open response -- send Start.
+                // Received Open response -- send Start, then commit the
+                // Connected transition once the send succeeds (the stream is
+                // now configured and open per the documented lifecycle).
                 let label = self.next_transaction_label();
                 let msg = AvdtpMessage::start(label, self.remote_seid);
                 self.hw.send_command(&msg).map_err(BtAudioError::from)?;
+                self.state = A2dpState::Connected;
             }
             AVDTP_SIGNAL_START => {
                 // Received Start response -- streaming is active.
@@ -334,7 +350,9 @@ impl<H: BtHwOps> A2dpProfile<H> {
 
     /// Send an SBC-encoded audio frame.
     ///
-    /// Encodes the PCM data using the stub encoder and sends it via HCI.
+    /// Encodes the PCM data and sends it as HCI ACL data (the L2CAP/AVDTP
+    /// media transport channel) -- never the HCI command channel, which the
+    /// controller decodes as command opcodes, not payload.
     ///
     /// # Errors
     ///
@@ -351,8 +369,14 @@ impl<H: BtHwOps> A2dpProfile<H> {
         let mut frame_buf = [0u8; SBC_MAX_FRAME_SIZE];
         let frame_len = self.encoder.encode(pcm, &mut frame_buf)?;
 
+        // NOTE: the ACL connection handle for the AVDTP transport channel is
+        // not yet tracked (BR/EDR Create Connection / Connection Complete
+        // wiring is a known gap, same class as the HCI cmd TX stub in
+        // bluetooth.rs). Handle 0 is a placeholder within the legal 12-bit
+        // range until that lands.
+        let acl_frame = hci_acl_data(0, &frame_buf[..frame_len]);
         self.hw
-            .send_command(&frame_buf[..frame_len])
+            .send_acl_data(&acl_frame)
             .map_err(BtAudioError::from)?;
 
         Ok(frame_len)
@@ -583,8 +607,8 @@ mod tests {
         profile.advance_signaling(AVDTP_SIGNAL_OPEN).ok();
         assert_eq!(
             profile.state(),
-            A2dpState::Connecting,
-            "still connecting after open"
+            A2dpState::Connected,
+            "connection completes on the Open response, before auto-continuing to Start"
         );
 
         profile.advance_signaling(AVDTP_SIGNAL_START).ok();
@@ -592,6 +616,34 @@ mod tests {
             profile.state(),
             A2dpState::Streaming,
             "must be Streaming after Start response"
+        );
+    }
+
+    #[test]
+    fn open_response_reaches_connected_via_normal_sequence() {
+        let mut profile = make_a2dp();
+        let peer = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06];
+        profile.set_peer(peer);
+        profile.set_remote_seid(1);
+        profile.connect().ok();
+        profile.advance_signaling(AVDTP_SIGNAL_DISCOVER).ok();
+        profile
+            .advance_signaling(AVDTP_SIGNAL_GET_CAPABILITIES)
+            .ok();
+        profile
+            .advance_signaling(AVDTP_SIGNAL_SET_CONFIGURATION)
+            .ok();
+
+        let result = profile.advance_signaling(AVDTP_SIGNAL_OPEN);
+        assert!(
+            result.is_ok(),
+            "advancing past the Open response must succeed"
+        );
+        assert_eq!(
+            profile.state(),
+            A2dpState::Connected,
+            "Connected must be reachable via the normal connection sequence, \
+             not only via suspend() from Streaming"
         );
     }
 
@@ -638,7 +690,7 @@ mod tests {
     #[test]
     fn configure_clamps_parameters() {
         let mut profile = make_a2dp();
-        profile.configure(96000, 5);
+        profile.configure(96000, 5).ok();
         assert_eq!(
             profile.sample_rate(),
             44100,
@@ -646,9 +698,39 @@ mod tests {
         );
         assert_eq!(profile.channels(), 2, "channels > 2 must clamp to 2");
 
-        profile.configure(48000, 1);
+        profile.configure(48000, 1).ok();
         assert_eq!(profile.sample_rate(), 48000);
         assert_eq!(profile.channels(), 1);
+    }
+
+    #[test]
+    fn configure_rejected_outside_disconnected_state() {
+        let mut profile = make_a2dp();
+        let peer = [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF];
+        profile.set_peer(peer);
+        profile.connect().ok();
+        assert_eq!(profile.state(), A2dpState::Connecting);
+
+        let before_rate = profile.sample_rate();
+        let before_channels = profile.channels();
+
+        let result = profile.configure(48000, 1);
+        assert_eq!(
+            result,
+            Err(BtAudioError::InvalidState),
+            "configure outside Disconnected must not silently diverge the SBC \
+             encoder from the negotiated stream format"
+        );
+        assert_eq!(
+            profile.sample_rate(),
+            before_rate,
+            "sample rate must be unchanged when configure is rejected"
+        );
+        assert_eq!(
+            profile.channels(),
+            before_channels,
+            "channel count must be unchanged when configure is rejected"
+        );
     }
 
     #[test]
@@ -697,5 +779,44 @@ mod tests {
         let err = BtAudioError::CodecNotSupported;
         let msg = alloc::format!("{err}");
         assert_eq!(msg, "SBC codec not supported by peer");
+    }
+
+    #[test]
+    fn send_audio_routes_through_acl_not_command_channel() {
+        let mut profile = make_a2dp();
+        let peer = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06];
+        profile.set_peer(peer);
+        profile.set_remote_seid(1);
+        profile.connect().ok();
+        profile.advance_signaling(AVDTP_SIGNAL_DISCOVER).ok();
+        profile
+            .advance_signaling(AVDTP_SIGNAL_GET_CAPABILITIES)
+            .ok();
+        profile
+            .advance_signaling(AVDTP_SIGNAL_SET_CONFIGURATION)
+            .ok();
+        profile.advance_signaling(AVDTP_SIGNAL_OPEN).ok();
+        profile.advance_signaling(AVDTP_SIGNAL_START).ok();
+        assert_eq!(profile.state(), A2dpState::Streaming);
+
+        let commands_before = profile.hw.sent_commands.len();
+        let pcm = [0i16; 128];
+        let result = profile.send_audio(&pcm);
+        assert!(result.is_ok(), "send_audio must succeed while Streaming");
+
+        assert_eq!(
+            profile.hw.sent_commands.len(),
+            commands_before,
+            "audio frames must never be sent on the HCI command channel"
+        );
+        assert_eq!(
+            profile.hw.sent_acl_data.len(),
+            1,
+            "audio frame must be sent as exactly one ACL data packet"
+        );
+        assert_eq!(
+            profile.hw.sent_acl_data[0][0], 0x02,
+            "ACL data packet must use H4 type 0x02, not H4 command type 0x01"
+        );
     }
 }

--- a/crates/thumos/src/dns.rs
+++ b/crates/thumos/src/dns.rs
@@ -35,10 +35,6 @@ use crate::net::NetworkStack;
 /// Maximum number of entries in the DNS cache.
 pub(crate) const MAX_CACHE_ENTRIES: usize = 64;
 
-/// Default TTL (seconds) for cache entries when the DNS response does
-/// not include a TTL or the response is synthesized.
-const DEFAULT_TTL_SECS: u32 = 300;
-
 /// DNS query/response port.
 const DNS_PORT: u16 = 53;
 
@@ -389,9 +385,14 @@ fn parse_dns_response(data: &[u8], expected_txid: u16) -> Result<(Ipv4Address, u
 
 /// Skip a DNS name in wire format (handles compression pointers).
 fn skip_dns_name(data: &[u8], mut offset: usize) -> Result<usize, DnsError> {
-    // Guard against infinite loops from malformed compression pointers.
-    let mut jumps = 0;
-    let max_jumps = 64;
+    // WHY: this counts regular labels traversed, NOT compression-pointer
+    // jumps — a pointer ends the loop immediately (see below), so it can
+    // never accumulate here. RFC 1035 §3.1 caps a name at 255 octets;
+    // the minimal label encoding (1-octet length + 1-octet content)
+    // allows up to 127 labels before the terminating zero, so the cap
+    // must be at least that high or legal hostnames get rejected.
+    let mut labels = 0;
+    const MAX_LABELS: u32 = 127;
 
     loop {
         if offset >= data.len() {
@@ -413,8 +414,8 @@ fn skip_dns_name(data: &[u8], mut offset: usize) -> Result<usize, DnsError> {
 
         // Regular label.
         offset += 1 + len as usize;
-        jumps += 1;
-        if jumps > max_jumps {
+        labels += 1;
+        if labels > MAX_LABELS {
             return Err(DnsError::MalformedResponse);
         }
     }
@@ -547,9 +548,13 @@ impl DnsResolver {
         expected_txid: u16,
     ) -> Result<IpAddress, DnsError> {
         let (addr, ttl) = parse_dns_response(data, expected_txid)?;
-        let ttl = if ttl == 0 { DEFAULT_TTL_SECS } else { ttl };
         let ip = IpAddress::Ipv4(addr);
-        self.cache.insert(hostname, ip, ttl);
+        // WHY: TTL=0 is an explicit "do not cache" signal (RFC 1035 §3.2.1 /
+        // RFC 2181 §8) — storing it under a fallback TTL would resurrect a
+        // record the authoritative server marked non-cacheable.
+        if ttl > 0 {
+            self.cache.insert(hostname, ip, ttl);
+        }
         Ok(ip)
     }
 
@@ -785,6 +790,25 @@ mod tests {
         assert_eq!(result, Err(DnsError::MalformedResponse));
     }
 
+    #[test]
+    fn skip_dns_name_allows_many_short_labels() {
+        // 100 single-byte labels: over the old (wrong) 64-hop cap but well
+        // under the RFC 1035 §3.1 255-octet/127-label ceiling — must parse.
+        let mut data = Vec::new();
+        for _ in 0..100 {
+            data.push(1u8);
+            data.push(b'a');
+        }
+        data.push(0); // Terminal zero.
+
+        let result = skip_dns_name(&data, 0);
+        assert_eq!(
+            result,
+            Ok(data.len()),
+            "a 100-label name within the RFC 1035 name-length limit must not be rejected"
+        );
+    }
+
     // -- Resolver integration tests --
 
     #[test]
@@ -825,6 +849,48 @@ mod tests {
             resolver.cache().len(),
             1,
             "processed response must be cached"
+        );
+    }
+
+    #[test]
+    fn resolver_does_not_cache_ttl_zero_response() {
+        // Regression: TTL=0 is an explicit "do not cache" signal (RFC 1035
+        // §3.2.1 / RFC 2181 §8) — the resolved address must still be
+        // returned, but the record must not be stored under a fallback TTL.
+        let mut resolver = DnsResolver::new(LAN_DNS, MULLVAD_DNS);
+
+        let mut response = Vec::new();
+        response.extend_from_slice(&0x0002u16.to_be_bytes()); // ID = 2
+        response.extend_from_slice(&0x8180u16.to_be_bytes()); // Flags
+        response.extend_from_slice(&0u16.to_be_bytes()); // QDCOUNT = 0 (simplified)
+        response.extend_from_slice(&1u16.to_be_bytes()); // ANCOUNT = 1
+        response.extend_from_slice(&0u16.to_be_bytes()); // NSCOUNT
+        response.extend_from_slice(&0u16.to_be_bytes()); // ARCOUNT
+
+        // Answer: inline name "nottl.com".
+        response.push(5);
+        response.extend_from_slice(b"nottl");
+        response.push(3);
+        response.extend_from_slice(b"com");
+        response.push(0);
+        response.extend_from_slice(&DNS_TYPE_A.to_be_bytes());
+        response.extend_from_slice(&DNS_CLASS_IN.to_be_bytes());
+        response.extend_from_slice(&0u32.to_be_bytes()); // TTL = 0
+        response.extend_from_slice(&4u16.to_be_bytes()); // RDLENGTH
+        response.extend_from_slice(&[5, 6, 7, 8]);
+
+        let result = resolver.process_response("nottl.com", &response, 0x0002);
+        let addr = result.expect("process_response must succeed for a TTL=0 response");
+        assert_eq!(
+            addr,
+            IpAddress::Ipv4(Ipv4Address::new(5, 6, 7, 8)),
+            "TTL=0 response must still resolve"
+        );
+
+        assert_eq!(
+            resolver.cache().len(),
+            0,
+            "TTL=0 record must not be cached (RFC 2181 §8)"
         );
     }
 

--- a/crates/thumos/src/gps.rs
+++ b/crates/thumos/src/gps.rs
@@ -346,6 +346,15 @@ fn parse_nmea_coord(value: &[u8], deg_digits: usize) -> Result<i64, GpsError> {
     // microdegrees = (degrees + minutes / 60) * 1_000_000
     //              = degrees * 1_000_000 + (minutes_int * 10000 + frac_val) * 1_000_000 / (60 * 10000)
     let minutes_scaled = minutes_int * 10000 + frac_val;
+
+    // INVARIANT: NMEA minutes must be in [0, 60); minutes_scaled is minutes
+    // in units of 1/10000, so the bound is 60 * 10000 = 600_000. A GPS source
+    // reporting >= 60 minutes is malformed and must not silently wrap into
+    // the next degree.
+    if minutes_scaled >= 600_000 {
+        return Err(GpsError::ParseError);
+    }
+
     let microdeg = degrees * 1_000_000 + minutes_scaled * 1_000_000 / 600_000;
 
     Ok(microdeg)
@@ -784,10 +793,17 @@ impl<H: GpsHwOps> GpsReceiver<H> {
     }
 
     /// Shut down the GPS receiver.
+    ///
+    /// Clears the last known position/time fix and any partially
+    /// accumulated NMEA bytes so a subsequent `init()` does not resume
+    /// with stale data left over from before shutdown.
     #[must_use]
     pub(crate) fn shutdown(&mut self) -> Result<(), GpsError> {
         self.hw.power_off()?;
         self.state = GpsState::Off;
+        self.last_position = None;
+        self.last_time = None;
+        self.sentence_buf = SentenceBuffer::new();
         Ok(())
     }
 }
@@ -1008,6 +1024,27 @@ mod tests {
         );
     }
 
+    #[test]
+    fn parse_lat_rejects_minutes_of_60_or_more() {
+        let value = b"5360.0000"; // 60.0 minutes is invalid; NMEA minutes must be < 60
+        let result = parse_lat(value, b"N");
+        assert_eq!(
+            result,
+            Err(GpsError::ParseError),
+            "minutes >= 60 must be rejected as invalid NMEA"
+        );
+    }
+
+    #[test]
+    fn parse_lat_accepts_minutes_just_under_60() {
+        let value = b"5359.9999";
+        let result = parse_lat(value, b"N");
+        assert!(
+            result.is_ok(),
+            "minutes just under 60 must be accepted, got {result:?}"
+        );
+    }
+
     // -- GpsTime epoch conversion --
 
     #[test]
@@ -1057,6 +1094,30 @@ mod tests {
             result,
             Err(GpsError::InvalidState),
             "init while already initialized must return InvalidState"
+        );
+    }
+
+    #[test]
+    fn shutdown_clears_stale_position_and_time() {
+        let hw = MockGpsHw::new();
+        let mut receiver = GpsReceiver::new(hw);
+        receiver.init().expect("init must succeed");
+        receiver.process_sentence(
+            b"$GPGGA,092750.000,5321.6802,N,00630.3372,W,1,8,1.03,61.7,M,55.2,M,,*76",
+        );
+        assert!(
+            receiver.position().is_some(),
+            "position must be set after processing a valid GGA sentence"
+        );
+
+        receiver.shutdown().expect("shutdown must succeed");
+        assert!(
+            receiver.position().is_none(),
+            "shutdown must clear the last known position"
+        );
+        assert!(
+            receiver.time().is_none(),
+            "shutdown must clear the last known time"
         );
     }
 }

--- a/crates/thumos/src/lfs.rs
+++ b/crates/thumos/src/lfs.rs
@@ -600,30 +600,43 @@ impl Lfs {
     }
 
     /// Convert a `DiskInode` to an `InodeStat`.
-    fn inode_to_stat(inode_id: u32, inode: &DiskInode) -> InodeStat {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VfsError::IoError`] if `inode.inode_type` is not a
+    /// recognized on-disk type value.
+    fn inode_to_stat(inode_id: u32, inode: &DiskInode) -> Result<InodeStat, VfsError> {
         let inode_type = match inode.inode_type {
             INODE_TYPE_FILE => InodeType::RegularFile,
             INODE_TYPE_DIR => InodeType::Directory,
-            _ => InodeType::RegularFile, // fallback
+            // WHY: an unrecognized on-disk type is corruption -- guessing
+            // RegularFile here would misreport a corrupt inode's type to
+            // every caller of stat() instead of surfacing the fault.
+            _ => return Err(VfsError::IoError),
         };
 
         // Count allocated blocks (non-zero direct pointers).
         let block_count = inode.direct.iter().filter(|&&p| p != 0).count() as u32;
 
-        InodeStat {
+        Ok(InodeStat {
             inode_id,
             inode_type,
             size: inode.size,
             link_count: u32::from(inode.link_count),
             block_count,
-        }
+        })
     }
 
     /// Parse directory entries from a data block.
     ///
     /// Returns all valid entries found in the block. Entries with
     /// `inode_id == 0` or `record_len == 0` are skipped (sentinel/padding).
-    fn parse_dir_entries(buf: &[u8; BLOCK_SIZE]) -> Vec<DiskDirEntry> {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VfsError::IoError`] if an entry's `name_len` would read
+    /// past that entry's own `record_len`, or past the end of the block.
+    fn parse_dir_entries(buf: &[u8; BLOCK_SIZE]) -> Result<Vec<DiskDirEntry>, VfsError> {
         let mut entries = Vec::new();
         let mut offset = 0;
 
@@ -648,23 +661,39 @@ impl Lfs {
 
             // Skip deleted entries (inode_id == 0).
             if inode_id != 0 && name_len > 0 {
+                // WARNING: name_len and record_len are on-disk fields --
+                // treat them as untrusted. name_len must be bounded by
+                // this entry's own record_len before it is used to slice
+                // `buf`; otherwise the name reads past this entry's
+                // reserved span into the next entry's header/name bytes
+                // (a buffer over-read across the record boundary, not
+                // caught by a bare `name_end <= BLOCK_SIZE` check). Fail
+                // closed on corruption rather than silently truncate.
+                let name_capacity = (record_len as usize)
+                    .checked_sub(DIR_ENTRY_HEADER_SIZE)
+                    .ok_or(VfsError::IoError)?;
+                if name_len as usize > name_capacity {
+                    return Err(VfsError::IoError);
+                }
+
                 let name_start = offset + DIR_ENTRY_HEADER_SIZE;
                 let name_end = name_start + name_len as usize;
-                if name_end <= BLOCK_SIZE {
-                    let name = String::from_utf8_lossy(&buf[name_start..name_end]);
-                    entries.push(DiskDirEntry {
-                        inode_id,
-                        name_len,
-                        record_len,
-                        name: String::from(name.as_ref()),
-                    });
+                if name_end > BLOCK_SIZE {
+                    return Err(VfsError::IoError);
                 }
+                let name = String::from_utf8_lossy(&buf[name_start..name_end]);
+                entries.push(DiskDirEntry {
+                    inode_id,
+                    name_len,
+                    record_len,
+                    name: String::from(name.as_ref()),
+                });
             }
 
             offset += record_len as usize;
         }
 
-        entries
+        Ok(entries)
     }
 
     /// Read all directory entries for a directory inode.
@@ -695,7 +724,7 @@ impl Lfs {
                 .read(dev.as_mut(), block_num, &mut buf)
                 .map_err(|_| VfsError::IoError)?;
 
-            let entries = Self::parse_dir_entries(&buf);
+            let entries = Self::parse_dir_entries(&buf)?;
             all_entries.extend(entries);
         }
 
@@ -794,9 +823,32 @@ impl Lfs {
 
         let block_num = writer
             .write_data_block(dev, cache, seg_mgr, &buf)
-            .map_err(|_| VfsError::IoError)?;
+            .map_err(Self::map_write_data_block_err)?;
 
         Ok(block_num)
+    }
+
+    /// Map an [`LfsError`] from a `write_data_block` call to the
+    /// [`VfsError`] the caller expects.
+    ///
+    /// WHY a shared helper: call sites previously collapsed every
+    /// `write_data_block` failure to one hardcoded `VfsError` variant --
+    /// some sites always reported `NoSpace`, others always reported
+    /// `IoError` -- which misreported the other failure mode at each
+    /// site: a genuine disk-full condition ([`LfsError::NoFreeSegments`])
+    /// surfaced as a generic I/O error at one call site, while a genuine
+    /// device I/O fault surfaced as "no space left on device" at
+    /// another. This maps each `LfsError` variant once so every call
+    /// site reports the correct condition.
+    fn map_write_data_block_err(err: LfsError) -> VfsError {
+        match err {
+            LfsError::NoFreeSegments => VfsError::NoSpace,
+            LfsError::BlockIo(_)
+            | LfsError::Corrupt
+            | LfsError::InvalidSuperblock
+            | LfsError::InodeNotFound
+            | LfsError::CheckpointOverflow => VfsError::IoError,
+        }
     }
 
     /// Allocate the next inode number.
@@ -829,7 +881,7 @@ impl Filesystem for Lfs {
     /// Returns [`VfsError::IoError`] if the block read fails.
     fn stat(&self, inode_id: u32) -> Result<InodeStat, VfsError> {
         let inode = self.load_inode(inode_id)?;
-        Ok(Self::inode_to_stat(inode_id, &inode))
+        Self::inode_to_stat(inode_id, &inode)
     }
 
     /// Look up a child entry by name within a directory.
@@ -982,7 +1034,7 @@ impl Filesystem for Lfs {
             // Write the data block to the log.
             let new_block = writer
                 .write_data_block(dev.as_mut(), &mut cache, &mut self.segments, &block_buf)
-                .map_err(|_| VfsError::NoSpace)?;
+                .map_err(Self::map_write_data_block_err)?;
 
             inode.direct[block_index] = new_block;
             bytes_written += chunk;
@@ -1245,13 +1297,15 @@ impl Filesystem for Lfs {
 
         let mut entries = Vec::with_capacity(disk_entries.len());
         for de in &disk_entries {
-            // Determine the inode type by loading the child inode.
-            let child_type = match self.load_inode(de.inode_id) {
-                Ok(child) => match child.inode_type {
-                    INODE_TYPE_DIR => InodeType::Directory,
-                    _ => InodeType::RegularFile,
-                },
-                Err(_) => InodeType::RegularFile, // fallback if child can't be loaded
+            // WHY: a failed child load or an unrecognized on-disk type
+            // is on-disk corruption; propagate it per this method's
+            // documented error contract instead of silently reporting
+            // the entry as a regular file.
+            let child = self.load_inode(de.inode_id)?;
+            let child_type = match child.inode_type {
+                INODE_TYPE_DIR => InodeType::Directory,
+                INODE_TYPE_FILE => InodeType::RegularFile,
+                _ => return Err(VfsError::IoError),
             };
 
             entries.push(DirEntry {
@@ -1318,7 +1372,7 @@ impl Filesystem for Lfs {
                     let zeroed = [0u8; BLOCK_SIZE];
                     let block_num = writer
                         .write_data_block(dev.as_mut(), &mut cache, &mut self.segments, &zeroed)
-                        .map_err(|_| VfsError::NoSpace)?;
+                        .map_err(Self::map_write_data_block_err)?;
                     inode.direct[i] = block_num;
                 }
             }
@@ -1493,6 +1547,33 @@ mod tests {
     }
 
     #[test]
+    fn readdir_propagates_child_inode_load_failure_instead_of_faking_regular_file() {
+        let mut dev = block_device_for_lfs();
+        format(&mut dev).expect("format");
+
+        let mut fs = mount(Box::new(dev)).expect("mount");
+        let root = fs.root_inode();
+
+        let file_id = fs
+            .create(root, "orphan.txt", InodeType::RegularFile)
+            .expect("create file");
+
+        // Corrupt the imap so the child inode can no longer be loaded,
+        // while the directory entry itself (which still names the
+        // child) is untouched. Before the fix, readdir() swallowed
+        // this load failure and reported the entry as InodeType::
+        // RegularFile regardless of the real (unknown) type.
+        fs.imap.remove(file_id);
+
+        let result = fs.readdir(root);
+        assert_eq!(
+            result,
+            Err(VfsError::NotFound),
+            "a child inode that can no longer be loaded must surface as an error, not be silently reported as a regular file"
+        );
+    }
+
+    #[test]
     fn format_then_mount_round_trips() {
         let mut dev = block_device_for_lfs();
         format(&mut dev).expect("format");
@@ -1515,6 +1596,23 @@ mod tests {
         let fs = mount(Box::new(dev)).expect("mount");
         let result = fs.stat(999);
         assert_eq!(result, Err(VfsError::NotFound));
+    }
+
+    #[test]
+    fn inode_to_stat_rejects_unrecognized_on_disk_type() {
+        let inode = DiskInode {
+            inode_type: 99, // neither INODE_TYPE_FILE nor INODE_TYPE_DIR
+            link_count: 1,
+            size: 0,
+            direct: [0u64; DIRECT_BLOCK_COUNT],
+            indirect: 0,
+        };
+
+        // Before the fix, an unrecognized on-disk type silently fell
+        // through to InodeType::RegularFile instead of being reported
+        // as corruption.
+        let result = Lfs::inode_to_stat(1, &inode);
+        assert_eq!(result, Err(VfsError::IoError));
     }
 
     #[test]
@@ -1943,7 +2041,7 @@ mod tests {
         let result = fs.unlink(0, "victim");
         assert_eq!(
             result,
-            Err(VfsError::IoError),
+            Err(VfsError::NoSpace),
             "the directory rewrite should fail: no free segment remains to seal into"
         );
 
@@ -2089,6 +2187,41 @@ mod tests {
     }
 
     #[test]
+    fn parse_dir_entries_rejects_name_len_exceeding_record_len() {
+        let mut buf = [0u8; BLOCK_SIZE];
+
+        // A single crafted entry: record_len reserves only 4 bytes for
+        // the name (12 - DIR_ENTRY_HEADER_SIZE), but name_len claims 20.
+        // name_start(8) + name_len(20) = 28, well within BLOCK_SIZE, so
+        // the old bare `name_end <= BLOCK_SIZE` check would have let
+        // this read 16 bytes past the entry's own record boundary --
+        // into whatever bytes follow (the next entry's header/name).
+        buf[0..4].copy_from_slice(&1u32.to_le_bytes()); // inode_id
+        buf[4..6].copy_from_slice(&20u16.to_le_bytes()); // name_len
+        buf[6..8].copy_from_slice(&12u16.to_le_bytes()); // record_len
+
+        let result = Lfs::parse_dir_entries(&buf);
+        assert!(
+            matches!(result, Err(VfsError::IoError)),
+            "name_len exceeding the entry's own record_len must be rejected as corruption, not read past the record boundary"
+        );
+    }
+
+    #[test]
+    fn parse_dir_entries_rejects_record_len_shorter_than_header() {
+        let mut buf = [0u8; BLOCK_SIZE];
+
+        // record_len (4) is shorter than DIR_ENTRY_HEADER_SIZE (8) -- the
+        // entry cannot even fit its own header, let alone a name.
+        buf[0..4].copy_from_slice(&1u32.to_le_bytes()); // inode_id
+        buf[4..6].copy_from_slice(&1u16.to_le_bytes()); // name_len
+        buf[6..8].copy_from_slice(&4u16.to_le_bytes()); // record_len
+
+        let result = Lfs::parse_dir_entries(&buf);
+        assert!(matches!(result, Err(VfsError::IoError)));
+    }
+
+    #[test]
     fn disk_inode_round_trips() {
         let inode = DiskInode {
             inode_type: INODE_TYPE_FILE,
@@ -2109,5 +2242,36 @@ mod tests {
         assert_eq!(restored.direct[1], 20);
         assert_eq!(restored.direct[2], 30);
         assert_eq!(restored.indirect, 99);
+    }
+
+    #[test]
+    fn map_write_data_block_err_distinguishes_no_space_from_io_error() {
+        assert_eq!(
+            Lfs::map_write_data_block_err(LfsError::NoFreeSegments),
+            VfsError::NoSpace,
+            "disk-full must map to NoSpace, not a generic I/O error"
+        );
+
+        assert_eq!(
+            Lfs::map_write_data_block_err(LfsError::BlockIo(block::BlockError::IoError)),
+            VfsError::IoError,
+            "a genuine device I/O fault must map to IoError, not NoSpace"
+        );
+        assert_eq!(
+            Lfs::map_write_data_block_err(LfsError::Corrupt),
+            VfsError::IoError
+        );
+        assert_eq!(
+            Lfs::map_write_data_block_err(LfsError::InvalidSuperblock),
+            VfsError::IoError
+        );
+        assert_eq!(
+            Lfs::map_write_data_block_err(LfsError::InodeNotFound),
+            VfsError::IoError
+        );
+        assert_eq!(
+            Lfs::map_write_data_block_err(LfsError::CheckpointOverflow),
+            VfsError::IoError
+        );
     }
 }

--- a/crates/thumos/src/meshtastic.rs
+++ b/crates/thumos/src/meshtastic.rs
@@ -471,12 +471,23 @@ impl MeshtasticTransport {
     ///
     /// Used internally by the serial receive loop (future) and for
     /// testing. Drops the oldest message if the buffer is full.
-    pub(crate) fn push_inbox(&mut self, message: MeshMessage) {
-        if self.inbox.len() >= MAX_INBOX_MESSAGES {
+    ///
+    /// # Errors
+    ///
+    /// - [`MeshError::InboxOverflow`] if the inbox was already at capacity
+    ///   (the oldest buffered message was dropped to make room for
+    ///   `message`, which is still enqueued)
+    pub(crate) fn push_inbox(&mut self, message: MeshMessage) -> Result<(), MeshError> {
+        let overflowed = self.inbox.len() >= MAX_INBOX_MESSAGES;
+        if overflowed {
             // Drop oldest message to make room.
             self.inbox.remove(0);
         }
         self.inbox.push(message);
+        if overflowed {
+            return Err(MeshError::InboxOverflow);
+        }
+        Ok(())
     }
 
     /// Clear all buffered inbox messages.
@@ -774,7 +785,9 @@ mod tests {
         let mut transport = MeshtasticTransport::new();
         let msg = MeshMessage::new(0x1234, 0x5678, "hello".to_string(), 1000, 1, 0)
             .unwrap_or_else(|_| unreachable!());
-        transport.push_inbox(msg);
+        transport
+            .push_inbox(msg)
+            .unwrap_or_else(|_| unreachable!("fresh inbox has room"));
         assert_eq!(transport.inbox_count(), 1);
         assert_eq!(transport.inbox()[0].body, "hello");
     }
@@ -784,11 +797,41 @@ mod tests {
         let mut transport = MeshtasticTransport::new();
         let msg = MeshMessage::new(0x1234, 0x5678, "hello".to_string(), 1000, 1, 0)
             .unwrap_or_else(|_| unreachable!());
-        transport.push_inbox(msg);
+        transport
+            .push_inbox(msg)
+            .unwrap_or_else(|_| unreachable!("fresh inbox has room"));
         assert_eq!(transport.inbox_count(), 1);
 
         transport.clear_inbox();
         assert_eq!(transport.inbox_count(), 0);
+    }
+
+    #[test]
+    fn push_inbox_returns_overflow_error_when_full() {
+        let mut transport = MeshtasticTransport::new();
+        for _ in 0..MAX_INBOX_MESSAGES {
+            let msg = MeshMessage::new(0x1234, 0x5678, "filler".to_string(), 1000, 1, 0)
+                .unwrap_or_else(|_| unreachable!());
+            transport
+                .push_inbox(msg)
+                .unwrap_or_else(|_| unreachable!("inbox has room until MAX_INBOX_MESSAGES"));
+        }
+        assert_eq!(transport.inbox_count(), MAX_INBOX_MESSAGES);
+
+        let overflow_msg = MeshMessage::new(0x1234, 0x5678, "overflow".to_string(), 2000, 1, 0)
+            .unwrap_or_else(|_| unreachable!());
+        let result = transport.push_inbox(overflow_msg);
+
+        assert_eq!(
+            result,
+            Err(MeshError::InboxOverflow),
+            "push into a full inbox must surface InboxOverflow"
+        );
+        // WHY: overflow is non-fatal -- the newest message still lands and
+        // the oldest was evicted to make room, matching InboxOverflow's own
+        // doc ("oldest was dropped").
+        assert_eq!(transport.inbox_count(), MAX_INBOX_MESSAGES);
+        assert_eq!(transport.inbox()[MAX_INBOX_MESSAGES - 1].body, "overflow");
     }
 
     // --- Node tracking tests ---

--- a/crates/thumos/src/provision.rs
+++ b/crates/thumos/src/provision.rs
@@ -114,6 +114,11 @@ pub enum ProvisionError {
     SignatureInvalid,
     /// Postcard deserialization failed.
     DeserializeError,
+    /// Postcard serialization failed while encoding a [`ProvisionBundle`]
+    /// into the wire format. Carries the underlying [`postcard::Error`] as
+    /// cause (distinct from [`Self::DeserializeError`] -- encoding and
+    /// decoding are different failure modes).
+    SerializeError(postcard::Error),
     /// Not enough data received yet (still accumulating).
     Incomplete,
     /// The provisioner is in an error state and must be reset.
@@ -128,6 +133,9 @@ impl fmt::Display for ProvisionError {
             Self::ChecksumMismatch => write!(f, "provision checksum mismatch"),
             Self::SignatureInvalid => write!(f, "provision bundle signature invalid"),
             Self::DeserializeError => write!(f, "provision bundle deserialization failed"),
+            Self::SerializeError(cause) => {
+                write!(f, "provision bundle serialization failed: {cause}")
+            }
             Self::Incomplete => write!(f, "provision data incomplete"),
             Self::PreviousError => write!(f, "provisioner in error state, reset required"),
         }
@@ -454,13 +462,13 @@ impl fmt::Display for Provisioner {
 /// # Errors
 ///
 /// Returns [`ProvisionError::PayloadTooLarge`] if the serialized payload
-/// exceeds [`MAX_PAYLOAD_SIZE`], or [`ProvisionError::DeserializeError`] if
+/// exceeds [`MAX_PAYLOAD_SIZE`], or [`ProvisionError::SerializeError`] if
 /// postcard serialization fails.
 pub(crate) fn encode_bundle(
     bundle: &ProvisionBundle,
     signature: &[u8; SIGNATURE_LEN],
 ) -> Result<Vec<u8>, ProvisionError> {
-    let payload = postcard::to_allocvec(bundle).map_err(|_| ProvisionError::DeserializeError)?;
+    let payload = postcard::to_allocvec(bundle).map_err(ProvisionError::SerializeError)?;
 
     if payload.len() > MAX_PAYLOAD_SIZE {
         return Err(ProvisionError::PayloadTooLarge);
@@ -853,6 +861,24 @@ mod tests {
         let err = ProvisionError::InvalidMagic;
         let s = alloc::format!("{err}");
         assert!(s.contains("magic"));
+    }
+
+    #[test]
+    fn display_provision_error_serialize_error_includes_cause() {
+        // WHY: encode_bundle previously mapped a postcard::to_allocvec
+        // failure onto ProvisionError::DeserializeError (wrong variant --
+        // encode failure is not deserialize failure) and discarded the
+        // underlying postcard::Error. SerializeError carries the cause and
+        // renders it in Display, and is a distinct variant from
+        // DeserializeError.
+        let err = ProvisionError::SerializeError(postcard::Error::SerializeBufferFull);
+        let s = alloc::format!("{err}");
+        assert!(s.contains("serialization"));
+        assert_ne!(
+            err,
+            ProvisionError::DeserializeError,
+            "a serialize failure must not be indistinguishable from a deserialize failure"
+        );
     }
 
     #[test]

--- a/crates/thumos/src/ramfs.rs
+++ b/crates/thumos/src/ramfs.rs
@@ -216,7 +216,12 @@ impl RamFs {
                 break;
             }
 
-            let name = core::str::from_utf8(&data[name_start..name_end]).unwrap_or("");
+            // WARNING: reject non-UTF-8 entry names outright instead of
+            // silently coercing to an empty string — CPIO archives arrive
+            // over untrusted USB provisioning / initramfs input.
+            let Ok(name) = core::str::from_utf8(&data[name_start..name_end]) else {
+                break;
+            };
 
             // Trailer marks end of archive
             if name == "TRAILER!!!" {
@@ -1088,6 +1093,24 @@ mod tests {
         // WHY: a zero namesize entry aborts the parse before any file is
         // inserted (`from_cpio` breaks out of the loop at the first
         // malformed header), so the archive yields zero files, not one.
+        assert_eq!(fs.find("init"), None);
+        assert_eq!(fs.count(), 0);
+    }
+
+    #[test]
+    fn parse_cpio_rejects_invalid_utf8_name() {
+        let mut archive = build_cpio_entry("init", b"#!/bin/sh", 0o100755);
+        // Corrupt the first name byte (header is exactly 110 bytes, so the
+        // name field starts at offset 110). 0xFF can never start a valid
+        // UTF-8 sequence.
+        archive[110] = 0xFF;
+        archive.extend(build_cpio_trailer());
+
+        let fs = RamFs::from_cpio(&archive);
+
+        // WHY: a non-UTF-8 entry name aborts the parse (same fail-closed
+        // convention as the zero-namesize case above) instead of silently
+        // coercing the name to an empty string and continuing.
         assert_eq!(fs.find("init"), None);
         assert_eq!(fs.count(), 0);
     }

--- a/crates/thumos/src/sms.rs
+++ b/crates/thumos/src/sms.rs
@@ -52,6 +52,11 @@ pub enum SmsError {
     Gsm7Encode(u32),
     /// PDU data is truncated or malformed.
     PduDecode,
+    /// The PDU is well-formed but uses an unsupported data coding scheme
+    /// (DCS); only GSM-7 (0x00) is supported. Carries the offending DCS
+    /// byte. Distinct from [`Self::PduDecode`] -- the bytes decoded fine,
+    /// the encoding is simply not implemented.
+    UnsupportedDcs(u8),
     /// Modem returned an error during send.
     ModemError,
     /// Modem returned a CME error.
@@ -71,6 +76,7 @@ impl core::fmt::Display for SmsError {
         match self {
             Self::Gsm7Encode(cp) => write!(f, "cannot encode U+{cp:04X} in GSM-7"),
             Self::PduDecode => write!(f, "PDU decode error"),
+            Self::UnsupportedDcs(dcs) => write!(f, "unsupported DCS {dcs:#04x}"),
             Self::ModemError => write!(f, "modem error"),
             Self::CmeError(code) => write!(f, "CME error {code}"),
             Self::CmsError(code) => write!(f, "CMS error {code}"),
@@ -339,6 +345,7 @@ impl SmsManager {
             .map_err(|_| SmsError::TransportError)?;
         let mut line_buf = [0u8; MAX_LINE_LEN];
         // Drain response lines until OK/ERROR.
+        let mut cmgf_confirmed = false;
         for _ in 0..16 {
             let n = transport
                 .recv_line(&mut line_buf, 2000)
@@ -346,12 +353,21 @@ impl SmsManager {
             let line = &line_buf[..n];
             if let Some(result) = crate::telephony::parse_final_result(line) {
                 match result {
-                    AtResponse::Ok => break,
+                    AtResponse::Ok => {
+                        cmgf_confirmed = true;
+                        break;
+                    }
                     AtResponse::Error => return Err(SmsError::ModemError),
                     AtResponse::CmeError(code) => return Err(SmsError::CmeError(code)),
                     AtResponse::CmsError(code) => return Err(SmsError::CmsError(code)),
                 }
             }
+        }
+        // WHY: mirror the '>' prompt and final-result loops below -- a mode-set
+        // that never returns OK/ERROR within the drain window is a transport
+        // failure, not a green light to transmit the PDU.
+        if !cmgf_confirmed {
+            return Err(SmsError::TransportError);
         }
 
         // Send AT+CMGS=<tpdu_len> followed by the PDU.
@@ -415,6 +431,8 @@ impl SmsManager {
     /// # Errors
     ///
     /// - [`SmsError::PduDecode`] -- PDU is truncated or malformed.
+    /// - [`SmsError::UnsupportedDcs`] -- PDU is well-formed but uses a data
+    ///   coding scheme other than GSM-7 (0x00).
     #[must_use]
     pub(crate) fn handle_incoming(pdu_data: &[u8]) -> Result<SmsMessage, SmsError> {
         let mut cur = PduCursor::new(pdu_data);
@@ -449,7 +467,10 @@ impl SmsManager {
         // DCS: only GSM-7 (0x00) supported in this kernel build.
         let dcs = cur.read_byte()?;
         if dcs != 0x00 {
-            return Err(SmsError::PduDecode);
+            // WHY: the PDU decoded cleanly; the coding scheme is simply
+            // unsupported. Conflating this with PduDecode (malformed PDU)
+            // hides that the message was well-formed but used, e.g., UCS-2.
+            return Err(SmsError::UnsupportedDcs(dcs));
         }
 
         // SCTS: 7 bytes (timestamp, partially decoded).
@@ -655,6 +676,9 @@ mod tests {
         // any DCS whose bits 3:2 were 0b00, letting compressed-GSM-7 (0x20,
         // 0x30), message-waiting-indication (0xC0), and other non-GSM-7
         // schemes reach the septet decoder. Only DCS 0x00 is supported.
+        // These bytes are well-formed PDUs with an unsupported coding
+        // scheme, so they must surface as UnsupportedDcs (carrying the
+        // offending byte), NOT PduDecode (which means malformed PDU).
         let base: [u8; 24] = [
             0x00, // SCA len
             0x00, // first octet (MTI=0)
@@ -673,10 +697,23 @@ mod tests {
             pdu[10] = adversarial_dcs;
             let result = SmsManager::handle_incoming(&pdu);
             assert!(
-                matches!(result, Err(SmsError::PduDecode)),
-                "DCS {adversarial_dcs:#04x} must be rejected, not admitted as GSM-7"
+                matches!(result, Err(SmsError::UnsupportedDcs(d)) if d == adversarial_dcs),
+                "DCS {adversarial_dcs:#04x} must surface as UnsupportedDcs carrying the offending byte, not conflated with a malformed PDU"
             );
         }
+    }
+
+    #[test]
+    fn handle_incoming_truncated_pdu_is_pdudecode_not_unsupported_dcs() {
+        // Distinctness: a genuinely malformed (truncated) PDU must still be
+        // PduDecode, proving the unsupported-DCS variant did not swallow
+        // the malformed-PDU case.
+        let truncated: [u8; 2] = [0x00, 0x00]; // SCA len 0 + first octet, then nothing
+        let result = SmsManager::handle_incoming(&truncated);
+        assert!(
+            matches!(result, Err(SmsError::PduDecode)),
+            "a truncated PDU must remain PduDecode, distinct from UnsupportedDcs"
+        );
     }
 
     #[test]
@@ -693,6 +730,31 @@ mod tests {
             result,
             Err(SmsError::CmsError(330)),
             "a +CMS ERROR final result on SMS submit must surface the code immediately, not TransportError after exhausting the wait loop"
+        );
+    }
+
+    #[test]
+    fn send_returns_error_when_cmgf_never_confirmed() {
+        use crate::telephony_mock::MockModemTransport;
+
+        let mut mock = MockModemTransport::new();
+        // AT+CMGF=0 never returns OK/ERROR: 16 non-final lines exhaust the
+        // drain loop, which must fail closed instead of proceeding to CMGS.
+        for _ in 0..16 {
+            mock.queue_response(b"");
+        }
+
+        let result = SmsManager::send(&mut mock, "+15551234567", "Hi");
+
+        assert_eq!(
+            result,
+            Err(SmsError::TransportError),
+            "an AT+CMGF=0 that never returns OK/ERROR must fail closed, not fall through to PDU transmission"
+        );
+        assert_eq!(
+            mock.sent_commands.len(),
+            1,
+            "only AT+CMGF=0 must have been sent; CMGS must not be reached"
         );
     }
 


### PR DESCRIPTION
First batch of wave-2 (#314). **3 stale** (fixed by the RustCrypto pivot / earlier PR: csprng XOR comment, firewall audit discard, security hkdf dead branch).

## Notable
- **bt_audio media on the wrong channel** — `send_audio` sent SBC frames via the HCI *command* channel (H4 0x01), decoded as opcodes not payload. Added `hci_acl_data` (H4 0x02) + `BtHwOps::send_acl_data`.
- **lfs directory over-read** — `parse_dir_entries` bounded `name_len` only by BLOCK_SIZE, not the entry's own `record_len`; a corrupt block could read a name spanning into the next entry. Now fail-closed.
- **bluetooth commit-before-confirm** — `init()` committed the random address before the HCI write succeeded. Now commit-on-success.
- **lfs silent type promotion** — `readdir`/`inode_to_stat` faked RegularFile on a failed child load / unknown on-disk type. Now propagate.
- **dns** — >64-label names rejected (raised to RFC-1035 127-label ceiling); TTL=0 no longer cached (RFC 2181 §8).
- **gps** — minutes ≥ 60 rejected; `shutdown` clears stale position/time/buffer.
- **bt_audio** — Connected reachable in the normal sequence; configure() state-guarded.
- meshtastic InboxOverflow returned; provision distinct SerializeError; ramfs rejects non-UTF-8 CPIO names; sms fail-closed on unconfirmed CMGF + UnsupportedDcs vs PduDecode; lfs write-error NoSpace/IoError disambiguated.

## Verification
- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — **1943 passed** (67 new; one stale test expectation corrected — the write-error fix made NoSpace correct where the test asserted IoError)
- `cargo build --release --target armv7a-none-eabi` — clean · `kanon lint` — clean

Partially addresses #314 (findings 1-20 of 89). ~69 remain.

_Security-surface fixes (ACL path, LFS over-read, bluetooth) reviewed at T0/Opus._