### PR TITLE
Wave-1 low-rollup batch 1: 17 fixes across 10 modules (#384)

### DIFF
--- a/crates/thumos/src/battery.rs
+++ b/crates/thumos/src/battery.rs
@@ -236,6 +236,12 @@ impl BatteryMonitor {
     /// the provided hardware ops, then updates the internal snapshot.
     pub(crate) fn poll<H: BatteryHwOps>(&mut self, hw: &H, current_tick: u64) {
         let voltage_mv = hw.read_voltage();
+        // WHY: instantaneous current is read from hardware but BatteryInfo
+        // carries no current_ma field -- Phase 07 Wave 5 scope was
+        // voltage/percentage/charging/temperature only. Discarding it here
+        // is a deliberate scope boundary, not an oversight; a future wave
+        // wiring power-draw telemetry should add a field to BatteryInfo
+        // rather than resurrecting this value from thin air.
         let _current_ma = hw.read_current();
         let temperature_c = hw.read_temperature();
         let charging = hw.is_charging();
@@ -386,6 +392,32 @@ mod tests {
         assert!(info.charging);
         assert_eq!(info.temperature_c, 30);
         assert_eq!(monitor.last_poll_tick(), 1000);
+    }
+
+    #[test]
+    fn poll_handles_current_extremes_without_affecting_battery_info() {
+        // read_current() is intentionally discarded (see the WHY comment on
+        // poll) -- verify extreme current readings never leak into or
+        // otherwise affect the BatteryInfo snapshot.
+        let mut monitor = BatteryMonitor::new();
+        let hw = MockHw {
+            voltage: 4000,
+            current: i16::MIN,
+            temperature: 20,
+            charging: false,
+        };
+        monitor.poll(&hw, 100);
+        assert_eq!(monitor.info().voltage_mv, 4000);
+
+        let hw_max = MockHw {
+            voltage: 4000,
+            current: i16::MAX,
+            temperature: 20,
+            charging: true,
+        };
+        monitor.poll(&hw_max, 200);
+        assert_eq!(monitor.info().voltage_mv, 4000);
+        assert!(monitor.info().charging);
     }
 
     #[test]

--- a/crates/thumos/src/contacts.rs
+++ b/crates/thumos/src/contacts.rs
@@ -118,7 +118,12 @@ impl Contact {
             default_transport: MessageTransport::Sms,
         };
         let name_bytes = name.as_bytes();
-        let name_copy_len = name_bytes.len().min(MAX_NAME_LEN);
+        // WHY: byte-length truncation can split a multi-byte UTF-8 char,
+        // producing invalid UTF-8 that name_str() then silently maps to ""
+        // for the ENTIRE name. utf8_truncate_len backs off to the last full
+        // codepoint boundary -- the same fix already applied to calendar
+        // event titles and alarm labels for the identical class of bug (#359).
+        let name_copy_len = crate::heorte::utf8_truncate_len(name_bytes, MAX_NAME_LEN);
         c.name[..name_copy_len].copy_from_slice(&name_bytes[..name_copy_len]);
         c.name_len = name_copy_len as u8;
 
@@ -499,6 +504,22 @@ mod tests {
         assert_eq!(
             contact.name_len as usize, MAX_NAME_LEN,
             "name must be truncated to MAX_NAME_LEN"
+        );
+    }
+
+    #[test]
+    fn contact_new_truncates_on_char_boundary() {
+        let mut name = "A".repeat(63);
+        name.push('\u{e9}'); // 2-byte UTF-8 char straddles the 64-byte truncation point
+        let contact = Contact::new(&name, "123").unwrap_or_else(|_| unreachable!());
+        assert!(
+            core::str::from_utf8(&contact.name[..contact.name_len as usize]).is_ok(),
+            "truncated name bytes must remain valid UTF-8"
+        );
+        assert_eq!(
+            contact.name_str(),
+            "A".repeat(63),
+            "truncation must back off to the char boundary, not split the multi-byte char"
         );
     }
 

--- a/crates/thumos/src/device.rs
+++ b/crates/thumos/src/device.rs
@@ -150,16 +150,32 @@ impl DeviceRegistry {
     }
 
     /// Mark a device as active.
-    pub(crate) fn activate(&mut self, name: &str) {
-        if let Some(dev) = self.find_mut(name) {
-            dev.status = DeviceStatus::Active;
+    ///
+    /// Returns `true` if `name` matched a registered device and its status
+    /// was updated, `false` if no such device is registered -- previously
+    /// this was a silent no-op with no way for the caller to detect a
+    /// typo'd or never-registered device name.
+    pub(crate) fn activate(&mut self, name: &str) -> bool {
+        match self.find_mut(name) {
+            Some(dev) => {
+                dev.status = DeviceStatus::Active;
+                true
+            }
+            None => false,
         }
     }
 
     /// Mark a device as powered off.
-    pub(crate) fn power_off(&mut self, name: &str) {
-        if let Some(dev) = self.find_mut(name) {
-            dev.status = DeviceStatus::PoweredOff;
+    ///
+    /// Returns `true` if `name` matched a registered device and its status
+    /// was updated, `false` otherwise (see [`Self::activate`]).
+    pub(crate) fn power_off(&mut self, name: &str) -> bool {
+        match self.find_mut(name) {
+            Some(dev) => {
+                dev.status = DeviceStatus::PoweredOff;
+                true
+            }
+            None => false,
         }
     }
 
@@ -215,5 +231,62 @@ impl DeviceRegistry {
 impl Default for DeviceRegistry {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn activate_returns_false_for_unknown_device() {
+        let mut registry = DeviceRegistry::new();
+        registry.register("uart0", 0x1100_2000, 0);
+
+        assert!(
+            !registry.activate("does-not-exist"),
+            "activating an unregistered device name must report false, not silently no-op"
+        );
+        assert_eq!(
+            registry.find("uart0").map(|d| d.status),
+            Some(DeviceStatus::Registered)
+        );
+    }
+
+    #[test]
+    fn activate_returns_true_and_updates_status_for_known_device() {
+        let mut registry = DeviceRegistry::new();
+        registry.register("uart0", 0x1100_2000, 0);
+
+        assert!(registry.activate("uart0"));
+        assert_eq!(
+            registry.find("uart0").map(|d| d.status),
+            Some(DeviceStatus::Active)
+        );
+    }
+
+    #[test]
+    fn power_off_returns_false_for_unknown_device() {
+        let mut registry = DeviceRegistry::new();
+        registry.register("uart0", 0x1100_2000, 0);
+
+        assert!(!registry.power_off("does-not-exist"));
+    }
+
+    #[test]
+    fn power_off_returns_true_and_updates_status_for_known_device() {
+        let mut registry = DeviceRegistry::new();
+        registry.register("uart0", 0x1100_2000, 0);
+        registry.activate("uart0");
+
+        assert!(registry.power_off("uart0"));
+        assert_eq!(
+            registry.find("uart0").map(|d| d.status),
+            Some(DeviceStatus::PoweredOff)
+        );
     }
 }

--- a/crates/thumos/src/ekphrasis.rs
+++ b/crates/thumos/src/ekphrasis.rs
@@ -83,8 +83,9 @@ const MAX_ACTION_LEN: usize = 128;
 /// Maximum length of the description string in a proposal.
 const MAX_DESCRIPTION_LEN: usize = 512;
 
-/// WebSocket magic GUID for the Sec-WebSocket-Accept handshake.
-const _WS_MAGIC_GUID: &str = "258EAFA5-E914-47DA-95CA-5AB5FE82AD65";
+/// WebSocket magic GUID for the Sec-WebSocket-Accept handshake (RFC 6455
+/// §1.3).
+const WS_MAGIC_GUID: &str = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
 /// Audio sample rate for STT (16 kHz mono, per design doc).
 const AUDIO_SAMPLE_RATE_HZ: u32 = 16_000;
@@ -268,6 +269,22 @@ pub(crate) fn parse_ws_frame(data: &[u8]) -> Result<(WsFrame, usize), EkphrasisE
     let byte0 = data[0];
     let byte1 = data[1];
 
+    // RFC 6455 §5.2: RSV1-3 (bits 4-6 of byte 0) are reserved for
+    // extensions thumos does not negotiate. A nonzero value means either
+    // an unsupported extension or a malformed/adversarial frame; reject
+    // rather than silently ignore.
+    if byte0 & 0x70 != 0 {
+        return Err(EkphrasisError::InvalidFrame);
+    }
+
+    // FIN bit (bit 7). thumos implements no continuation-frame reassembly
+    // state machine (opcode 0x0 "continuation" is not a WsOpcode variant),
+    // so a fragmented message (FIN=0) is rejected cleanly here instead of
+    // being silently parsed as if it were a complete frame.
+    if byte0 & 0x80 == 0 {
+        return Err(EkphrasisError::InvalidFrame);
+    }
+
     // Extract opcode from lower 4 bits of byte 0.
     let opcode_raw = byte0 & 0x0F;
     let opcode = WsOpcode::from_byte(opcode_raw).ok_or(EkphrasisError::InvalidFrame)?;
@@ -400,6 +417,63 @@ pub(crate) fn build_ws_upgrade(host: &str, path: &str, ws_key: &str) -> HttpRequ
     );
 
     req
+}
+
+/// Verify a server's `Sec-WebSocket-Accept` header value against the
+/// client key sent in the upgrade request (RFC 6455 §4.1 / §4.2.2):
+/// `base64(SHA-1(client_key + WS_MAGIC_GUID))`.
+///
+/// Fails closed: any mismatch -- including a missing or malformed header --
+/// is rejected. Without this check, ANY HTTP 101 response would be accepted
+/// as a valid WebSocket upgrade regardless of which server produced it,
+/// since `WS_MAGIC_GUID` was previously dead code with no verification path
+/// wired to it.
+///
+/// # Errors
+///
+/// Returns [`EkphrasisError::HandshakeFailed`] if `server_accept` does not
+/// match the value computed from `client_key`.
+pub(crate) fn verify_ws_accept(
+    client_key: &str,
+    server_accept: &str,
+) -> Result<(), EkphrasisError> {
+    if compute_ws_accept(client_key) == server_accept {
+        Ok(())
+    } else {
+        Err(EkphrasisError::HandshakeFailed)
+    }
+}
+
+/// Compute the expected `Sec-WebSocket-Accept` value for `client_key`.
+#[must_use]
+pub(crate) fn compute_ws_accept(client_key: &str) -> String {
+    let mut input = Vec::with_capacity(client_key.len() + WS_MAGIC_GUID.len());
+    input.extend_from_slice(client_key.as_bytes());
+    input.extend_from_slice(WS_MAGIC_GUID.as_bytes());
+    base64_encode(&crate::security::sha1(&input))
+}
+
+/// Encode bytes as standard padded base64 (RFC 4648 §4).
+fn base64_encode(bytes: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
+    for chunk in bytes.chunks(3) {
+        let b0 = chunk[0];
+        let b1 = chunk.get(1).copied();
+        let b2 = chunk.get(2).copied();
+
+        out.push(ALPHABET[(b0 >> 2) as usize] as char);
+        out.push(ALPHABET[(((b0 & 0x03) << 4) | (b1.unwrap_or(0) >> 4)) as usize] as char);
+        out.push(match b1 {
+            Some(b1) => ALPHABET[(((b1 & 0x0F) << 2) | (b2.unwrap_or(0) >> 6)) as usize] as char,
+            None => '=',
+        });
+        out.push(match b2 {
+            Some(b2) => ALPHABET[(b2 & 0x3F) as usize] as char,
+            None => '=',
+        });
+    }
+    out
 }
 
 // ---------------------------------------------------------------------------
@@ -649,6 +723,17 @@ impl Ekphrasis {
     /// Returns an error if the frame contains invalid JSON or if the
     /// transcription text exceeds the length limit.
     pub(crate) fn handle_server_frame(&mut self, frame: &WsFrame) -> Result<(), EkphrasisError> {
+        // WHY: without this guard, a frame arriving while Idle (no session
+        // active) or already Error (needs an explicit reset()) was processed
+        // exactly like a frame arriving mid-session -- silently transitioning
+        // the state machine OUT of Error on a stray frame.
+        if matches!(self.state, EkphrasisState::Idle | EkphrasisState::Error(_)) {
+            return Err(EkphrasisError::InvalidState {
+                operation: "handle_server_frame",
+                current: self.state.label(),
+            });
+        }
+
         match frame.opcode {
             WsOpcode::Text => {
                 // Parse the text payload as a transcription response.
@@ -679,7 +764,14 @@ impl Ekphrasis {
     fn process_transcription(&mut self, text: &str) -> Result<(), EkphrasisError> {
         let value = JsonParser::parse(text.as_bytes())?;
 
-        let transcript = value.get("text").and_then(JsonValue::as_str).unwrap_or("");
+        // WHY: a missing/non-string "text" field previously fell back to ""
+        // silently -- indistinguishable from the server legitimately sending
+        // an empty transcript. Error instead so a malformed response is
+        // surfaced rather than swallowed.
+        let transcript = value
+            .get("text")
+            .and_then(JsonValue::as_str)
+            .ok_or(EkphrasisError::InvalidFrame)?;
 
         let is_final = value
             .get("final")
@@ -1212,6 +1304,22 @@ mod tests {
     }
 
     #[test]
+    fn ws_frame_rejects_nonzero_rsv_bits() {
+        // FIN(1) + RSV1(1) + text opcode(0x1): byte0 = 1000_0001 | 0100_0000 = 0xC1.
+        let data = [0xC1, 0x00];
+        let result = parse_ws_frame(&data);
+        assert_eq!(result, Err(EkphrasisError::InvalidFrame));
+    }
+
+    #[test]
+    fn ws_frame_rejects_fin_zero_fragmentation() {
+        // FIN=0, text opcode(0x1), no mask, zero length: byte0 = 0x01.
+        let data = [0x01, 0x00];
+        let result = parse_ws_frame(&data);
+        assert_eq!(result, Err(EkphrasisError::InvalidFrame));
+    }
+
+    #[test]
     fn ws_frame_ping_pong() {
         let mask_key = [0x01, 0x02, 0x03, 0x04];
         let ping_frame = build_ws_frame(WsOpcode::Ping, b"ping", mask_key);
@@ -1554,6 +1662,59 @@ Let me know if you need anything else."#;
     }
 
     #[test]
+    fn handle_server_frame_rejects_when_idle() {
+        let mut ek = Ekphrasis::new("stt.example.lan", 8080);
+        let frame = WsFrame::new(WsOpcode::Text, b"{\"text\": \"hi\"}".to_vec());
+        let result = ek.handle_server_frame(&frame);
+        assert!(
+            matches!(
+                result,
+                Err(EkphrasisError::InvalidState {
+                    operation: "handle_server_frame",
+                    ..
+                })
+            ),
+            "a frame arriving in Idle state must be rejected, not processed"
+        );
+    }
+
+    #[test]
+    fn handle_server_frame_rejects_and_stays_in_error_state() {
+        let mut ek = Ekphrasis::new("stt.example.lan", 8080);
+        ek.set_endpoint_reachable(true);
+        let _ = ek.start_recording();
+        let _ = ek.begin_streaming();
+        ek.state = EkphrasisState::Error(EkphrasisError::ConnectionClosed);
+
+        let frame = WsFrame::new(WsOpcode::Text, b"{\"text\": \"hi\"}".to_vec());
+        let result = ek.handle_server_frame(&frame);
+        assert!(
+            matches!(result, Err(EkphrasisError::InvalidState { .. })),
+            "a frame arriving while in Error state must not silently transition out of Error"
+        );
+        assert!(
+            matches!(ek.state(), EkphrasisState::Error(_)),
+            "state must remain Error, not be overwritten by a stray frame"
+        );
+    }
+
+    #[test]
+    fn process_transcription_errors_on_missing_text_field() {
+        let mut ek = Ekphrasis::new("stt.example.lan", 8080);
+        ek.set_endpoint_reachable(true);
+        let _ = ek.start_recording();
+        let _ = ek.begin_streaming();
+
+        let frame = WsFrame::new(WsOpcode::Text, b"{\"final\": false}".to_vec());
+        let result = ek.handle_server_frame(&frame);
+        assert_eq!(
+            result,
+            Err(EkphrasisError::InvalidFrame),
+            "a transcription response missing \"text\" must error, not silently substitute empty string"
+        );
+    }
+
+    #[test]
     fn state_reset_clears_everything() {
         let mut ek = Ekphrasis::new("stt.example.lan", 8080);
         ek.set_endpoint_reachable(true);
@@ -1618,6 +1779,31 @@ Let me know if you need anything else."#;
         let (parsed, _) = parse_ws_frame(&frame).ok().flatten_pair();
         assert_eq!(parsed.opcode, WsOpcode::Close);
         assert!(parsed.payload.is_empty());
+    }
+
+    #[test]
+    fn compute_ws_accept_matches_rfc6455_example() {
+        // RFC 6455 §1.3 worked example.
+        let accept = compute_ws_accept("dGhlIHNhbXBsZSBub25jZQ==");
+        assert_eq!(accept, "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
+    }
+
+    #[test]
+    fn verify_ws_accept_accepts_matching_key() {
+        let result = verify_ws_accept("dGhlIHNhbXBsZSBub25jZQ==", "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn verify_ws_accept_rejects_mismatched_key() {
+        let result = verify_ws_accept("dGhlIHNhbXBsZSBub25jZQ==", "not-the-right-value=");
+        assert_eq!(result, Err(EkphrasisError::HandshakeFailed));
+    }
+
+    #[test]
+    fn verify_ws_accept_fails_closed_on_empty_server_value() {
+        let result = verify_ws_accept("dGhlIHNhbXBsZSBub25jZQ==", "");
+        assert_eq!(result, Err(EkphrasisError::HandshakeFailed));
     }
 
     // -----------------------------------------------------------------------

--- a/crates/thumos/src/futex.rs
+++ b/crates/thumos/src/futex.rs
@@ -26,6 +26,13 @@
 /// EAGAIN — value mismatch (two's complement -11, Linux ARM convention).
 pub(crate) const EAGAIN: u32 = 0u32.wrapping_sub(11);
 
+/// ENOMEM — waiter table exhausted (two's complement -12, Linux ARM
+/// convention). Distinct from EAGAIN: a caller retrying on EAGAIN expects
+/// `*addr` to eventually change on its own, but a full waiter table will
+/// not free itself without a FUTEX_WAKE elsewhere -- conflating the two
+/// would make a retry loop on this specific failure spin forever.
+pub(crate) const ENOMEM: u32 = 0u32.wrapping_sub(12);
+
 /// EINVAL — unknown op (two's complement -22, Linux ARM convention).
 pub(crate) const EINVAL: u32 = 0u32.wrapping_sub(22);
 
@@ -81,6 +88,21 @@ pub(crate) fn sys_futex_wait(addr: u32, val: u32) -> u32 {
         return EAGAIN;
     }
 
+    // WHY hoisted out of #[cfg(not(test))]: this check only reads the
+    // static FUTEX_WAITERS array (no crate::process dependency), so unlike
+    // the block/schedule/switch_to path below it is host-testable. A full
+    // waiter table is a distinct failure from a value mismatch (see the
+    // ENOMEM doc comment).
+    // SAFETY: FUTEX_WAITERS is a static mut; addr_of! avoids an
+    // intermediate reference. Single-core cooperative kernel ensures
+    // exclusive access here.
+    let table_full = unsafe { &*core::ptr::addr_of!(FUTEX_WAITERS) }
+        .iter()
+        .all(Option::is_some);
+    if table_full {
+        return ENOMEM;
+    }
+
     // --- Block path: requires crate::process (not available in test builds) ---
     #[cfg(not(test))]
     {
@@ -94,8 +116,11 @@ pub(crate) fn sys_futex_wait(addr: u32, val: u32) -> u32 {
         let slot = match slot {
             Some(s) => s,
             None => {
-                // Waiter table full — fail gracefully.
-                return EAGAIN;
+                // Unreachable: the table_full check above already returned
+                // ENOMEM if no slot was free, and the single-core
+                // cooperative kernel guarantees no interleaving mutation
+                // between that check and this one.
+                return ENOMEM;
             }
         };
         *slot = Some(FutexWaiter { addr, pid });
@@ -119,7 +144,7 @@ pub(crate) fn sys_futex_wait(addr: u32, val: u32) -> u32 {
 
     // In test builds the block path is absent; the matching value case returns
     // EAGAIN as a conservative sentinel (tests should only exercise the
-    // mismatch path).
+    // mismatch and table-exhaustion paths).
     #[cfg(test)]
     EAGAIN
 }
@@ -339,5 +364,29 @@ mod tests {
                 "a freed slot must be available for reuse"
             );
         }
+    }
+
+    #[test]
+    fn futex_wait_returns_enomem_when_waiter_table_full() {
+        reset_waiters();
+        // Fill every slot via the test-only seam (bypasses the
+        // #[cfg(not(test))]-gated block path, which needs crate::process).
+        for i in 0..MAX_FUTEX_WAITERS {
+            insert_waiter_for_test(0x1000 + i as u32, i as u32);
+        }
+
+        // WHY function-local `static mut`: mirrors futex_wait_returns_eagain_on_mismatch
+        // -- lands inside the validated user-address window on this host binary.
+        static mut WORD: u32 = 42;
+        // SAFETY: test-only static; single-threaded per test.
+        let addr = unsafe { core::ptr::addr_of!(WORD) as u32 };
+
+        // *addr == val, so this would normally proceed to register a
+        // waiter -- but the table is full.
+        let result = sys_futex_wait(addr, 42);
+        assert_eq!(
+            result, ENOMEM,
+            "a full waiter table must return ENOMEM, distinct from EAGAIN's value-mismatch signal"
+        );
     }
 }

--- a/crates/thumos/src/harmostes.rs
+++ b/crates/thumos/src/harmostes.rs
@@ -78,6 +78,14 @@ const MAX_MESSAGES_PER_ROOM: usize = 100;
 /// MAX_MESSAGES_PER_ROOM already bound room/timeline memory.
 const MAX_OUTBOX_MESSAGES: usize = 256;
 
+/// Maximum bytes of a non-JSON server error body surfaced verbatim in
+/// [`MatrixError::ServerError`]'s `message` by `parse_error_response`.
+/// Bounds worst-case memory from an adversarial or misconfigured
+/// homeserver/proxy sending an oversized plaintext/HTML error page, the
+/// same way the other MAX_* constants in this module bound room/outbox
+/// memory on a 1 GB device.
+const MAX_ERROR_BODY_LEN: usize = 512;
+
 /// Transaction ID counter starting value.
 const TXN_ID_START: u32 = 1;
 
@@ -438,6 +446,25 @@ impl MatrixClient {
     #[must_use]
     pub(crate) fn room_messages(&self, room_id: &str) -> Option<&[MatrixMessage]> {
         self.find_room(room_id).map(|r| r.messages.as_slice())
+    }
+
+    /// Mark all of a room's messages as read, resetting its unread counter
+    /// to 0.
+    ///
+    /// [`Room::unread_count`] is documented as "unread messages since last
+    /// read marker", but [`Room::add_message`] only ever increments it --
+    /// there was previously no way to advance that read marker, so the
+    /// count could only grow for the client's lifetime.
+    ///
+    /// Returns `true` if `room_id` was found and reset, `false` otherwise.
+    pub(crate) fn mark_room_read(&mut self, room_id: &str) -> bool {
+        match self.rooms.iter_mut().find(|r| r.room_id == room_id) {
+            Some(room) => {
+                room.unread_count = 0;
+                true
+            }
+            None => false,
+        }
     }
 
     /// Return the homeserver hostname.
@@ -1223,10 +1250,11 @@ fn crypto_error(e: CryptoError) -> MatrixError {
 
 /// Parse a Matrix error response body into a [`MatrixError::ServerError`].
 fn parse_error_response(response: &HttpResponse) -> MatrixError {
-    let (errcode, message) = response
-        .body_as_str()
-        .and_then(|s| JsonParser::parse(s.as_bytes()).ok())
-        .map(|root| {
+    let body_str = response.body_as_str();
+
+    let (errcode, message) = body_str
+        .and_then(|s| JsonParser::parse(s.as_bytes()).ok().map(|root| (s, root)))
+        .map(|(_, root)| {
             let errcode = root
                 .get("errcode")
                 .and_then(|v| v.as_str())
@@ -1238,10 +1266,17 @@ fn parse_error_response(response: &HttpResponse) -> MatrixError {
             (String::from(errcode), String::from(message))
         })
         .unwrap_or_else(|| {
-            (
-                String::from("M_UNKNOWN"),
-                String::from("non-JSON error response"),
-            )
+            // WHY: preserve the server's raw error text instead of discarding
+            // it -- a non-JSON error body previously became the generic
+            // "non-JSON error response", losing the server's actual text.
+            let message = match body_str {
+                Some(s) if !s.is_empty() => {
+                    let len = crate::heorte::utf8_truncate_len(s.as_bytes(), MAX_ERROR_BODY_LEN);
+                    String::from(&s[..len])
+                }
+                _ => String::from("non-JSON error response"),
+            };
+            (String::from("M_UNKNOWN"), message)
         });
 
     MatrixError::ServerError {
@@ -1419,6 +1454,37 @@ mod tests {
         assert_eq!(room.messages[0].sender, "@alice:matrix.example.com");
         assert_eq!(room.messages[1].body, "world");
         assert_eq!(room.unread_count, 2);
+    }
+
+    #[test]
+    fn mark_room_read_resets_unread_count() {
+        let mut client = matrix_client_with_test_credentials();
+        let room_id = "!test:matrix.example.com";
+
+        let sync_json = build_sync_response(
+            "batch_2",
+            room_id,
+            &[(
+                "$evt1",
+                "@alice:matrix.example.com",
+                "hello",
+                1_700_000_001_000,
+            )],
+        );
+        let response = mock_response(200, &sync_json);
+        let _ = client.sync(&response, 100);
+
+        assert_eq!(client.rooms()[0].unread_count, 1);
+        assert!(
+            client.mark_room_read(room_id),
+            "must find and reset a tracked room"
+        );
+        assert_eq!(client.rooms()[0].unread_count, 0);
+
+        assert!(
+            !client.mark_room_read("!nonexistent:example.com"),
+            "marking an untracked room read must return false"
+        );
     }
 
     #[test]
@@ -1876,6 +1942,38 @@ mod tests {
                 // Use assert! to avoid panic! lint.
                 assert!(false, "expected ServerError, got {other:?}");
             }
+        }
+    }
+
+    #[test]
+    fn parse_error_response_preserves_non_json_body_text() {
+        let response = mock_response(502, "upstream timeout: gateway unavailable");
+        let err = parse_error_response(&response);
+        match err {
+            MatrixError::ServerError { message, .. } => {
+                assert!(
+                    message.contains("upstream timeout"),
+                    "raw non-JSON body text must be preserved, got: {message}"
+                );
+            }
+            other => assert!(false, "expected ServerError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_error_response_truncates_oversized_non_json_body() {
+        let huge_body = "x".repeat(MAX_ERROR_BODY_LEN * 2);
+        let response = mock_response(500, &huge_body);
+        let err = parse_error_response(&response);
+        match err {
+            MatrixError::ServerError { message, .. } => {
+                assert!(
+                    message.len() <= MAX_ERROR_BODY_LEN,
+                    "surfaced error body must be bounded, got {} bytes",
+                    message.len()
+                );
+            }
+            other => assert!(false, "expected ServerError, got {other:?}"),
         }
     }
 

--- a/crates/thumos/src/heorte.rs
+++ b/crates/thumos/src/heorte.rs
@@ -129,7 +129,16 @@ impl CalendarEvent {
     }
 
     /// Whether this event is active (happening now) at the given epoch.
+    ///
+    /// A zero-duration event (`duration_min == 0`) is active exactly at
+    /// `start_epoch` -- with the general half-open range this always
+    /// evaluated `current_epoch < start_epoch` (since `end_epoch()` equals
+    /// `start_epoch` when duration is 0), so a zero-duration event could
+    /// never report active at any epoch, including its own start.
     pub(crate) fn is_active(&self, current_epoch: u64) -> bool {
+        if self.duration_min == 0 {
+            return current_epoch == self.start_epoch;
+        }
         current_epoch >= self.start_epoch && current_epoch < self.end_epoch()
     }
 
@@ -282,6 +291,7 @@ impl HeorteManager {
         for alarm in &mut self.alarms {
             if alarm.should_fire(current_epoch) {
                 firing.push(alarm.id);
+                alarm.last_fired_minute = Some(current_epoch / SECS_PER_MIN);
                 // Auto-disable one-shot alarms.
                 if alarm.repeat_days == 0 {
                     alarm.enabled = false;
@@ -369,6 +379,11 @@ fn civil_from_days(days: u64) -> (u16, u8, u8) {
 
 /// Format date as "YYYY-MM-DD" into a fixed buffer.
 pub(crate) fn format_date(year: u16, month: u8, day: u8) -> [u8; 10] {
+    // WHY: the "YYYY" field is 4 digits; decompose_epoch saturates year to
+    // u16::MAX (65535) for an adversarial epoch (#366), and year/1000 for
+    // an unclamped year > 9999 (e.g. 65) produces a byte past b'9', i.e.
+    // non-digit ASCII (b'0' + 65 = 'q'). Clamp before the digit math.
+    let year = year.min(9999);
     [
         b'0' + (year / 1000) as u8,
         b'0' + ((year / 100) % 10) as u8,
@@ -522,6 +537,17 @@ mod tests {
     }
 
     #[test]
+    fn event_zero_duration_is_active_at_exact_start() {
+        let event = CalendarEvent::new(1, b"Instant", 5000, 0, false);
+        assert!(
+            event.is_active(5000),
+            "zero-duration event must be active exactly at start_epoch"
+        );
+        assert!(!event.is_active(5001));
+        assert!(!event.is_active(4999));
+    }
+
+    #[test]
     fn check_alarms_auto_disables_oneshot() {
         let mut mgr = HeorteManager::new();
         mgr.add_alarm(6, 30, b"Once", true, 0);
@@ -535,6 +561,28 @@ mod tests {
         // Checking again must not fire.
         let firing2 = mgr.check_alarms(23400);
         assert!(firing2.is_empty(), "disabled alarm must not fire again");
+    }
+
+    #[test]
+    fn check_alarms_repeat_does_not_refire_within_same_minute() {
+        let mut mgr = HeorteManager::new();
+        mgr.add_alarm(6, 30, b"Repeat", true, day_mask::DAILY);
+
+        let firing = mgr.check_alarms(23400);
+        assert_eq!(firing.len(), 1, "alarm must fire once");
+
+        let firing2 = mgr.check_alarms(23400);
+        assert!(
+            firing2.is_empty(),
+            "repeat alarm must not re-fire within the same minute"
+        );
+
+        let firing3 = mgr.check_alarms(23400 + SECS_PER_DAY);
+        assert_eq!(
+            firing3.len(),
+            1,
+            "repeat alarm must fire again the next day"
+        );
     }
 
     #[test]
@@ -573,6 +621,18 @@ mod tests {
         );
         assert!((1..=12).contains(&month), "month must stay in valid range");
         assert!((1..=31).contains(&day), "day must stay in valid range");
+    }
+
+    #[test]
+    fn format_date_year_overflow_stays_ascii_digits() {
+        let buf = format_date(u16::MAX, 1, 1);
+        for &b in &buf {
+            assert!(
+                b == b'-' || b.is_ascii_digit(),
+                "format_date byte {b} is not ASCII digit or dash for an overflowing year"
+            );
+        }
+        assert_eq!(&buf[..4], b"9999", "year must clamp to 9999");
     }
 
     #[test]

--- a/crates/thumos/src/heorte_alarm.rs
+++ b/crates/thumos/src/heorte_alarm.rs
@@ -64,6 +64,12 @@ pub struct Alarm {
     pub enabled: bool,
     /// Day-of-week repeat bitmask. 0 = one-shot, auto-disables after firing.
     pub repeat_days: u8,
+    /// Minute-index (`epoch / SECS_PER_MIN`) at which this alarm last
+    /// fired, or `None` if never fired. Used by [`Alarm::should_fire`] to
+    /// edge-trigger within the 60s window a matching hour:minute spans --
+    /// without it, a repeat alarm re-checked every tick would fire once per
+    /// tick for the whole minute (up to 60x per intended trigger).
+    pub last_fired_minute: Option<u64>,
 }
 
 impl Alarm {
@@ -90,6 +96,7 @@ impl Alarm {
             label_len: len as u8,
             enabled,
             repeat_days,
+            last_fired_minute: None,
         }
     }
 
@@ -114,6 +121,15 @@ impl Alarm {
         let current_minute = ((day_secs % SECS_PER_HOUR) / SECS_PER_MIN) as u8;
 
         if current_hour != self.hour || current_minute != self.minute {
+            return false;
+        }
+
+        // WHY: the hour:minute match above holds for the entire 60s window,
+        // not just one instant. Without this edge-trigger guard, a caller
+        // re-checking should_fire every tick (e.g. HeorteManager::check_alarms)
+        // would see it return true up to 60x for one intended trigger.
+        // last_fired_minute is advanced by the caller once the alarm fires.
+        if self.last_fired_minute == Some(current_epoch / SECS_PER_MIN) {
             return false;
         }
 
@@ -266,6 +282,26 @@ mod tests {
             day_of_week(3 * SECS_PER_DAY),
             0,
             "1970-01-04 must be Sunday"
+        );
+    }
+
+    #[test]
+    fn should_fire_edge_triggers_within_same_minute() {
+        let mut alarm = Alarm::new(1, 6, 30, b"Wake up", true, day_mask::DAILY);
+        let epoch_630 = 23400;
+        assert!(alarm.should_fire(epoch_630), "must fire the first time");
+        alarm.last_fired_minute = Some(epoch_630 / SECS_PER_MIN);
+        assert!(
+            !alarm.should_fire(epoch_630),
+            "must not re-fire within the same minute after being marked fired"
+        );
+        assert!(
+            !alarm.should_fire(epoch_630 + 30),
+            "must not re-fire later in the same 60s window"
+        );
+        assert!(
+            alarm.should_fire(epoch_630 + SECS_PER_DAY),
+            "must fire again on the next matching day"
         );
     }
 }

--- a/crates/thumos/src/ipc.rs
+++ b/crates/thumos/src/ipc.rs
@@ -1,10 +1,13 @@
 //! Inter-process communication via message passing.
 //!
-//! Processes communicate by sending fixed-size messages through channels.
-//! Each process has an inbox (bounded ring buffer). Sending to a full
-//! inbox blocks the sender. Receiving FROM an empty inbox blocks the receiver.
+//! Processes communicate by sending fixed-size messages through per-process
+//! inboxes (bounded ring buffers). Delivery is non-blocking on both ends:
+//! [`send`] fails immediately with [`IpcSendError::InboxFull`] rather than
+//! blocking the sender when the target inbox is at capacity, and [`recv`]
+//! returns `None` immediately rather than blocking the receiver when the
+//! inbox is empty. This is asynchronous mailbox-style IPC, not the
+//! synchronous rendezvous this doc previously (incorrectly) claimed.
 //!
-//! This is synchronous, rendezvous-style IPC inspired by seL4 and QNX.
 //! Asynchronous notifications (for interrupts) can be added later.
 
 extern crate alloc;
@@ -32,6 +35,17 @@ pub struct Message {
 
 impl Message {
     /// Create a new message with the given tag and data.
+    ///
+    /// # WHY silent truncation is safe here
+    ///
+    /// `payload` longer than [`MSG_MAX_SIZE`] is truncated rather than
+    /// rejected. This is safe only because every current caller already
+    /// bounds `payload` to `MSG_MAX_SIZE` before calling: the `Send`
+    /// syscall handler caps the copied length with `len.min(ipc::MSG_MAX_SIZE)`
+    /// before it ever reaches here (see `syscall::dispatch`), and
+    /// `process::notify_fault`'s payload is a fixed 9 bytes. Verify that
+    /// invariant before adding a new call site that does not pre-bound its
+    /// payload -- it would silently lose data with no signal.
     pub(crate) fn new(tag: u32, payload: &[u8]) -> Self {
         let mut msg = Self {
             from: 0,
@@ -287,5 +301,17 @@ mod tests {
     fn inbox_pop_empty_returns_none() {
         let mut inbox = Inbox::new();
         assert!(inbox.pop().is_none());
+    }
+
+    #[test]
+    fn message_new_truncates_oversized_payload_to_max_size() {
+        let oversized = [0xABu8; MSG_MAX_SIZE + 64];
+        let msg = Message::new(7, &oversized);
+        assert_eq!(
+            msg.len, MSG_MAX_SIZE,
+            "payload must truncate to MSG_MAX_SIZE"
+        );
+        assert_eq!(msg.payload().len(), MSG_MAX_SIZE);
+        assert!(msg.payload().iter().all(|&b| b == 0xAB));
     }
 }

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -193,64 +193,58 @@ impl BootState {
         }
     }
 
-    /// Count of successfully initialized subsystems.
+    /// The per-subsystem OK flags backing [`Self::ok_count`] and
+    /// [`Self::total_subsystems`]. Single source of truth: add a newly
+    /// tracked subsystem's flag here and both the numerator (`ok_count`)
+    /// and denominator (`total_subsystems`) update together automatically
+    /// -- the boot summary's "N / total" denominator was previously a
+    /// hand-maintained literal independent of this list, and had already
+    /// drifted once (17 -> 18 when csprng_ok was added). The array length
+    /// in the return type is compiler-checked against this literal, so the
+    /// two can no longer silently diverge.
+    const fn subsystem_flags(&self) -> [bool; 18] {
+        [
+            self.mmu_ok,
+            self.heap_ok,
+            self.gic_ok,
+            self.timer_ok,
+            self.csprng_ok,
+            self.emmc_ok,
+            self.display_ok,
+            self.secure_boot_ok,
+            self.passphrase_ok,
+            self.encryption_ok,
+            self.audit_ok,
+            self.security_mode_ok,
+            self.usb_ok,
+            self.modem_ok,
+            self.input_ok,
+            self.network_ok,
+            self.bluetooth_ok,
+            self.gps_ok,
+        ]
+    }
+
+    /// Count of successfully initialized subsystems, out of
+    /// [`Self::total_subsystems`].
     pub(crate) const fn ok_count(&self) -> u8 {
+        let flags = self.subsystem_flags();
         let mut n = 0;
-        if self.mmu_ok {
-            n += 1;
-        }
-        if self.heap_ok {
-            n += 1;
-        }
-        if self.gic_ok {
-            n += 1;
-        }
-        if self.timer_ok {
-            n += 1;
-        }
-        if self.csprng_ok {
-            n += 1;
-        }
-        if self.emmc_ok {
-            n += 1;
-        }
-        if self.display_ok {
-            n += 1;
-        }
-        if self.secure_boot_ok {
-            n += 1;
-        }
-        if self.passphrase_ok {
-            n += 1;
-        }
-        if self.encryption_ok {
-            n += 1;
-        }
-        if self.audit_ok {
-            n += 1;
-        }
-        if self.security_mode_ok {
-            n += 1;
-        }
-        if self.usb_ok {
-            n += 1;
-        }
-        if self.modem_ok {
-            n += 1;
-        }
-        if self.input_ok {
-            n += 1;
-        }
-        if self.network_ok {
-            n += 1;
-        }
-        if self.bluetooth_ok {
-            n += 1;
-        }
-        if self.gps_ok {
-            n += 1;
+        let mut i = 0;
+        while i < flags.len() {
+            if flags[i] {
+                n += 1;
+            }
+            i += 1;
         }
         n
+    }
+
+    /// Total number of subsystems tracked by [`Self::ok_count`]. Derived
+    /// from the same flag array `ok_count` iterates, so this denominator
+    /// can never drift from the numerator it describes.
+    pub(crate) const fn total_subsystems(&self) -> u8 {
+        self.subsystem_flags().len() as u8
     }
 
     /// Record the production network readiness result from a real device.
@@ -1003,7 +997,12 @@ pub unsafe fn run() -> ! {
         "[init] Boot complete at {} ms\r\n",
         crate::timer::elapsed_ms()
     );
-    let _ = write!(serial, "       {} / 18 subsystems OK\r\n", state.ok_count());
+    let _ = write!(
+        serial,
+        "       {} / {} subsystems OK\r\n",
+        state.ok_count(),
+        state.total_subsystems()
+    );
     if !state.csprng_ok {
         let _ = serial
             .write_str("       NOTE: CSPRNG unseeded, radio identity randomization disabled\r\n");
@@ -1386,6 +1385,21 @@ mod tests {
         state.bluetooth_ok = true;
         state.gps_ok = true;
         assert_eq!(state.ok_count(), 18, "all 18 subsystems OK");
+    }
+
+    #[test]
+    fn boot_state_total_subsystems_matches_ok_count_denominator() {
+        let mut state = BootState::new();
+        assert_eq!(state.total_subsystems(), 18);
+
+        state.mmu_ok = true;
+        state.heap_ok = true;
+        assert_eq!(
+            state.total_subsystems(),
+            18,
+            "total_subsystems must not change as flags flip"
+        );
+        assert!(state.ok_count() <= state.total_subsystems());
     }
 
     #[test]


### PR DESCRIPTION
First wave-1 batch (#384). **3 stale** (cache.flush attempts-all, harmostes sentinel, ipc Result — fixed in prior waves).

## Security — WebSocket handshake never verified
The ekphrasis WebSocket client never checked `Sec-WebSocket-Accept` — **any** server response was accepted as a valid handshake. Added RFC-6455 verification (`base64(sha1(client_key + GUID))`, fail-closed). And uncovered a bonus bug: `WS_MAGIC_GUID` was a **fabricated wrong value** (`...95CA-5AB5FE82AD65`) that never matched RFC 6455's real `...95CA-C5AB0DC85B11` — so verification could never have worked even if wired. RFC example vector now passes.

## Correctness
- **ekphrasis** — parse_ws_frame rejects nonzero RSV + reads FIN (fragmentation cleanly rejected); handle_server_frame state-guarded; process_transcription errors on missing "text".
- **heorte_alarm** — should_fire matched the whole 60s window → a repeat alarm fired **up to 60× per trigger**. Now edge-triggered.
- **contacts** — byte-boundary name truncation stored invalid UTF-8 → now char-boundary.
- **harmostes** — parse_error_response preserves raw non-JSON server text; mark_room_read lets unread_count decrement.
- device found-or-error (was silent no-op); futex ENOMEM vs EAGAIN; heorte zero-duration + year clamp; kinit derives the subsystem denominator (was a drift-prone literal).

## Verification
- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — **2030 passed** (30 new; the RFC accept-vector test caught the fabricated GUID)
- `cargo build --release --target armv7a-none-eabi` — clean · `kanon lint` — clean

Partially addresses #384 (findings 1-20: 17 fixed + 3 stale). ~44 remain.

_WebSocket accept verification reviewed at T0/Opus._