### PR TITLE
Wave-2 low-rollup batch 2: 18 fixes incl. csprng boot-hang + socket errnos (#314)

### DIFF
--- a/crates/thumos/src/audit.rs
+++ b/crates/thumos/src/audit.rs
@@ -207,12 +207,23 @@ impl fmt::Debug for AuditEntry {
 
 impl fmt::Display for AuditEntry {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let detail_str = core::str::from_utf8(self.detail()).unwrap_or("?");
         write!(
             f,
-            "[t={} pid={} {}] {}",
-            self.timestamp, self.pid, self.event_type, detail_str,
-        )
+            "[t={} pid={} {}] ",
+            self.timestamp, self.pid, self.event_type,
+        )?;
+        // WHY: non-UTF8 detail bytes previously collapsed to a single "?"
+        // via str::from_utf8(...).unwrap_or("?"), erasing the audit
+        // content entirely. Render every byte instead: printable ASCII
+        // as-is, everything else \xHH-escaped, so no content is lost.
+        for &byte in self.detail() {
+            if byte.is_ascii_graphic() || byte == b' ' {
+                write!(f, "{}", char::from(byte))?;
+            } else {
+                write!(f, "\\x{byte:02x}")?;
+            }
+        }
+        Ok(())
     }
 }
 
@@ -906,6 +917,38 @@ mod tests {
         assert!(
             display.contains("Daily->Sentinel"),
             "display must contain detail"
+        );
+    }
+
+    #[test]
+    fn entry_display_escapes_non_utf8_detail() {
+        let mut log = AuditLog::new();
+        // 0xFF is never a valid UTF-8 lead byte; the old
+        // str::from_utf8(...).unwrap_or("?") path collapsed this whole
+        // detail to a single '?', discarding the two legible bytes
+        // alongside it.
+        log_one(
+            &mut log,
+            AuditEventType::ModemAnomaly,
+            7,
+            &[0xFFu8, b'X', b'Y'],
+            9000,
+        );
+
+        let (older, newer) = log.recent(1);
+        let entries: alloc::vec::Vec<&AuditEntry> = older.iter().chain(newer.iter()).collect();
+        let display = entries[0].to_string();
+        assert!(
+            display.contains("\\xff"),
+            "non-UTF8 byte must render as a hex escape, not vanish: {display}"
+        );
+        assert!(
+            display.contains("XY"),
+            "legible bytes alongside a non-UTF8 byte must not be discarded: {display}"
+        );
+        assert!(
+            !display.contains('?'),
+            "detail must never collapse to a bare '?': {display}"
         );
     }
 

