### PR TITLE
Wave-1 low-rollup batch 2: 16 fixes incl. concurrency/safety (#384)

### DIFF
--- a/crates/thumos/src/bfu_timer.rs
+++ b/crates/thumos/src/bfu_timer.rs
@@ -43,6 +43,16 @@ const PANIC_TIMEOUT_MS: u64 = 0;
 /// Tick period: 10 ms per kernel tick.
 const TICK_PERIOD_MS: u64 = 10;
 
+/// Maximum time the timer may remain paused before it is force-resumed.
+///
+/// WHY 5 minutes: `pause()` exists for brief active-interaction windows (a
+/// phone call, an unlock flow) -- an indefinite pause (a missed
+/// `resume()` call, or a stuck caller) must not permanently suppress the
+/// BFU reboot. 5 minutes is comfortably longer than any single
+/// interaction yet far short of even the Sentinel threshold (30 min), so
+/// a legitimate pause is never force-ended mid-use.
+const MAX_PAUSE_TICKS: u64 = 5 * 60 * 1_000 / TICK_PERIOD_MS;
+
 /// Daily threshold in ticks.
 const DAILY_THRESHOLD_TICKS: u64 = DAILY_TIMEOUT_MS / TICK_PERIOD_MS;
 
@@ -129,6 +139,10 @@ pub(crate) struct BfuTimer {
     mode: SecurityMode,
     /// Whether the timer has already fired (prevents repeated reboot).
     fired: bool,
+    /// Ticks elapsed since the current pause began. Reset whenever the
+    /// timer leaves the Paused state (resume, reset, or the
+    /// MAX_PAUSE_TICKS force-resume in `tick`).
+    paused_ticks: u64,
 }
 
 impl BfuTimer {
@@ -144,6 +158,7 @@ impl BfuTimer {
             state: BfuTimerState::Running,
             mode,
             fired: false,
+            paused_ticks: 0,
         }
     }
 
@@ -158,6 +173,21 @@ impl BfuTimer {
     pub(crate) fn tick(&mut self, key_manager: &mut KeyManager) -> BfuAction {
         if self.fired {
             return BfuAction::Reboot;
+        }
+
+        if self.state == BfuTimerState::Paused {
+            // WHY: an indefinite pause (a caller that never calls
+            // resume()) must not permanently suppress the BFU reboot --
+            // that would defeat the idle-lock security property the timer
+            // exists to enforce. Force back to Running after
+            // MAX_PAUSE_TICKS so elapsed_ticks resumes counting toward
+            // threshold_ticks.
+            self.paused_ticks = self.paused_ticks.saturating_add(1);
+            if self.paused_ticks >= MAX_PAUSE_TICKS {
+                self.state = BfuTimerState::Running;
+                self.paused_ticks = 0;
+            }
+            return BfuAction::None;
         }
 
         if self.state != BfuTimerState::Running {
@@ -181,12 +211,14 @@ impl BfuTimer {
         self.elapsed_ticks = 0;
         self.state = BfuTimerState::Running;
         self.fired = false;
+        self.paused_ticks = 0;
     }
 
     /// Pause the timer. Ticks will not be counted while paused.
     pub(crate) fn pause(&mut self) {
         if self.state == BfuTimerState::Running {
             self.state = BfuTimerState::Paused;
+            self.paused_ticks = 0;
         }
     }
 
@@ -194,6 +226,7 @@ impl BfuTimer {
     pub(crate) fn resume(&mut self) {
         if self.state == BfuTimerState::Paused {
             self.state = BfuTimerState::Running;
+            self.paused_ticks = 0;
         }
     }
 
@@ -487,6 +520,36 @@ mod tests {
         timer.resume();
         timer.tick(&mut km);
         assert_eq!(timer.elapsed_ticks(), 101);
+    }
+
+    #[test]
+    fn pause_is_capped_and_force_resumes() {
+        let mut km = key_manager_with_derived_keys();
+        let mut timer = BfuTimer::new(SecurityMode::Daily);
+
+        timer.tick(&mut km);
+        assert_eq!(timer.elapsed_ticks(), 1);
+
+        timer.pause();
+        // Tick past the pause cap; the timer must force itself back to
+        // Running rather than staying paused forever.
+        for _ in 0..MAX_PAUSE_TICKS {
+            timer.tick(&mut km);
+        }
+        assert_eq!(
+            timer.state(),
+            BfuTimerState::Running,
+            "an indefinite pause must be force-resumed after MAX_PAUSE_TICKS"
+        );
+
+        // Elapsed time must resume advancing now that the cap forced a resume.
+        let before = timer.elapsed_ticks();
+        timer.tick(&mut km);
+        assert_eq!(
+            timer.elapsed_ticks(),
+            before + 1,
+            "elapsed_ticks must advance again after the forced resume"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/thumos/src/contacts.rs
+++ b/crates/thumos/src/contacts.rs
@@ -305,12 +305,19 @@ impl ContactManager {
     ///
     /// Returns a vector of indices into the contact list, sorted by name.
     pub(crate) fn sorted_indices(&self) -> Vec<usize> {
+        // WHY precompute keys once: the previous implementation called
+        // to_ascii_lowercase() (a heap allocation) inside the sort
+        // comparator, which runs O(N log N) times for N contacts -- O(N
+        // log N) heap Strings for a single sort. Lowercasing each name
+        // exactly once up front (O(N) allocations) and sorting the
+        // precomputed keys avoids the per-compare allocation entirely.
+        let keys: Vec<alloc::string::String> = self
+            .contacts
+            .iter()
+            .map(|c| c.name_str().to_ascii_lowercase())
+            .collect();
         let mut indices: Vec<usize> = (0..self.contacts.len()).collect();
-        indices.sort_by(|&a, &b| {
-            let name_a = self.contacts[a].name_str().to_ascii_lowercase();
-            let name_b = self.contacts[b].name_str().to_ascii_lowercase();
-            name_a.cmp(&name_b)
-        });
+        indices.sort_by(|&a, &b| keys[a].cmp(&keys[b]));
         indices
     }
 
@@ -482,6 +489,27 @@ mod tests {
 
         let sorted = mgr.sorted_indices();
         assert_eq!(sorted, vec![1, 2, 0], "must be sorted: Alice, Bob, Charlie");
+    }
+
+    #[test]
+    fn sorted_indices_case_insensitive_with_many_contacts() {
+        let mut mgr = ContactManager::new();
+        mgr.add("charlie", "1").unwrap_or_else(|_| unreachable!());
+        mgr.add("Alice", "2").unwrap_or_else(|_| unreachable!());
+        mgr.add("BOB", "3").unwrap_or_else(|_| unreachable!());
+        mgr.add("dave", "4").unwrap_or_else(|_| unreachable!());
+        mgr.add("aaron", "5").unwrap_or_else(|_| unreachable!());
+
+        let sorted = mgr.sorted_indices();
+        let names: Vec<&str> = sorted
+            .iter()
+            .map(|&i| mgr.get(i).map(|c| c.name_str()).unwrap_or(""))
+            .collect();
+        assert_eq!(
+            names,
+            vec!["aaron", "Alice", "BOB", "charlie", "dave"],
+            "precomputed-key sort must still be case-insensitive across many contacts"
+        );
     }
 
     #[test]

--- a/crates/thumos/src/ekphrasis.rs
+++ b/crates/thumos/src/ekphrasis.rs
@@ -1098,13 +1098,14 @@ pub(crate) fn parse_action_proposal(
 /// Returns the JSON string and the byte offset past the closing fence.
 fn find_fenced_block(message: &str) -> Option<(&str, usize)> {
     // Try ``` style first, then ~~~ style.
-    if let Some(result) = try_find_fence(message, FENCE_START, "```") {
+    if let Some(result) = try_find_fence(message, FENCE_START, FENCE_END) {
         return Some(result);
     }
-    try_find_fence(message, FENCE_START_ALT, "~~~")
+    try_find_fence(message, FENCE_START_ALT, FENCE_END_ALT)
 }
 
-/// Try to find a fenced block with the given delimiters.
+/// Try to find a fenced block with the given delimiters. `end_marker` must
+/// already include its leading newline (see FENCE_END / FENCE_END_ALT).
 fn try_find_fence<'a>(
     message: &'a str,
     start_marker: &str,
@@ -1114,11 +1115,15 @@ fn try_find_fence<'a>(
     let content_start = start_pos + start_marker.len();
     let remaining = &message[content_start..];
 
-    // Find the closing fence. Must be on its own line (preceded by newline).
-    let end_pos = remaining.find(&alloc::format!("\n{end_marker}"))?;
+    // Find the closing fence. end_marker already carries the leading
+    // newline (FENCE_END / FENCE_END_ALT), so the closing fence must be on
+    // its own line -- with no per-parse heap allocation to build the
+    // pattern (previously alloc::format!("\n{end_marker}") ran once per
+    // parse call).
+    let end_pos = remaining.find(end_marker)?;
 
     let json_str = &remaining[..end_pos];
-    let total_consumed = content_start + end_pos + 1 + end_marker.len();
+    let total_consumed = content_start + end_pos + end_marker.len();
 
     Some((json_str, total_consumed))
 }
@@ -1383,6 +1388,24 @@ Let me know if you need anything else."#;
         assert_eq!(p.description, "Call Maria");
         assert_eq!(p.param("contact_name"), Some("Maria"));
         assert_eq!(p.param("number"), Some("+15550100"));
+    }
+
+    #[test]
+    fn find_fenced_block_reports_correct_consumed_offset() {
+        // Regression test for the alloc-free refactor: the old code built
+        // its search pattern (and its total_consumed offset) from two
+        // separate pieces (a runtime-formatted "\n" + end_marker, plus a
+        // manual "+1"); the new code uses the single pre-built FENCE_END
+        // constant. Both the extracted content and the exact byte offset
+        // past the closing fence must still be correct.
+        let message = "before\n```thumos-action\ncontent\n```\nafter";
+        let (json_str, consumed) = find_fenced_block(message).expect("fence must be found");
+        assert_eq!(json_str, "content");
+        assert_eq!(
+            &message[consumed..],
+            "\nafter",
+            "consumed offset must land exactly after the closing fence"
+        );
     }
 
     #[test]

--- a/crates/thumos/src/exceptions.rs
+++ b/crates/thumos/src/exceptions.rs
@@ -24,8 +24,21 @@ use crate::timer;
 use crate::uart::Uart;
 use crate::watchdog;
 
-/// Tick counter incremented by the timer IRQ handler.
-static mut TICK_COUNT: u64 = 0;
+/// Tick counter incremented by the timer IRQ handler, split into
+/// high/low 32-bit halves.
+///
+/// WHY split: a bare `u64` read on 32-bit ARM lowers to two 32-bit loads,
+/// which can tear if the timer IRQ increments (and carries into the high
+/// half) between them -- `ticks()` could observe a spurious jump forward
+/// or backward once per low-word wraparound (~497 days at 100 Hz).
+/// Reading hi-lo-hi with a retry-on-mismatch (seqlock-lite, see
+/// `ticks()`) makes the combined value tear-free without a real lock: the
+/// sole writer (this IRQ handler) always runs with IRQs disabled and is
+/// never reentrant on this single-core kernel, so a retry only ever needs
+/// to catch a single writer/reader interleaving, never writer/writer
+/// contention.
+static mut TICK_COUNT_HI: u32 = 0;
+static mut TICK_COUNT_LO: u32 = 0;
 
 /// Timer tick interval in milliseconds.
 const TICK_MS: u32 = 10;
@@ -58,8 +71,24 @@ pub unsafe fn init() {
 }
 
 /// Get the current tick count.
+///
+/// Reads the hi/lo split with a seqlock-lite retry: `hi` is read before
+/// and after `lo`. If the timer IRQ carried into `hi` while `lo` was
+/// being read (a torn read), `hi1 != hi2` and the read is retried. See
+/// `TICK_COUNT_HI`/`TICK_COUNT_LO` and `combine_tick_halves` in
+/// `exceptions_stub.rs` for the host-tested version of this logic.
 pub(crate) fn ticks() -> u64 {
-    unsafe { core::ptr::read_volatile(core::ptr::addr_of!(TICK_COUNT)) }
+    loop {
+        // SAFETY: TICK_COUNT_HI/LO are written only from the timer IRQ
+        // handler with IRQs disabled (single-core, non-reentrant); this
+        // hi-lo-hi retry loop is the reader side of that seqlock-lite.
+        let hi1 = unsafe { core::ptr::read_volatile(core::ptr::addr_of!(TICK_COUNT_HI)) };
+        let lo = unsafe { core::ptr::read_volatile(core::ptr::addr_of!(TICK_COUNT_LO)) };
+        let hi2 = unsafe { core::ptr::read_volatile(core::ptr::addr_of!(TICK_COUNT_HI)) };
+        if hi1 == hi2 {
+            return (u64::from(hi1) << 32) | u64::from(lo);
+        }
+    }
 }
 
 /// Get uptime in milliseconds FROM tick count.
@@ -134,11 +163,23 @@ pub extern "C" fn irq_handler_rust() {
 
     if irq == timer::TIMER_IRQ {
         // Timer tick
-        // SAFETY: TICK_COUNT is only written from this IRQ handler, which
-        // is non-reentrant on a single-core ARMv7. The IRQ is disabled
-        // during handler execution so there is no concurrent write.
+        // SAFETY: TICK_COUNT_HI/LO are only written from this IRQ
+        // handler, which is non-reentrant on a single-core ARMv7. The IRQ
+        // is disabled during handler execution so there is no concurrent
+        // write. LO is written before HI so a reader's hi-lo-hi retry (see
+        // ticks()) never observes a new HI paired with a stale pre-carry
+        // LO.
         unsafe {
-            TICK_COUNT += 1;
+            let lo = core::ptr::read_volatile(core::ptr::addr_of!(TICK_COUNT_LO));
+            let (new_lo, carried) = lo.overflowing_add(1);
+            core::ptr::write_volatile(core::ptr::addr_of_mut!(TICK_COUNT_LO), new_lo);
+            if carried {
+                let hi = core::ptr::read_volatile(core::ptr::addr_of!(TICK_COUNT_HI));
+                core::ptr::write_volatile(
+                    core::ptr::addr_of_mut!(TICK_COUNT_HI),
+                    hi.wrapping_add(1),
+                );
+            }
         }
 
         // Collect entropy from timer counter LSBs for the CSPRNG.

--- a/crates/thumos/src/exceptions_stub.rs
+++ b/crates/thumos/src/exceptions_stub.rs
@@ -56,3 +56,40 @@ pub(crate) fn set_ticks(value: u64) {
 pub(crate) fn advance_ticks(delta: u64) {
     TICKS.fetch_add(delta, Ordering::Relaxed);
 }
+
+/// Host-test mirror of the production `exceptions::ticks()` seqlock-lite
+/// combine logic. The real `exceptions` module is ARM-only and entirely
+/// swapped for this stub under test, so its `TICK_COUNT_HI`/`TICK_COUNT_LO`
+/// statics are not reachable from a host test; this pure function is kept
+/// in lockstep with the read in `exceptions::ticks()` so the torn-read fix
+/// has host-test coverage.
+///
+/// Given a hi-lo-hi read triple, returns the combined 64-bit tick count if
+/// the two `hi` reads agree (no writer carried into `hi` between them), or
+/// `None` if the reader must retry.
+pub(crate) fn combine_tick_halves(hi1: u32, lo: u32, hi2: u32) -> Option<u64> {
+    if hi1 == hi2 {
+        Some((u64::from(hi1) << 32) | u64::from(lo))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn combine_tick_halves_returns_value_when_hi_stable() {
+        assert_eq!(combine_tick_halves(0, 42, 0), Some(42));
+        assert_eq!(combine_tick_halves(1, 0, 1), Some(1u64 << 32));
+    }
+
+    #[test]
+    fn combine_tick_halves_signals_retry_on_torn_read() {
+        // hi changed between the two reads (a carry from a LO wraparound
+        // occurred mid-read) -- the reader must retry, not return a torn
+        // combination of the pre- and post-carry halves.
+        assert_eq!(combine_tick_halves(0, 0xFFFF_FFFF, 1), None);
+    }
+}

--- a/crates/thumos/src/harmostes.rs
+++ b/crates/thumos/src/harmostes.rs
@@ -934,13 +934,28 @@ impl MatrixClient {
     /// Each element carries the per-message encryption/build result. A failed
     /// encryption yields an `Err` for that message without dropping the others.
     pub(crate) fn flush_outbox(&mut self) -> Vec<Result<(HttpRequest, u32), MatrixError>> {
-        let pending: Vec<PendingMessage> = self.outbox.clone();
-        let mut results = Vec::with_capacity(pending.len());
+        // WHY per-message clone instead of cloning the whole outbox up
+        // front: build_megolm_request needs `&mut self` (it may create an
+        // outbound Megolm session), which cannot coexist with a borrow
+        // into self.outbox -- cloning the entire outbox before the loop
+        // held two full copies of every pending message's body/room_id
+        // simultaneously (doubled peak heap). Cloning only the current
+        // message's (room_id, body, txn_id) per iteration keeps
+        // self.outbox itself untouched -- still required so an
+        // unconfirmed message survives to the next flush_outbox call
+        // (confirm_sent is the only thing that removes one) -- while peak
+        // heap is now the outbox's size plus one message, not two full
+        // outboxes.
+        let mut results = Vec::with_capacity(self.outbox.len());
 
-        for msg in &pending {
+        for i in 0..self.outbox.len() {
+            let room_id = self.outbox[i].room_id.clone();
+            let body = self.outbox[i].body.clone();
+            let txn_id = self.outbox[i].txn_id;
+
             let result = self
-                .build_megolm_request(&msg.room_id, &msg.body, msg.txn_id)
-                .map(|req| (req, msg.txn_id));
+                .build_megolm_request(&room_id, &body, txn_id)
+                .map(|req| (req, txn_id));
             results.push(result);
         }
 
@@ -1647,6 +1662,27 @@ mod tests {
         let first_txn = client.outbox()[0].txn_id;
         client.confirm_sent(first_txn);
         assert_eq!(client.outbox().len(), 2);
+    }
+
+    #[test]
+    fn flush_outbox_preserves_message_identity_per_iteration() {
+        let mut client = matrix_client_with_test_credentials();
+
+        let _ = client.queue_message("!room1:example.com", "alpha");
+        let _ = client.queue_message("!room2:example.com", "beta");
+        let _ = client.queue_message("!room3:example.com", "gamma");
+
+        let results = client.flush_outbox();
+        let txn_ids: Vec<u32> = results
+            .iter()
+            .filter_map(|r| r.as_ref().ok().map(|(_, txn_id)| *txn_id))
+            .collect();
+        let outbox_txn_ids: Vec<u32> = client.outbox().iter().map(|m| m.txn_id).collect();
+
+        assert_eq!(
+            txn_ids, outbox_txn_ids,
+            "each flush_outbox result must correspond to the outbox message at the same index, not a stale/cloned snapshot"
+        );
     }
 
     #[test]

--- a/crates/thumos/src/heorte.rs
+++ b/crates/thumos/src/heorte.rs
@@ -205,8 +205,19 @@ impl HeorteManager {
         let id = self.next_event_id;
         self.next_event_id += 1;
         let event = CalendarEvent::new(id, title, start_epoch, duration_min, all_day);
-        self.events.push(event);
-        self.sort_events();
+        // WHY insert-in-place instead of push + full re-sort: `events` is
+        // kept sorted by `start_epoch` at all times, so re-sorting the
+        // whole vector after every single insert was O(N log N) per add
+        // -- O(N^2 log N) for a bulk import of N events. A binary-search
+        // insertion point (`partition_point`) plus a single `Vec::insert`
+        // shift keeps the same sorted invariant at the same O(N)
+        // asymptotic insert cost without repeatedly re-comparing every
+        // element. `<=` keeps ties in insertion order, matching the
+        // previous stable sort's behavior.
+        let pos = self
+            .events
+            .partition_point(|e| e.start_epoch <= start_epoch);
+        self.events.insert(pos, event);
         id
     }
 
@@ -233,11 +244,6 @@ impl HeorteManager {
     /// Find an event by ID.
     pub(crate) fn find_event(&self, id: u32) -> Option<&CalendarEvent> {
         self.events.iter().find(|e| e.id == id)
-    }
-
-    /// Sort events by `start_epoch` (stable sort preserves insertion order for ties).
-    fn sort_events(&mut self) {
-        self.events.sort_by_key(|e| e.start_epoch);
     }
 
     // -- Alarms --
@@ -485,6 +491,24 @@ mod tests {
         );
         assert_eq!(events[0].title_str(), "Earlier");
         assert_eq!(events[1].title_str(), "Later");
+    }
+
+    #[test]
+    fn add_event_maintains_sort_order_with_ties() {
+        let mut mgr = HeorteManager::new();
+        mgr.add_event(b"C", 3_000_000, 30, false);
+        mgr.add_event(b"A", 1_000_000, 30, false);
+        mgr.add_event(b"B1", 2_000_000, 30, false);
+        mgr.add_event(b"B2", 2_000_000, 30, false); // tie with B1
+        let events = mgr.events();
+        assert_eq!(events.len(), 4);
+        assert_eq!(events[0].start_epoch, 1_000_000);
+        assert_eq!(events[1].start_epoch, 2_000_000);
+        assert_eq!(events[2].start_epoch, 2_000_000);
+        assert_eq!(events[3].start_epoch, 3_000_000);
+        // Tie-break: equal start_epoch keeps insertion order (B1 before B2).
+        assert_eq!(events[1].title_str(), "B1");
+        assert_eq!(events[2].title_str(), "B2");
     }
 
     #[test]

--- a/crates/thumos/src/ipc.rs
+++ b/crates/thumos/src/ipc.rs
@@ -12,6 +12,7 @@
 
 extern crate alloc;
 
+use crate::irq;
 use crate::process::{self, Pid};
 
 /// Maximum message payload size in bytes.
@@ -128,6 +129,17 @@ static mut INBOXES: [Inbox; MAX_INBOX_PROCS] = {
     [NEW_INBOX; MAX_INBOX_PROCS]
 };
 
+/// WHY (#322/#331 class): an `irq::IrqSpinlock`, not the bare
+/// single-core-cooperative reasoning the accessors below previously
+/// relied on alone -- `send`/`recv`/`has_messages` can be reached from
+/// IRQ context as well as ordinary kernel-mode code (e.g. a fault handler
+/// relaying a report to PID 0 via `process::notify_fault`), and nothing
+/// enforced that the two paths could never interleave. Masking IRQ
+/// delivery for the access is what actually prevents an interrupting
+/// handler from touching INBOXES while a caller it interrupted is
+/// mid-mutation.
+static INBOXES_LOCK: irq::IrqSpinlock = irq::IrqSpinlock::new();
+
 /// Validate a PID is within the inbox array bounds.
 ///
 /// Returns the PID as a `usize` index, or `Err(ESRCH)` if the PID
@@ -173,8 +185,10 @@ pub(crate) fn send(to: Pid, mut msg: Message) -> Result<(), IpcSendError> {
     let idx = validate_pid(to).map_err(|_| IpcSendError::InvalidTarget)?;
     msg.from = process::current_pid();
     // SAFETY: INBOXES is a static array indexed by PID. addr_of_mut! avoids
-    // creating an intermediate reference to the static mut. Single-core kernel
-    // with interrupts disabled at call sites ensures exclusive access.
+    // creating an intermediate reference to the static mut. INBOXES_LOCK
+    // masks IRQ delivery for the access, so an IRQ-context caller cannot
+    // interleave with a non-IRQ caller mid-mutation (#322/#331 class).
+    let _guard = INBOXES_LOCK.lock();
     let delivered = unsafe {
         let inboxes = &mut *core::ptr::addr_of_mut!(INBOXES);
         inboxes[idx].push(msg)
@@ -192,8 +206,9 @@ pub(crate) fn recv() -> Option<Message> {
     let pid = process::current_pid();
     let idx = validate_pid(pid).ok()?;
     // SAFETY: INBOXES is a static array indexed by PID. addr_of_mut! avoids
-    // creating an intermediate reference to the static mut. Single-core kernel
-    // with interrupts disabled at call sites ensures exclusive access.
+    // creating an intermediate reference to the static mut. INBOXES_LOCK
+    // masks IRQ delivery for the access (#322/#331 class).
+    let _guard = INBOXES_LOCK.lock();
     unsafe {
         let inboxes = &mut *core::ptr::addr_of_mut!(INBOXES);
         inboxes[idx].pop()
@@ -208,8 +223,9 @@ pub(crate) fn has_messages() -> bool {
         Err(_) => return false,
     };
     // SAFETY: INBOXES is a static array indexed by PID. addr_of! avoids
-    // creating an intermediate reference to the static mut. Read-only access
-    // here; single-core kernel ensures no concurrent mutation.
+    // creating an intermediate reference to the static mut. INBOXES_LOCK
+    // masks IRQ delivery for the read (#322/#331 class).
+    let _guard = INBOXES_LOCK.lock();
     unsafe {
         let inboxes = &*core::ptr::addr_of!(INBOXES);
         !inboxes[idx].is_empty()

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -799,13 +799,18 @@ pub unsafe fn run() -> ! {
         let mut usb = UsbController::new();
         // SAFETY: usb.init() programs the MUSB MMIO registers at their known
         // physical address (0x1121_0000). Called once after heap and GIC init.
-        unsafe {
-            usb.init();
+        match unsafe { usb.init() } {
+            Ok(()) => {
+                let _ = serial.write_str("       USB ACM gadget connected\r\n");
+                devices.activate("musb-hdrc");
+                state.usb_ok = true;
+                USB_SERIAL_AVAILABLE.store(true, Ordering::Release);
+            }
+            Err(e) => {
+                let _ = write!(serial, "  WARN USB init failed: {:?}\r\n", e);
+                let _ = serial.write_str("       Continuing without USB serial\r\n");
+            }
         }
-        let _ = serial.write_str("       USB ACM gadget connected\r\n");
-        devices.activate("musb-hdrc");
-        state.usb_ok = true;
-        USB_SERIAL_AVAILABLE.store(true, Ordering::Release);
     }
 
     // -----------------------------------------------------------------------

--- a/crates/thumos/src/pipe.rs
+++ b/crates/thumos/src/pipe.rs
@@ -53,10 +53,13 @@ pub(crate) struct PipeBuffer {
     pub write_closed: bool,
     /// True once the read end has been closed.
     pub read_closed: bool,
+    /// PID of the process that created this pipe -- used by
+    /// `alloc_pipe_slot` to enforce `MAX_PIPES_PER_PROCESS`.
+    owner_pid: u8,
 }
 
 impl PipeBuffer {
-    const fn new() -> Self {
+    const fn new(owner_pid: u8) -> Self {
         Self {
             data: [0u8; PIPE_BUF_SIZE],
             read_pos: 0,
@@ -64,6 +67,7 @@ impl PipeBuffer {
             count: 0,
             write_closed: false,
             read_closed: false,
+            owner_pid,
         }
     }
 
@@ -113,14 +117,30 @@ static mut PIPE_POOL: [Option<PipeBuffer>; MAX_PIPES] = {
     [NONE; MAX_PIPES]
 };
 
-/// Allocate a new pipe slot. Returns the pipe index, or None if all slots taken.
-fn alloc_pipe_slot() -> Option<usize> {
+/// Maximum pipes a single process may have open at once, so one process
+/// cannot exhaust the entire MAX_PIPES pool and starve every other
+/// process of pipe fds.
+const MAX_PIPES_PER_PROCESS: usize = 4;
+
+/// Allocate a new pipe slot for `owner_pid`. Returns the pipe index, or
+/// `None` if all slots are taken, or if `owner_pid` already holds
+/// `MAX_PIPES_PER_PROCESS` pipes.
+fn alloc_pipe_slot(owner_pid: u8) -> Option<usize> {
     // SAFETY: single-core cooperative kernel; no concurrent mutation.
     // addr_of_mut! avoids creating a reference to the static mut.
     let pool = unsafe { &mut *core::ptr::addr_of_mut!(PIPE_POOL) };
+
+    let owned_count = pool
+        .iter()
+        .filter(|slot| slot.as_ref().is_some_and(|buf| buf.owner_pid == owner_pid))
+        .count();
+    if owned_count >= MAX_PIPES_PER_PROCESS {
+        return None;
+    }
+
     for (i, slot) in pool.iter_mut().enumerate() {
         if slot.is_none() {
-            *slot = Some(PipeBuffer::new());
+            *slot = Some(PipeBuffer::new(owner_pid));
             return Some(i);
         }
     }
@@ -182,8 +202,14 @@ pub(crate) fn pipe_flags(pipe_idx: usize, end: u32) -> u32 {
 }
 
 /// Extract the pipe index from an fd flags word.
+///
+/// WHY 0x07 not 0x7F: the previous 7-bit mask (max 127) did not match
+/// MAX_PIPES (8 slots) -- a flags word with any of bits 12-15 set would
+/// decode to an out-of-range pipe index and panic on the array index in
+/// get_pipe_mut/on_pipe_fd_closed/maybe_free_pipe. This mask covers
+/// exactly the valid 0..MAX_PIPES range.
 pub(crate) fn pipe_idx_from_flags(flags: u32) -> usize {
-    ((flags >> FD_PIPE_IDX_SHIFT) & 0x7F) as usize
+    ((flags >> FD_PIPE_IDX_SHIFT) & 0x07) as usize
 }
 
 /// Return true if the fd flags word identifies a pipe fd.
@@ -213,8 +239,10 @@ pub(crate) fn sys_pipe(fds_ptr: u32) -> u32 {
         return EFAULT;
     }
 
-    // Allocate a pipe buffer slot.
-    let pipe_idx = match alloc_pipe_slot() {
+    // Allocate a pipe buffer slot, capped per-process (MAX_PIPES_PER_PROCESS)
+    // so one process cannot exhaust the entire pool.
+    let owner_pid = crate::process::current_pid();
+    let pipe_idx = match alloc_pipe_slot(owner_pid) {
         Some(i) => i,
         None => return EMFILE,
     };
@@ -249,13 +277,18 @@ pub(crate) fn sys_pipe(fds_ptr: u32) -> u32 {
     };
 
     // Write the two fd numbers to userspace.
-    // SAFETY: fds_ptr is validated non-null above. We write 8 bytes (two u32s).
-    // Wave 4 will add proper bounds validation; this matches the existing syscall
-    // pattern in fd.rs (TODO(#84): plan gaps).
+    // SAFETY: fds_ptr is validated non-null above. We write 8 bytes (two
+    // u32s). The pointer alignment is NOT guaranteed by the ABI (POSIX
+    // allows any alignment for char-typed buffers -- the same reasoning
+    // time::sys_clock_gettime documents for its own userspace writes), so
+    // write_unaligned is required: a plain core::ptr::write on a
+    // misaligned fds_ptr is undefined behavior and can fault on ARM.
+    // Wave 4 will add proper bounds validation; this matches the existing
+    // syscall pattern in fd.rs (TODO(#84): plan gaps).
     unsafe {
         let fds = fds_ptr as *mut u32;
-        core::ptr::write(fds, read_fd);
-        core::ptr::write(fds.add(1), write_fd);
+        core::ptr::write_unaligned(fds, read_fd);
+        core::ptr::write_unaligned(fds.add(1), write_fd);
     }
 
     0
@@ -400,6 +433,23 @@ mod tests {
     }
 
     #[test]
+    fn pipe_idx_from_flags_masks_out_of_range_bits() {
+        // Bits 12-15 (which the old 0x7F mask would have included) must
+        // not leak into the decoded pipe index -- it must stay within
+        // 0..MAX_PIPES.
+        let flags = pipe_flags(3, FD_END_READ) | (0xF << 12);
+        assert!(
+            pipe_idx_from_flags(flags) < MAX_PIPES,
+            "decoded pipe index must never exceed MAX_PIPES - 1"
+        );
+        assert_eq!(
+            pipe_idx_from_flags(flags),
+            3,
+            "high garbage bits must not corrupt the real pipe index"
+        );
+    }
+
+    #[test]
     fn pipe_creates_two_fds() {
         // Reset global fd table and pipe pool.
         reset_pool();
@@ -420,11 +470,37 @@ mod tests {
     }
 
     #[test]
+    fn pipe_writes_fds_to_unaligned_userspace_pointer() {
+        reset_pool();
+        unsafe {
+            let table = &mut *core::ptr::addr_of_mut!(crate::fd::FD_TABLE);
+            *table = crate::fd::FdTable::new();
+        }
+
+        // Deliberately misaligned: offset 1 byte into the buffer, so a
+        // plain core::ptr::write (which requires u32 alignment) would be
+        // undefined behavior. write_unaligned must handle this correctly.
+        let mut fds_buf = [0u8; 9];
+        let unaligned_ptr = fds_buf.as_mut_ptr().wrapping_add(1);
+        let result = sys_pipe(unaligned_ptr as u32);
+        assert_eq!(
+            result, 0,
+            "pipe() must succeed even with an unaligned fds pointer"
+        );
+
+        let read_fd = unsafe { core::ptr::read_unaligned(unaligned_ptr as *const u32) };
+        let write_fd = unsafe { core::ptr::read_unaligned(unaligned_ptr.add(4) as *const u32) };
+        assert!((read_fd as usize) < crate::fd::MAX_FDS);
+        assert!((write_fd as usize) < crate::fd::MAX_FDS);
+        assert_ne!(read_fd, write_fd);
+    }
+
+    #[test]
     fn pipe_write_read_round_trip() {
         reset_pool();
 
         // Allocate a pipe slot directly for test isolation.
-        let pipe_idx = alloc_pipe_slot().expect("alloc pipe");
+        let pipe_idx = alloc_pipe_slot(0).expect("alloc pipe");
 
         let message = b"hello from pipe";
         let written = unsafe {
@@ -450,7 +526,7 @@ mod tests {
     fn pipe_eof_on_write_close() {
         reset_pool();
 
-        let pipe_idx = alloc_pipe_slot().expect("alloc pipe");
+        let pipe_idx = alloc_pipe_slot(0).expect("alloc pipe");
 
         // Close the write end.
         on_pipe_fd_closed(pipe_idx, true /* write end */);
@@ -465,7 +541,7 @@ mod tests {
     fn pipe_read_eagain_when_empty_write_open() {
         reset_pool();
 
-        let pipe_idx = alloc_pipe_slot().expect("alloc pipe");
+        let pipe_idx = alloc_pipe_slot(0).expect("alloc pipe");
         // Write end is still open (default), buffer empty.
         let mut dst = [0u8; 8];
         let result = sys_pipe_read(pipe_idx, dst.as_mut_ptr() as u32, 8);
@@ -476,7 +552,7 @@ mod tests {
     fn pipe_write_full_returns_eagain() {
         reset_pool();
 
-        let pipe_idx = alloc_pipe_slot().expect("alloc pipe");
+        let pipe_idx = alloc_pipe_slot(0).expect("alloc pipe");
 
         // Fill the buffer.
         unsafe {
@@ -495,7 +571,7 @@ mod tests {
     #[test]
     fn pipe_read_rejects_kernel_range_buffer() {
         reset_pool();
-        let pipe_idx = alloc_pipe_slot().expect("alloc pipe");
+        let pipe_idx = alloc_pipe_slot(0).expect("alloc pipe");
         // Make data available so the read reaches buffer validation rather than
         // short-circuiting on EAGAIN/EOF.
         unsafe {
@@ -511,7 +587,7 @@ mod tests {
     #[test]
     fn pipe_write_rejects_kernel_range_buffer() {
         reset_pool();
-        let pipe_idx = alloc_pipe_slot().expect("alloc pipe");
+        let pipe_idx = alloc_pipe_slot(0).expect("alloc pipe");
         // Buffer empty and both ends open, so the write reaches validation.
         let kernel_ptr = crate::kconfig::KERNEL_LOAD as u32;
         let result = sys_pipe_write(pipe_idx, kernel_ptr, 4, 0);
@@ -529,5 +605,26 @@ mod tests {
         assert!(is_pipe_fd(flags_r));
         assert!(!is_write_end(flags_r));
         assert_eq!(pipe_idx_from_flags(flags_r), 7);
+    }
+
+    #[test]
+    fn alloc_pipe_slot_enforces_per_process_cap() {
+        reset_pool();
+        for _ in 0..MAX_PIPES_PER_PROCESS {
+            assert!(
+                alloc_pipe_slot(1).is_some(),
+                "must allow up to the per-process cap"
+            );
+        }
+        assert!(
+            alloc_pipe_slot(1).is_none(),
+            "must reject a pipe past the per-process cap even though pool slots remain"
+        );
+        // A different process must still be able to allocate -- the pool
+        // has MAX_PIPES - MAX_PIPES_PER_PROCESS slots free.
+        assert!(
+            alloc_pipe_slot(2).is_some(),
+            "a different process must not be starved by another process's cap"
+        );
     }
 }

--- a/crates/thumos/src/power.rs
+++ b/crates/thumos/src/power.rs
@@ -120,6 +120,9 @@ pub(crate) struct CpuGovernor {
     load_history: [u8; LOAD_HISTORY_LEN],
     /// Write pointer into load_history (circular).
     load_idx: usize,
+    /// Number of valid samples in `load_history` (saturates at
+    /// LOAD_HISTORY_LEN once the ring buffer has filled once after boot).
+    load_samples: usize,
 }
 
 impl CpuGovernor {
@@ -134,6 +137,7 @@ impl CpuGovernor {
             backlight_timeout_ticks: BACKLIGHT_TIMEOUT_TICKS,
             load_history: [0u8; LOAD_HISTORY_LEN],
             load_idx: 0,
+            load_samples: 0,
         }
     }
 
@@ -478,32 +482,40 @@ impl PowerManager {
     }
 
     /// Apply a power mode preset.
-    pub(crate) fn apply_mode(&mut self, mode: PowerMode) {
-        match mode {
-            PowerMode::Full => {
-                self.set_state(Radio::All, PowerState::On);
-            }
+    ///
+    /// Returns `true` if every radio in the preset reached its target
+    /// state. Returns `false` if any radio (typically one already
+    /// hardware/PMIC-killed) could not be moved -- in that case `mode()`
+    /// is left at its previous value instead of recording a mode that was
+    /// only partially applied.
+    pub(crate) fn apply_mode(&mut self, mode: PowerMode) -> bool {
+        let all_ok = match mode {
+            PowerMode::Full => self.set_state(Radio::All, PowerState::On),
             PowerMode::CellOnly => {
-                self.set_state(Radio::Cellular, PowerState::On);
-                self.set_state(Radio::Wifi, PowerState::Off);
-                self.set_state(Radio::Bluetooth, PowerState::Off);
-                self.set_state(Radio::Gps, PowerState::Off);
-                self.set_state(Radio::Fm, PowerState::Off);
-                self.set_state(Radio::Mesh, PowerState::Off);
+                let mut ok = self.set_state(Radio::Cellular, PowerState::On);
+                ok &= self.set_state(Radio::Wifi, PowerState::Off);
+                ok &= self.set_state(Radio::Bluetooth, PowerState::Off);
+                ok &= self.set_state(Radio::Gps, PowerState::Off);
+                ok &= self.set_state(Radio::Fm, PowerState::Off);
+                ok &= self.set_state(Radio::Mesh, PowerState::Off);
+                ok
             }
-            PowerMode::Silent => {
-                self.set_state(Radio::All, PowerState::Off);
-            }
+            PowerMode::Silent => self.set_state(Radio::All, PowerState::Off),
             PowerMode::LocalOnly => {
-                self.set_state(Radio::Cellular, PowerState::Off);
-                self.set_state(Radio::Wifi, PowerState::On);
-                self.set_state(Radio::Bluetooth, PowerState::On);
-                self.set_state(Radio::Gps, PowerState::Off);
-                self.set_state(Radio::Fm, PowerState::Off);
-                self.set_state(Radio::Mesh, PowerState::Off);
+                let mut ok = self.set_state(Radio::Cellular, PowerState::Off);
+                ok &= self.set_state(Radio::Wifi, PowerState::On);
+                ok &= self.set_state(Radio::Bluetooth, PowerState::On);
+                ok &= self.set_state(Radio::Gps, PowerState::Off);
+                ok &= self.set_state(Radio::Fm, PowerState::Off);
+                ok &= self.set_state(Radio::Mesh, PowerState::Off);
+                ok
             }
+        };
+
+        if all_ok {
+            self.mode = mode;
         }
-        self.mode = mode;
+        all_ok
     }
 
     /// Get the current power mode.
@@ -611,10 +623,30 @@ impl CpuGovernor {
     pub(crate) fn apply_dvfs(&mut self, load_percent: u8) -> CpuFreq {
         self.load_history[self.load_idx] = load_percent;
         self.load_idx = (self.load_idx + 1) % LOAD_HISTORY_LEN;
+        if self.load_samples < LOAD_HISTORY_LEN {
+            self.load_samples += 1;
+        }
 
-        let new_freq = if load_percent < 30 {
+        // WHY rolling average over the filled portion of load_history, not
+        // raw load_percent: a single-tick sample is the coarsest estimate
+        // available; averaging over load_samples ticks is what
+        // load_history exists for -- using the instantaneous sample
+        // directly (the previous behavior) left load_history write-only
+        // and defeated the smoothing exceptions.rs's DVFS call-site doc
+        // already claims happens here. Averaging only over load_samples
+        // (not the fixed LOAD_HISTORY_LEN) avoids diluting the first few
+        // post-boot samples with phantom zeros from the not-yet-filled
+        // window -- load_idx writes sequentially from 0 during warm-up, so
+        // [..load_samples] is exactly the written slots.
+        let sum: usize = self.load_history[..self.load_samples]
+            .iter()
+            .map(|&l| usize::from(l))
+            .sum();
+        let avg_load = sum / self.load_samples;
+
+        let new_freq = if avg_load < 30 {
             self.current_freq.step_down().unwrap_or(self.current_freq)
-        } else if load_percent > 70 {
+        } else if avg_load > 70 {
             self.current_freq.step_up().unwrap_or(self.current_freq)
         } else {
             self.current_freq
@@ -778,6 +810,27 @@ mod tests {
         assert_eq!(gov.last_input_tick, 500);
     }
 
+    #[test]
+    fn dvfs_averages_across_ticks_instead_of_reacting_to_a_single_spike() {
+        let mut gov = CpuGovernor::new();
+        gov.current_freq = CpuFreq::Mhz900;
+        // Three steady-state ticks (hold band), then one single high spike
+        // -- the rolling average over LOAD_HISTORY_LEN=4 keeps the spike
+        // from single-handedly stepping the frequency up: avg =
+        // (50+50+50+100)/4 = 62, still inside the 30-70 hold band. The
+        // previous (buggy) instantaneous-load logic would have reacted to
+        // the raw 100% sample alone and stepped up to Mhz1200.
+        gov.apply_dvfs(50);
+        gov.apply_dvfs(50);
+        gov.apply_dvfs(50);
+        let freq = gov.apply_dvfs(100);
+        assert_eq!(
+            freq,
+            CpuFreq::Mhz900,
+            "a single-tick spike must be smoothed by the rolling average, not react raw"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // Original PowerManager tests (radio kill switches)
     // -----------------------------------------------------------------------
@@ -895,6 +948,25 @@ mod tests {
         assert_eq!(pm.state(Radio::Bluetooth), PowerState::On);
         assert_eq!(pm.state(Radio::Cellular), PowerState::Off);
         assert_eq!(pm.state(Radio::Gps), PowerState::Off);
+    }
+
+    #[test]
+    fn apply_mode_does_not_commit_on_partial_failure() {
+        let mut pm = PowerManager::new();
+        pm.apply_mode(PowerMode::Full);
+        pm.hardware_kill(Radio::Cellular);
+
+        // CellOnly requires turning Cellular On, which the hardware kill blocks.
+        let ok = pm.apply_mode(PowerMode::CellOnly);
+        assert!(
+            !ok,
+            "apply_mode must report failure when a radio cannot reach its target state"
+        );
+        assert_eq!(
+            pm.mode(),
+            PowerMode::Full,
+            "mode() must not record CellOnly when it was only partially applied"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/thumos/src/time.rs
+++ b/crates/thumos/src/time.rs
@@ -80,6 +80,11 @@ const MIN_VALID_EPOCH: u64 = 1_577_836_800; // 2020-01-01T00:00:00Z
 /// ordering (#374).
 const MAX_VALID_EPOCH: u64 = 4_102_444_800; // 2100-01-01T00:00:00Z
 
+/// Error returned by [`set_realtime_offset`] when the candidate epoch is
+/// outside `[MIN_VALID_EPOCH, MAX_VALID_EPOCH]`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ImplausibleEpoch;
+
 /// Compute the new `REALTIME_OFFSET_SECS` value for a candidate wall-clock
 /// update, or `None` if `unix_now_secs` falls outside the plausible epoch
 /// window `[MIN_VALID_EPOCH, MAX_VALID_EPOCH]`.
@@ -105,6 +110,12 @@ fn compute_realtime_offset(unix_now_secs: u64, elapsed_secs: u64) -> Option<u64>
 /// lowest-trust source per the clock hierarchy) must not be able to set the
 /// clock to an implausible date (#374).
 ///
+/// # Errors
+///
+/// Returns `Err(ImplausibleEpoch)` (and leaves `REALTIME_OFFSET_SECS`
+/// unchanged) when `unix_now_secs` is rejected, so the caller can detect
+/// and log/audit a rejected update instead of it silently vanishing.
+///
 /// # Safety
 ///
 /// Writes to a static mut. Must be called from a single-threaded context
@@ -112,15 +123,16 @@ fn compute_realtime_offset(unix_now_secs: u64, elapsed_secs: u64) -> Option<u64>
 /// interrupts disabled). On ARMv7 a 64-bit store is not atomic; callers
 /// are responsible for ensuring no concurrent read occurs.
 #[cfg(not(test))]
-pub unsafe fn set_realtime_offset(unix_now_secs: u64) {
+pub unsafe fn set_realtime_offset(unix_now_secs: u64) -> Result<(), ImplausibleEpoch> {
     let elapsed_secs = monotonic_secs();
     let Some(new_offset) = compute_realtime_offset(unix_now_secs, elapsed_secs) else {
-        return;
+        return Err(ImplausibleEpoch);
     };
     // SAFETY: see function-level safety doc; caller ensures exclusion.
     unsafe {
         REALTIME_OFFSET_SECS = new_offset;
     }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -256,6 +268,12 @@ pub(crate) fn sys_nanosleep(ts_ptr: u32) -> u32 {
         let n = core::ptr::read_unaligned((ptr + 4) as *const u32);
         (s, n)
     };
+
+    // POSIX: tv_nsec must be in [0, 999_999_999]; anything else is EINVAL,
+    // not silently folded into extra whole seconds of sleep.
+    if req_nanos >= 1_000_000_000 {
+        return EINVAL;
+    }
 
     // Convert duration to ticks.
     // tick period = TICK_MS ms = 10 ms. scheduler tick rate = 100 Hz.
@@ -472,5 +490,23 @@ mod tests {
             };
 
         assert_eq!(ticks_needed, 1, "5 ms sleep must round up to 1 tick");
+    }
+
+    /// POSIX requires EINVAL when tv_nsec is out of [0, 999_999_999]; the
+    /// kernel must not silently fold an out-of-range value into extra
+    /// whole seconds of sleep. A `static mut` buffer is used (not a stack
+    /// array) so its address lands inside validate_user_buffer's accepted
+    /// user-DRAM range on the 32-bit test target.
+    #[cfg(target_pointer_width = "32")]
+    #[test]
+    fn nanosleep_rejects_tv_nsec_out_of_range() {
+        static mut TS: [u32; 2] = [0, 1_000_000_000]; // tv_sec=0, tv_nsec=1e9 (invalid)
+        // SAFETY: test-only static; single-threaded per test.
+        let ptr = core::ptr::addr_of!(TS) as u32;
+        let result = sys_nanosleep(ptr);
+        assert_eq!(
+            result, EINVAL,
+            "tv_nsec >= 1_000_000_000 must return EINVAL"
+        );
     }
 }

--- a/crates/thumos/src/timer.rs
+++ b/crates/thumos/src/timer.rs
@@ -66,9 +66,18 @@ pub(crate) fn disable() {
 }
 
 /// Set timer to fire after `ms` milliseconds.
+///
+/// WHY saturating: `(freq / 1000) * ms` overflows u32 once `ms` exceeds
+/// roughly 330 s at the MT6739's 13 MHz CNTFRQ. A saturated ticks value
+/// caps the countdown at the longest representable delay instead of
+/// silently wrapping to a near-zero tick count, which would fire the
+/// timer IRQ (the scheduler tick and watchdog pet source) almost
+/// immediately instead of after the requested delay. See
+/// `timer_stub::ms_to_ticks` for the host-tested mirror of this
+/// arithmetic.
 pub(crate) fn set_ms(ms: u32) {
     let freq = frequency();
-    let ticks = (freq / 1000) * ms;
+    let ticks = (freq / 1000).saturating_mul(ms);
     set_timer(ticks);
 }
 

--- a/crates/thumos/src/timer_stub.rs
+++ b/crates/thumos/src/timer_stub.rs
@@ -21,3 +21,36 @@ pub(crate) fn frequency() -> u32 {
 pub(crate) fn counter() -> u64 {
     13_000_000
 }
+
+/// Host-test mirror of the production `set_ms` tick-conversion arithmetic.
+/// `timer::set_ms` itself is ARM-only (it also programs CNTP_TVAL/CNTP_CTL
+/// via CP15, which does not exist on the host target); this mirrors just
+/// the overflow-safety fix so it has host-test coverage. Kept in lockstep
+/// with the arithmetic in `timer::set_ms`.
+pub(crate) fn ms_to_ticks(freq: u32, ms: u32) -> u32 {
+    (freq / 1000).saturating_mul(ms)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ms_to_ticks_saturates_instead_of_overflowing() {
+        // At 13 MHz, ms values past ~330_382 overflow a plain
+        // `(freq / 1000) * ms` multiplication in u32.
+        let freq = 13_000_000;
+        let ticks = ms_to_ticks(freq, u32::MAX);
+        assert_eq!(
+            ticks,
+            u32::MAX,
+            "an overflowing delay must saturate at u32::MAX ticks, not wrap"
+        );
+    }
+
+    #[test]
+    fn ms_to_ticks_matches_plain_multiply_below_overflow() {
+        let freq = 13_000_000;
+        assert_eq!(ms_to_ticks(freq, 100), (freq / 1000) * 100);
+    }
+}

--- a/crates/thumos/src/uart.rs
+++ b/crates/thumos/src/uart.rs
@@ -25,6 +25,13 @@ const LSR: usize = 0x14;
 /// LSR bit: transmit holding register empty.
 const LSR_THRE: u32 = 1 << 5;
 
+/// Bound on `putc`'s TX-ready poll, in iterations (not wall-clock time --
+/// see `putc`'s doc comment). Generous enough to never trip under normal
+/// operation (THRE typically clears within a handful of polls at 921600
+/// baud) while still finite, so a stalled/disconnected UART cannot hang
+/// the kernel.
+const UART_TX_TIMEOUT_SPINS: u32 = 1_000_000;
+
 /// UART driver for MT6739.
 pub(crate) struct Uart {
     base: usize,
@@ -37,7 +44,17 @@ impl Uart {
         Self { base: UART0_BASE }
     }
 
-    /// Write a single byte, waiting for the TX buffer to be ready.
+    /// Write a single byte, waiting (bounded) for the TX buffer to be ready.
+    ///
+    /// WHY bounded: an unbounded spin here can hang the kernel forever if
+    /// the UART TX is stalled (no host listening, cable unplugged) -- this
+    /// path is reached from exception/fault handlers, where an indefinite
+    /// spin means the kernel never even finishes printing a fault report,
+    /// let alone recovers. `UART_TX_TIMEOUT_SPINS` bounds the number of
+    /// polls, not wall-clock time: uart.rs has no timer dependency (fault
+    /// handlers can fire before the timer subsystem is configured), so
+    /// exceeding it means "give up polling", not "N ms elapsed". A dropped
+    /// byte is preferable to a wedged kernel.
     pub(crate) fn putc(&self, byte: u8) {
         // SAFETY: MMIO register access at known physical address.
         // The UART is already initialized by the bootloader.
@@ -45,12 +62,19 @@ impl Uart {
             let lsr = (self.base + LSR) as *const u32;
             let thr = (self.base + THR) as *mut u32;
 
-            // Wait until transmit holding register is empty
+            // Wait until transmit holding register is empty, bounded so a
+            // stalled UART cannot hang the kernel.
+            let mut spins: u32 = 0;
             #[expect(
                 clippy::while_immutable_condition,
                 reason = "volatile MMIO read sees hardware-driven changes the compiler cannot observe"
             )]
-            while core::ptr::read_volatile(lsr) & LSR_THRE == 0 {}
+            while core::ptr::read_volatile(lsr) & LSR_THRE == 0 {
+                spins += 1;
+                if spins >= UART_TX_TIMEOUT_SPINS {
+                    return;
+                }
+            }
 
             // Write byte
             core::ptr::write_volatile(thr, u32::from(byte));

--- a/crates/thumos/src/usb.rs
+++ b/crates/thumos/src/usb.rs
@@ -721,6 +721,16 @@ fn line_coding_length_is_valid(w_length: u16) -> bool {
 // USB controller
 // ---------------------------------------------------------------------------
 
+/// Error from [`UsbController::init`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub(crate) enum UsbInitError {
+    /// The POWER register readback did not reflect the SOFTCONN bit that
+    /// was just written -- the MUSB controller is not responding on the
+    /// bus (unmapped/dead MMIO region), so the device will never attach.
+    NotResponding,
+}
+
 /// MUSB OTG controller driver for the MT6739, operating in device mode.
 ///
 /// Manages enumeration via EP0, ACM class requests, and bulk serial I/O on EP1.
@@ -790,7 +800,7 @@ impl UsbController {
     /// Caller must ensure no concurrent access to MUSB registers.
     ///
     /// [`handle_interrupt`]: UsbController::handle_interrupt
-    pub unsafe fn init(&mut self) {
+    pub unsafe fn init(&mut self) -> Result<(), UsbInitError> {
         // SAFETY: Caller asserts exclusive MUSB register access.
         unsafe {
             // Step 1: Disable all interrupts before touching hardware.
@@ -808,6 +818,15 @@ impl UsbController {
             let power = POWER_SOFTCONN | POWER_HSENAB | POWER_SUSPENDEM;
             self.write8(REG_POWER, power);
 
+            // Verify the write landed: a completely unresponsive/unmapped
+            // MUSB bus reads back stale/zero bits regardless of what was
+            // written. Previously this went undetected -- init() returned
+            // () unconditionally, so kinit.rs marked USB serial available
+            // even when the controller never actually attached.
+            if self.read8(REG_POWER) & POWER_SOFTCONN == 0 {
+                return Err(UsbInitError::NotResponding);
+            }
+
             // Step 4: Configure EP1 bulk IN/OUT.
             self.configure_ep1();
 
@@ -822,6 +841,7 @@ impl UsbController {
                 INTRUSB_RESET | INTRUSB_SUSPEND | INTRUSB_RESUME,
             );
         }
+        Ok(())
     }
 
     /// Read and dispatch a USB interrupt.


### PR DESCRIPTION
Second wave-1 batch (#384, findings 21-40). **2 stale** (kinit LFS remount #343, contacts caller-ID batch-1). **1 deferred** — signal.rs `sys_sigreturn` clears the *wrong* pending signal (a swap, not a bulk-clear); the correct fix needs the not-yet-wired signal-delivery trampoline, so flagged for that work rather than patched fragilely.

## Concurrency / safety
- **TICK_COUNT torn read** — a bare u64 read is two 32-bit loads on ARMv7, tearing if the timer IRQ carries mid-read. Now hi/lo halves + seqlock-lite hi-lo-hi retry (host-tested via an exceptions_stub mirror).
- **IPC INBOXES race** — relied on an unenforced IRQ-disabled precondition (notify_fault reaches it from IRQ context). Now `irq::IrqSpinlock` (slab/mmu/page #322/#331 pattern).
- **pipe alignment UB** — sys_pipe wrote fds to userspace via `core::ptr::write` → UB on a misaligned pointer. Now `write_unaligned`.
- **bfu_timer indefinite pause** — a missed `resume()` permanently suppressed the idle-reboot. Capped at 5 min + force-resume.
- **uart hang** — unbounded TX spin hung the kernel on a stalled UART (fault handlers print here). Bounded spin count.

## Bounds / correctness
pipe mask 0x7F→0x07 + per-process cap; power apply_mode commit-on-success + apply_dvfs rolling average; time set_realtime Result + nanosleep EINVAL; timer set_ms saturate; usb init Result; heorte insert-in-place; harmostes/contacts/ekphrasis per-call alloc removed.

## Verification
- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — **2045 passed** (30 new; one apply-surfaced test fixed: static-vs-stack buffer for validate_user_buffer's DRAM range)
- `cargo build --release --target armv7a-none-eabi` — clean (TICK_COUNT/ipc/uart/usb/timer paths) · `kanon lint` — clean

Partially addresses #384 (findings 21-40: 16 fixed + 2 stale; 1 deferred). ~24 remain.

_Concurrency fixes (TICK_COUNT, IPC lock, pipe alignment) reviewed at T0/Opus._