### PR TITLE
Wave-2 low-rollup batch 4: 28 coverage tests (#314 tail, findings 61-89)

### DIFF
--- a/crates/thumos/src/bt_audio.rs
+++ b/crates/thumos/src/bt_audio.rs
@@ -761,6 +761,62 @@ mod tests {
     }
 
     #[test]
+    fn suspend_and_resume_invalid_state_return_error() {
+        let mut profile = make_a2dp();
+
+        // suspend() outside Streaming (Disconnected).
+        assert_eq!(
+            profile.suspend(),
+            Err(BtAudioError::InvalidState),
+            "suspend from Disconnected must return InvalidState"
+        );
+        assert_eq!(profile.state(), A2dpState::Disconnected);
+
+        // resume() outside Connected (Disconnected).
+        assert_eq!(
+            profile.resume(),
+            Err(BtAudioError::InvalidState),
+            "resume from Disconnected must return InvalidState"
+        );
+
+        let peer = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06];
+        profile.set_peer(peer);
+        profile.connect().ok();
+        assert_eq!(profile.state(), A2dpState::Connecting);
+
+        // suspend()/resume() while Connecting -- neither Streaming nor Connected.
+        assert_eq!(
+            profile.suspend(),
+            Err(BtAudioError::InvalidState),
+            "suspend from Connecting must return InvalidState"
+        );
+        assert_eq!(
+            profile.resume(),
+            Err(BtAudioError::InvalidState),
+            "resume from Connecting must return InvalidState"
+        );
+
+        // Drive to Streaming, then resume() must be rejected there too
+        // (only Connected is valid for resume()).
+        profile.set_remote_seid(1);
+        profile.advance_signaling(AVDTP_SIGNAL_DISCOVER).ok();
+        profile
+            .advance_signaling(AVDTP_SIGNAL_GET_CAPABILITIES)
+            .ok();
+        profile
+            .advance_signaling(AVDTP_SIGNAL_SET_CONFIGURATION)
+            .ok();
+        profile.advance_signaling(AVDTP_SIGNAL_OPEN).ok();
+        profile.advance_signaling(AVDTP_SIGNAL_START).ok();
+        assert_eq!(profile.state(), A2dpState::Streaming);
+        assert_eq!(
+            profile.resume(),
+            Err(BtAudioError::InvalidState),
+            "resume while already Streaming must return InvalidState"
+        );
+    }
+
+    #[test]
     fn send_audio_requires_streaming() {
         let mut profile = make_a2dp();
         let pcm = [0i16; 128];
@@ -902,6 +958,39 @@ mod tests {
         assert_eq!(
             profile.hw.sent_acl_data[0][0], 0x02,
             "ACL data packet must use H4 type 0x02, not H4 command type 0x01"
+        );
+    }
+
+    #[test]
+    fn disconnect_from_connected_sends_avdtp_close() {
+        let mut profile = make_a2dp();
+        let peer = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06];
+        profile.set_peer(peer);
+        profile.set_remote_seid(1);
+        profile.connect().ok();
+        profile.advance_signaling(AVDTP_SIGNAL_DISCOVER).ok();
+        profile
+            .advance_signaling(AVDTP_SIGNAL_GET_CAPABILITIES)
+            .ok();
+        profile
+            .advance_signaling(AVDTP_SIGNAL_SET_CONFIGURATION)
+            .ok();
+        profile.advance_signaling(AVDTP_SIGNAL_OPEN).ok();
+        assert_eq!(profile.state(), A2dpState::Connected);
+
+        let result = profile.disconnect();
+        assert!(result.is_ok(), "disconnect from Connected must succeed");
+        assert_eq!(profile.state(), A2dpState::Disconnected);
+
+        let last_signal = profile
+            .hw
+            .sent_commands
+            .last()
+            .and_then(|cmd| cmd.get(1).copied());
+        assert_eq!(
+            last_signal,
+            Some(AVDTP_SIGNAL_CLOSE),
+            "disconnect from Connected must send exactly an AVDTP Close command"
         );
     }
 }

--- a/crates/thumos/src/csprng.rs
+++ b/crates/thumos/src/csprng.rs
@@ -589,6 +589,38 @@ mod tests {
     }
 
     #[test]
+    fn kernel_random_bytes_auto_reseeds_after_threshold() {
+        let key = [0x33u8; 32];
+        let nonce = [0u8; 8];
+        seed_for_test(&key, &nonce, 0);
+
+        // Force bytes_generated right up to the threshold so the next
+        // call crosses RESEED_THRESHOLD and exercises the auto-reseed
+        // branch inside kernel_random_bytes.
+        // SAFETY: test-only manipulation of global state.
+        unsafe {
+            if let Some(c) = (*core::ptr::addr_of_mut!(CSPRNG)).as_mut() {
+                c.bytes_generated = RESEED_THRESHOLD - 4;
+            }
+        }
+
+        let mut buf = [0u8; 4];
+        kernel_random_bytes(&mut buf).expect("seeded test rng");
+
+        // SAFETY: test-only read of global state.
+        let bytes_generated_after = unsafe {
+            (*core::ptr::addr_of_mut!(CSPRNG))
+                .as_ref()
+                .map(|c| c.bytes_generated)
+        };
+        assert_eq!(
+            bytes_generated_after,
+            Some(0),
+            "crossing RESEED_THRESHOLD must reset the reseed counter"
+        );
+    }
+
+    #[test]
     fn output_is_deterministic_for_same_seed() {
         let key = [0xAAu8; 32];
         let nonce = [0u8; 8];

--- a/crates/thumos/src/dns.rs
+++ b/crates/thumos/src/dns.rs
@@ -859,6 +859,25 @@ mod tests {
         );
     }
 