--- a/crates/thumos/src/bt_audio.rs
+++ b/crates/thumos/src/bt_audio.rs
@@ -406,7 +406,15 @@ impl<H: BtHwOps> A2dpProfile<H> {
 
     /// Resume a suspended audio stream.
     ///
-    /// Transitions from Connected back to Streaming.
+    /// Sends AVDTP Start to the peer. Mirrors the initial connect-to-
+    /// streaming transition: this does NOT advance the state to
+    /// Streaming by itself -- call `advance_signaling(AVDTP_SIGNAL_START)`
+    /// when the peer's Start response arrives, exactly as after the
+    /// initial Start sent during signaling (see the `AVDTP_SIGNAL_OPEN`
+    /// arm of `advance_signaling`). Keeping Streaming gated behind the
+    /// same single peer-ACK path avoids a second path that granted it on
+    /// local send alone, inconsistent with every other transition into
+    /// Streaming.
     ///
     /// # Errors
     ///
@@ -422,7 +430,6 @@ impl<H: BtHwOps> A2dpProfile<H> {
         let msg = AvdtpMessage::start(label, self.remote_seid);
         self.hw.send_command(&msg).map_err(BtAudioError::from)?;
 
-        self.state = A2dpState::Streaming;
         Ok(())
     }
 
@@ -669,9 +676,22 @@ mod tests {
         assert!(result.is_ok(), "suspend must succeed");
         assert_eq!(profile.state(), A2dpState::Connected);
 
-        // Resume.
+        // Resume: sends Start but does not itself grant Streaming --
+        // that requires the peer's ACK via advance_signaling(), exactly
+        // like the initial connect-to-streaming transition.
         let result = profile.resume();
         assert!(result.is_ok(), "resume must succeed");
+        assert_eq!(
+            profile.state(),
+            A2dpState::Connected,
+            "resume() alone must not grant Streaming without a peer ACK"
+        );
+
+        let result = profile.advance_signaling(AVDTP_SIGNAL_START);
+        assert!(
+            result.is_ok(),
+            "advancing past the peer's Start ACK must succeed"
+        );
         assert_eq!(profile.state(), A2dpState::Streaming);
     }
 

--- a/crates/thumos/src/csprng.rs
+++ b/crates/thumos/src/csprng.rs
@@ -61,6 +61,16 @@ const SEED_ENTROPY_BITS: u32 = 256;
 /// entropy, so only bit-flips within this mask are credited.
 const TIMER_JITTER_MASK: u32 = 0x0000_0FFF;
 
+/// Maximum wall-clock time `init()` will spin waiting for
+/// `SEED_ENTROPY_BITS` before giving up and reporting failure.
+///
+/// WHY 30s: at the 10ms scheduler tick period even a single flipped
+/// jitter bit per tick reaches 256 bits in ~2.6s; 30s is a generous
+/// multiple that tolerates a noisy/slow timer without masking a
+/// genuinely dead entropy source (a permanent unbounded `wfi` loop here
+/// was a permanent boot hang if the timer ISR never delivered a sample).
+const CSPRNG_INIT_TIMEOUT_MS: u64 = 30_000;
+
 // ---------------------------------------------------------------------------
 // Errors
 // ---------------------------------------------------------------------------
@@ -245,33 +255,66 @@ pub unsafe fn add_entropy(data: &[u8]) {
 /// seeded, spins (busy-polls) until it is — the timer ISR is running at this
 /// point and will call `collect_timer_entropy()` each tick.
 ///
+/// Bounded by `CSPRNG_INIT_TIMEOUT_MS`, measured against the free-running
+/// CNTPCT counter (`crate::timer::elapsed_ms()`) rather than the IRQ-
+/// driven tick count: if the timer ISR never fires at all, the tick
+/// count never advances either (the same handler drives both), so it
+/// cannot detect that failure mode -- CNTPCT keeps counting in hardware
+/// regardless of whether interrupts are ever delivered. Returns `false`
+/// on timeout and leaves the CSPRNG unseeded; `kernel_random_bytes()`
+/// then fails closed with `CsprngError::NotSeeded` forever, exactly as
+/// it already does before `init()` runs. The only behavior change is
+/// that a starved entropy source degrades the boot (per the kinit
+/// Hubris fault-isolation model) instead of hanging it.
+///
 /// # Safety
 ///
 /// Must be called exactly once from kinit, after `exceptions::init()` (timer
 /// running), before any driver calls `kernel_random_bytes()`. IRQs must be
 /// enabled at call time so the timer ISR can supply entropy.
-pub unsafe fn init() {
-    // Spin until the entropy pool has accumulated a full seed estimate.
-    loop {
+#[must_use = "a `false` return means the CSPRNG is unseeded; the caller must record and report the degraded boot state"]
+pub unsafe fn init() -> bool {
+    // SAFETY: elapsed_ms() only reads the free-running CP15 CNTPCT/CNTFRQ
+    // registers; no state is mutated.
+    #[cfg(not(test))]
+    let deadline_start = crate::timer::elapsed_ms();
+
+    // Spin until the entropy pool has accumulated a full seed estimate,
+    // or until CSPRNG_INIT_TIMEOUT_MS elapses.
+    let seeded = loop {
         // SAFETY: ENTROPY is accessed read-only here; writes only come from the
         // IRQ handler which cannot execute concurrently on single-core ARMv7.
         // addr_of! avoids creating a shared reference to the static mut.
         let seeded = unsafe { (*core::ptr::addr_of!(ENTROPY)).is_seeded() };
         if seeded {
-            break;
+            break true;
         }
-        // Yield to allow the timer IRQ to fire.
+
         #[cfg(not(test))]
-        // SAFETY: WFI is a hint instruction available at all ARM privilege levels.
-        unsafe {
-            core::arch::asm!("wfi");
+        {
+            let elapsed = crate::timer::elapsed_ms().saturating_sub(deadline_start);
+            if elapsed >= CSPRNG_INIT_TIMEOUT_MS {
+                break false;
+            }
+            // Yield to allow the timer IRQ to fire.
+            // SAFETY: WFI is a hint instruction available at all ARM privilege levels.
+            unsafe {
+                core::arch::asm!("wfi");
+            }
         }
-        // On test host: init() is not exercised (seed_for_test bypasses it);
-        // break to prevent an infinite loop should it ever be reached.
+
+        // On test host: init() is not exercised for real entropy
+        // collection (seed_for_test bypasses it); break unseeded so the
+        // fail-closed path below runs instead of spinning forever should
+        // this ever execute.
         #[cfg(test)]
         {
-            break;
+            break false;
         }
+    };
+
+    if !seeded {
+        return false;
     }
 
     // Seed the DRBG from the entropy pool.
@@ -290,6 +333,7 @@ pub unsafe fn init() {
         CSPRNG = Some(csprng);
         INITIALIZED = true;
     }
+    true
 }
 
 /// Generate `buf.len()` cryptographically random bytes.
@@ -385,6 +429,44 @@ pub fn seed_for_test(key: &[u8; 32], nonce: &[u8; 8], counter: u64) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- init() fail-closed timeout path ---
+
+    #[test]
+    fn init_without_sufficient_entropy_returns_false_and_stays_unseeded() {
+        // Under #[cfg(test)], init()'s spin loop breaks unseeded on the
+        // first iteration (no real timer ISR to feed it) rather than
+        // looping forever -- this exercises the fail-closed return path
+        // that used to unconditionally seed FROM a zero-entropy pool.
+        // SAFETY: test-only; nextest process isolation means ENTROPY/
+        // CSPRNG/INITIALIZED here are fresh for this test (see
+        // seed_for_test's SAFETY comment for the same guarantee).
+        let seeded = unsafe { init() };
+        assert!(
+            !seeded,
+            "init() must not report seeded with zero accumulated entropy"
+        );
+
+        let mut buf = [0u8; 4];
+        assert_eq!(
+            kernel_random_bytes(&mut buf),
+            Err(CsprngError::NotSeeded),
+            "an init() that gave up before reaching SEED_ENTROPY_BITS must leave \
+             the CSPRNG unseeded (fail-closed), not silently seed FROM an empty pool"
+        );
+    }
+
+    #[test]
+    fn csprng_init_timeout_is_sane() {
+        assert!(
+            CSPRNG_INIT_TIMEOUT_MS >= 5_000,
+            "timeout must be generous enough for a slow/noisy real timer"
+        );
+        assert!(
+            CSPRNG_INIT_TIMEOUT_MS <= 60_000,
+            "timeout must not stall boot for an unreasonable amount of time"
+        );
+    }
 
     // --- Entropy pool tests ---
 

--- a/crates/thumos/src/dns.rs
+++ b/crates/thumos/src/dns.rs
@@ -285,9 +285,22 @@ fn build_dns_query(hostname: &str, txid: u16) -> Result<Vec<u8>, DnsError> {
     packet.extend_from_slice(&0u16.to_be_bytes()); // NSCOUNT
     packet.extend_from_slice(&0u16.to_be_bytes()); // ARCOUNT
 
-    // QNAME: encode hostname as DNS labels.
+    // QNAME: encode hostname as DNS labels. RFC 1035 section 3.1 caps the
+    // total encoded name -- every length-prefix octet plus every label
+    // octet plus the terminating zero -- at 255 octets; the per-label
+    // <= 63 check above does not bound the SUM across many short labels,
+    // so a long dotted name could otherwise produce an out-of-spec query
+    // with no error.
+    const DNS_MAX_NAME_LEN: usize = 255;
+    let mut qname_len: usize = 0;
     for label in hostname.split('.') {
         if label.is_empty() || label.len() > 63 {
+            return Err(DnsError::InvalidName);
+        }
+        qname_len = qname_len
+            .checked_add(1 + label.len())
+            .ok_or(DnsError::InvalidName)?;
+        if qname_len >= DNS_MAX_NAME_LEN {
             return Err(DnsError::InvalidName);
         }
         packet.push(label.len() as u8);
@@ -957,6 +970,22 @@ mod tests {
             result,
             Err(DnsError::NoRecords),
             "zero answer count must return NoRecords"
+        );
+    }
+
+    #[test]
+    fn build_query_rejects_oversized_total_name() {
+        // Five 63-byte labels: each is individually legal (<= 63 bytes),
+        // but the total encoded QNAME (5 * (1 + 63) + 1 = 321 bytes)
+        // blows well past the RFC 1035 section 3.1 255-byte ceiling. Only
+        // the per-label check existed before; this must be caught too.
+        let label = "a".repeat(63);
+        let hostname = alloc::format!("{label}.{label}.{label}.{label}.{label}");
+        let result = build_dns_query(&hostname, 0x0001);
+        assert_eq!(
+            result,
+            Err(DnsError::InvalidName),
+            "a total QNAME over 255 bytes must return InvalidName even when every label is individually legal"
         );
     }
 

--- a/crates/thumos/src/firewall.rs
+++ b/crates/thumos/src/firewall.rs
@@ -266,10 +266,12 @@ impl Firewall {
 
     /// Evaluate an inbound (RX) packet against the firewall rules.
     ///
-    /// Parses the raw IPv4 packet, checks DNS blocklist for outbound DNS
-    /// queries, then evaluates rules in order. If no rule matches, the
-    /// default inbound policy (deny) applies. Parse failures are denied
-    /// (fail-closed).
+    /// Parses the raw IPv4 packet, checks the DNS blocklist for any packet
+    /// destined to port 53 (the check is direction-agnostic -- it runs
+    /// identically in [`Self::evaluate_tx`], so an inbound packet is
+    /// covered too, not just outbound queries), then evaluates rules in
+    /// order. If no rule matches, the default inbound policy (deny)
+    /// applies. Parse failures are denied (fail-closed).
     pub(crate) fn evaluate_rx(&mut self, packet: &[u8]) -> Action {
         let action = self.classify(packet, Direction::Inbound);
         self.record(action);
@@ -278,7 +280,8 @@ impl Firewall {
 
     /// Evaluate an outbound (TX) packet against the firewall rules.
     ///
-    /// DNS queries to blocked domains are denied before rule evaluation.
+    /// DNS queries to blocked domains are denied before rule evaluation
+    /// (the same direction-agnostic check [`Self::evaluate_rx`] runs).
     /// If no rule matches, the default outbound policy (allow) applies.
     /// Parse failures are denied (fail-closed).
     pub(crate) fn evaluate_tx(&mut self, packet: &[u8]) -> Action {
@@ -294,9 +297,20 @@ impl Firewall {
     /// `"doubleclick.net"`). Matching is case-insensitive.
     pub(crate) fn is_dns_blocked(&self, hostname: &str) -> bool {
         let lower = hostname.to_ascii_lowercase();
+        self.is_dns_blocked_lowercased(&lower)
+    }
+
+    /// Same as [`Self::is_dns_blocked`], for a caller that already holds a
+    /// lowercased hostname.
+    ///
+    /// `check_dns_blocklist` (the per-packet hot path) builds its domain
+    /// via `extract_query_domain`, which lowercases while it decodes --
+    /// routing through here instead of `is_dns_blocked` avoids a second
+    /// heap-allocated `to_ascii_lowercase()` on every DNS-destined packet.
+    fn is_dns_blocked_lowercased(&self, lowercased_hostname: &str) -> bool {
         self.dns_blocklist
             .iter()
-            .any(|suffix| domain_matches_suffix(&lower, suffix))
+            .any(|suffix| domain_matches_suffix(lowercased_hostname, suffix))
     }
 
     /// Return a reference to the firewall statistics.
@@ -412,7 +426,7 @@ impl Firewall {
         };
 
         let domain = extract_query_domain(dns_payload)?;
-        Some(self.is_dns_blocked(&domain))
+        Some(self.is_dns_blocked_lowercased(&domain))
     }
 
     /// Update statistics based on the action taken.
@@ -581,7 +595,11 @@ fn extract_query_domain(data: &[u8]) -> Option<String> {
         if !domain.is_empty() {
             domain.push('.');
         }
-        domain.push_str(label);
+        // Lowercase while building: the only consumer is
+        // check_dns_blocklist, which compares directly against the
+        // (already-lowercased) blocklist via is_dns_blocked_lowercased --
+        // doing it here avoids a second per-packet allocation.
+        domain.extend(label.chars().map(|c| c.to_ascii_lowercase()));
 
         pos = label_end;
     }
@@ -869,6 +887,22 @@ mod tests {
         assert!(
             fw.is_dns_blocked("analytics.google.com"),
             "analytics.google.com must be blocked"
+        );
+    }
+
+    #[test]
+    fn is_dns_blocked_lowercased_matches_public_api_for_lowercase_input() {
+        let mut fw = Firewall::new();
+        fw.add_dns_block("doubleclick.net");
+
+        assert!(
+            fw.is_dns_blocked_lowercased("sub.doubleclick.net"),
+            "a lowercase subdomain of a blocklisted suffix must match through the fast path"
+        );
+        assert_eq!(
+            fw.is_dns_blocked_lowercased("sub.doubleclick.net"),
+            fw.is_dns_blocked("sub.doubleclick.net"),
+            "the pre-lowercased fast path must agree with the public case-insensitive API"
         );
     }
 

--- a/crates/thumos/src/gps.rs
+++ b/crates/thumos/src/gps.rs
@@ -221,9 +221,12 @@ fn validate_checksum(sentence: &[u8]) -> Result<(), GpsError> {
         checksum ^= b;
     }
 
-    // Parse the expected checksum (two hex chars after *).
+    // Parse the expected checksum (two hex chars after *). Invalid hex
+    // digits mean the sentence is malformed, not that a computed
+    // checksum merely disagreed with the claimed value -- those are
+    // distinct failure classes.
     let expected =
-        parse_hex_byte(sentence[star + 1], sentence[star + 2]).ok_or(GpsError::ChecksumMismatch)?;
+        parse_hex_byte(sentence[star + 1], sentence[star + 2]).ok_or(GpsError::ParseError)?;
 
     if checksum == expected {
         Ok(())
@@ -962,6 +965,20 @@ mod tests {
             validate_checksum(sentence),
             Err(GpsError::ChecksumMismatch),
             "corrupted checksum must be rejected"
+        );
+    }
+
+    #[test]
+    fn validate_checksum_rejects_non_hex_digits_as_parse_error() {
+        // "ZZ" are not valid hex digits -- this is a malformed sentence,
+        // not a checksum that was computed and disagreed. Distinct from
+        // validate_checksum_rejects_bad_checksum's well-formed-but-wrong-
+        // value case.
+        let sentence = b"$GPGGA,092750.000,5321.6802,N,00630.3372,W,1,8,1.03,61.7,M,55.2,M,,*ZZ";
+        assert_eq!(
+            validate_checksum(sentence),
+            Err(GpsError::ParseError),
+            "non-hex checksum digits must be ParseError, not ChecksumMismatch"
         );
     }
 

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -144,6 +144,7 @@ pub(crate) struct BootState {
     pub(crate) heap_ok: bool,
     pub(crate) gic_ok: bool,
     pub(crate) timer_ok: bool,
+    pub(crate) csprng_ok: bool,
     pub(crate) emmc_ok: bool,
     pub(crate) display_ok: bool,
     pub(crate) secure_boot_ok: bool,
@@ -171,6 +172,7 @@ impl BootState {
             heap_ok: false,
             gic_ok: false,
             timer_ok: false,
+            csprng_ok: false,
             emmc_ok: false,
             display_ok: false,
             secure_boot_ok: false,
@@ -204,6 +206,9 @@ impl BootState {
             n += 1;
         }
         if self.timer_ok {
+            n += 1;
+        }
+        if self.csprng_ok {
             n += 1;
         }
         if self.emmc_ok {
@@ -465,18 +470,25 @@ pub unsafe fn run() -> ! {
     state.timer_ok = true;
 
     // -----------------------------------------------------------------------
-    // Step 5b: CSPRNG (ChaCha20, seeded from timer entropy)
+    // Step 5b: CSPRNG (ChaCha20, seeded from timer entropy; fault-tolerant
+    // with timeout)
     // -----------------------------------------------------------------------
     let _ = serial.write_str("[init] CSPRNG (ChaCha20)\r\n");
     // SAFETY: called once after exceptions::init() (timer running, IRQs enabled).
     // csprng::init() spins on WFI until the entropy pool accumulates a full
     // SEED_ENTROPY_BITS estimate of timer-jitter entropy, then seeds the
-    // ChaCha20Rng DRBG and sets INITIALIZED. Must complete before any radio
-    // driver init.
-    unsafe {
-        csprng::init();
+    // ChaCha20Rng DRBG and sets INITIALIZED -- bounded by a wall-clock
+    // timeout so a dead timer ISR degrades the boot instead of hanging it.
+    // Must complete before any radio driver init.
+    state.csprng_ok = unsafe { csprng::init() };
+    if state.csprng_ok {
+        let _ = serial.write_str("       CSPRNG ready\r\n");
+    } else {
+        let _ = serial.write_str(
+            "  WARN CSPRNG timed out waiting for timer entropy -- random bytes unavailable\r\n",
+        );
+        let _ = serial.write_str("       Radio identity randomization disabled\r\n");
     }
-    let _ = serial.write_str("       CSPRNG ready\r\n");
 
     // -----------------------------------------------------------------------
     // Step 5c: Hardware watchdog (WDT)
@@ -991,7 +1003,11 @@ pub unsafe fn run() -> ! {
         "[init] Boot complete at {} ms\r\n",
         crate::timer::elapsed_ms()
     );
-    let _ = write!(serial, "       {} / 17 subsystems OK\r\n", state.ok_count());
+    let _ = write!(serial, "       {} / 18 subsystems OK\r\n", state.ok_count());
+    if !state.csprng_ok {
+        let _ = serial
+            .write_str("       NOTE: CSPRNG unseeded, radio identity randomization disabled\r\n");
+    }
     if !state.display_ok {
         let _ = serial.write_str("       NOTE: display unavailable, USB serial only\r\n");
     }
@@ -1296,6 +1312,7 @@ mod tests {
         assert!(!state.heap_ok, "initial heap_ok must be false");
         assert!(!state.gic_ok, "initial gic_ok must be false");
         assert!(!state.timer_ok, "initial timer_ok must be false");
+        assert!(!state.csprng_ok, "initial csprng_ok must be false");
         assert!(!state.emmc_ok, "initial emmc_ok must be false");
         assert!(!state.display_ok, "initial display_ok must be false");
         assert!(
@@ -1354,6 +1371,7 @@ mod tests {
         state.heap_ok = true;
         state.gic_ok = true;
         state.timer_ok = true;
+        state.csprng_ok = true;
         state.emmc_ok = true;
         state.display_ok = true;
         state.secure_boot_ok = true;
@@ -1367,7 +1385,7 @@ mod tests {
         state.network_ok = true;
         state.bluetooth_ok = true;
         state.gps_ok = true;
-        assert_eq!(state.ok_count(), 17, "all 17 subsystems OK");
+        assert_eq!(state.ok_count(), 18, "all 18 subsystems OK");
     }
 
     #[test]

--- a/crates/thumos/src/lfs.rs
+++ b/crates/thumos/src/lfs.rs
@@ -1148,29 +1148,45 @@ impl Filesystem for Lfs {
             name: String::from(name),
         });
 
-        // Write the updated directory data block.
-        let dir_block = Self::write_dir_block(
+        // Write the updated directory data block. On failure, the new
+        // inode above is already durable in the imap with no directory
+        // entry pointing to it -- roll back the imap insert so a failed
+        // create() never leaks storage (mirror of the dangling-reference
+        // guard in unlink(): that guard avoids a namespace entry
+        // outliving its imap entry; this guard avoids an imap entry
+        // outliving its namespace entry).
+        let dir_block = match Self::write_dir_block(
             dev.as_mut(),
             &mut cache,
             writer,
             &mut self.segments,
             &entries,
-        )?;
+        ) {
+            Ok(block) => block,
+            Err(e) => {
+                self.imap.remove(new_inode_id);
+                return Err(e);
+            }
+        };
 
         // Update parent inode to point to the new directory data block.
         parent.direct[0] = dir_block;
         parent.size = entries.iter().map(|e| e.record_len as u64).sum();
 
-        writer
-            .write_inode(
-                dev.as_mut(),
-                &mut cache,
-                &mut self.imap,
-                &mut self.segments,
-                dir_inode,
-                &parent,
-            )
-            .map_err(|_| VfsError::IoError)?;
+        match writer.write_inode(
+            dev.as_mut(),
+            &mut cache,
+            &mut self.imap,
+            &mut self.segments,
+            dir_inode,
+            &parent,
+        ) {
+            Ok(_) => {}
+            Err(_) => {
+                self.imap.remove(new_inode_id);
+                return Err(VfsError::IoError);
+            }
+        }
 
         drop(cache);
         drop(dev);
@@ -2058,6 +2074,43 @@ mod tests {
         assert!(
             dir_entries.iter().any(|e| e.name == "victim"),
             "directory entry must remain after a failed unlink"
+        );
+    }
+
+    #[test]
+    fn create_failure_rolls_back_orphaned_imap_entry() {
+        use alloc::format;
+
+        let mut dev = block_device_for_lfs();
+        format(&mut dev).expect("format");
+
+        let mut fs = mount(Box::new(dev)).expect("mount");
+        let root = fs.root_inode();
+
+        // Fill the one-block directory to capacity (256 fixed-size
+        // entries; see create_past_one_block_capacity_fails_without_dropping_entries).
+        let mut created = 0usize;
+        loop {
+            let name = format!("file{:03}", created);
+            match fs.create(root, &name, InodeType::RegularFile) {
+                Ok(_) => created += 1,
+                Err(VfsError::NoSpace) => break,
+                Err(e) => panic!("unexpected error at entry {created}: {e:?}"),
+            }
+            if created > 300 {
+                panic!("directory did not report NoSpace within expected bounds");
+            }
+        }
+
+        // The 257th create() allocated (and durably wrote) a new inode
+        // via write_inode() before write_dir_block() rejected the entry
+        // for lack of room -- without a rollback, that inode is now an
+        // orphan: present in the imap, reachable FROM no directory.
+        let orphan_candidate = fs.next_inode - 1;
+        assert!(
+            fs.stat(orphan_candidate).is_err(),
+            "a create() that fails after write_inode() but before the directory entry \
+             lands must roll back the imap insert, not leak the inode"
         );
     }
 

--- a/crates/thumos/src/net.rs
+++ b/crates/thumos/src/net.rs
@@ -157,9 +157,23 @@ impl core::fmt::Display for NetError {
 /// Every frame transmitted through this device is enqueued and returned on
 /// the next [`Device::receive`] call, in FIFO order. The device uses the
 /// Ethernet medium so that the full ARP / IP path is exercised.
+/// Maximum number of frames the [`LoopbackDevice`] TX queue holds before
+/// new frames are dropped.
+///
+/// WHY bounded: `transmit()` always returns a token and `consume()`
+/// always enqueues -- smoltcp's `TxToken` API has no backpressure signal
+/// -- so an unbounded queue grows without limit whenever polling drains
+/// RX slower than TX produces frames (heap exhaustion on a 128 MB
+/// device). A fixed cap converts that into ordinary tail-drop packet
+/// loss, which every protocol layered on top (TCP retransmission, UDP
+/// at-most-once) already tolerates.
+const LOOPBACK_QUEUE_CAPACITY: usize = 64;
+
 pub(crate) struct LoopbackDevice {
     /// FIFO queue of frames awaiting reception.
     queue: VecDeque<Vec<u8>>,
+    /// Count of frames dropped because the queue was at capacity.
+    dropped_frames: usize,
 }
 
 impl LoopbackDevice {
@@ -167,12 +181,18 @@ impl LoopbackDevice {
     pub(crate) fn new() -> Self {
         Self {
             queue: VecDeque::new(),
+            dropped_frames: 0,
         }
     }
 
     /// Return the number of frames currently queued for reception.
     pub(crate) fn queued_frames(&self) -> usize {
         self.queue.len()
+    }
+
+    /// Return the number of frames dropped because the TX queue was full.
+    pub(crate) fn dropped_frames(&self) -> usize {
+        self.dropped_frames
     }
 }
 
@@ -193,6 +213,7 @@ impl phy::RxToken for LoopbackRxToken {
 /// Transmit token for [`LoopbackDevice`].
 pub(crate) struct LoopbackTxToken<'a> {
     queue: &'a mut VecDeque<Vec<u8>>,
+    dropped_frames: &'a mut usize,
 }
 
 impl<'a> phy::TxToken for LoopbackTxToken<'a> {
@@ -202,7 +223,11 @@ impl<'a> phy::TxToken for LoopbackTxToken<'a> {
     {
         let mut buffer = vec![0u8; len];
         let result = f(&mut buffer);
-        self.queue.push_back(buffer);
+        if self.queue.len() < LOOPBACK_QUEUE_CAPACITY {
+            self.queue.push_back(buffer);
+        } else {
+            *self.dropped_frames = self.dropped_frames.saturating_add(1);
+        }
         result
     }
 }
@@ -224,6 +249,7 @@ impl Device for LoopbackDevice {
             let rx = LoopbackRxToken { buffer };
             let tx = LoopbackTxToken {
                 queue: &mut self.queue,
+                dropped_frames: &mut self.dropped_frames,
             };
             (rx, tx)
         })
@@ -232,6 +258,7 @@ impl Device for LoopbackDevice {
     fn transmit(&mut self, _timestamp: Instant) -> Option<Self::TxToken<'_>> {
         Some(LoopbackTxToken {
             queue: &mut self.queue,
+            dropped_frames: &mut self.dropped_frames,
         })
     }
 }
@@ -976,6 +1003,33 @@ mod tests {
             });
         }
         assert_eq!(device.queued_frames(), 0);
+    }
+
+    #[test]
+    fn loopback_tx_queue_is_bounded() {
+        let mut device = LoopbackDevice::new();
+        let now = Instant::from_millis(0);
+
+        // Transmit far more frames than LOOPBACK_QUEUE_CAPACITY without
+        // ever draining via receive() -- the failure mode this bound
+        // exists to prevent: unbounded heap growth from polling
+        // starvation.
+        let attempts = LOOPBACK_QUEUE_CAPACITY + 10;
+        for _ in 0..attempts {
+            let tx = device.transmit(now).unwrap();
+            phy::TxToken::consume(tx, 8, |_buf| {});
+        }
+
+        assert_eq!(
+            device.queued_frames(),
+            LOOPBACK_QUEUE_CAPACITY,
+            "the TX queue must never grow past LOOPBACK_QUEUE_CAPACITY"
+        );
+        assert_eq!(
+            device.dropped_frames(),
+            10,
+            "frames beyond capacity must be counted as dropped, not silently discarded"
+        );
     }
 
     #[test]

--- a/crates/thumos/src/provision.rs
+++ b/crates/thumos/src/provision.rs
@@ -321,6 +321,17 @@ impl Provisioner {
             self.state = ProvisionState::Receiving;
         }
 
+        // Reject growth beyond the maximum possible message size (header +
+        // max payload + checksum + signature) BEFORE extending the
+        // buffer, not after -- RECV_BUF_CAPACITY exists precisely to cap
+        // this but was never wired in, leaving the buffer to grow without
+        // bound if a caller ever hands receive_chunk() a chunk (or a run
+        // of chunks) larger than any well-formed bundle could need.
+        if self.buffer.len().saturating_add(data.len()) > RECV_BUF_CAPACITY {
+            self.state = ProvisionState::Error(ProvisionError::PayloadTooLarge);
+            return &self.state;
+        }
+
         self.buffer.extend_from_slice(data);
 
         // Try to parse the header if we haven't yet.
@@ -710,6 +721,29 @@ mod tests {
         assert_eq!(
             *state,
             ProvisionState::Error(ProvisionError::PayloadTooLarge)
+        );
+    }
+
+    #[test]
+    fn receive_chunk_rejects_growth_beyond_recv_buf_capacity() {
+        // A single over-sized chunk, larger than any well-formed bundle
+        // could ever need (RECV_BUF_CAPACITY = header + max payload +
+        // checksum + signature). Content is irrelevant -- the cap must
+        // reject growth BEFORE parsing a header, not rely on the
+        // payload_len check (which only fires once a header is present).
+        let mut oversized = Vec::new();
+        oversized.resize(RECV_BUF_CAPACITY + 1, 0u8);
+
+        let mut prov = Provisioner::new();
+        let state = prov.receive_chunk(&oversized);
+        assert_eq!(
+            *state,
+            ProvisionState::Error(ProvisionError::PayloadTooLarge),
+            "a chunk larger than RECV_BUF_CAPACITY must be rejected before buffering"
+        );
+        assert!(
+            prov.buffer.is_empty(),
+            "the oversized chunk must never be appended to the receive buffer"
         );
     }
 

--- a/crates/thumos/src/sms.rs
+++ b/crates/thumos/src/sms.rs
@@ -479,6 +479,15 @@ impl SmsManager {
 
         // User data length (septets) and packed user data.
         let udl = usize::from(cur.read_byte()?);
+        // GSM 03.40: TP-UD is at most 140 octets, i.e. 160 GSM-7 septets,
+        // for a single (non-concatenated) segment. This kernel does not
+        // parse the concatenation UDH, so no legitimately encodable
+        // single-segment message can claim a larger UDL; treat it as a
+        // malformed PDU rather than decoding whatever bytes follow.
+        const MAX_SINGLE_SEGMENT_SEPTETS: usize = 160;
+        if udl > MAX_SINGLE_SEGMENT_SEPTETS {
+            return Err(SmsError::PduDecode);
+        }
         let ud_byte_count = udl.saturating_mul(7).div_ceil(8);
         let ud_bytes = cur.read_slice(ud_byte_count)?;
         let body = decode_gsm7(ud_bytes, udl)?;
@@ -701,6 +710,36 @@ mod tests {
                 "DCS {adversarial_dcs:#04x} must surface as UnsupportedDcs carrying the offending byte, not conflated with a malformed PDU"
             );
         }
+    }
+
+    #[test]
+    fn handle_incoming_rejects_udl_over_160() {
+        // Same fixed PDU prefix as handle_incoming_parses_pdu, but with a
+        // UDL claiming 161 septets -- one past GSM 03.40's 160-septet
+        // ceiling for a single (non-concatenated) TP-UD. This kernel does
+        // not parse a concatenation UDH, so no larger UDL can legitimately
+        // describe one segment; it must be rejected as malformed rather
+        // than decoded from whatever bytes happen to follow.
+        let mut pdu = alloc::vec![
+            0x00, // SCA len
+            0x00, // first octet (MTI=0)
+            0x0A, // OA len (10 digits)
+            0x91, // OA type (international)
+            0x21, 0x43, 0x65, 0x87, 0x09, // BCD +1234567890
+            0x00, // PID
+            0x00, // DCS (GSM-7)
+            0x32, 0x10, 0x51, 0x21, 0x03, 0x00, 0x00, // SCTS
+            0xA1, // UDL: 161 septets
+        ];
+        // 161 septets needs ceil(161*7/8) = 141 packed bytes; pad enough
+        // that a plain truncation error could never mask the UDL bound.
+        pdu.extend(core::iter::repeat(0u8).take(141));
+
+        let result = SmsManager::handle_incoming(&pdu);
+        assert!(
+            matches!(result, Err(SmsError::PduDecode)),
+            "UDL=161 (over the 160-septet single-segment ceiling) must be rejected"
+        );
     }
 
     #[test]

--- a/crates/thumos/src/socket.rs
+++ b/crates/thumos/src/socket.rs
@@ -61,6 +61,26 @@ pub(crate) const EOPNOTSUPP: u32 = 0u32.wrapping_sub(95);
 /// Address already in use.
 pub(crate) const EADDRINUSE: u32 = 0u32.wrapping_sub(98);
 
+/// Address not available (an unaddressable remote/local endpoint, e.g. a
+/// zero port or unspecified address smoltcp's connect()/send() refused).
+pub(crate) const EADDRNOTAVAIL: u32 = 0u32.wrapping_sub(99);
+
+/// Resource temporarily unavailable (no datagram currently queued).
+pub(crate) const EAGAIN: u32 = 0u32.wrapping_sub(11);
+
+/// Message too long (a received datagram exceeded the caller's buffer
+/// and was dropped rather than truncated-and-delivered).
+pub(crate) const EMSGSIZE: u32 = 0u32.wrapping_sub(90);
+
+/// Destination address required (no valid peer address for a datagram send).
+pub(crate) const EDESTADDRREQ: u32 = 0u32.wrapping_sub(89);
+
+/// No buffer space available.
+pub(crate) const ENOBUFS: u32 = 0u32.wrapping_sub(105);
+
+/// Transport endpoint is already connected.
+pub(crate) const EISCONN: u32 = 0u32.wrapping_sub(106);
+
 // -- fd kind encoding (same bit-field scheme as pipe.rs) --
 
 /// FD kind mask: low 8 bits of flags identify the fd type.
@@ -407,13 +427,17 @@ pub(crate) fn sys_bind(fd: u32, addr_ptr: u32, addr_len: u32) -> u32 {
         None => return fd::EBADF,
     };
 
-    // Check port not already in use by another socket.
+    // Check port not already in use by another socket of the SAME
+    // transport. TCP and UDP have independent port spaces (e.g. a
+    // resolver legitimately binds UDP/53 and TCP/53 simultaneously) --
+    // comparing bound_port alone made a UDP bind falsely conflict with an
+    // unrelated TCP bind on the same port number.
     for (i, slot) in sock_table.iter().enumerate() {
         if i == fd_idx {
             continue;
         }
         if let Some(other) = slot {
-            if other.bound_port == port {
+            if other.bound_port == port && other.socket_type == socket_type {
                 return EADDRINUSE;
             }
         }
@@ -591,8 +615,17 @@ pub(crate) fn sys_connect(fd: u32, addr_ptr: u32, addr_len: u32) -> u32 {
                 tcp_socket.connect(cx, remote, local_port)
             };
 
-            if connect_result.is_err() {
-                return ECONNREFUSED;
+            if let Err(err) = connect_result {
+                // WHY: smoltcp's ConnectError distinguishes two genuinely
+                // different failures; collapsing both into ECONNREFUSED
+                // told userspace "the peer refused" even when the local
+                // socket was already open (EISCONN) or the endpoint was
+                // never addressable in the first place (EADDRNOTAVAIL) --
+                // neither of which involved the peer at all.
+                return match err {
+                    tcp::ConnectError::InvalidState => EISCONN,
+                    tcp::ConnectError::Unaddressable => EADDRNOTAVAIL,
+                };
             }
 
             // Update bound_port in socket info.
@@ -602,8 +635,15 @@ pub(crate) fn sys_connect(fd: u32, addr_ptr: u32, addr_len: u32) -> u32 {
             }
         }
         SocketType::Udp => {
-            // UDP connect just sets the default peer address.
-            // No network I/O needed.
+            // WHY: a UDP "connect" only records the default peer address
+            // for subsequent send/recv -- smoltcp performs no handshake
+            // and never validates it. Port 0 is not a routable endpoint;
+            // reject it explicitly rather than silently caching an
+            // unroutable peer that every later send_slice()/recv_slice()
+            // would then act on.
+            if peer_port == 0 {
+                return fd::EINVAL;
+            }
         }
     }
 
@@ -735,7 +775,12 @@ pub(crate) fn sys_sendto(
 
             match udp_socket.send_slice(data, dest) {
                 Ok(()) => len,
-                Err(_) => fd::EINVAL,
+                // WHY: smoltcp's udp::SendError distinguishes "no valid
+                // destination" from "the tx buffer has no room for this
+                // datagram"; collapsing both into EINVAL hid which one
+                // actually happened.
+                Err(udp::SendError::Unaddressable) => EDESTADDRREQ,
+                Err(udp::SendError::BufferFull) => ENOBUFS,
             }
         }
     }
@@ -855,7 +900,16 @@ pub(crate) fn sys_recvfrom(
                     }
                     n as u32
                 }
-                Err(_) => 0,
+                // WHY: collapsing every recv error to a bare 0 (the TCP
+                // arm's legitimate EOF sentinel) masked genuine UDP
+                // failures as an empty read. Exhausted means "nothing
+                // queued yet" (would-block, not an error); Truncated means
+                // a datagram WAS received and then silently dropped
+                // because it didn't fit -- that must not read as "0 bytes
+                // received", or the caller can't tell a real truncation
+                // from an empty socket.
+                Err(udp::RecvError::Exhausted) => EAGAIN,
+                Err(udp::RecvError::Truncated) => EMSGSIZE,
             }
         }
     }
@@ -1088,6 +1142,54 @@ mod tests {
         assert_eq!(info.bound_port, 8080);
     }
 
+    /// Pointer-dependent test: only runs on 32-bit targets.
+    #[test]
+    #[cfg(target_pointer_width = "32")]
+    fn udp_bind_does_not_conflict_with_tcp_bind_on_same_port() {
+        unsafe {
+            setup_test_network();
+        }
+        let tcp_fd = sys_socket(AF_INET, SOCK_STREAM, 0);
+        let udp_fd = sys_socket(AF_INET, SOCK_DGRAM, 0);
+        assert!(tcp_fd < MAX_FDS as u32 && udp_fd < MAX_FDS as u32);
+
+        static mut TCP_ADDR: SockaddrIn = SockaddrIn {
+            sin_family: 0,
+            sin_port: 0,
+            sin_addr: 0,
+            sin_zero: [0u8; 8],
+        };
+        // SAFETY: test-only static; single-threaded per test.
+        let tcp_addr = unsafe { &mut *core::ptr::addr_of_mut!(TCP_ADDR) };
+        *tcp_addr = SockaddrIn::new(53, Ipv4Address::new(0, 0, 0, 0));
+        let tcp_bind = sys_bind(
+            tcp_fd,
+            tcp_addr as *const SockaddrIn as u32,
+            core::mem::size_of::<SockaddrIn>() as u32,
+        );
+        assert_eq!(tcp_bind, 0, "TCP bind to port 53 must succeed");
+
+        static mut UDP_ADDR: SockaddrIn = SockaddrIn {
+            sin_family: 0,
+            sin_port: 0,
+            sin_addr: 0,
+            sin_zero: [0u8; 8],
+        };
+        // SAFETY: test-only static; single-threaded per test.
+        let udp_addr = unsafe { &mut *core::ptr::addr_of_mut!(UDP_ADDR) };
+        *udp_addr = SockaddrIn::new(53, Ipv4Address::new(0, 0, 0, 0));
+        let udp_bind = sys_bind(
+            udp_fd,
+            udp_addr as *const SockaddrIn as u32,
+            core::mem::size_of::<SockaddrIn>() as u32,
+        );
+        assert_eq!(
+            udp_bind, 0,
+            "UDP bind to the same port number as an existing TCP bind must succeed: \
+             TCP and UDP have independent port spaces"
+        );
+    }
+
     #[test]
     fn bind_rejects_kernel_range_addr_ptr() {
         // No socket setup needed: validate_user_buffer runs before the
@@ -1098,6 +1200,37 @@ mod tests {
             result,
             fd::EFAULT,
             "kernel-range addr_ptr must return EFAULT"
+        );
+    }
+
+    /// Pointer-dependent test: only runs on 32-bit targets.
+    #[test]
+    #[cfg(target_pointer_width = "32")]
+    fn udp_connect_rejects_peer_port_zero() {
+        unsafe {
+            setup_test_network();
+        }
+        let fd = sys_socket(AF_INET, SOCK_DGRAM, 0);
+        assert!(fd < MAX_FDS as u32);
+
+        static mut ADDR: SockaddrIn = SockaddrIn {
+            sin_family: 0,
+            sin_port: 0,
+            sin_addr: 0,
+            sin_zero: [0u8; 8],
+        };
+        // SAFETY: test-only static; single-threaded per test.
+        let addr = unsafe { &mut *core::ptr::addr_of_mut!(ADDR) };
+        *addr = SockaddrIn::new(0, Ipv4Address::new(93, 184, 216, 34));
+        let result = sys_connect(
+            fd,
+            addr as *const SockaddrIn as u32,
+            core::mem::size_of::<SockaddrIn>() as u32,
+        );
+        assert_eq!(
+            result,
+            fd::EINVAL,
+            "UDP connect to peer port 0 must be rejected as an unroutable endpoint"
         );
     }
 
@@ -1186,6 +1319,44 @@ mod tests {
         );
     }
 
+    /// Pointer-dependent test: only runs on 32-bit targets.
+    #[test]
+    #[cfg(target_pointer_width = "32")]
+    fn tcp_connect_twice_returns_eisconn_not_econnrefused() {
+        unsafe {
+            setup_test_network();
+        }
+        let fd = sys_socket(AF_INET, SOCK_STREAM, 0);
+        assert!(fd < MAX_FDS as u32);
+
+        static mut ADDR: SockaddrIn = SockaddrIn {
+            sin_family: 0,
+            sin_port: 0,
+            sin_addr: 0,
+            sin_zero: [0u8; 8],
+        };
+        // SAFETY: test-only static; single-threaded per test.
+        let addr = unsafe { &mut *core::ptr::addr_of_mut!(ADDR) };
+        *addr = SockaddrIn::new(80, Ipv4Address::new(93, 184, 216, 34));
+
+        let first = sys_connect(
+            fd,
+            addr as *const SockaddrIn as u32,
+            core::mem::size_of::<SockaddrIn>() as u32,
+        );
+        assert_eq!(first, 0, "first connect() must succeed");
+
+        let second = sys_connect(
+            fd,
+            addr as *const SockaddrIn as u32,
+            core::mem::size_of::<SockaddrIn>() as u32,
+        );
+        assert_eq!(
+            second, EISCONN,
+            "connect() on an already-open TCP socket must return EISCONN, not ECONNREFUSED"
+        );
+    }
+
     #[test]
     fn bind_sets_local_port() {
         // SAFETY: test-only; setup_test_network resets global state.
@@ -1202,6 +1373,66 @@ mod tests {
         let info = sock_table[fd as usize].as_ref().expect("socket info");
         assert_eq!(info.bound_port, 0, "socket should start unbound");
         assert_eq!(info.socket_type, SocketType::Udp);
+    }
+
+    /// Pointer-dependent test: only runs on 32-bit targets.
+    #[test]
+    #[cfg(target_pointer_width = "32")]
+    fn udp_sendto_unaddressable_dest_returns_edestaddrreq() {
+        unsafe {
+            setup_test_network();
+        }
+        let fd = sys_socket(AF_INET, SOCK_DGRAM, 0);
+        assert!(fd < MAX_FDS as u32);
+
+        static mut DEST: SockaddrIn = SockaddrIn {
+            sin_family: 0,
+            sin_port: 0,
+            sin_addr: 0,
+            sin_zero: [0u8; 8],
+        };
+        // SAFETY: test-only static; single-threaded per test.
+        let dest = unsafe { &mut *core::ptr::addr_of_mut!(DEST) };
+        // Port 0 on an EXPLICIT sendto destination bypasses sys_connect()
+        // entirely (that guard only covers connect()), reaching smoltcp's
+        // own udp::SendError::Unaddressable check directly.
+        *dest = SockaddrIn::new(0, Ipv4Address::new(93, 184, 216, 34));
+
+        let data = b"x";
+        let result = sys_sendto(
+            fd,
+            data.as_ptr() as u32,
+            data.len() as u32,
+            0,
+            dest as *const SockaddrIn as u32,
+            core::mem::size_of::<SockaddrIn>() as u32,
+        );
+        assert_eq!(
+            result, EDESTADDRREQ,
+            "an unaddressable UDP destination must return EDESTADDRREQ, not the old generic EINVAL"
+        );
+    }
+
+    /// Pointer-dependent test: only runs on 32-bit targets.
+    #[test]
+    #[cfg(target_pointer_width = "32")]
+    fn udp_recvfrom_with_no_data_returns_eagain_not_zero() {
+        unsafe {
+            setup_test_network();
+        }
+        let fd = sys_socket(AF_INET, SOCK_DGRAM, 0);
+        assert!(fd < MAX_FDS as u32);
+
+        static mut BUF: [u8; 16] = [0u8; 16];
+        // SAFETY: test-only static; single-threaded per test.
+        let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUF) };
+
+        let result = sys_recvfrom(fd, buf.as_mut_ptr() as u32, buf.len() as u32, 0, 0, 0);
+        assert_eq!(
+            result, EAGAIN,
+            "recv on a UDP socket with nothing queued must return EAGAIN, not the old \
+             generic 0 (indistinguishable from a legitimate zero-byte datagram)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Second wave-2 batch (#314, findings 21-40). **2 stale** (bluetooth already commit-on-success); **2 too-large** (bt_audio Connecting-timeout needs a periodic caller = Phase-07 Wave-8; dns_tls query timeout needs a deadline through the `TlsTransport` trait with no hardware impl yet — flagged for the operator bundle).

## Critical — csprng boot-hang
`csprng::init()` spun forever in an unbounded `WFI` loop if the timer ISR never fired — a **permanent boot hang**. Now bounded (30s) against the **free-running CNTPCT** counter (not the ISR-driven tick, which can't detect its own handler failing); on timeout the CSPRNG stays unseeded and `kernel_random_bytes` keeps failing closed. Wired through kinit BootState with a WARN. Also fixes a latent cfg(test) path that seeded from an empty pool.

## Socket errno disambiguation (5)
TCP/UDP independent port spaces on bind; reject UDP peer port 0; TCP connect → EISCONN/EADDRNOTAVAIL (was all ECONNREFUSED); UDP send → EDESTADDRREQ/ENOBUFS; UDP recv → EAGAIN/EMSGSIZE (was a bare `0` indistinguishable from an empty datagram).

## Other
lfs create() rolls back the orphaned imap inode on partial write failure; net LoopbackDevice TX queue bounded (was unbounded heap growth); provision enforces RECV_BUF_CAPACITY on pre-auth USB input; sms UDL>160 rejected; dns QNAME 255-byte cap; gps non-hex checksum→ParseError; audit hex-escapes non-UTF8 detail; firewall halves per-packet allocs; bt_audio resume() awaits peer ACK.

## Verification
- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — **1958 passed** (15 new; 2 apply-surfaced compile errors fixed inline)
- `cargo build --release --target armv7a-none-eabi` — clean (csprng cfg(not(test)) timing path) · `kanon lint` — clean

Partially addresses #314 (findings 21-40: 18 fixed + 2 stale; 2 architectural). ~49 remain.

_csprng boot-path + socket/provision security surface reviewed at T0/Opus._