### PR TITLE
Wave-1 low-rollup batch 3: security + coverage (#384 tail)

### DIFF
--- a/crates/thumos/src/battery.rs
+++ b/crates/thumos/src/battery.rs
@@ -376,6 +376,16 @@ mod tests {
     }
 
     #[test]
+    fn monitor_initial_last_poll_tick_is_zero() {
+        let monitor = BatteryMonitor::new();
+        assert_eq!(
+            monitor.last_poll_tick(),
+            0,
+            "boot-gap state must report no prior poll"
+        );
+    }
+
+    #[test]
     fn monitor_poll_updates_info() {
         let mut monitor = BatteryMonitor::new();
         let hw = MockHw {

--- a/crates/thumos/src/ccci.rs
+++ b/crates/thumos/src/ccci.rs
@@ -2013,11 +2013,27 @@ impl CcciDriver {
 
     /// Run the full boot sequence to completion.
     ///
+    /// `timeout_ms` bounds the CUMULATIVE wall-clock time across all boot
+    /// steps, checked before each step starts. Each individual step's
+    /// internal hardware poll is already iteration-bounded by
+    /// `BOOT_POLL_MAX`, but that bounds neither the wall-clock duration of
+    /// a single poll nor the sum across steps -- a caller-supplied overall
+    /// deadline (finding 47: `MODEM_BOOT_TIMEOUT_MS` was previously only
+    /// compared against elapsed time AFTER this function returned, which
+    /// enforced nothing) is what actually caps total modem boot time.
+    ///
     /// # Safety
     ///
     /// Same as `boot_modem_step`.
-    pub(crate) unsafe fn boot_modem(&mut self, timestamp: u64) -> Result<(), CcciError> {
+    pub(crate) unsafe fn boot_modem(
+        &mut self,
+        timestamp: u64,
+        timeout_ms: u64,
+    ) -> Result<(), CcciError> {
         while self.boot_state != BootStep::Complete {
+            if crate::timer::elapsed_ms().saturating_sub(timestamp) > timeout_ms {
+                return Err(CcciError::BootFailed(self.boot_state));
+            }
             // SAFETY: same preconditions as boot_modem_step: all CCCI hardware
             // registers must be mapped and the caller is in early boot context.
             unsafe {
@@ -2182,6 +2198,20 @@ mod tests {
             parse_dma_error(0x0000_0007),
             Err(CcciError::DmaError(0x0000_0007))
         );
+    }
+
+    #[test]
+    fn boot_modem_aborts_when_cumulative_deadline_already_exceeded() {
+        // WHY (finding 47): timer_stub::elapsed_ms() returns a fixed
+        // constant under host test, so a start of 0 with timeout_ms = 0 is
+        // already exceeded on the very first loop iteration -- this
+        // exercises the deadline check without touching any MMIO (no real
+        // boot step ever runs).
+        let mut ccci = CcciDriver::new();
+        // SAFETY: test-only; the deadline check short-circuits before any
+        // hardware register access, so no CCCI MMIO needs to be mapped.
+        let result = unsafe { ccci.boot_modem(0, 0) };
+        assert_eq!(result, Err(CcciError::BootFailed(BootStep::EnableClocks)));
     }
 
     #[test]

--- a/crates/thumos/src/console.rs
+++ b/crates/thumos/src/console.rs
@@ -188,3 +188,40 @@ impl Default for Console {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn receive_byte_buffers_printable_chars() {
+        let mut console = Console::new();
+        console.receive_byte(b'h');
+        console.receive_byte(b'i');
+        assert_eq!(console.line_len, 2);
+        assert_eq!(&console.line_buf[..2], b"hi");
+    }
+
+    #[test]
+    fn receive_byte_overflow_drops_excess_bytes_without_panic() {
+        let mut console = Console::new();
+        for _ in 0..MAX_CMD_LEN + 16 {
+            console.receive_byte(b'x');
+        }
+        assert_eq!(
+            console.line_len,
+            MAX_CMD_LEN - 1,
+            "line buffer must cap at MAX_CMD_LEN - 1, dropping excess bytes rather than overflowing"
+        );
+    }
+
+    #[test]
+    fn receive_byte_backspace_after_overflow_shrinks_buffer() {
+        let mut console = Console::new();
+        for _ in 0..MAX_CMD_LEN + 16 {
+            console.receive_byte(b'x');
+        }
+        console.receive_byte(0x7F);
+        assert_eq!(console.line_len, MAX_CMD_LEN - 2);
+    }
+}

--- a/crates/thumos/src/device.rs
+++ b/crates/thumos/src/device.rs
@@ -289,4 +289,41 @@ mod tests {
             Some(DeviceStatus::PoweredOff)
         );
     }
+
+    #[test]
+    fn list_returns_all_registered_devices() {
+        let mut registry = DeviceRegistry::new();
+        assert!(registry.list().is_empty());
+        registry.register("uart0", 0x1100_2000, 0);
+        registry.register("uart1", 0x1100_3000, 0);
+        assert_eq!(registry.list().len(), 2);
+    }
+
+    #[test]
+    fn count_by_status_reflects_registry_state() {
+        let mut registry = DeviceRegistry::new();
+        registry.register("uart0", 0x1100_2000, 0);
+        registry.register("uart1", 0x1100_3000, 0);
+        registry.activate("uart0");
+
+        assert_eq!(registry.count_by_status(DeviceStatus::Registered), 1);
+        assert_eq!(registry.count_by_status(DeviceStatus::Active), 1);
+        assert_eq!(registry.count_by_status(DeviceStatus::PoweredOff), 0);
+    }
+
+    #[test]
+    fn register_mt6739_devices_populates_expected_device_set() {
+        let mut registry = DeviceRegistry::new();
+        registry.register_mt6739_devices();
+
+        assert_eq!(registry.list().len(), 18);
+        assert!(registry.find("uart0").is_some());
+        assert!(registry.find("ccci-cldma").is_some());
+        assert!(registry.find("gic-cpu").is_some());
+        assert_eq!(
+            registry.count_by_status(DeviceStatus::Registered),
+            18,
+            "all devices start in the Registered state"
+        );
+    }
 }

--- a/crates/thumos/src/ekphrasis.rs
+++ b/crates/thumos/src/ekphrasis.rs
@@ -114,6 +114,10 @@ pub enum EkphrasisError {
     EndpointUnreachable,
     /// WebSocket handshake failed or was rejected by the server.
     HandshakeFailed,
+    /// The `host` or `ws_key` passed to [`build_ws_upgrade`] contains a
+    /// control character (CR, LF, NUL, or other C0/DEL byte) that could
+    /// corrupt the HTTP request line or inject additional headers.
+    InvalidUpgradeParam,
     /// A WebSocket frame was malformed or violated protocol constraints.
     InvalidFrame,
     /// The frame payload exceeds [`MAX_WS_FRAME_PAYLOAD`].
@@ -143,6 +147,7 @@ impl fmt::Display for EkphrasisError {
         match self {
             Self::EndpointUnreachable => write!(f, "aletheia STT endpoint unreachable"),
             Self::HandshakeFailed => write!(f, "WebSocket handshake failed"),
+            Self::InvalidUpgradeParam => write!(f, "invalid WebSocket upgrade parameter"),
             Self::InvalidFrame => write!(f, "invalid WebSocket frame"),
             Self::PayloadTooLarge => write!(f, "WebSocket payload too large"),
             Self::TextTooLong => write!(f, "transcription text exceeds limit"),
@@ -391,6 +396,13 @@ pub(crate) fn build_ws_frame(opcode: WsOpcode, payload: &[u8], mask_key: [u8; 4]
 // WebSocket upgrade request
 // ---------------------------------------------------------------------------
 
+/// Return true if `s` contains a byte that could corrupt an HTTP header
+/// or request line if written verbatim: a C0 control byte (including CR,
+/// LF, NUL) or DEL.
+fn contains_control_byte(s: &str) -> bool {
+    s.bytes().any(|b| b < 0x20 || b == 0x7F)
+}
+
 /// Build an HTTP/1.1 WebSocket upgrade request for the aletheia STT endpoint.
 ///
 /// The `ws_key` should be a base64-encoded 16-byte random value (per
@@ -399,8 +411,22 @@ pub(crate) fn build_ws_frame(opcode: WsOpcode, payload: &[u8], mask_key: [u8; 4]
 ///
 /// Returns an [`HttpRequest`] that can be serialized with `build_raw()`
 /// and sent over a TCP socket.
+///
+/// # Errors
+///
+/// Returns [`EkphrasisError::InvalidUpgradeParam`] if `host` or `ws_key`
+/// contains a control character (CR, LF, NUL, etc.) that could corrupt
+/// the HTTP request line or inject additional headers.
 #[must_use]
-pub(crate) fn build_ws_upgrade(host: &str, path: &str, ws_key: &str) -> HttpRequest {
+pub(crate) fn build_ws_upgrade(
+    host: &str,
+    path: &str,
+    ws_key: &str,
+) -> Result<HttpRequest, EkphrasisError> {
+    if contains_control_byte(host) || contains_control_byte(ws_key) {
+        return Err(EkphrasisError::InvalidUpgradeParam);
+    }
+
     let mut req = HttpRequest::new(HttpMethod::Get, String::from(host), String::from(path));
 
     req.add_header(String::from("Upgrade"), String::from("websocket"));
@@ -416,7 +442,7 @@ pub(crate) fn build_ws_upgrade(host: &str, path: &str, ws_key: &str) -> HttpRequ
         String::from("stt-audio"),
     );
 
-    req
+    Ok(req)
 }
 
 /// Verify a server's `Sec-WebSocket-Accept` header value against the
@@ -737,9 +763,19 @@ impl Ekphrasis {
         match frame.opcode {
             WsOpcode::Text => {
                 // Parse the text payload as a transcription response.
-                let text = core::str::from_utf8(&frame.payload)
-                    .map_err(|_| EkphrasisError::InvalidFrame)?;
-                self.process_transcription(text)
+                let result = core::str::from_utf8(&frame.payload)
+                    .map_err(|_| EkphrasisError::InvalidFrame)
+                    .and_then(|text| self.process_transcription(text));
+                if let Err(ref err) = result {
+                    // WHY: a malformed/corrupt server response (bad UTF-8,
+                    // invalid JSON, missing "text" field, oversized text)
+                    // leaves the stream untrustworthy -- move to Error so
+                    // the caller must call reset() explicitly instead of
+                    // silently retrying on the next frame. This is the
+                    // transition the Idle|Error guard above assumes exists.
+                    self.state = EkphrasisState::Error(err.clone());
+                }
+                result
             }
             WsOpcode::Close => {
                 self.state = EkphrasisState::Idle;
@@ -900,8 +936,12 @@ impl Ekphrasis {
     /// Build a WebSocket upgrade request for the STT endpoint.
     ///
     /// The `ws_key` should be a base64-encoded 16-byte random value.
-    #[must_use]
-    pub(crate) fn ws_upgrade_request(&self, ws_key: &str) -> HttpRequest {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EkphrasisError::InvalidUpgradeParam`] if the configured
+    /// host or `ws_key` contains a control character.
+    pub(crate) fn ws_upgrade_request(&self, ws_key: &str) -> Result<HttpRequest, EkphrasisError> {
         build_ws_upgrade(&self.aletheia_host, STT_WS_PATH, ws_key)
     }
 
@@ -1268,6 +1308,21 @@ mod tests {
     }
 
     #[test]
+    fn ws_frame_roundtrip_extended_64bit_length() {
+        // Exactly MAX_WS_FRAME_PAYLOAD (65536) bytes — payload_len > 0xFFFF
+        // forces the 64-bit extended length header (len_indicator == 127).
+        let payload = vec![0x99; MAX_WS_FRAME_PAYLOAD];
+        let mask_key = [0xAA, 0xBB, 0xCC, 0xDD];
+
+        let frame_bytes = build_ws_frame(WsOpcode::Binary, &payload, mask_key);
+        let (parsed, consumed) = parse_ws_frame(&frame_bytes).ok().flatten_pair();
+
+        assert_eq!(consumed, frame_bytes.len());
+        assert_eq!(parsed.payload.len(), MAX_WS_FRAME_PAYLOAD);
+        assert_eq!(parsed.payload, payload);
+    }
+
+    #[test]
     fn ws_frame_parse_unmasked_server_frame() {
         // Server-to-client frames are unmasked.
         // Build manually: FIN + Text, len=5, "hello".
@@ -1577,6 +1632,25 @@ Let me know if you need anything else."#;
     }
 
     #[test]
+    fn stop_recording_returns_partial_text_when_no_final() {
+        let mut ek = Ekphrasis::new("stt.example.lan", 8080);
+        ek.set_endpoint_reachable(true);
+        let _ = ek.start_recording();
+        let _ = ek.begin_streaming();
+
+        let partial_frame = WsFrame::new(
+            WsOpcode::Text,
+            b"{\"text\": \"partial only\", \"final\": false}".to_vec(),
+        );
+        let _ = ek.handle_server_frame(&partial_frame);
+        assert!(ek.final_text().is_empty());
+        assert_eq!(ek.partial_text(), "partial only");
+
+        let result = ek.stop_recording();
+        assert_eq!(result, Ok(String::from("partial only")));
+    }
+
+    #[test]
     fn state_stop_from_idle_fails() {
         let mut ek = Ekphrasis::new("stt.example.lan", 8080);
         let result = ek.stop_recording();
@@ -1738,6 +1812,22 @@ Let me know if you need anything else."#;
     }
 
     #[test]
+    fn handle_server_frame_transitions_to_error_on_malformed_response() {
+        let mut ek = Ekphrasis::new("stt.example.lan", 8080);
+        ek.set_endpoint_reachable(true);
+        let _ = ek.start_recording();
+        let _ = ek.begin_streaming();
+
+        let frame = WsFrame::new(WsOpcode::Text, b"{\"final\": false}".to_vec());
+        let result = ek.handle_server_frame(&frame);
+        assert!(result.is_err());
+        assert!(
+            matches!(ek.state(), EkphrasisState::Error(_)),
+            "a malformed transcription response must move the state machine to Error, requiring an explicit reset()"
+        );
+    }
+
+    #[test]
     fn state_reset_clears_everything() {
         let mut ek = Ekphrasis::new("stt.example.lan", 8080);
         ek.set_endpoint_reachable(true);
@@ -1780,7 +1870,9 @@ Let me know if you need anything else."#;
     #[test]
     fn ekphrasis_ws_upgrade_request() {
         let ek = Ekphrasis::new("stt.example.lan", 8080);
-        let req = ek.ws_upgrade_request("dGVzdC1rZXk=");
+        let req = ek
+            .ws_upgrade_request("dGVzdC1rZXk=")
+            .expect("a control-char-free host/key must build a request");
 
         assert_eq!(req.host, "stt.example.lan");
         assert_eq!(req.path, "/stt/stream");
@@ -1794,6 +1886,20 @@ Let me know if you need anything else."#;
                 .iter()
                 .any(|(k, v)| k == "Sec-WebSocket-Key" && v == "dGVzdC1rZXk=")
         );
+    }
+
+    #[test]
+    fn ws_upgrade_rejects_crlf_in_host() {
+        let ek = Ekphrasis::new("stt.example.lan\r\nX-Injected: evil", 8080);
+        let result = ek.ws_upgrade_request("dGVzdC1rZXk=");
+        assert!(matches!(result, Err(EkphrasisError::InvalidUpgradeParam)));
+    }
+
+    #[test]
+    fn ws_upgrade_rejects_nul_in_key() {
+        let ek = Ekphrasis::new("stt.example.lan", 8080);
+        let result = ek.ws_upgrade_request("dGVz\0dC1rZXk=");
+        assert!(matches!(result, Err(EkphrasisError::InvalidUpgradeParam)));
     }
 
     #[test]
@@ -1838,6 +1944,7 @@ Let me know if you need anything else."#;
         let errors = [
             EkphrasisError::EndpointUnreachable,
             EkphrasisError::HandshakeFailed,
+            EkphrasisError::InvalidUpgradeParam,
             EkphrasisError::InvalidFrame,
             EkphrasisError::PayloadTooLarge,
             EkphrasisError::TextTooLong,

--- a/crates/thumos/src/elf.rs
+++ b/crates/thumos/src/elf.rs
@@ -244,6 +244,22 @@ fn validate(data: &[u8]) -> Result<(usize, ValidatedElf), ElfError> {
         }
     }
 
+    // WHY (finding 49): e_entry is a fully attacker-controlled u32 header
+    // field, entirely independent of the PT_LOAD segments validated above.
+    // Both callers (kinit.rs's boot-time spawn of /init and /shell, and
+    // syscall.rs's sys_execve) transmute this address straight to a
+    // callable function pointer and jump to it -- an entry point outside
+    // every loaded segment is an arbitrary jump/code-execution primitive,
+    // not merely a crash. Require entry to fall within a segment that was
+    // actually loaded before it is ever handed back to a caller.
+    let entry_in_loaded_segment = (0..segments.count).any(|i| {
+        let (vaddr, memsz, _, _) = segments.segments[i];
+        entry >= vaddr && entry < vaddr.saturating_add(memsz)
+    });
+    if !entry_in_loaded_segment {
+        return Err(ElfError::InvalidSegment);
+    }
+
     Ok((entry, segments))
 }
 
@@ -536,13 +552,55 @@ mod tests {
 
     #[test]
     fn parse_accepts_valid_elf() {
-        // A valid ELF header with phnum=0 should parse successfully
-        // without triggering any page allocation (no PT_LOAD segments).
+        // A valid ELF with one PT_LOAD segment covering e_entry must parse
+        // successfully. WHY a real segment (finding 49): entry is no
+        // longer accepted merely because the header is well-formed -- it
+        // must fall within a segment that was actually loaded, or the
+        // address handed to kinit.rs's transmute+call would be
+        // unmapped/arbitrary. A phnum=0 image (no code loaded at all) can
+        // no longer have any valid entry point.
+        let mut buf = [0u8; ELF32_EHDR_SIZE + ELF32_PHDR_SIZE];
         let h = make_valid_ehdr();
+        buf[..ELF32_EHDR_SIZE].copy_from_slice(&h);
+        buf[44] = 1; // e_phnum = 1
+        // e_entry (offset 24): moved to the start of the PT_LOAD segment below.
+        buf[24..28].copy_from_slice(&0x4010_0000u32.to_le_bytes());
+
+        // Elf32Phdr at offset 52: p_type = PT_LOAD (1).
+        buf[52..56].copy_from_slice(&1u32.to_le_bytes());
+        // p_vaddr (offset 60): inside the allowed load region, matching e_entry.
+        buf[60..64].copy_from_slice(&0x4010_0000u32.to_le_bytes());
+        // p_memsz (offset 72): small, just needs to contain e_entry.
+        buf[72..76].copy_from_slice(&0x1000u32.to_le_bytes());
+
         let (entry, validated) =
-            validate(&h).expect("valid ELF header with no segments must parse");
-        assert_eq!(entry, 0x8000, "entry point must match e_entry");
-        assert_eq!(validated.count, 0, "no PT_LOAD segments expected");
+            validate(&buf).expect("valid ELF with entry inside a loaded segment must parse");
+        assert_eq!(entry, 0x4010_0000, "entry point must match e_entry");
+        assert_eq!(validated.count, 1, "one PT_LOAD segment expected");
+    }
+
+    /// finding 49: e_entry outside every loaded PT_LOAD segment must be
+    /// rejected -- kinit.rs and syscall.rs's sys_execve both transmute this
+    /// address straight to a callable function pointer, so an unvalidated
+    /// entry point is an arbitrary jump/code-execution primitive, not just
+    /// a crash.
+    #[test]
+    fn parse_rejects_entry_outside_loaded_segment() {
+        let mut buf = [0u8; ELF32_EHDR_SIZE + ELF32_PHDR_SIZE];
+        let h = make_valid_ehdr();
+        buf[..ELF32_EHDR_SIZE].copy_from_slice(&h);
+        buf[44] = 1; // e_phnum = 1
+        // e_entry (offset 24): left at make_valid_ehdr()'s 0x8000 default,
+        // which is NOT inside the segment below.
+
+        // Elf32Phdr at offset 52: p_type = PT_LOAD (1).
+        buf[52..56].copy_from_slice(&1u32.to_le_bytes());
+        // p_vaddr (offset 60): inside the allowed load region, but does not
+        // contain e_entry (0x8000).
+        buf[60..64].copy_from_slice(&0x4010_0000u32.to_le_bytes());
+        buf[72..76].copy_from_slice(&0x1000u32.to_le_bytes());
+
+        assert_eq!(validate(&buf).unwrap_err(), ElfError::InvalidSegment);
     }
 
     // ---- #328: load() must not leak physical pages ----
@@ -571,6 +629,9 @@ mod tests {
         let h = make_valid_ehdr();
         data[..ELF32_EHDR_SIZE].copy_from_slice(&h);
         data[44] = 1; // e_phnum = 1
+        // e_entry (offset 24): must fall within the PT_LOAD segment below
+        // (finding 49) -- reuse the segment's own vaddr as the entry point.
+        data[24..28].copy_from_slice(&(vaddr as u32).to_le_bytes());
 
         // Elf32Phdr at offset 52: p_type = PT_LOAD (1).
         data[52..56].copy_from_slice(&1u32.to_le_bytes());
@@ -639,6 +700,9 @@ mod tests {
         let h = make_valid_ehdr();
         data[..ELF32_EHDR_SIZE].copy_from_slice(&h);
         data[44] = 1; // e_phnum = 1
+        // e_entry (offset 24): must fall within the PT_LOAD segment below
+        // (finding 49) -- reuse the segment's own vaddr as the entry point.
+        data[24..28].copy_from_slice(&(vaddr as u32).to_le_bytes());
         data[52..56].copy_from_slice(&1u32.to_le_bytes()); // p_type = PT_LOAD
         data[60..64].copy_from_slice(&(vaddr as u32).to_le_bytes());
         data[72..76].copy_from_slice(&16u32.to_le_bytes()); // p_memsz = 16

--- a/crates/thumos/src/exceptions_stub.rs
+++ b/crates/thumos/src/exceptions_stub.rs
@@ -75,6 +75,17 @@ pub(crate) fn combine_tick_halves(hi1: u32, lo: u32, hi2: u32) -> Option<u64> {
     }
 }
 
+/// Host-test mirror of the production tick-increment carry logic in
+/// `exceptions::irq_handler_rust`'s timer-tick branch. Given the current
+/// hi/lo halves, returns the incremented pair, carrying into `hi` when
+/// `lo` wraps. Kept in lockstep with the write in `irq_handler_rust` so the
+/// carry-on-overflow path (previously untested) has host-test coverage.
+pub(crate) fn advance_tick_halves(hi: u32, lo: u32) -> (u32, u32) {
+    let (new_lo, carried) = lo.overflowing_add(1);
+    let new_hi = if carried { hi.wrapping_add(1) } else { hi };
+    (new_hi, new_lo)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -91,5 +102,15 @@ mod tests {
         // occurred mid-read) -- the reader must retry, not return a torn
         // combination of the pre- and post-carry halves.
         assert_eq!(combine_tick_halves(0, 0xFFFF_FFFF, 1), None);
+    }
+
+    #[test]
+    fn advance_tick_halves_increments_lo_without_carry() {
+        assert_eq!(advance_tick_halves(0, 41), (0, 42));
+    }
+
+    #[test]
+    fn advance_tick_halves_carries_into_hi_on_lo_wraparound() {
+        assert_eq!(advance_tick_halves(0, u32::MAX), (1, 0));
     }
 }

--- a/crates/thumos/src/harmostes.rs
+++ b/crates/thumos/src/harmostes.rs
@@ -574,6 +574,9 @@ impl MatrixClient {
         push_u64(&mut path, SYNC_LONG_POLL_MS);
 
         if let Some(ref token) = self.sync_token {
+            if token.bytes().any(|b| b == b' ' || b.is_ascii_control()) {
+                return Err(MatrixError::MalformedSync);
+            }
             path.push_str("&since=");
             path.push_str(token);
         }
@@ -969,14 +972,21 @@ impl MatrixClient {
     /// Build a join-room HTTP request.
     ///
     /// Uses POST `/_matrix/client/v3/join/{roomId}`.
-    pub(crate) fn build_join_request(&self, room_id: &str) -> HttpRequest {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MatrixError::InvalidId`] if `room_id` is not a well-formed
+    /// Matrix room ID (#373: prevents CRLF/path injection via the join path).
+    pub(crate) fn build_join_request(&self, room_id: &str) -> Result<HttpRequest, MatrixError> {
+        let validated_room = MatrixRoomId::new(room_id)?;
+
         let mut path = String::from(API_PREFIX);
         path.push_str("/join/");
-        path.push_str(room_id);
+        path.push_str(&validated_room);
 
         let mut req = http_client::post_json(&self.homeserver, &path, b"{}");
         http_client::with_auth(&mut req, &self.access_token);
-        req
+        Ok(req)
     }
 
     /// Process a join-room HTTP response.
@@ -1012,7 +1022,12 @@ impl MatrixClient {
     /// Join a room (build request + queue join). The caller handles transport.
     ///
     /// Returns the built HTTP request.
-    pub(crate) fn join_room(&self, room_id: &str) -> HttpRequest {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MatrixError::InvalidId`] if `room_id` is not a well-formed
+    /// Matrix room ID.
+    pub(crate) fn join_room(&self, room_id: &str) -> Result<HttpRequest, MatrixError> {
         self.build_join_request(room_id)
     }
 
@@ -1920,7 +1935,12 @@ mod tests {
         let client = matrix_client_with_test_credentials();
         let room_id = "!target:matrix.example.com";
 
-        let req = client.build_join_request(room_id);
+        let result = client.build_join_request(room_id);
+        assert!(result.is_ok());
+        let req = result.ok().unwrap_or_else(|| {
+            // Fallback that never executes -- satisfies no-unwrap lint.
+            HttpRequest::new(http_client::HttpMethod::Get, String::new(), String::new())
+        });
 
         // Verify path.
         assert!(req.path.contains("/join/"));
@@ -1932,6 +1952,17 @@ mod tests {
             .iter()
             .any(|(k, v)| k == "Authorization" && v.contains("Bearer"));
         assert!(has_auth);
+    }
+
+    #[test]
+    fn join_room_rejects_crlf_injected_room_id() {
+        // #373-class: build_join_request must reject a room_id carrying a
+        // CRLF/control byte before it reaches the HTTP request path.
+        let client = matrix_client_with_test_credentials();
+        let malicious = "!room:example.com\r\nX-Injected: evil";
+
+        let result = client.build_join_request(malicious);
+        assert!(result.is_err());
     }
 
     #[test]
@@ -1952,6 +1983,25 @@ mod tests {
         let result = client.process_join_response(room_id, &response);
         assert!(result.is_ok());
         assert_eq!(client.rooms().len(), 1);
+    }
+
+    #[test]
+    fn process_join_response_rejects_beyond_max_rooms() {
+        let mut client = matrix_client_with_test_credentials();
+        let response = mock_response(200, "{}");
+
+        for i in 0..MAX_ROOMS {
+            let mut room_id = String::from("!room");
+            push_u32(&mut room_id, i as u32);
+            room_id.push_str(":example.com");
+            let result = client.process_join_response(&room_id, &response);
+            assert!(result.is_ok());
+        }
+        assert_eq!(client.rooms().len(), MAX_ROOMS);
+
+        let result = client.process_join_response("!overflow:example.com", &response);
+        assert_eq!(result.err(), Some(MatrixError::RoomCapacityReached));
+        assert_eq!(client.rooms().len(), MAX_ROOMS);
     }
 
     #[test]
@@ -2024,6 +2074,21 @@ mod tests {
     }
 
     #[test]
+    fn build_sync_request_rejects_crlf_in_sync_token() {
+        // A malicious homeserver's next_batch must not be able to inject a
+        // CRLF/space/control byte into the next /sync request line.
+        let mut client = matrix_client_with_test_credentials();
+        let body = build_sync_response("evil\r\nX-Injected: 1", "!room:example.com", &[]);
+        let response = mock_response(200, &body);
+
+        let result = client.sync(&response, 0);
+        assert!(result.is_ok());
+
+        let result = client.build_sync_request();
+        assert_eq!(result.err(), Some(MatrixError::MalformedSync));
+    }
+
+    #[test]
     fn process_send_response_extracts_event_id() {
         let client = matrix_client_with_test_credentials();
 
@@ -2031,6 +2096,25 @@ mod tests {
         let result = client.process_send_response(&response);
         assert!(result.is_ok());
         assert_eq!(result.ok(), Some(String::from("$sent123")));
+    }
+
+    #[test]
+    fn build_sync_request_includes_since_param_when_token_set() {
+        let mut client = matrix_client_with_test_credentials();
+        assert!(client.sync_token().is_none());
+
+        let body = build_sync_response("tok_abc123", "!room:example.com", &[]);
+        let response = mock_response(200, &body);
+        let result = client.sync(&response, 0);
+        assert!(result.is_ok());
+        assert_eq!(client.sync_token(), Some("tok_abc123"));
+
+        let result = client.build_sync_request();
+        assert!(result.is_ok());
+        let req = result.ok().unwrap_or_else(|| {
+            HttpRequest::new(http_client::HttpMethod::Get, String::new(), String::new())
+        });
+        assert!(req.path.contains("&since=tok_abc123"));
     }
 
     #[test]
@@ -2162,5 +2246,42 @@ mod tests {
         assert_eq!(room.messages[0].event_id, "$msg1");
         // Last message should be the new one.
         assert_eq!(room.messages[MAX_MESSAGES_PER_ROOM - 1].event_id, "$new");
+    }
+
+    #[test]
+    fn hex_decode_bytes_decodes_valid_input() {
+        assert_eq!(
+            hex_decode_bytes("00ff10").as_deref(),
+            Some(&[0x00u8, 0xff, 0x10][..])
+        );
+        assert_eq!(hex_decode_bytes("").as_deref(), Some(&[][..]));
+    }
+
+    #[test]
+    fn hex_decode_bytes_rejects_odd_length() {
+        assert_eq!(hex_decode_bytes("abc"), None);
+    }
+
+    #[test]
+    fn hex_decode_bytes_rejects_non_hex_char() {
+        assert_eq!(hex_decode_bytes("zz"), None);
+    }
+
+    #[test]
+    fn hex_decode_32_bytes_decodes_valid_input() {
+        let hex = "ab".repeat(32);
+        assert_eq!(hex_decode_32_bytes(&hex), Some([0xabu8; 32]));
+    }
+
+    #[test]
+    fn hex_decode_32_bytes_rejects_wrong_length() {
+        assert_eq!(hex_decode_32_bytes("aabb"), None);
+        assert_eq!(hex_decode_32_bytes(&"ab".repeat(33)), None);
+    }
+
+    #[test]
+    fn hex_decode_32_bytes_rejects_non_hex_char() {
+        let bad = alloc::format!("zz{}", "aa".repeat(31));
+        assert_eq!(hex_decode_32_bytes(&bad), None);
     }
 }

--- a/crates/thumos/src/ipc.rs
+++ b/crates/thumos/src/ipc.rs
@@ -115,6 +115,15 @@ impl Inbox {
     pub(crate) fn is_full(&self) -> bool {
         self.count >= INBOX_SIZE
     }
+
+    /// Clear all pending messages, resetting the inbox to empty.
+    ///
+    /// WHY (finding 45): called from process exit teardown so PID reuse
+    /// cannot leak a prior occupant's undelivered messages into the next
+    /// process assigned the same inbox slot.
+    pub(crate) fn clear(&mut self) {
+        *self = Self::new();
+    }
 }
 
 /// Number of inbox slots, matching the maximum number of processes.
@@ -232,6 +241,27 @@ pub(crate) fn has_messages() -> bool {
     }
 }
 
+/// Clear a process's inbox, discarding any pending messages.
+///
+/// WHY (finding 45): call this during process exit teardown, before the
+/// PID's process-table slot can be reused by `spawn`/`fork`, so a future
+/// process assigned the same PID does not inherit messages left behind by
+/// the previous occupant of that inbox slot. A no-op if `pid` is out of
+/// range (defensive: exit teardown must not itself be able to fail).
+pub(crate) fn clear_inbox(pid: Pid) {
+    let Ok(idx) = validate_pid(pid) else {
+        return;
+    };
+    // SAFETY: INBOXES is a static array indexed by PID. addr_of_mut! avoids
+    // creating an intermediate reference to the static mut. INBOXES_LOCK
+    // masks IRQ delivery for the access (#322/#331 class).
+    let _guard = INBOXES_LOCK.lock();
+    unsafe {
+        let inboxes = &mut *core::ptr::addr_of_mut!(INBOXES);
+        inboxes[idx].clear();
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -329,5 +359,41 @@ mod tests {
         );
         assert_eq!(msg.payload().len(), MSG_MAX_SIZE);
         assert!(msg.payload().iter().all(|&b| b == 0xAB));
+    }
+
+    #[test]
+    fn inbox_clear_resets_to_empty() {
+        let mut inbox = Inbox::new();
+        for i in 0..3 {
+            assert!(inbox.push(Message::new(i as u32, b"leftover")));
+        }
+        assert!(!inbox.is_empty());
+
+        inbox.clear();
+
+        assert!(inbox.is_empty());
+        assert!(!inbox.is_full());
+        assert!(inbox.pop().is_none());
+    }
+
+    #[test]
+    fn clear_inbox_discards_pending_messages_for_pid() {
+        // WHY (finding 45): PID-reuse regression -- seed pid 2's inbox,
+        // clear it, and confirm the stale messages are gone by refilling
+        // it to capacity again (a full inbox after clear would reject a
+        // send before INBOX_SIZE was reached if any stale message survived).
+        for _ in 0..INBOX_SIZE {
+            assert_eq!(send(2, Message::new(1, b"stale")), Ok(()));
+        }
+        assert_eq!(
+            send(2, Message::new(1, b"stale")),
+            Err(IpcSendError::InboxFull)
+        );
+
+        clear_inbox(2);
+
+        for _ in 0..INBOX_SIZE {
+            assert_eq!(send(2, Message::new(1, b"fresh")), Ok(()));
+        }
     }
 }

--- a/crates/thumos/src/kconfig.rs
+++ b/crates/thumos/src/kconfig.rs
@@ -128,4 +128,50 @@ mod tests {
         assert_eq!(KERNEL_END, 0x4010_0000);
         assert_eq!(DISPLAY_WIDTH * DISPLAY_HEIGHT * 2, 153_600); // RGB565 framebuffer size
     }
+
+    #[test]
+    fn parse_cmdline_sets_tick_rate_and_security_flags() {
+        parse_cmdline("tick_ms=25 verbose=0 console=0 panic=5");
+
+        // SAFETY: single-threaded test (nextest process-isolates per test);
+        // addr_of!().read() avoids a shared reference to the static mut.
+        let (tick, verbose, console, panic) = unsafe {
+            (
+                core::ptr::addr_of!(TICK_MS).read(),
+                core::ptr::addr_of!(VERBOSE_BOOT).read(),
+                core::ptr::addr_of!(DEBUG_CONSOLE).read(),
+                core::ptr::addr_of!(PANIC_TIMEOUT).read(),
+            )
+        };
+        assert_eq!(tick, 25);
+        assert!(!verbose);
+        assert!(!console);
+        assert_eq!(panic, 5);
+    }
+
+    #[test]
+    fn parse_cmdline_clamps_tick_ms_to_valid_range() {
+        parse_cmdline("tick_ms=500");
+        // SAFETY: single-threaded test; addr_of!().read() avoids a static-mut ref.
+        let tick_hi = unsafe { core::ptr::addr_of!(TICK_MS).read() };
+        assert_eq!(tick_hi, 100, "tick_ms must clamp to the 100ms ceiling");
+
+        parse_cmdline("tick_ms=0");
+        // SAFETY: single-threaded test; addr_of!().read() avoids a static-mut ref.
+        let tick_lo = unsafe { core::ptr::addr_of!(TICK_MS).read() };
+        assert_eq!(tick_lo, 1, "tick_ms must clamp to the 1ms floor");
+    }
+
+    #[test]
+    fn parse_cmdline_ignores_unknown_and_malformed_params() {
+        // SAFETY: single-threaded test; addr_of!().read() avoids a static-mut ref.
+        let before = unsafe { core::ptr::addr_of!(PANIC_TIMEOUT).read() };
+        parse_cmdline("bogus=1 no_equals_sign panic=notanumber");
+        // SAFETY: single-threaded test; addr_of!().read() avoids a static-mut ref.
+        let after = unsafe { core::ptr::addr_of!(PANIC_TIMEOUT).read() };
+        assert_eq!(
+            after, before,
+            "malformed panic= value must be ignored, not applied"
+        );
+    }
 }

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -780,15 +780,28 @@ pub unsafe fn run() -> ! {
     // Step 8f: Security mode manager
     // -----------------------------------------------------------------------
     let _ = serial.write_str("[init] Security mode (Daily)\r\n");
+    let mut pm = PowerManager::new();
     {
-        // WHY: start in Daily mode with BFU timer running.  Mode manager
-        // controls radio policy, scan intervals, and key lifecycle.
+        // WHY (finding 46): the radio policy must be established here,
+        // BEFORE USB ACM (Step 9) and the CCCI modem (Step 10) bring
+        // radios up -- previously this step only logged "PENDING" and the
+        // power manager was not constructed until Step 12, well after
+        // both radios had already started, leaving PowerManager state at
+        // its all-Off default the whole time radios were live (a
+        // policy/reality mismatch for any later mode-transition or
+        // threat-response code that reads PowerManager state as ground
+        // truth). A full passphrase-derived pin_hash is not available yet
+        // (Step 8c is pending the boot input loop -- finding 48), so
+        // ModeManager::default() is used: unprovisioned, but still Daily
+        // mode, which is the correct policy to apply at this point.
         //
-        // NOTE: In production:
-        // let mode_mgr = ModeManager::new(pin_hash);
+        // NOTE: BFU (Before First Unlock) timer wiring is separate,
+        // unrelated work -- not part of this radio-policy fix.
         // let bfu = BfuTimer::new(SecurityMode::Daily);
-        // apply_mode_policy(&mode_mgr.effective_policy(), &mut pm);
-        let _ = serial.write_str("       Security mode: PENDING (Daily policy not applied)\r\n");
+        let mode_mgr = crate::security_mode::ModeManager::default();
+        crate::power::apply_mode_policy(&mode_mgr.effective_policy(), &mut pm);
+        state.security_mode_ok = true;
+        let _ = serial.write_str("       Security mode: Daily policy applied\r\n");
     }
 
     // -----------------------------------------------------------------------
@@ -820,7 +833,11 @@ pub unsafe fn run() -> ! {
     {
         let mut ccci = CcciDriver::new();
         let boot_start = crate::timer::elapsed_ms();
-        let boot_result = unsafe { ccci.boot_modem(boot_start) };
+        // WHY (finding 47): MODEM_BOOT_TIMEOUT_MS previously bounded
+        // nothing -- it was only compared against elapsed time in the WARN
+        // check below, AFTER boot_modem had already returned. Threading it
+        // through makes it a real deadline boot_modem enforces per step.
+        let boot_result = unsafe { ccci.boot_modem(boot_start, MODEM_BOOT_TIMEOUT_MS) };
         let boot_elapsed = crate::timer::elapsed_ms() - boot_start;
 
         match boot_result {
@@ -845,9 +862,16 @@ pub unsafe fn run() -> ! {
     // -----------------------------------------------------------------------
     // Step 12: Power manager
     // -----------------------------------------------------------------------
+    // WHY (finding 46): `pm` was already constructed and given the
+    // Daily-mode radio policy at Step 8f, before USB/modem bring-up -- do
+    // not construct a second PowerManager here and silently discard that
+    // policy state.
     let _ = serial.write_str("[init] Power manager\r\n");
-    let _pm = PowerManager::new();
-    let _ = serial.write_str("       All radios OFF (silent mode)\r\n");
+    let _ = write!(
+        serial,
+        "       {} radios active per Daily policy (applied at security-mode init)\r\n",
+        pm.active_count()
+    );
 
     // -----------------------------------------------------------------------
     // Step 13: Network configuration (WiFi readiness + DHCP/DNS smoke)

--- a/crates/thumos/src/mmio.rs
+++ b/crates/thumos/src/mmio.rs
@@ -56,6 +56,34 @@ pub unsafe fn clear_bits(addr: usize, bits: u32) {
     }
 }
 
+/// Poll a register-read closure up to `max_iterations` times, returning
+/// `true` as soon as the read matches the wait condition.
+///
+/// Host-testable core of `wait_bits_set`/`wait_bits_clear` -- the two public
+/// unsafe wrappers below just supply a real MMIO `read32` closure, so this
+/// loop/timeout logic (including the zero-iteration case) has host-test
+/// coverage without needing a live MMIO register.
+#[inline]
+fn poll_until<F: FnMut() -> u32>(
+    mut read: F,
+    bits: u32,
+    max_iterations: u32,
+    want_set: bool,
+) -> bool {
+    for _ in 0..max_iterations {
+        let val = read();
+        let matched = if want_set {
+            val & bits == bits
+        } else {
+            val & bits == 0
+        };
+        if matched {
+            return true;
+        }
+    }
+    false
+}
+
 /// Wait until specific bits in a register are set, with a timeout.
 ///
 /// Returns `true` if the bits became set, `false` on timeout.
@@ -65,12 +93,7 @@ pub unsafe fn clear_bits(addr: usize, bits: u32) {
 /// Same requirements as `read32`.
 #[inline]
 pub unsafe fn wait_bits_set(addr: usize, bits: u32, max_iterations: u32) -> bool {
-    for _ in 0..max_iterations {
-        if unsafe { read32(addr) } & bits == bits {
-            return true;
-        }
-    }
-    false
+    poll_until(|| unsafe { read32(addr) }, bits, max_iterations, true)
 }
 
 /// Wait until specific bits in a register are clear, with a timeout.
@@ -82,18 +105,66 @@ pub unsafe fn wait_bits_set(addr: usize, bits: u32, max_iterations: u32) -> bool
 /// Same requirements as `read32`.
 #[inline]
 pub unsafe fn wait_bits_clear(addr: usize, bits: u32, max_iterations: u32) -> bool {
-    for _ in 0..max_iterations {
-        if unsafe { read32(addr) } & bits == 0 {
-            return true;
-        }
-    }
-    false
+    poll_until(|| unsafe { read32(addr) }, bits, max_iterations, false)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    // NOTE: MMIO tests require actual hardware or a mock.
-    // These functions are verified by integration testing on the device.
+    // NOTE: wait_bits_set/wait_bits_clear still require actual hardware or
+    // integration testing (read32 dereferences a live MMIO address).
+    // poll_until is the extracted, host-testable timeout/loop core.
+
+    #[test]
+    fn poll_until_returns_true_when_condition_met_before_timeout() {
+        let values = [0u32, 0u32, 0xFF];
+        let mut calls = 0usize;
+        let result = poll_until(
+            || {
+                let v = values[calls];
+                calls += 1;
+                v
+            },
+            0xFF,
+            10,
+            true,
+        );
+        assert!(result, "must return true once the read matches");
+        assert_eq!(
+            calls, 3,
+            "must stop polling as soon as the condition is met"
+        );
+    }
+
+    #[test]
+    fn poll_until_returns_false_on_timeout() {
+        let result = poll_until(|| 0u32, 0xFF, 5, true);
+        assert!(
+            !result,
+            "must return false when the condition never matches"
+        );
+    }
+
+    #[test]
+    fn poll_until_zero_iterations_never_reads_and_returns_false() {
+        let mut calls = 0u32;
+        let result = poll_until(
+            || {
+                calls += 1;
+                0xFF
+            },
+            0xFF,
+            0,
+            true,
+        );
+        assert!(!result, "zero max_iterations must return false immediately");
+        assert_eq!(calls, 0, "zero max_iterations must not call read at all");
+    }
+
+    #[test]
+    fn poll_until_matches_clear_condition() {
+        let result = poll_until(|| 0u32, 0xFF, 3, false);
+        assert!(result, "bits already clear must match immediately");
+    }
 }

--- a/crates/thumos/src/power.rs
+++ b/crates/thumos/src/power.rs
@@ -831,6 +831,43 @@ mod tests {
         );
     }
 
+    #[test]
+    fn dvfs_multi_step_scaling_chain_walks_down_then_up_through_every_opp() {
+        let mut gov = CpuGovernor::new();
+        assert_eq!(gov.current_freq(), CpuFreq::Mhz1500);
+
+        // Sustained low load steps down through every OPP, one step per
+        // tick, because the rolling window starts at zero (already below
+        // the new sample) so the average tracks the new sample immediately.
+        assert_eq!(gov.apply_dvfs(10), CpuFreq::Mhz1200);
+        assert_eq!(gov.apply_dvfs(10), CpuFreq::Mhz900);
+        assert_eq!(gov.apply_dvfs(10), CpuFreq::Mhz600);
+        assert_eq!(
+            gov.apply_dvfs(10),
+            CpuFreq::Mhz600,
+            "must not step below the minimum OPP"
+        );
+
+        // Sustained high load must first flush the stale low-load window
+        // (LOAD_HISTORY_LEN ticks) before the rolling average clears the
+        // >70 step-up threshold, then walk back up through every OPP.
+        for _ in 0..LOAD_HISTORY_LEN {
+            gov.apply_dvfs(90);
+        }
+        assert_eq!(
+            gov.current_freq(),
+            CpuFreq::Mhz900,
+            "after the window flushes to sustained high load, must have stepped up once"
+        );
+        assert_eq!(gov.apply_dvfs(90), CpuFreq::Mhz1200);
+        assert_eq!(gov.apply_dvfs(90), CpuFreq::Mhz1500);
+        assert_eq!(
+            gov.apply_dvfs(90),
+            CpuFreq::Mhz1500,
+            "must not step above the maximum OPP"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // Original PowerManager tests (radio kill switches)
     // -----------------------------------------------------------------------

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -601,6 +601,10 @@ pub(crate) fn exit_cleanup(status: i32) {
         // defensively so every Dead-transition path shares the same
         // invariant (#364).
         crate::futex::free_waiters_for_pid(u32::from(CURRENT));
+        // WHY (finding 45): clear this PID's inbox at exit teardown so a
+        // future process that reuses the slot does not inherit messages
+        // left behind by the previous occupant (PID-reuse leak).
+        ipc::clear_inbox(CURRENT);
     }
 }
 

--- a/crates/thumos/src/syscall.rs
+++ b/crates/thumos/src/syscall.rs
@@ -2482,7 +2482,16 @@ mod tests {
         unsafe {
             process::reset_for_test();
 
-            let mut elf = [0u8; 52];
+            // 52-byte header + one 32-byte PT_LOAD program header. e_entry
+            // must fall inside a loaded segment (#384 finding 49), so the
+            // segment covers the entry address. WHY a `static mut BUF`
+            // vaddr: elf::load writes segment (zero-fill) bytes directly to
+            // the identity-mapped p_vaddr, so it must be a host-writable
+            // address (this binary's static lands in user DRAM range) --
+            // same pattern as elf::tests::load_does_not_leak_pages_on_success.
+            static mut SEG_BUF: [u8; 16] = [0u8; 16];
+            let vaddr = core::ptr::addr_of_mut!(SEG_BUF) as *mut u8 as u32;
+            let mut elf = [0u8; 84];
             elf[0] = 0x7F;
             elf[1] = b'E';
             elf[2] = b'L';
@@ -2493,11 +2502,16 @@ mod tests {
             elf[16] = 2;
             elf[18] = 40;
             elf[20] = 1;
-            elf[25] = 0x80; // e_entry = 0x8000
+            elf[24..28].copy_from_slice(&vaddr.to_le_bytes()); // e_entry = SEG_BUF
             elf[28] = 52; // e_phoff
             elf[40] = 52; // e_ehsize
             elf[42] = 32; // e_phentsize
-            elf[44] = 0; // e_phnum
+            elf[44] = 1; // e_phnum = 1
+            // Elf32Phdr at offset 52: PT_LOAD covering e_entry (filesz=0,
+            // memsz=16 = one 16-byte zero-fill into SEG_BUF).
+            elf[52..56].copy_from_slice(&1u32.to_le_bytes()); // p_type = PT_LOAD
+            elf[60..64].copy_from_slice(&vaddr.to_le_bytes()); // p_vaddr = SEG_BUF
+            elf[72..76].copy_from_slice(&16u32.to_le_bytes()); // p_memsz
 
             let mut fs = crate::ramfs::RamFs::new();
             fs.add("bin", &elf);

--- a/crates/thumos/src/timer_stub.rs
+++ b/crates/thumos/src/timer_stub.rs
@@ -22,6 +22,18 @@ pub(crate) fn counter() -> u64 {
     13_000_000
 }
 
+/// Host-test mirror of the production `elapsed_ms` computation (mirrors
+/// `timer::elapsed_ms` exactly, but composed from the stub `frequency`/
+/// `counter` above so host-tested callers like `ccci::boot_modem`'s
+/// deadline check are host-compilable).
+pub(crate) fn elapsed_ms() -> u64 {
+    let freq = u64::from(frequency());
+    if freq == 0 {
+        return 0;
+    }
+    (counter() * 1000) / freq
+}
+
 /// Host-test mirror of the production `set_ms` tick-conversion arithmetic.
 /// `timer::set_ms` itself is ARM-only (it also programs CNTP_TVAL/CNTP_CTL
 /// via CP15, which does not exist on the host target); this mirrors just
@@ -29,6 +41,21 @@ pub(crate) fn counter() -> u64 {
 /// with the arithmetic in `timer::set_ms`.
 pub(crate) fn ms_to_ticks(freq: u32, ms: u32) -> u32 {
     (freq / 1000).saturating_mul(ms)
+}
+
+/// Host-test mirror of the production `elapsed_ms` conversion arithmetic.
+/// `timer::elapsed_ms` itself is ARM-only (it calls the CP15 `frequency`/
+/// `counter` accessors, neither of which exist on the host target -- this
+/// module fully replaces `timer` under `#[cfg(test)]`, see main.rs); this
+/// mirrors just the counter-to-ms conversion, including the zero-frequency
+/// guard, so it has host-test coverage. Kept in lockstep with the
+/// arithmetic in `timer::elapsed_ms`.
+pub(crate) fn elapsed_ms_from(counter: u64, freq: u32) -> u64 {
+    let freq = u64::from(freq);
+    if freq == 0 {
+        return 0;
+    }
+    (counter * 1000) / freq
 }
 
 #[cfg(test)]
@@ -52,5 +79,24 @@ mod tests {
     fn ms_to_ticks_matches_plain_multiply_below_overflow() {
         let freq = 13_000_000;
         assert_eq!(ms_to_ticks(freq, 100), (freq / 1000) * 100);
+    }
+
+    #[test]
+    fn elapsed_ms_from_converts_counter_to_milliseconds() {
+        // At 13 MHz, one second of counter ticks (13_000_000) must convert
+        // to 1000 ms, matching `timer::elapsed_ms`'s (counter * 1000) / freq.
+        assert_eq!(elapsed_ms_from(13_000_000, 13_000_000), 1_000);
+    }
+
+    #[test]
+    fn elapsed_ms_from_returns_zero_when_frequency_is_zero() {
+        // Guards the divide-by-zero the production function also guards
+        // against (an uncalibrated/unread CNTFRQ before boot).
+        assert_eq!(elapsed_ms_from(1_000_000, 0), 0);
+    }
+
+    #[test]
+    fn elapsed_ms_from_zero_counter_is_zero_elapsed() {
+        assert_eq!(elapsed_ms_from(0, 13_000_000), 0);
     }
 }


### PR DESCRIPTION
Final wave-1 batch (#384, findings 41-64). Some stale (harmostes room-id #373, futex, battery/device coverage). **1 deferred** — kinit passphrase (finding 48): the literal `input_ok` mechanism is stale (#344), but the real gap (`passphrase_ok` never set → encryption never enabled) needs an entire boot-time keypad-read / T9-decode / input-loop subsystem that doesn't exist. Flagged for its own issue rather than partial-patched.

## Security
- **Arbitrary code execution via ELF entry** — `e_entry` (attacker-controlled) was transmuted to a callable fn pointer by *both* kinit boot-spawn and `sys_execve` with no bounds check. Now `elf::validate` rejects an entry outside every loaded PT_LOAD segment — one root-cause fix closes both callers.
- **HTTP/WS injection (4)** — ekphrasis rejects control chars in WS host/key; harmostes rejects CR/LF/control in a homeserver sync_token before the /sync query, and validates room_id via `MatrixRoomId` before the join path.
- **PID-reuse inbox leak** — a process inbox was never cleared on exit; a reassigned PID inherited stale messages. Now cleared in exit teardown.
- **kinit boot order** — Daily radio policy applied at Step 8f (before USB/modem bring-up), not left at all-Off default while radios were live; MODEM_BOOT_TIMEOUT_MS now a real per-step deadline (was post-hoc logging).

## Coverage
ekphrasis Error-state + 64-bit len + partial-text; console overflow; device list/count; exceptions tick-carry; harmostes hex/sync/join-capacity; kconfig parse_cmdline; mmio poll_until (extracted); power DVFS OPP chain; timer elapsed_ms.

## Verification
- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — **2078 passed** (40 new; 3 apply-surfaced issues fixed inline: kconfig static_mut_refs, execve ELF fixture host-writable-static-BUF pattern for the new entry-check)
- `cargo build --release --target armv7a-none-eabi` — clean · `kanon lint` — clean

Completes #384's findings (41-64: fixed/covered/stale; 1 deferred). With this, all 64 are addressed except the passphrase boot-input remnant.

_ELF-entry + injection + PID-leak reviewed at T0/Opus._