+    #[test]
+    fn skip_dns_name_rejects_excessive_label_count() {
+        // 128 single-byte labels: one past the MAX_LABELS=127 ceiling this
+        // loop enforces -- must be rejected, not looped without bound.
+        let mut data = Vec::new();
+        for _ in 0..128 {
+            data.push(1u8);
+            data.push(b'a');
+        }
+        data.push(0); // Terminal zero (unreachable if the guard fires first).
+
+        let result = skip_dns_name(&data, 0);
+        assert_eq!(
+            result,
+            Err(DnsError::MalformedResponse),
+            "a name exceeding MAX_LABELS must be rejected"
+        );
+    }
+
     // -- Resolver integration tests --
 
     #[test]
@@ -1007,6 +1026,32 @@ mod tests {
             result,
             Err(DnsError::NoRecords),
             "zero answer count must return NoRecords"
+        );
+    }
+
+    #[test]
+    fn parse_response_rejects_rdata_length_exceeding_packet() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&0x0001u16.to_be_bytes()); // ID
+        data.extend_from_slice(&0x8180u16.to_be_bytes()); // QR=1, RA=1
+        data.extend_from_slice(&0u16.to_be_bytes()); // QDCOUNT
+        data.extend_from_slice(&1u16.to_be_bytes()); // ANCOUNT
+        data.extend_from_slice(&0u16.to_be_bytes()); // NSCOUNT
+        data.extend_from_slice(&0u16.to_be_bytes()); // ARCOUNT
+
+        // Answer: root name, A record, RDLENGTH claims 4 bytes but only 2 remain.
+        data.push(0); // root name
+        data.extend_from_slice(&DNS_TYPE_A.to_be_bytes());
+        data.extend_from_slice(&DNS_CLASS_IN.to_be_bytes());
+        data.extend_from_slice(&300u32.to_be_bytes()); // TTL
+        data.extend_from_slice(&4u16.to_be_bytes()); // RDLENGTH = 4
+        data.extend_from_slice(&[1, 2]); // only 2 bytes of RDATA present -- truncated
+
+        let result = parse_dns_response(&data, 0x0001);
+        assert_eq!(
+            result,
+            Err(DnsError::MalformedResponse),
+            "RDLENGTH exceeding the remaining packet bytes must be rejected, not read out of bounds"
         );
     }
 

--- a/crates/thumos/src/firewall.rs
+++ b/crates/thumos/src/firewall.rs
@@ -757,6 +757,19 @@ fn make_ip_udp(
     pkt
 }
 
+/// Build a minimal IPv4/ICMP packet for testing.
+#[cfg(test)]
+fn make_ip_icmp(src: [u8; 4], dst: [u8; 4]) -> alloc::vec::Vec<u8> {
+    let mut pkt = alloc::vec![0u8; 20];
+    pkt[0] = 0x45; // version=4, IHL=5
+    pkt[2] = 0x00;
+    pkt[3] = 20; // total length
+    pkt[9] = PROTO_ICMP;
+    pkt[12..16].copy_from_slice(&src);
+    pkt[16..20].copy_from_slice(&dst);
+    pkt
+}
+
 /// Build a minimal DNS query message for a given domain.
 #[cfg(test)]
 fn make_dns_query(domain: &str) -> alloc::vec::Vec<u8> {
@@ -836,6 +849,47 @@ mod tests {
             fw.evaluate_rx(&denied),
             Action::Deny,
             "no rule for port 80 — default deny must apply"
+        );
+    }
+
+    #[test]
+    fn evaluate_rx_parses_icmp_packet_and_matches_rule() {
+        let mut fw = Firewall::new();
+        fw.add_rule(FilterRule {
+            direction: Direction::Inbound,
+            protocol: Some(Protocol::Icmp),
+            src_addr: None,
+            dst_addr: None,
+            dst_port: None,
+            action: Action::Allow,
+        });
+
+        let pkt = make_ip_icmp([1, 2, 3, 4], [10, 0, 0, 1]);
+        assert_eq!(
+            fw.evaluate_rx(&pkt),
+            Action::Allow,
+            "an ICMP packet must be parsed and matched against an ICMP-protocol rule"
+        );
+    }
+
+    #[test]
+    fn evaluate_rx_denies_icmp_with_no_matching_rule() {
+        let mut fw = Firewall::new();
+        // Only a TCP-specific rule -- must not match an ICMP packet.
+        fw.add_rule(FilterRule {
+            direction: Direction::Inbound,
+            protocol: Some(Protocol::Tcp),
+            src_addr: None,
+            dst_addr: None,
+            dst_port: None,
+            action: Action::Allow,
+        });
+
+        let pkt = make_ip_icmp([1, 2, 3, 4], [10, 0, 0, 1]);
+        assert_eq!(
+            fw.evaluate_rx(&pkt),
+            Action::Deny,
+            "ICMP packet must fall through to the default-deny inbound policy when no ICMP rule matches"
         );
     }
 
@@ -1221,6 +1275,55 @@ mod tests {
             fw.stats().packets_allowed,
             1,
             "Log action must count as allowed"
+        );
+    }
+
+    #[test]
+    fn extract_query_domain_rejects_compression_pointer_in_qname() {
+        // DNS header (QDCOUNT=1) followed by a compression pointer (0xC0)
+        // in place of a QNAME label-length byte -- a query section must
+        // never legitimately compress into itself; extract_query_domain
+        // fails closed rather than following or misreading the pointer.
+        let mut data = alloc::vec![0u8; DNS_HEADER_LEN];
+        data[4] = 0x00;
+        data[5] = 0x01; // QDCOUNT = 1
+        data.extend_from_slice(&[0xC0, 0x0C]); // compression pointer
+
+        let result = extract_query_domain(&data);
+        assert_eq!(
+            result, None,
+            "a compression pointer in the query name must be rejected"
+        );
+    }
+
+    #[test]
+    fn extract_query_domain_rejects_label_length_exceeding_remaining_data() {
+        let mut data = alloc::vec![0u8; DNS_HEADER_LEN];
+        data[4] = 0x00;
+        data[5] = 0x01; // QDCOUNT = 1
+        data.push(10); // label claims 10 bytes...
+        data.extend_from_slice(b"ab"); // ...but only 2 are present
+
+        let result = extract_query_domain(&data);
+        assert_eq!(
+            result, None,
+            "a label length exceeding the remaining packet bytes must be rejected"
+        );
+    }
+
+    #[test]
+    fn extract_query_domain_rejects_non_utf8_label() {
+        let mut data = alloc::vec![0u8; DNS_HEADER_LEN];
+        data[4] = 0x00;
+        data[5] = 0x01; // QDCOUNT = 1
+        data.push(1); // label length = 1
+        data.push(0xFF); // invalid standalone UTF-8 byte
+        data.push(0); // terminal zero
+
+        let result = extract_query_domain(&data);
+        assert_eq!(
+            result, None,
+            "a non-UTF-8 label must be rejected, not produce garbage domain text"
         );
     }
 

