### PR TITLE
Wave-2 low-rollup batch 3: 17 fixes incl. 4 security (#314)

### DIFF
--- a/crates/thumos/src/audit.rs
+++ b/crates/thumos/src/audit.rs
@@ -306,6 +306,13 @@ pub(crate) struct AuditLog {
     count: usize,
     /// HMAC of the most recently appended entry (chains the next append).
     last_hmac: [u8; SHA256_DIGEST_LEN],
+    /// HMAC that chains into the current oldest live entry. Equal to
+    /// `GENESIS_HMAC` until the ring first wraps; from then on it holds
+    /// the HMAC of the entry evicted to make room for the current
+    /// oldest entry, captured by `log_event` at eviction time, so
+    /// `verify_chain` can validate the oldest live entry after wrap
+    /// instead of trusting it unchecked.
+    root_hmac: [u8; SHA256_DIGEST_LEN],
 }
 
 impl AuditLog {
@@ -332,6 +339,7 @@ impl AuditLog {
             head: 0,
             count: 0,
             last_hmac: GENESIS_HMAC,
+            root_hmac: GENESIS_HMAC,
         }
     }
 
@@ -384,7 +392,13 @@ impl AuditLog {
         let hmac = security::hmac_sha256(hmac_key, &serialized[..len]);
         entry.hmac = hmac;
 
-        // Write into the ring buffer.
+        // Write into the ring buffer. If the ring is already full, this
+        // write evicts the current oldest entry; capture its HMAC as the
+        // new chain root so verify_chain can still validate the new
+        // oldest entry (which chained from the evicted one) after wrap.
+        if self.count == MAX_ENTRIES {
+            self.root_hmac = self.entries[self.head].hmac;
+        }
         self.entries[self.head] = entry;
         self.head = (self.head + 1) % MAX_ENTRIES;
         if self.count < MAX_ENTRIES {
@@ -401,15 +415,15 @@ impl AuditLog {
     /// from (content || previous HMAC) and comparing against the stored
     /// HMAC.  Any mismatch indicates tampering.
     ///
-    /// # Important
+    /// # Ring buffer wrap
     ///
-    /// After a ring buffer wrap, the chain's genesis HMAC (all zeros) is
-    /// lost because the oldest entry was overwritten.  In this case,
-    /// verification starts from the oldest live entry using the HMAC of
-    /// the entry *before* it (which is the overwritten slot's HMAC, now
-    /// unknown).  To handle this, when the buffer has wrapped, we trust
-    /// the oldest entry's HMAC as the chain root and verify from the
-    /// second-oldest forward.
+    /// After a ring buffer wrap, the true genesis HMAC (all zeros) is no
+    /// longer the chain root for the oldest live entry -- that entry
+    /// chained from whatever occupied its slot before eviction.
+    /// `log_event` captures the evicted entry's HMAC into `root_hmac`
+    /// before overwriting it, so verification always has a real
+    /// (non-trusted) root to check the oldest live entry against; no
+    /// entry is ever skipped or trusted unchecked.
     ///
     /// # Errors
     ///
@@ -431,17 +445,17 @@ impl AuditLog {
 
         // Determine the previous HMAC for the first entry in the chain.
         // If the buffer has not wrapped, the genesis HMAC is all zeros.
-        // If wrapped, we trust the oldest entry's stored HMAC and start
-        // verification from the second entry.
-        let (verify_start, mut prev_hmac) = if wrapped {
-            // Trust the oldest entry's HMAC as chain root after wrap.
-            let oldest = &self.entries[start];
-            (1, oldest.hmac)
+        // If wrapped, `root_hmac` holds the HMAC of the entry that was
+        // evicted to make room for the current oldest live entry
+        // (captured in `log_event`), so every live entry -- including
+        // the oldest -- is verified below; none are trusted unchecked.
+        let mut prev_hmac = if wrapped {
+            self.root_hmac
         } else {
-            (0, GENESIS_HMAC)
+            GENESIS_HMAC
         };
 
-        for i in verify_start..self.count {
+        for i in 0..self.count {
             let idx = (start + i) % MAX_ENTRIES;
             let entry = &self.entries[idx];
 
@@ -692,6 +706,39 @@ mod tests {
         assert!(
             result.is_ok(),
             "chain must verify after multiple wraps: {result:?}"
+        );
+    }
+
+    #[test]
+    fn chain_detects_oldest_entry_tamper_after_wrap() {
+        let mut log = AuditLog::new();
+
+        // Fill the buffer completely, then wrap once so the oldest live
+        // entry (at ring index `log.head`) chained from an entry that
+        // was evicted, not from the genesis HMAC.
+        for i in 0..MAX_ENTRIES {
+            log_one(
+                &mut log,
+                AuditEventType::PacketDeny,
+                i as u32,
+                b"fill",
+                i as u64 * 10,
+            );
+        }
+        log_one(&mut log, AuditEventType::AuthFail, 9999, b"overflow", 99999);
+        assert!(log.has_wrapped());
+
+        // Tamper with the new oldest live entry (index `log.head`) --
+        // exactly the entry the pre-fix code trusted unconditionally
+        // instead of verifying.
+        let oldest_idx = log.head;
+        log.entries[oldest_idx].detail[0] ^= 0xFF;
+
+        let result = log.verify_chain(&TEST_KEY);
+        assert_eq!(
+            result,
+            Err(AuditError::ChainTampered),
+            "tampering the oldest live entry after a ring-buffer wrap must be detected, not trusted (pre-fix: this returned Ok)"
         );
     }
 

--- a/crates/thumos/src/bluetooth.rs
+++ b/crates/thumos/src/bluetooth.rs
@@ -815,6 +815,15 @@ mod tests {
     }
 
     #[test]
+    fn hci_le_set_scan_params_uses_random_own_address_type() {
+        let cmd = hci_le_set_scan_params();
+        assert_eq!(
+            cmd[9], 0x01,
+            "own_address_type must be 0x01 (random) for LE privacy, never 0x00 (public)"
+        );
+    }
+
+    #[test]
     fn hci_acl_data_uses_acl_type_not_command_type() {
         let payload = [0xAA, 0xBB, 0xCC];
         let frame = hci_acl_data(0x0042, &payload);
@@ -850,6 +859,19 @@ mod tests {
     }
 
     #[test]
+    fn init_in_non_off_state_returns_invalid_state() {
+        let hw = MockBtHw::new();
+        let mut adapter = BtAdapter::new(hw);
+        adapter.init(0).ok(); // first init succeeds, transitions Off -> Ready
+        let result = adapter.init(0);
+        assert_eq!(
+            result,
+            Err(BtError::InvalidState),
+            "init while already Ready must return InvalidState, not re-run hardware setup"
+        );
+    }
+
+    #[test]
     fn start_scan_transitions_to_scanning() {
         let hw = MockBtHw::new();
         let mut adapter = BtAdapter::new(hw);
@@ -879,6 +901,19 @@ mod tests {
     }
 
     #[test]
+    fn stop_scan_in_ready_state_returns_invalid_state() {
+        let hw = MockBtHw::new();
+        let mut adapter = BtAdapter::new(hw);
+        adapter.init(0).ok(); // Ready, not Scanning
+        let result = adapter.stop_scan();
+        assert_eq!(
+            result,
+            Err(BtError::InvalidState),
+            "stop_scan outside Scanning state must return InvalidState"
+        );
+    }
+
+    #[test]
     fn add_scan_result_deduplicates_by_address() {
         let hw = MockBtHw::new();
         let mut adapter = BtAdapter::new(hw);
@@ -898,6 +933,23 @@ mod tests {
             adapter.scan_results()[0].rssi,
             -50,
             "RSSI must be updated to the latest observation"
+        );
+    }
+
+    #[test]
+    fn add_scan_result_caps_at_max_scan_results() {
+        let hw = MockBtHw::new();
+        let mut adapter = BtAdapter::new(hw);
+
+        // Flood with more distinct addresses than MAX_SCAN_RESULTS allows.
+        for i in 0..(MAX_SCAN_RESULTS + 8) {
+            adapter.add_scan_result(BleDevice::new([i as u8, 0, 0, 0, 0, 0], -50));
+        }
+
+        assert_eq!(
+            adapter.scan_results().len(),
+            MAX_SCAN_RESULTS,
+            "scan results must cap at MAX_SCAN_RESULTS even under a flood of distinct addresses"
         );
     }
 

--- a/crates/thumos/src/briar.rs
+++ b/crates/thumos/src/briar.rs
@@ -735,6 +735,43 @@ mod tests {
     }
 
     #[test]
+    fn push_inbox_drops_oldest_when_full() {
+        let mut transport = BriarTransport::new();
+        let id = [0x01; 32];
+        let contact = BriarContact::new(id, b"Alice").unwrap_or_else(|_| unreachable!());
+        transport.add_contact(contact).ok();
+
+        for i in 0..MAX_INBOX_MESSAGES {
+            let msg =
+                BriarMessage::new(id, "m".to_string(), i as u64).unwrap_or_else(|_| unreachable!());
+            transport.push_inbox(msg).ok();
+        }
+        assert_eq!(transport.inbox_count(), MAX_INBOX_MESSAGES);
+
+        // One more push over capacity must drop the oldest (timestamp 0),
+        // not silently grow past MAX_INBOX_MESSAGES or drop the newest.
+        let overflow_msg = BriarMessage::new(id, "overflow".to_string(), MAX_INBOX_MESSAGES as u64)
+            .unwrap_or_else(|_| unreachable!());
+        transport.push_inbox(overflow_msg).ok();
+
+        assert_eq!(
+            transport.inbox_count(),
+            MAX_INBOX_MESSAGES,
+            "inbox must stay capped at MAX_INBOX_MESSAGES after overflow"
+        );
+        assert_eq!(
+            transport.inbox()[0].timestamp,
+            1,
+            "the oldest message (timestamp 0) must have been dropped, not the newest"
+        );
+        assert_eq!(
+            transport.inbox().last().map(|m| m.timestamp),
+            Some(MAX_INBOX_MESSAGES as u64),
+            "the newly pushed message must be present at the newest end"
+        );
+    }
+
+    #[test]
     fn clear_inbox_empties_buffer() {
         let mut transport = BriarTransport::new();
         let id = [0x01; 32];

--- a/crates/thumos/src/bt_audio.rs
+++ b/crates/thumos/src/bt_audio.rs
@@ -156,6 +156,11 @@ pub(crate) struct A2dpProfile<H: BtHwOps> {
     remote_seid: u8,
     /// Local stream endpoint ID.
     local_seid: u8,
+    /// AVDTP signal ID whose response is currently awaited during the
+    /// Connecting sequence (Discover -> GetCapabilities ->
+    /// SetConfiguration -> Open -> Start) or during resume(). `None`
+    /// when no signaling response is outstanding.
+    pending_signal: Option<u8>,
     /// Bluetooth hardware backend.
     hw: H,
 }
@@ -175,6 +180,7 @@ impl<H: BtHwOps> A2dpProfile<H> {
             transaction_label: 0,
             remote_seid: 0,
             local_seid: 1,
+            pending_signal: None,
             hw,
         }
     }
@@ -274,6 +280,7 @@ impl<H: BtHwOps> A2dpProfile<H> {
         self.hw
             .send_command(&discover)
             .map_err(BtAudioError::from)?;
+        self.pending_signal = Some(AVDTP_SIGNAL_DISCOVER);
 
         Ok(())
     }
@@ -300,12 +307,26 @@ impl<H: BtHwOps> A2dpProfile<H> {
             return Err(BtAudioError::InvalidState);
         }
 
+        // WARNING(security): dispatching purely on the peer-supplied
+        // `signal` ID with no ordering check let a malicious/misbehaving
+        // peer inject e.g. AVDTP_SIGNAL_START as the very first response
+        // and jump straight from Connecting to Streaming, skipping SBC
+        // codec negotiation entirely. `pending_signal` tracks which
+        // response this profile is actually waiting for (set by
+        // connect()/resume() and advanced below); any other signal is a
+        // protocol violation and is rejected here, before the dispatch.
+        if self.pending_signal != Some(signal) {
+            self.state = A2dpState::Error(BtAudioError::AvdtpError);
+            return Err(BtAudioError::AvdtpError);
+        }
+
         match signal {
             AVDTP_SIGNAL_DISCOVER => {
                 // Received Discover response -- send GetCapabilities.
                 let label = self.next_transaction_label();
                 let msg = AvdtpMessage::get_capabilities(label, self.remote_seid);
                 self.hw.send_command(&msg).map_err(BtAudioError::from)?;
+                self.pending_signal = Some(AVDTP_SIGNAL_GET_CAPABILITIES);
             }
             AVDTP_SIGNAL_GET_CAPABILITIES => {
                 // Received GetCapabilities response -- send SetConfiguration.
@@ -318,12 +339,14 @@ impl<H: BtHwOps> A2dpProfile<H> {
                     &header,
                 );
                 self.hw.send_command(&msg).map_err(BtAudioError::from)?;
+                self.pending_signal = Some(AVDTP_SIGNAL_SET_CONFIGURATION);
             }
             AVDTP_SIGNAL_SET_CONFIGURATION => {
                 // Received SetConfiguration response -- send Open.
                 let label = self.next_transaction_label();
                 let msg = AvdtpMessage::open(label, self.remote_seid);
                 self.hw.send_command(&msg).map_err(BtAudioError::from)?;
+                self.pending_signal = Some(AVDTP_SIGNAL_OPEN);
             }
             AVDTP_SIGNAL_OPEN => {
                 // Received Open response -- send Start, then commit the
@@ -333,10 +356,12 @@ impl<H: BtHwOps> A2dpProfile<H> {
                 let msg = AvdtpMessage::start(label, self.remote_seid);
                 self.hw.send_command(&msg).map_err(BtAudioError::from)?;
                 self.state = A2dpState::Connected;
+                self.pending_signal = Some(AVDTP_SIGNAL_START);
             }
             AVDTP_SIGNAL_START => {
                 // Received Start response -- streaming is active.
                 self.state = A2dpState::Streaming;
+                self.pending_signal = None;
             }
             _ => {
                 // Unknown or unexpected signal.
@@ -429,6 +454,7 @@ impl<H: BtHwOps> A2dpProfile<H> {
         let label = self.next_transaction_label();
         let msg = AvdtpMessage::start(label, self.remote_seid);
         self.hw.send_command(&msg).map_err(BtAudioError::from)?;
+        self.pending_signal = Some(AVDTP_SIGNAL_START);
 
         Ok(())
     }
@@ -627,6 +653,33 @@ mod tests {
     }
 
     #[test]
+    fn advance_signaling_rejects_out_of_order_start_before_negotiation() {
+        let mut profile = make_a2dp();
+        let peer = [0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE];
+        profile.set_peer(peer);
+        profile.set_remote_seid(2);
+        profile.connect().ok();
+        assert_eq!(profile.state(), A2dpState::Connecting);
+
+        // A malicious/misbehaving peer sends Start as if it were the
+        // very first signaling response, skipping GetCapabilities ->
+        // SetConfiguration -> Open. Before the fix, advance_signaling()
+        // dispatched purely on the signal ID with no ordering check, so
+        // this reached Streaming without ever negotiating the SBC codec.
+        let result = profile.advance_signaling(AVDTP_SIGNAL_START);
+        assert_eq!(
+            result,
+            Err(BtAudioError::AvdtpError),
+            "an out-of-order Start response must be rejected, not fast-forward to Streaming"
+        );
+        assert_ne!(
+            profile.state(),
+            A2dpState::Streaming,
+            "must never reach Streaming without codec negotiation"
+        );
+    }
+
+    #[test]
     fn open_response_reaches_connected_via_normal_sequence() {
         let mut profile = make_a2dp();
         let peer = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06];
@@ -651,6 +704,18 @@ mod tests {
             A2dpState::Connected,
             "Connected must be reachable via the normal connection sequence, \
              not only via suspend() from Streaming"
+        );
+    }
+
+    #[test]
+    fn advance_signaling_in_disconnected_state_returns_invalid_state() {
+        let mut profile = make_a2dp();
+        // No connect() call -- profile is still Disconnected.
+        let result = profile.advance_signaling(AVDTP_SIGNAL_DISCOVER);
+        assert_eq!(
+            result,
+            Err(BtAudioError::InvalidState),
+            "advance_signaling before connect() (Disconnected state) must return InvalidState"
         );
     }
 

--- a/crates/thumos/src/dns.rs
+++ b/crates/thumos/src/dns.rs
@@ -425,6 +425,14 @@ fn skip_dns_name(data: &[u8], mut offset: usize) -> Result<usize, DnsError> {
             return Ok(offset + 2);
         }
 
+        if len & 0xC0 != 0 {
+            // Reserved extended label type (RFC 1035 section 3.1: top two
+            // bits 01 or 10). The low 6 bits are not a valid label length
+            // under this scheme -- treating them as one would desync the
+            // parser from the real packet structure.
+            return Err(DnsError::MalformedResponse);
+        }
+
         // Regular label.
         offset += 1 + len as usize;
         labels += 1;
@@ -819,6 +827,35 @@ mod tests {
             result,
             Ok(data.len()),
             "a 100-label name within the RFC 1035 name-length limit must not be rejected"
+        );
+    }
+
+    #[test]
+    fn skip_dns_name_rejects_reserved_extended_label_type() {
+        // A length byte of 0x40 (0b01000000) has the RFC 1035 section 3.1
+        // reserved top-bit pattern 01 (extended label type), not a
+        // regular 6-bit length. Before the fix, only 0xC0 (0b11,
+        // compression pointer) was special-cased and this byte was
+        // silently treated as a 0x40-byte-long regular label, desyncing
+        // the parser from the real packet structure.
+        let data = [0x40u8, b'a', b'b', 0u8];
+        let result = skip_dns_name(&data, 0);
+        assert_eq!(
+            result,
+            Err(DnsError::MalformedResponse),
+            "a reserved extended label type (top bits 01) must be rejected, not treated as a length"
+        );
+    }
+
+    #[test]
+    fn skip_dns_name_rejects_top_bit_10_label_type() {
+        // 0x80 (0b10000000) is the other RFC 1035 reserved top-bit pattern.
+        let data = [0x80u8, b'a', b'b', 0u8];
+        let result = skip_dns_name(&data, 0);
+        assert_eq!(
+            result,
+            Err(DnsError::MalformedResponse),
+            "a reserved extended label type (top bits 10) must be rejected, not treated as a length"
         );
     }
 

--- a/crates/thumos/src/dns_tls.rs
+++ b/crates/thumos/src/dns_tls.rs
@@ -254,9 +254,21 @@ pub(crate) fn build_dns_query(hostname: &str, txid: u16) -> Result<Vec<u8>, DotE
     packet.extend_from_slice(&0u16.to_be_bytes()); // NSCOUNT
     packet.extend_from_slice(&0u16.to_be_bytes()); // ARCOUNT
 
-    // QNAME: encode hostname as DNS labels.
+    // QNAME: encode hostname as DNS labels. RFC 1035 section 3.1 caps the
+    // total encoded name -- every length-prefix octet plus every label
+    // octet plus the terminating zero -- at 255 octets; the per-label
+    // <= 63 check alone does not bound the SUM across many short labels
+    // (mirrors dns.rs's build_dns_query, fixed in an earlier batch).
+    const DNS_MAX_NAME_LEN: usize = 255;
+    let mut qname_len: usize = 0;
     for label in hostname.split('.') {
         if label.is_empty() || label.len() > 63 {
+            return Err(DotError::InvalidName);
+        }
+        qname_len = qname_len
+            .checked_add(1 + label.len())
+            .ok_or(DotError::InvalidName)?;
+        if qname_len >= DNS_MAX_NAME_LEN {
             return Err(DotError::InvalidName);
         }
         packet.push(label.len() as u8);
@@ -295,8 +307,20 @@ pub(crate) fn build_dns_query_typed(
     packet.extend_from_slice(&0u16.to_be_bytes());
     packet.extend_from_slice(&0u16.to_be_bytes());
 
+    // RFC 1035 section 3.1: total encoded QNAME (length-prefix octets +
+    // label octets + terminating zero) is capped at 255 octets; the
+    // per-label <= 63 check alone does not bound the sum (mirrors
+    // build_dns_query above).
+    const DNS_MAX_NAME_LEN: usize = 255;
+    let mut qname_len: usize = 0;
     for label in hostname.split('.') {
         if label.is_empty() || label.len() > 63 {
+            return Err(DotError::InvalidName);
+        }
+        qname_len = qname_len
+            .checked_add(1 + label.len())
+            .ok_or(DotError::InvalidName)?;
+        if qname_len >= DNS_MAX_NAME_LEN {
             return Err(DotError::InvalidName);
         }
         packet.push(label.len() as u8);
@@ -698,6 +722,22 @@ mod tests {
     }
 
     #[test]
+    fn build_query_rejects_oversized_total_name() {
+        // Five 63-byte labels: each individually legal (<= 63 bytes), but
+        // the total encoded QNAME (5 * (1 + 63) + 1 = 321 bytes) blows
+        // past the RFC 1035 section 3.1 255-byte ceiling. Only the
+        // per-label check existed before; this must be caught too.
+        let label = "a".repeat(63);
+        let hostname = alloc::format!("{label}.{label}.{label}.{label}.{label}");
+        let result = build_dns_query(&hostname, 0x0001);
+        assert_eq!(
+            result,
+            Err(DotError::InvalidName),
+            "a total QNAME over 255 bytes must return InvalidName even when every label is individually legal"
+        );
+    }
+
+    #[test]
     fn build_query_typed_uses_record_type() {
         let result = build_dns_query_typed("example.com", 0xABCD, 28); // AAAA = 28
         assert!(result.is_ok(), "typed query must succeed");
@@ -708,6 +748,18 @@ mod tests {
         let qtype_offset = DNS_HEADER_SIZE + 13;
         let qtype = u16::from_be_bytes([packet[qtype_offset], packet[qtype_offset + 1]]);
         assert_eq!(qtype, 28, "QTYPE must be AAAA (28)");
+    }
+
+    #[test]
+    fn build_query_typed_rejects_oversized_total_name() {
+        let label = "a".repeat(63);
+        let hostname = alloc::format!("{label}.{label}.{label}.{label}.{label}");
+        let result = build_dns_query_typed(&hostname, 0x0001, 28);
+        assert_eq!(
+            result,
+            Err(DotError::InvalidName),
+            "build_dns_query_typed must enforce the same 255-byte QNAME ceiling as build_dns_query"
+        );
     }
 
     // -- Pin verification tests -----------------------------------------------

--- a/crates/thumos/src/lfs.rs
+++ b/crates/thumos/src/lfs.rs
@@ -575,6 +575,31 @@ pub(crate) fn mount(mut dev: Box<dyn BlockDevice>) -> Result<Lfs, LfsError> {
 // ---------------------------------------------------------------------------
 
 impl Lfs {
+    /// Validate that an on-disk block pointer falls within the
+    /// filesystem's own block extent before it is used to address the
+    /// block cache.
+    ///
+    /// `inode.direct[]` entries are on-disk, untrusted data: a
+    /// corrupted or maliciously crafted inode could set them to any
+    /// `u64`. Every block the filesystem itself allocates stays within
+    /// `[1, superblock.block_count)` (block 0 is the superblock, never
+    /// an allocatable data block), so any pointer outside that range is
+    /// corruption -- fail closed rather than let it reach the block
+    /// cache and read/write memory outside the filesystem's own
+    /// extent, even when that block number is still within the raw
+    /// block device's physical capacity.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VfsError::IoError`] if `block_num` is 0 or `>=
+    /// superblock.block_count`.
+    fn validate_block_num(&self, block_num: u64) -> Result<(), VfsError> {
+        if block_num == 0 || block_num >= self.superblock.block_count {
+            return Err(VfsError::IoError);
+        }
+        Ok(())
+    }
+
     /// Load a `DiskInode` from disk given its inode ID.
     ///
     /// Looks up the block number via the imap, reads the block, and
@@ -697,6 +722,13 @@ impl Lfs {
     }
 
     /// Read all directory entries for a directory inode.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VfsError::IoError`] if `inode.size` does not fit in
+    /// `usize` on this target (32-bit ARM: on-disk `size` is `u64` and
+    /// must never silently truncate through an `as usize` cast), or if
+    /// `inode.inode_type` is not a directory.
     fn read_dir_entries(&self, inode: &DiskInode) -> Result<Vec<DiskDirEntry>, VfsError> {
         if inode.inode_type != INODE_TYPE_DIR {
             return Err(VfsError::NotADirectory);
@@ -708,7 +740,8 @@ impl Lfs {
         let data_blocks = if inode.size == 0 {
             0
         } else {
-            ((inode.size as usize + BLOCK_SIZE - 1) / BLOCK_SIZE).min(DIRECT_BLOCK_COUNT)
+            let size = usize::try_from(inode.size).map_err(|_| VfsError::IoError)?;
+            size.div_ceil(BLOCK_SIZE).min(DIRECT_BLOCK_COUNT)
         };
 
         for i in 0..data_blocks {
@@ -716,6 +749,11 @@ impl Lfs {
             if block_num == 0 {
                 continue;
             }
+            // WARNING: inode.direct[] is on-disk, untrusted data -- a
+            // corrupted or crafted inode could point anywhere. Bound it
+            // to the filesystem's own extent before it ever reaches the
+            // block cache (#security).
+            self.validate_block_num(block_num)?;
 
             let mut buf = [0u8; BLOCK_SIZE];
             let mut dev = self.dev.borrow_mut();
@@ -955,6 +993,11 @@ impl Filesystem for Lfs {
                 bytes_read += chunk;
                 continue;
             }
+            // WARNING: inode.direct[] is on-disk, untrusted data -- a
+            // corrupted or crafted inode could point anywhere. Bound it
+            // to the filesystem's own extent before it ever reaches the
+            // block cache (#security).
+            self.validate_block_num(block_num)?;
 
             let mut block_buf = [0u8; BLOCK_SIZE];
             {
@@ -999,6 +1042,11 @@ impl Filesystem for Lfs {
 
         self.ensure_writer()?;
 
+        // Captured before the writer/cache borrows below so the extent
+        // check inside the loop doesn't need a `&self` method call while
+        // `self.writer` is exclusively borrowed.
+        let block_count = self.superblock.block_count;
+
         let mut bytes_written = 0usize;
         let mut dev = self.dev.borrow_mut();
         let mut cache = self.cache.borrow_mut();
@@ -1020,6 +1068,15 @@ impl Filesystem for Lfs {
             if block_offset != 0 || bytes_written + BLOCK_SIZE > buf.len() {
                 let existing_block = inode.direct[block_index];
                 if existing_block != 0 {
+                    // WARNING: inode.direct[] is on-disk, untrusted data --
+                    // bound it to the filesystem's own extent before it
+                    // reaches the block cache (#security, mirrors read()'s
+                    // validate_block_num; inlined here because `writer`
+                    // already holds an exclusive borrow of `self.writer`,
+                    // so a `&self` method call is not available).
+                    if existing_block >= block_count {
+                        return Err(VfsError::IoError);
+                    }
                     cache
                         .read(dev.as_mut(), existing_block, &mut block_buf)
                         .map_err(|_| VfsError::IoError)?;
@@ -1615,6 +1672,30 @@ mod tests {
     }
 
     #[test]
+    fn read_dir_entries_rejects_size_that_overflows_usize_on_32_bit() {
+        let mut dev = block_device_for_lfs();
+        format(&mut dev).expect("format");
+        let fs = mount(Box::new(dev)).expect("mount");
+
+        // On this 32-bit test target (i686/armv7 usize), u32::MAX + 1
+        // does not fit in usize. Before the fix, `inode.size as usize`
+        // silently truncated instead of erroring.
+        let inode = DiskInode {
+            inode_type: INODE_TYPE_DIR,
+            link_count: 1,
+            size: u64::from(u32::MAX) + 1,
+            direct: [0u64; DIRECT_BLOCK_COUNT],
+            indirect: 0,
+        };
+
+        let result = fs.read_dir_entries(&inode);
+        assert!(
+            matches!(result, Err(VfsError::IoError)),
+            "an inode size that does not fit in usize must be rejected, not silently truncated"
+        );
+    }
+
+    #[test]
     fn inode_to_stat_rejects_unrecognized_on_disk_type() {
         let inode = DiskInode {
             inode_type: 99, // neither INODE_TYPE_FILE nor INODE_TYPE_DIR
@@ -1639,6 +1720,36 @@ mod tests {
         let fs = mount(Box::new(dev)).expect("mount");
         let result = fs.lookup(fs.root_inode(), "nonexistent");
         assert_eq!(result, Err(VfsError::NotFound));
+    }
+
+    #[test]
+    fn read_dir_entries_rejects_direct_pointer_outside_extent() {
+        let mut dev = block_device_for_lfs();
+        format(&mut dev).expect("format");
+        let mut fs = mount(Box::new(dev)).expect("mount");
+
+        // Simulate a corrupted/crafted inode whose direct pointer targets
+        // a block within the raw device's capacity but outside the
+        // filesystem's own declared extent -- the block-device layer
+        // alone would happily serve this read (it is a valid LBA); only
+        // a filesystem-level bound check catches it.
+        let real_block_count = fs.superblock.block_count;
+        fs.superblock.block_count = 4;
+
+        let mut inode = DiskInode {
+            inode_type: INODE_TYPE_DIR,
+            link_count: 1,
+            size: BLOCK_SIZE as u64,
+            direct: [0u64; DIRECT_BLOCK_COUNT],
+            indirect: 0,
+        };
+        inode.direct[0] = real_block_count - 1;
+
+        let result = fs.read_dir_entries(&inode);
+        assert!(
+            matches!(result, Err(VfsError::IoError)),
+            "a direct block pointer inside the raw device but outside the filesystem's own extent must be rejected, not read"
+        );
     }
 
     #[test]

--- a/crates/thumos/src/meshtastic.rs
+++ b/crates/thumos/src/meshtastic.rs
@@ -253,7 +253,9 @@ impl MeshMessage {
     ///
     /// - [`MeshError::MessageTooLong`] if `body` exceeds the limit
     /// - [`MeshError::InvalidHopCount`] if `hop_count` exceeds maximum
-    /// - [`MeshError::InvalidNodeId`] if `from_node` is zero
+    /// - [`MeshError::InvalidNodeId`] if `from_node` is zero or
+    ///   [`BROADCAST_NODE_ID`] (broadcast is a destination-only address,
+    ///   never a valid sender)
     pub(crate) fn new(
         from_node: u32,
         to_node: u32,
@@ -262,7 +264,7 @@ impl MeshMessage {
         hop_count: u8,
         channel: u8,
     ) -> Result<Self, MeshError> {
-        if from_node == 0 {
+        if from_node == 0 || from_node == BROADCAST_NODE_ID {
             return Err(MeshError::InvalidNodeId);
         }
         if body.len() > MAX_MESSAGE_BODY_LEN {
@@ -671,6 +673,16 @@ mod tests {
             result,
             Err(MeshError::InvalidNodeId),
             "message from node 0 must fail"
+        );
+    }
+
+    #[test]
+    fn message_broadcast_as_from_node_fails() {
+        let result = MeshMessage::new(BROADCAST_NODE_ID, 0x5678, "hello".to_string(), 0, 0, 0);
+        assert_eq!(
+            result,
+            Err(MeshError::InvalidNodeId),
+            "BROADCAST_NODE_ID is a destination-only address and must be rejected as a sender"
         );
     }
 

--- a/crates/thumos/src/sms.rs
+++ b/crates/thumos/src/sms.rs
@@ -69,6 +69,10 @@ pub enum SmsError {
     NumberTooLong,
     /// Message text too long for single-segment SMS.
     MessageTooLong,
+    /// The inbox was already at capacity ([`MAX_INBOX_MESSAGES`]); the
+    /// oldest buffered message was dropped to make room for the new
+    /// one, which is still enqueued.
+    InboxOverflow,
 }
 
 impl core::fmt::Display for SmsError {
@@ -83,6 +87,7 @@ impl core::fmt::Display for SmsError {
             Self::TransportError => write!(f, "transport error"),
             Self::NumberTooLong => write!(f, "phone number too long"),
             Self::MessageTooLong => write!(f, "message too long"),
+            Self::InboxOverflow => write!(f, "inbox overflow, oldest message dropped"),
         }
     }
 }
@@ -95,6 +100,10 @@ const MAX_GSM7_SEPTETS: usize = 160;
 
 /// Maximum phone number length stored in `SmsMessage.sender`.
 const MAX_SENDER_LEN: usize = 32;
+
+/// Maximum number of messages retained in the inbox before the oldest
+/// is dropped to make room (unbounded SMS flood protection).
+const MAX_INBOX_MESSAGES: usize = 256;
 
 // ---------------------------------------------------------------------------
 // BCD address encoding (ported from klesis/src/pdu.rs)
@@ -148,7 +157,15 @@ fn encode_bcd_address(number: &str) -> Result<Vec<u8>, SmsError> {
 ///
 /// `len_digits` is the number of significant digits. `type_byte` is the
 /// type-of-address octet. `bcd` contains the packed BCD bytes.
-fn decode_bcd_address(len_digits: u8, type_byte: u8, bcd: &[u8]) -> String {
+///
+/// # Errors
+///
+/// Returns [`SmsError::PduDecode`] if any significant nibble is outside
+/// `0..=9` -- a network-supplied PDU that claims a BCD digit of 0xA-0xE
+/// has no valid decimal-digit meaning and must not be rendered as a
+/// non-digit character in the sender field (same class as the klesis
+/// BCD fix).
+fn decode_bcd_address(len_digits: u8, type_byte: u8, bcd: &[u8]) -> Result<String, SmsError> {
     let mut number = String::new();
     if type_byte == 0x91 {
         number.push('+');
@@ -161,14 +178,20 @@ fn decode_bcd_address(len_digits: u8, type_byte: u8, bcd: &[u8]) -> String {
 
         let lo_digit_index = idx * 2;
         if lo_digit_index < digit_count {
+            if lo > 9 {
+                return Err(SmsError::PduDecode);
+            }
             number.push(char::from(b'0' + lo));
         }
         let hi_digit_index = idx * 2 + 1;
         if hi_digit_index < digit_count && hi != 0x0F {
+            if hi > 9 {
+                return Err(SmsError::PduDecode);
+            }
             number.push(char::from(b'0' + hi));
         }
     }
-    number
+    Ok(number)
 }
 
 // ---------------------------------------------------------------------------
@@ -453,7 +476,7 @@ impl SmsManager {
         let oa_type = cur.read_byte()?;
         let oa_bcd_bytes = usize::from(oa_len_digits.div_ceil(2));
         let oa_bcd = cur.read_slice(oa_bcd_bytes)?;
-        let sender_str = decode_bcd_address(oa_len_digits, oa_type, oa_bcd);
+        let sender_str = decode_bcd_address(oa_len_digits, oa_type, oa_bcd)?;
 
         // Build sender field.
         let mut sender = [0u8; MAX_SENDER_LEN];
@@ -526,8 +549,27 @@ impl SmsManager {
     }
 
     /// Add a message to the inbox (used by `handle_incoming`).
-    pub(crate) fn receive(&mut self, msg: SmsMessage) {
+    ///
+    /// Drops the oldest message if the buffer is already at
+    /// [`MAX_INBOX_MESSAGES`] capacity, bounding heap growth under an
+    /// SMS flood.
+    ///
+    /// # Errors
+    ///
+    /// - [`SmsError::InboxOverflow`] if the inbox was already at capacity
+    ///   (the oldest buffered message was dropped to make room for `msg`,
+    ///   which is still enqueued)
+    pub(crate) fn receive(&mut self, msg: SmsMessage) -> Result<(), SmsError> {
+        let overflowed = self.inbox.len() >= MAX_INBOX_MESSAGES;
+        if overflowed {
+            // Drop oldest message to make room.
+            self.inbox.remove(0);
+        }
         self.inbox.push(msg);
+        if overflowed {
+            return Err(SmsError::InboxOverflow);
+        }
+        Ok(())
     }
 }
 
@@ -833,15 +875,63 @@ mod tests {
     }
 
     #[test]
-    fn mark_read_updates_flag() {
+    fn receive_caps_inbox_and_drops_oldest_under_flood() {
         let mut manager = SmsManager::new();
-        manager.receive(SmsMessage {
+        for i in 0..MAX_INBOX_MESSAGES {
+            let result = manager.receive(SmsMessage {
+                sender: [0u8; MAX_SENDER_LEN],
+                sender_len: 0,
+                body: String::from("m"),
+                timestamp: i as u64,
+                read: false,
+            });
+            assert!(result.is_ok(), "inbox has room until MAX_INBOX_MESSAGES");
+        }
+        assert_eq!(manager.inbox().len(), MAX_INBOX_MESSAGES);
+
+        // One more message over capacity must drop the oldest, not grow
+        // the inbox unbounded (the pre-fix behavior under an SMS flood).
+        let result = manager.receive(SmsMessage {
             sender: [0u8; MAX_SENDER_LEN],
             sender_len: 0,
-            body: String::from("test"),
-            timestamp: 0,
+            body: String::from("overflow"),
+            timestamp: MAX_INBOX_MESSAGES as u64,
             read: false,
         });
+        assert_eq!(
+            result,
+            Err(SmsError::InboxOverflow),
+            "push into a full inbox must surface InboxOverflow"
+        );
+        assert_eq!(
+            manager.inbox().len(),
+            MAX_INBOX_MESSAGES,
+            "inbox must stay capped at MAX_INBOX_MESSAGES, not grow unbounded under flood"
+        );
+        assert_eq!(
+            manager.inbox()[0].timestamp,
+            1,
+            "the oldest message must have been dropped to make room"
+        );
+        assert_eq!(
+            manager.inbox().last().map(|m| m.timestamp),
+            Some(MAX_INBOX_MESSAGES as u64),
+            "the newly received message must be enqueued"
+        );
+    }
+
+    #[test]
+    fn mark_read_updates_flag() {
+        let mut manager = SmsManager::new();
+        manager
+            .receive(SmsMessage {
+                sender: [0u8; MAX_SENDER_LEN],
+                sender_len: 0,
+                body: String::from("test"),
+                timestamp: 0,
+                read: false,
+            })
+            .ok();
         assert!(!manager.inbox()[0].read, "message must start unread");
         manager.mark_read(0);
         assert!(
@@ -853,20 +943,24 @@ mod tests {
     #[test]
     fn delete_removes_message() {
         let mut manager = SmsManager::new();
-        manager.receive(SmsMessage {
-            sender: [0u8; MAX_SENDER_LEN],
-            sender_len: 0,
-            body: String::from("msg1"),
-            timestamp: 0,
-            read: false,
-        });
-        manager.receive(SmsMessage {
-            sender: [0u8; MAX_SENDER_LEN],
-            sender_len: 0,
-            body: String::from("msg2"),
-            timestamp: 0,
-            read: false,
-        });
+        manager
+            .receive(SmsMessage {
+                sender: [0u8; MAX_SENDER_LEN],
+                sender_len: 0,
+                body: String::from("msg1"),
+                timestamp: 0,
+                read: false,
+            })
+            .ok();
+        manager
+            .receive(SmsMessage {
+                sender: [0u8; MAX_SENDER_LEN],
+                sender_len: 0,
+                body: String::from("msg2"),
+                timestamp: 0,
+                read: false,
+            })
+            .ok();
         assert_eq!(manager.inbox().len(), 2);
         manager.delete(0);
         assert_eq!(manager.inbox().len(), 1);
@@ -893,8 +987,23 @@ mod tests {
         let bcd = bcd.unwrap_or_default();
         let decoded = decode_bcd_address(bcd[0], bcd[1], &bcd[2..]);
         assert_eq!(
-            decoded, "+15551234567",
+            decoded,
+            Ok(String::from("+15551234567")),
             "BCD round-trip must preserve number"
+        );
+    }
+
+    #[test]
+    fn decode_bcd_address_rejects_non_decimal_nibble() {
+        // Low nibble 0xA (10) has no decimal-digit meaning; before the
+        // fix this silently emitted ':' (b'0' + 10) into the sender
+        // field instead of being rejected.
+        let bcd = [0x1Au8];
+        let decoded = decode_bcd_address(2, 0x81, &bcd);
+        assert_eq!(
+            decoded,
+            Err(SmsError::PduDecode),
+            "a BCD nibble outside 0-9 must be rejected, not rendered as a non-digit character"
         );
     }
 

--- a/crates/thumos/src/socket.rs
+++ b/crates/thumos/src/socket.rs
@@ -27,6 +27,7 @@ use smoltcp::iface::SocketHandle;
 use smoltcp::socket::{tcp, udp};
 use smoltcp::wire::{IpAddress, IpEndpoint, Ipv4Address};
 
+use crate::csprng;
 use crate::fd::{self, FileDescriptor, MAX_FDS};
 use crate::net::{self, FirewallDevice, LoopbackDevice, NetworkStack};
 
@@ -261,11 +262,25 @@ fn socket_flags() -> u32 {
 
 /// Next ephemeral port to allocate.
 ///
-/// WHY static counter: simple sequential allocation from the IANA ephemeral
-/// range (49152-65535). Good enough for a kernel with MAX_SOCKETS=32.
+/// WHY static counter: fallback sequential allocation from the IANA
+/// ephemeral range (49152-65535), used only while the CSPRNG is not yet
+/// seeded (see `alloc_ephemeral_port`). Good enough for a kernel with
+/// MAX_SOCKETS=32.
 static mut NEXT_EPHEMERAL_PORT: u16 = 49152;
 
 /// Allocate an ephemeral port that is not currently in use.
+///
+/// The starting point within the ephemeral range is drawn from the
+/// kernel CSPRNG on every call so allocated source ports are not
+/// trivially predictable to an off-path attacker (a sequential counter
+/// lets a blind attacker guess the next port and race a spoofed
+/// packet/connection into place before the real one completes). If the
+/// CSPRNG is not yet seeded (early boot, before `csprng::init()`
+/// completes), falls back to the previous sequential counter rather
+/// than blocking or panicking -- source-port randomization is
+/// defense-in-depth, not key material, so degrading to
+/// predictable-but-functional allocation is correct here (mirrors
+/// `dns.rs`'s CSPRNG-unseeded TXID fallback).
 ///
 /// # Safety
 ///
@@ -274,7 +289,15 @@ static mut NEXT_EPHEMERAL_PORT: u16 = 49152;
 unsafe fn alloc_ephemeral_port() -> Option<u16> {
     unsafe {
         let table = get_socket_table();
-        let start = *core::ptr::addr_of!(NEXT_EPHEMERAL_PORT);
+
+        const EPHEMERAL_RANGE: u16 = 65535 - 49152 + 1;
+        let start = {
+            let mut rand_buf = [0u8; 2];
+            match csprng::kernel_random_bytes(&mut rand_buf) {
+                Ok(()) => 49152 + (u16::from_le_bytes(rand_buf) % EPHEMERAL_RANGE),
+                Err(_) => *core::ptr::addr_of!(NEXT_EPHEMERAL_PORT),
+            }
+        };
 
         // Scan up to the full ephemeral range (49152..65535).
         for offset in 0..16384u16 {
@@ -969,6 +992,51 @@ mod tests {
             // Initialize network stack.
             init_network_stack();
         }
+    }
+
+    #[test]
+    fn alloc_ephemeral_port_is_not_sequential_when_csprng_seeded() {
+        // SAFETY: test-only; setup_test_network resets global state.
+        unsafe {
+            setup_test_network();
+        }
+        csprng::seed_for_test(&[0x42u8; 32], &[0u8; 8], 0);
+
+        let mut ports = alloc::vec::Vec::new();
+        for _ in 0..8 {
+            let port = unsafe { alloc_ephemeral_port() }.expect("port allocation must succeed");
+            ports.push(port);
+        }
+
+        // Before the fix, alloc_ephemeral_port() always returned a
+        // strictly sequential run (49152, 49153, 49154, ...) starting
+        // from a fixed, predictable counter -- trivially guessable by
+        // an off-path attacker. With a seeded CSPRNG, consecutive
+        // allocations must not all differ by exactly 1; the chance of
+        // that happening by genuine randomness is astronomically small.
+        let all_sequential = ports.windows(2).all(|w| w[1] == w[0].wrapping_add(1));
+        assert!(
+            !all_sequential,
+            "ephemeral ports must be randomized, not allocated sequentially: {ports:?}"
+        );
+    }
+
+    #[test]
+    fn alloc_ephemeral_port_falls_back_when_csprng_unseeded() {
+        // SAFETY: test-only; setup_test_network resets global state.
+        // CSPRNG is never seeded in this test process (nextest runs
+        // each test in its own process), exercising the fail-open
+        // fallback path -- it must still return a valid port, never
+        // hang or panic.
+        unsafe {
+            setup_test_network();
+        }
+
+        let port = unsafe { alloc_ephemeral_port() };
+        assert!(
+            port.is_some_and(|p| (49152..=65535).contains(&p)),
+            "an unseeded CSPRNG must still allocate a valid ephemeral port via the deterministic fallback"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Third wave-2 batch (#314, findings 41-60). **3 stale** (ramfs/lfs already capped, bluetooth already tested).

## Security (4)
- **audit chain tamper gap** — after a ring wrap, `verify_chain` *trusted* the oldest live entry's own HMAC and verified from the second-oldest, so the oldest entry was never tamper-checked. Now `log_event` captures each evicted entry's HMAC into `root_hmac`; every live entry is verified. Test: tamper the post-wrap oldest → ChainTampered (was Ok).
- **AVDTP injection** — `advance_signaling` dispatched on the peer's signal ID with no ordering; a peer could send SIGNAL_START first and reach Streaming without codec negotiation. Now a `pending_signal` field enforces ordered progression.
- **crafted-inode block read** — lfs read/write used on-disk `inode.direct[]` block numbers with no FS-extent bound (a crafted inode could read blocks in-device but out-of-extent). Added `validate_block_num`.
- **predictable ephemeral ports** — sequential from 49152 → now CSPRNG-drawn, fail-*open* to the counter when unseeded (a source port is defense-in-depth, not key material).

## Other
sms inbox cap + BCD nibble reject; dns reserved-label reject; dns_tls QNAME 255-cap (second builder); lfs inode.size try_from (32-bit truncation); meshtastic rejects broadcast-as-sender. Plus coverage: audit tamper, bluetooth ×4, briar drop-oldest, bt_audio guards.

## Verification
- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — **1977 passed** (36 new; 2 apply-surfaced assert_eq→matches! fixed inline)
- `cargo build --release --target armv7a-none-eabi` — clean (socket csprng path) · `kanon lint` — clean

Partially addresses #314 (findings 41-60: 17 fixed + 3 stale). ~29 remain.

_All 4 security fixes (audit chain, AVDTP, lfs extent, port randomization) reviewed at T0/Opus._