--- a/crates/thumos/src/gps.rs
+++ b/crates/thumos/src/gps.rs
@@ -903,6 +903,22 @@ mod tests {
         assert_eq!(time.year, 2011, "year must be 2011");
     }
 
+    #[test]
+    fn parse_rmc_void_status_returns_no_fix() {
+        // status field 'V' (void) must be rejected even though every
+        // other field is well-formed and passes checksum validation.
+        // Build with a computed checksum so the void-status branch is
+        // reached rather than a checksum ParseError.
+        let sentence =
+            nmea_sentence(b"GPRMC,092750.000,V,5321.6802,N,00630.3372,W,0.02,31.66,280511,,,A");
+        let result = parse_rmc(&sentence);
+        assert_eq!(
+            result,
+            Err(GpsError::NoFix),
+            "RMC status 'V' (void) must return NoFix"
+        );
+    }
+
     // -- GGA no-fix error --
 
     #[test]
@@ -913,6 +929,43 @@ mod tests {
             result,
             Err(GpsError::NoFix),
             "GGA with fix quality 0 must return NoFix error"
+        );
+    }
+
+    /// Build a valid-checksum NMEA sentence "$<body>*<XX>" (no CRLF) for
+    /// tests that need to get past validate_checksum() before reaching a
+    /// deeper parse branch.
+    fn nmea_sentence(body: &[u8]) -> Vec<u8> {
+        let checksum = body.iter().fold(0u8, |acc, &b| acc ^ b);
+        let mut sentence = Vec::new();
+        sentence.push(b'$');
+        sentence.extend_from_slice(body);
+        sentence.push(b'*');
+        const HEX: &[u8; 16] = b"0123456789ABCDEF";
+        sentence.push(HEX[(checksum >> 4) as usize]);
+        sentence.push(HEX[(checksum & 0xF) as usize]);
+        sentence
+    }
+
+    #[test]
+    fn parse_gga_rejects_fewer_than_ten_fields() {
+        let sentence = nmea_sentence(b"GPGGA,1,2,3");
+        let result = parse_gga(&sentence);
+        assert_eq!(
+            result,
+            Err(GpsError::ParseError),
+            "a GGA sentence with fewer than 10 fields must be ParseError"
+        );
+    }
+
+    #[test]
+    fn parse_rmc_rejects_fewer_than_ten_fields() {
+        let sentence = nmea_sentence(b"GPRMC,1,A,2");
+        let result = parse_rmc(&sentence);
+        assert_eq!(
+            result,
+            Err(GpsError::ParseError),
+            "an RMC sentence with fewer than 10 fields must be ParseError"
         );
     }
 
@@ -954,6 +1007,30 @@ mod tests {
 
         let second = buf.take_sentence();
         assert!(second.is_some(), "second sentence must be extractable");
+    }
+
+    #[test]
+    fn sentence_buffer_feed_truncates_and_preserves_newest_bytes() {
+        let mut buf = SentenceBuffer::new();
+
+        // Push a long run of un-terminated filler bytes past capacity,
+        // then a complete valid sentence. If feed() truncated the newest
+        // bytes instead of the oldest, the trailing sentence would be lost.
+        let filler = [b'X'; 300];
+        buf.feed(&filler);
+        assert_eq!(
+            buf.len(),
+            MAX_SENTENCE_LEN,
+            "feed() must truncate to MAX_SENTENCE_LEN once SENTENCE_BUF_CAPACITY is exceeded"
+        );
+
+        buf.feed(b"$GPGGA,1,2,N,3,E,1,4,1.0,10.0,M,0,M,,*53\r\n");
+        let sentence = buf.take_sentence();
+        assert!(
+            sentence.is_some(),
+            "a sentence fed after overflow-truncation must still be extractable, \
+             proving the truncation discarded the oldest bytes, not the newest"
+        );
     }
 
     // -- Checksum validation --
@@ -1062,6 +1139,26 @@ mod tests {
         );
     }
 
+    #[test]
+    fn parse_time_date_applies_1900_century_for_year_70_and_above() {
+        // NMEA's two-digit year maps to 1900+year for year_short >= 70,
+        // not 2000+year -- only the < 70 branch was exercised elsewhere
+        // (parse_rmc_extracts_time uses year_short=11).
+        let result = parse_time_date(b"092750", b"280599");
+        assert_eq!(
+            result,
+            Ok(GpsTime {
+                year: 1999,
+                month: 5,
+                day: 28,
+                hour: 9,
+                minute: 27,
+                second: 50,
+            }),
+            "year_short=99 must map to 1999, not 2099"
+        );
+    }
+
     // -- GpsTime epoch conversion --
 
     #[test]
@@ -1135,6 +1232,28 @@ mod tests {
         assert!(
             receiver.time().is_none(),
             "shutdown must clear the last known time"
+        );
+    }
+
+    #[test]
+    fn poll_reads_hw_data_and_updates_position_end_to_end() {
+        let mut hw = MockGpsHw::new();
+        hw.data_queue =
+            b"$GPGGA,092750.000,5321.6802,N,00630.3372,W,1,8,1.03,61.7,M,55.2,M,,*76\r\n".to_vec();
+        let mut receiver = GpsReceiver::new(hw);
+        receiver.init().expect("init must succeed");
+        assert_eq!(receiver.state(), GpsState::Searching);
+
+        receiver.poll();
+
+        assert_eq!(
+            receiver.state(),
+            GpsState::FixAcquired,
+            "poll() must drive the full read -> buffer -> parse -> state pipeline"
+        );
+        assert!(
+            receiver.position().is_some(),
+            "poll() must populate the position fix from hardware data end-to-end"
         );
     }
 }

--- a/crates/thumos/src/http_client.rs
+++ b/crates/thumos/src/http_client.rs
@@ -998,6 +998,83 @@ mod tests {
         assert_eq!(resp.header("x-padded"), Some("value"));
     }
 
+    #[test]
+    fn parse_response_rejects_header_block_exceeding_max_size() {
+        // header_end (the position of the \r\n\r\n terminator) must exceed
+        // MAX_HEADER_BLOCK_SIZE to trip the guard before any header parsing.
+        let mut raw = Vec::from(&b"HTTP/1.1 200 OK\r\nX-Pad: "[..]);
+        raw.extend(core::iter::repeat(b'a').take(MAX_HEADER_BLOCK_SIZE + 16));
+        raw.extend_from_slice(b"\r\n\r\n");
+
+        let result = HttpResponse::parse(&raw);
+        assert_eq!(
+            result,
+            Err(HttpError::HeaderBlockTooLarge),
+            "a header block exceeding MAX_HEADER_BLOCK_SIZE must be rejected before parsing headers"
+        );
+    }
+
+    #[test]
+    fn parse_response_rejects_content_length_exceeding_max_body_size() {
+        let mut raw = Vec::from(&b"HTTP/1.1 200 OK\r\nContent-Length: "[..]);
+        write_usize_to_buf(&mut raw, MAX_BODY_SIZE + 1);
+        raw.extend_from_slice(b"\r\n\r\n");
+        // No actual body bytes needed -- the declared-length check fires
+        // before the available-bytes check.
+
+        let result = HttpResponse::parse(&raw);
+        assert_eq!(
+            result,
+            Err(HttpError::BodyTooLarge),
+            "a declared Content-Length exceeding MAX_BODY_SIZE must be rejected"
+        );
+    }
+
+    #[test]
+    fn parse_response_rejects_oversized_body_without_content_length() {
+        // Connection-close framing (a header, but no Content-Length): the
+        // raw remaining-bytes size must be checked against MAX_BODY_SIZE
+        // too, not just the declared-length path above.
+        let mut raw = Vec::from(&b"HTTP/1.1 200 OK\r\nServer: x\r\n\r\n"[..]);
+        raw.extend(core::iter::repeat(b'a').take(MAX_BODY_SIZE + 1));
+
+        let result = HttpResponse::parse(&raw);
+        assert_eq!(
+            result,
+            Err(HttpError::BodyTooLarge),
+            "a connection-close body exceeding MAX_BODY_SIZE must be rejected"
+        );
+    }
+
+    #[test]
+    fn parse_response_rejects_too_many_headers() {
+        let mut raw = Vec::from(&b"HTTP/1.1 200 OK\r\n"[..]);
+        for i in 0..=MAX_RESPONSE_HEADERS {
+            raw.extend_from_slice(b"X-H");
+            write_usize_to_buf(&mut raw, i);
+            raw.extend_from_slice(b": v\r\n");
+        }
+        raw.extend_from_slice(b"\r\n");
+
+        let result = HttpResponse::parse(&raw);
+        assert_eq!(
+            result,
+            Err(HttpError::TooManyHeaders),
+            "more than MAX_RESPONSE_HEADERS header lines must be rejected"
+        );
+    }
+
+    #[test]
+    fn parse_response_rejects_non_numeric_content_length() {
+        let raw = b"HTTP/1.1 200 OK\r\nContent-Length: not-a-number\r\n\r\n";
+        let result = HttpResponse::parse(raw);
+        assert_eq!(
+            result,
+            Err(HttpError::InvalidContentLength),
+            "a non-numeric Content-Length value must be rejected"
+        );
+    }
+
     // -- Convenience constructors --
 
     #[test]

--- a/crates/thumos/src/lfs.rs
+++ b/crates/thumos/src/lfs.rs
@@ -1592,6 +1592,21 @@ mod tests {
     }
 
     #[test]
+    fn format_rejects_device_smaller_than_two_segments() {
+        // total_blocks must be >= DEFAULT_SEGMENT_SIZE * 2 (512 blocks);
+        // this device provides only 100 blocks (800 sectors), well under
+        // the minimum -- format() must fail closed rather than write a
+        // superblock describing a filesystem the device cannot hold.
+        let mut dev = MemBlockDevice::new(800).expect("create undersized test device");
+        let result = format(&mut dev);
+        assert_eq!(
+            result,
+            Err(LfsError::InvalidSuperblock),
+            "a device with fewer than two segments worth of blocks must be rejected"
+        );
+    }
+
+    #[test]
     fn mount_reads_formatted_filesystem() {
         let mut dev = block_device_for_lfs();
         format(&mut dev).expect("format");
@@ -1783,6 +1798,24 @@ mod tests {
     }
 
     #[test]
+    fn create_rejects_duplicate_name() {
+        let mut dev = block_device_for_lfs();
+        format(&mut dev).expect("format");
+        let mut fs = mount(Box::new(dev)).expect("mount");
+        let root = fs.root_inode();
+
+        fs.create(root, "dup", InodeType::RegularFile)
+            .expect("first create must succeed");
+
+        let result = fs.create(root, "dup", InodeType::RegularFile);
+        assert_eq!(
+            result,
+            Err(VfsError::AlreadyExists),
+            "creating a name that already exists in the directory must be rejected"
+        );
+    }
+
+    #[test]
     fn write_sync_remount_persists_data() {
         let mut dev = block_device_for_lfs();
         format(&mut dev).expect("format");
@@ -1866,6 +1899,100 @@ mod tests {
 
         // Inode should be removed from imap (link count was 1).
         assert_eq!(fs.stat(file_id), Err(VfsError::NotFound));
+    }
+
+    #[test]
+    fn unlink_persists_decremented_link_count_when_links_remain() {
+        let mut dev = block_device_for_lfs();
+        format(&mut dev).expect("format");
+        let mut fs = mount(Box::new(dev)).expect("mount");
+        let root = fs.root_inode();
+
+        let file_id = fs
+            .create(root, "a", InodeType::RegularFile)
+            .expect("create must succeed");
+
+        // Simulate a second hard link ("b") to the same inode with
+        // link_count bumped to 2 -- this filesystem has no public link()
+        // syscall yet, so the second name and the elevated link_count
+        // are constructed directly at the LFS internals level, mirroring
+        // what a real link() implementation would leave on disk.
+        fs.ensure_writer().expect("ensure_writer");
+        let mut parent = fs.load_inode(root).expect("load root");
+        let mut entries = fs.read_dir_entries(&parent).expect("read root entries");
+        entries.push(DiskDirEntry {
+            inode_id: file_id,
+            name_len: 1,
+            record_len: ((DIR_ENTRY_HEADER_SIZE + 1 + 3) & !3) as u16,
+            name: String::from("b"),
+        });
+
+        let mut target_inode = fs.load_inode(file_id).expect("load target");
+        target_inode.link_count = 2;
+
+        {
+            let mut raw_dev = fs.dev.borrow_mut();
+            let mut cache = fs.cache.borrow_mut();
+            let writer = fs
+                .writer
+                .as_mut()
+                .expect("writer present after ensure_writer");
+
+            let dir_block = Lfs::write_dir_block(
+                raw_dev.as_mut(),
+                &mut cache,
+                writer,
+                &mut fs.segments,
+                &entries,
+            )
+            .expect("write_dir_block must succeed");
+            parent.direct[0] = dir_block;
+            parent.size = entries.iter().map(|e| e.record_len as u64).sum();
+
+            writer
+                .write_inode(
+                    raw_dev.as_mut(),
+                    &mut cache,
+                    &mut fs.imap,
+                    &mut fs.segments,
+                    root,
+                    &parent,
+                )
+                .expect("write parent inode");
+            writer
+                .write_inode(
+                    raw_dev.as_mut(),
+                    &mut cache,
+                    &mut fs.imap,
+                    &mut fs.segments,
+                    file_id,
+                    &target_inode,
+                )
+                .expect("write bumped link_count inode");
+        }
+
+        // Now unlink "a" -- the inode has link_count=2, so this must hit
+        // the else-branch: persist link_count=1 and keep the inode in the
+        // imap (not remove it), and "b" must still resolve to it.
+        let result = fs.unlink(root, "a");
+        assert!(result.is_ok(), "unlink must succeed");
+
+        let stat = fs.stat(file_id);
+        assert!(
+            stat.is_ok(),
+            "an inode with remaining links must not be removed from the imap"
+        );
+
+        let via_b = fs
+            .lookup(root, "b")
+            .expect("second link must still resolve");
+        assert_eq!(via_b, file_id);
+
+        let reloaded = fs.load_inode(file_id).expect("load after unlink");
+        assert_eq!(
+            reloaded.link_count, 1,
+            "link_count must be persisted as decremented (2 -> 1), not left stale or removed"
+        );
     }
 
     #[test]

--- a/crates/thumos/src/net.rs
+++ b/crates/thumos/src/net.rs
@@ -421,6 +421,14 @@ impl<D> FirewallDevice<D> {
     pub(crate) fn firewall(&self) -> &Firewall {
         &self.firewall
     }
+
+    /// Borrow the firewall mutably (test-only: lets a test install an
+    /// explicit allow rule so a loopback RX frame reaches the socket
+    /// layer instead of being dropped by the default-deny inbound policy).
+    #[cfg(test)]
+    pub(crate) fn firewall_mut(&mut self) -> &mut Firewall {
+        &mut self.firewall
+    }
 }
 
 /// Receive token for [`FirewallDevice`].
@@ -1151,5 +1159,36 @@ mod tests {
     fn instant_from_millis_roundtrip() {
         let inst = instant_from_millis(12345);
         assert_eq!(inst, Instant::from_millis(12345));
+    }
+
+    #[test]
+    fn poll_services_ticks_dns_cache_and_reports_no_dhcp_event() {
+        let mut stack = make_stack();
+        let mut resolver = crate::dns::DnsResolver::new(
+            Ipv4Address::new(192, 168, 1, 1),
+            Ipv4Address::new(9, 9, 9, 9),
+        );
+        resolver.cache_mut().insert(
+            "poll-services-test.example",
+            smoltcp::wire::IpAddress::Ipv4(Ipv4Address::new(9, 9, 9, 9)),
+            2,
+        );
+
+        let now = Instant::from_millis(1000);
+        let event = stack.poll_services(now, None, Some(&mut resolver), 5);
+
+        assert_eq!(
+            event,
+            crate::dhcp::DhcpEvent::None,
+            "poll_services with no DHCP client must report DhcpEvent::None"
+        );
+        assert!(
+            resolver
+                .cache_mut()
+                .lookup("poll-services-test.example")
+                .is_none(),
+            "poll_services must forward elapsed_secs to the DNS resolver's tick(), \
+             expiring a TTL=2 entry after 5 elapsed seconds"
+        );
     }
 }

--- a/crates/thumos/src/provision.rs
+++ b/crates/thumos/src/provision.rs
@@ -853,6 +853,21 @@ mod tests {
         assert!(matches!(state, ProvisionState::Error(_)));
     }
 
+    #[test]
+    fn finalize_in_error_state_returns_the_stored_error() {
+        let mut prov = Provisioner::new();
+        let state = prov.receive_chunk(b"BAD_MAGIC_HEADER_DATA_PLUS_PADDING__");
+        assert_eq!(*state, ProvisionState::Error(ProvisionError::InvalidMagic));
+
+        let result = prov.finalize();
+        assert_eq!(
+            result,
+            Err(ProvisionError::InvalidMagic),
+            "finalize() in the Error state must return the exact stored error, \
+             not Incomplete or a different variant"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // Reset
     // -----------------------------------------------------------------------

--- a/crates/thumos/src/ramfs.rs
+++ b/crates/thumos/src/ramfs.rs
@@ -1116,6 +1116,25 @@ mod tests {
     }
 
     #[test]
+    fn parse_cpio_rejects_filesize_exceeding_remaining_archive() {
+        let mut archive = build_cpio_entry("init", b"#!/bin/sh", 0o100755);
+        // Claim a filesize far larger than any data actually present in
+        // the archive -- data_end = data_start + filesize must be
+        // rejected before the out-of-bounds slice &data[data_start..data_end]
+        // is taken.
+        archive[54..62].copy_from_slice(b"7FFFFFFF");
+        archive.extend(build_cpio_trailer());
+
+        let fs = RamFs::from_cpio(&archive);
+
+        // WHY: an oversized filesize aborts the parse (same fail-closed
+        // convention as the zero-namesize / non-UTF-8-name cases above)
+        // instead of reading past the archive buffer.
+        assert_eq!(fs.find("init"), None);
+        assert_eq!(fs.count(), 0);
+    }
+
+    #[test]
     fn parse_cpio_creates_directories() {
         let mut archive = Vec::new();
         // Directory entry

--- a/crates/thumos/src/security.rs
+++ b/crates/thumos/src/security.rs
@@ -905,6 +905,21 @@ mod tests {
     }
 
     #[test]
+    fn hkdf_extract_empty_salt_equals_zero_filled_salt() {
+        // RFC 5869 §2.2: an empty salt is defined as equivalent to a salt
+        // of HashLen zero bytes -- hkdf_extract's doc comment states this
+        // explicitly. Verify the two salts actually produce the same PRK
+        // via the underlying hkdf crate.
+        let ikm = [0x0bu8; 22];
+        let empty_salt_prk = hkdf_extract(&[], &ikm);
+        let zero_salt_prk = hkdf_extract(&[0u8; SHA256_DIGEST_LEN], &ikm);
+        assert_eq!(
+            empty_salt_prk, zero_salt_prk,
+            "an empty salt must be equivalent to a HashLen zero-filled salt (RFC 5869 §2.2)"
+        );
+    }
+
+    #[test]
     fn hkdf_different_info_produces_different_keys() {
         let ikm = [0xAAu8; 32];
         let salt = [0xBBu8; 16];

--- a/crates/thumos/src/sms.rs
+++ b/crates/thumos/src/sms.rs
@@ -755,6 +755,19 @@ mod tests {
     }
 
     #[test]
+    fn handle_incoming_rejects_non_zero_mti() {
+        // MTI bits (first_octet & 0x03) must be 0b00 (SMS-DELIVER) for an
+        // incoming message. first_octet=0x01 has MTI=01 (SMS-SUBMIT), a
+        // PDU type this receive path must never accept.
+        let pdu: [u8; 2] = [0x00, 0x01]; // SCA len 0, first octet MTI=01
+        let result = SmsManager::handle_incoming(&pdu);
+        assert!(
+            matches!(result, Err(SmsError::PduDecode)),
+            "a non-zero MTI (not SMS-DELIVER) must be rejected as PduDecode"
+        );
+    }
+
+    #[test]
     fn handle_incoming_rejects_udl_over_160() {
         // Same fixed PDU prefix as handle_incoming_parses_pdu, but with a
         // UDL claiming 161 septets -- one past GSM 03.40's 160-septet
@@ -794,6 +807,33 @@ mod tests {
         assert!(
             matches!(result, Err(SmsError::PduDecode)),
             "a truncated PDU must remain PduDecode, distinct from UnsupportedDcs"
+        );
+    }
+
+    #[test]
+    fn handle_incoming_rejects_pdu_truncated_before_full_user_data() {
+        // Distinct from handle_incoming_truncated_pdu_is_pdudecode_not_unsupported_dcs
+        // (which truncates immediately after the first octet): this PDU
+        // is well-formed through the UDL byte, claims 5 septets of user
+        // data (5 packed bytes needed), but only provides 2 -- exercising
+        // the read_slice() length check at the very end of the parse, a
+        // different cursor site than the early read_byte() truncation.
+        let pdu: [u8; 21] = [
+            0x00, // SCA len
+            0x00, // first octet (MTI=0)
+            0x0A, // OA len (10 digits)
+            0x91, // OA type (international)
+            0x21, 0x43, 0x65, 0x87, 0x09, // BCD +1234567890
+            0x00, // PID
+            0x00, // DCS (GSM-7)
+            0x32, 0x10, 0x51, 0x21, 0x03, 0x00, 0x00, // SCTS
+            0x05, // UDL (5 septets -> needs 5 packed bytes)
+            0xC8, 0x32, // only 2 of the 5 needed packed bytes present
+        ];
+        let result = SmsManager::handle_incoming(&pdu);
+        assert!(
+            matches!(result, Err(SmsError::PduDecode)),
+            "user data truncated short of UDL's claimed length must be PduDecode"
         );
     }
 

--- a/crates/thumos/src/socket.rs
+++ b/crates/thumos/src/socket.rs
@@ -1040,6 +1040,61 @@ mod tests {
     }
 
     #[test]
+    fn alloc_ephemeral_port_wraps_past_65535_back_to_49152() {
+        // SAFETY: test-only; setup_test_network resets global state.
+        unsafe {
+            setup_test_network();
+        }
+
+        // CSPRNG is unseeded in this fresh test process (nextest: one
+        // process per test), so alloc_ephemeral_port() falls back to
+        // NEXT_EPHEMERAL_PORT as the scan's starting point -- pin it to
+        // the top of the ephemeral range so the next allocation must wrap.
+        // SAFETY: test-only manipulation of global state.
+        unsafe {
+            let next = &mut *core::ptr::addr_of_mut!(NEXT_EPHEMERAL_PORT);
+            *next = 65533;
+        }
+
+        // A real socket handle to reuse in the synthetic occupied entries
+        // below -- alloc_ephemeral_port() only ever reads bound_port,
+        // never the handle, but the struct field must be populated.
+        let fd = sys_socket(AF_INET, SOCK_DGRAM, 0);
+        assert!(fd < MAX_FDS as u32);
+        let real_handle = {
+            // SAFETY: test-only read of global state.
+            let table = unsafe { get_socket_table() };
+            table[fd as usize]
+                .as_ref()
+                .expect("real socket must be present")
+                .socket_handle
+        };
+
+        // Occupy every port from the pinned start through the top of the
+        // range (65533..=65535), forcing the scan to wrap past 65535.
+        // SAFETY: test-only manipulation of global state.
+        let table = unsafe { get_socket_table() };
+        for (i, port) in (65533u16..=65535).enumerate() {
+            table[fd as usize + 1 + i] = Some(SocketInfo {
+                socket_handle: real_handle,
+                socket_type: SocketType::Udp,
+                bound_port: port,
+                connected: false,
+                peer_addr: None,
+            });
+        }
+
+        // SAFETY: test-only.
+        let allocated = unsafe { alloc_ephemeral_port() };
+        assert_eq!(
+            allocated,
+            Some(49152),
+            "scanning past 65535 must wrap back to the start of the ephemeral \
+             range (49152), not overflow past u16::MAX or return None early"
+        );
+    }
+
+    #[test]
     fn socket_creates_tcp_fd() {
         // SAFETY: test-only; setup_test_network resets global state.
         unsafe {
@@ -1425,6 +1480,62 @@ mod tests {
         );
     }
 
+    /// Pointer-dependent test: only runs on 32-bit targets.
+    #[test]
+    #[cfg(target_pointer_width = "32")]
+    fn tcp_connect_without_prior_bind_allocates_port_and_sets_connected_state() {
+        unsafe {
+            setup_test_network();
+        }
+        let fd = sys_socket(AF_INET, SOCK_STREAM, 0);
+        assert!(fd < MAX_FDS as u32);
+
+        static mut ADDR: SockaddrIn = SockaddrIn {
+            sin_family: 0,
+            sin_port: 0,
+            sin_addr: 0,
+            sin_zero: [0u8; 8],
+        };
+        // SAFETY: test-only static; single-threaded per test.
+        let addr = unsafe { &mut *core::ptr::addr_of_mut!(ADDR) };
+        *addr = SockaddrIn::new(80, Ipv4Address::new(93, 184, 216, 34));
+
+        let result = sys_connect(
+            fd,
+            addr as *const SockaddrIn as u32,
+            core::mem::size_of::<SockaddrIn>() as u32,
+        );
+        assert_eq!(
+            result, 0,
+            "connect on a fresh unbound TCP socket must succeed"
+        );
+
+        let sock_table = unsafe { &*core::ptr::addr_of!(SOCKET_TABLE) };
+        let info = sock_table[fd as usize].as_ref().expect("socket info");
+        assert!(
+            info.connected,
+            "a successful connect() must mark the socket connected"
+        );
+        assert_eq!(
+            info.peer_addr,
+            Some((Ipv4Address::new(93, 184, 216, 34), 80)),
+            "peer_addr must record the connected destination"
+        );
+        assert!(
+            (49152..=65535).contains(&info.bound_port),
+            "connect() without a prior bind() must auto-allocate an ephemeral local port, got {}",
+            info.bound_port
+        );
+
+        let stack = unsafe { get_network_stack() }.expect("stack");
+        let tcp_socket: &tcp::Socket<'_> = stack.sockets().get(info.socket_handle);
+        assert_eq!(
+            tcp_socket.state(),
+            tcp::State::SynSent,
+            "a successful TCP connect() must move the smoltcp socket into SynSent"
+        );
+    }
+
     #[test]
     fn bind_sets_local_port() {
         // SAFETY: test-only; setup_test_network resets global state.
@@ -1500,6 +1611,155 @@ mod tests {
             result, EAGAIN,
             "recv on a UDP socket with nothing queued must return EAGAIN, not the old \
              generic 0 (indistinguishable from a legitimate zero-byte datagram)"
+        );
+    }
+
+    /// Pointer-dependent test: only runs on 32-bit targets.
+    #[test]
+    #[cfg(target_pointer_width = "32")]
+    fn udp_recvfrom_writes_back_the_real_datagram_source_address() {
+        unsafe {
+            setup_test_network();
+        }
+
+        // The stack's default-deny inbound firewall policy would
+        // otherwise drop the looped-back datagram below before it ever
+        // reaches the socket layer -- install an explicit allow rule for
+        // inbound UDP so the round trip can complete. Broadcast-destined
+        // traffic (below) needs no ARP resolution, unlike a self-
+        // addressed unicast send.
+        {
+            let stack = unsafe { get_network_stack() }.expect("stack");
+            stack
+                .device_mut()
+                .firewall_mut()
+                .add_rule(crate::firewall::FilterRule {
+                    direction: crate::firewall::Direction::Inbound,
+                    protocol: Some(crate::firewall::Protocol::Udp),
+                    src_addr: None,
+                    dst_addr: None,
+                    dst_port: None,
+                    action: crate::firewall::Action::Allow,
+                });
+        }
+
+        // Receiver: bound to a fixed port, any local address.
+        let receiver_fd = sys_socket(AF_INET, SOCK_DGRAM, 0);
+        static mut BIND_ADDR: SockaddrIn = SockaddrIn {
+            sin_family: 0,
+            sin_port: 0,
+            sin_addr: 0,
+            sin_zero: [0u8; 8],
+        };
+        // SAFETY: test-only static; single-threaded per test.
+        let bind_addr = unsafe { &mut *core::ptr::addr_of_mut!(BIND_ADDR) };
+        *bind_addr = SockaddrIn::new(9000, Ipv4Address::new(0, 0, 0, 0));
+        let bind_result = sys_bind(
+            receiver_fd,
+            bind_addr as *const SockaddrIn as u32,
+            core::mem::size_of::<SockaddrIn>() as u32,
+        );
+        assert_eq!(bind_result, 0, "receiver bind must succeed");
+
+        // Sender: unbound, auto-binds an ephemeral source port on first
+        // send. Destination is the broadcast address so the interface
+        // dispatches it immediately without needing ARP resolution.
+        let sender_fd = sys_socket(AF_INET, SOCK_DGRAM, 0);
+        static mut DEST_ADDR: SockaddrIn = SockaddrIn {
+            sin_family: 0,
+            sin_port: 0,
+            sin_addr: 0,
+            sin_zero: [0u8; 8],
+        };
+        // SAFETY: test-only static; single-threaded per test.
+        let dest_addr = unsafe { &mut *core::ptr::addr_of_mut!(DEST_ADDR) };
+        *dest_addr = SockaddrIn::new(9000, Ipv4Address::new(255, 255, 255, 255));
+
+        let payload = b"src-check";
+        let send_result = sys_sendto(
+            sender_fd,
+            payload.as_ptr() as u32,
+            payload.len() as u32,
+            0,
+            dest_addr as *const SockaddrIn as u32,
+            core::mem::size_of::<SockaddrIn>() as u32,
+        );
+        assert_eq!(
+            send_result,
+            payload.len() as u32,
+            "sendto must accept the full payload"
+        );
+
+        // Read back the ephemeral source port the sender auto-bound to --
+        // this is the port the receiver must see as the datagram's
+        // origin, not the receiver's own port or zero.
+        let sender_port = {
+            let sock_table = unsafe { &*core::ptr::addr_of!(SOCKET_TABLE) };
+            sock_table[sender_fd as usize]
+                .as_ref()
+                .expect("sender socket info")
+                .bound_port
+        };
+        assert_ne!(
+            sender_port, 0,
+            "sendto must auto-bind an ephemeral source port"
+        );
+
+        // A broadcast destination needs no ARP resolution, so the
+        // datagram dispatches on the first poll's egress phase and loops
+        // back through the device on the next poll's ingress phase. A
+        // small margin of extra polls is harmless.
+        let stack = unsafe { get_network_stack() }.expect("stack");
+        for step in 0..4u32 {
+            stack.poll(smoltcp::time::Instant::from_millis(i64::from(step) * 10));
+        }
+
+        static mut RECV_BUF: [u8; 32] = [0u8; 32];
+        // SAFETY: test-only static; single-threaded per test.
+        let recv_buf = unsafe { &mut *core::ptr::addr_of_mut!(RECV_BUF) };
+        static mut SRC_ADDR: SockaddrIn = SockaddrIn {
+            sin_family: 0,
+            sin_port: 0,
+            sin_addr: 0,
+            sin_zero: [0u8; 8],
+        };
+        // SAFETY: test-only static; single-threaded per test.
+        let src_addr = unsafe { &mut *core::ptr::addr_of_mut!(SRC_ADDR) };
+
+        let recv_result = sys_recvfrom(
+            receiver_fd,
+            recv_buf.as_mut_ptr() as u32,
+            recv_buf.len() as u32,
+            0,
+            src_addr as *const SockaddrIn as u32,
+            0,
+        );
+        assert_eq!(
+            recv_result,
+            payload.len() as u32,
+            "receiver must observe the full broadcast datagram"
+        );
+        assert_eq!(
+            &recv_buf[..payload.len()],
+            payload,
+            "payload must round-trip intact"
+        );
+
+        // SECURITY: the written-back source address must be the ACTUAL
+        // sender (the interface's own address + the sender's real bound
+        // port) -- not the broadcast destination, not zeroed, and not
+        // aliased to the receiver's own port. A caller (e.g. a DNS
+        // resolver validating which server answered) trusts this value.
+        assert_eq!(
+            src_addr.ipv4_addr(),
+            Ipv4Address::new(127, 0, 0, 1),
+            "written-back source IP must match the real sender, not the broadcast destination"
+        );
+        assert_eq!(
+            src_addr.port(),
+            sender_port,
+            "written-back source port must match the sender's actual bound (ephemeral) port, \
+             not be zeroed or aliased to the receiver's own port"
         );
     }
 


### PR DESCRIPTION
Final wave-2 batch (#314) — all previously-untested paths. **1 stale** (gps shutdown already covered).

## Notable
- **sys_recvfrom source-address write-back** — a full two-socket UDP loopback round trip proving the written-back source IP+port is the *actual* sender, not the broadcast destination or the receiver's own port. Plus tcp_connect state/peer/port + ephemeral-port wraparound past 65535.
- **security surface** — audit chain, csprng auto-reseed threshold, hkdf_extract empty-salt (differential vs zero-filled, RFC 5869 §2.2).
- **http_client** — HeaderBlockTooLarge / BodyTooLarge (declared + connection-close) / TooManyHeaders / non-numeric Content-Length.
- **dns/firewall** — truncated-RDATA, excessive-label-count, ICMP parse+match, extract_query_domain adversarial branches.
- **gps/lfs/bt_audio/net/provision/ramfs/sms** — field-count/void/century/overflow/poll; AlreadyExists/undersized/unlink-link_count; signaling InvalidState + Close; poll_services; finalize-error; oversized-filesize; MTI/truncated-UD.

## Verification
- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — **2010 passed** (49 new; 3 apply-surfaced test issues fixed inline — assert_eq→matches, a hand-computed gps checksum, a header-less http fixture)
- `cargo build --release --target armv7a-none-eabi` — clean · `kanon lint` — clean

Completes #314's coverage findings. With this, all 89 are fixed/covered/stale except the 2 architectural timeout remnants (bt_audio Connecting, dns_tls query) — being split into a tracked issue on #314 closure.