### PR TITLE
Wave-3 low-rollup batch 1: 19 fixes incl. W^X + panic-wipe integrity (#337)

### DIFF
--- a/crates/thumos/src/dhcp.rs
+++ b/crates/thumos/src/dhcp.rs
@@ -192,6 +192,12 @@ impl DhcpClient {
             Some(Err(())) => {
                 // Clear interface IP addresses.
                 stack.iface_mut().update_ip_addrs(|addrs| addrs.clear());
+                // WHY (finding 1): the Configured arm above adds a default
+                // gateway route via set_default_gateway when the DHCP
+                // server provides one; Deconfigured must symmetrically
+                // remove it, or a stale gateway route survives lease
+                // expiry / a NAK with no IP address behind it.
+                stack.iface_mut().routes_mut().remove_default_ipv4_route();
                 self.configured = false;
                 DhcpEvent::Deconfigured
             }
@@ -276,5 +282,44 @@ mod tests {
         assert_eq!(config.address.prefix_len(), 24);
         assert_eq!(config.gateway, Some(Ipv4Address::new(192, 168, 1, 1)));
         assert_eq!(config.dns_servers.len(), 2);
+    }
+
+    #[test]
+    fn dhcp_error_from_net_error_maps_every_variant() {
+        // Done-when (finding 20): every NetError variant must map to a
+        // well-defined DhcpError, including InvalidHandle -- which has no
+        // direct DhcpError counterpart and collapses to SocketSetFull.
+        assert_eq!(
+            DhcpError::from(NetError::SocketSetFull),
+            DhcpError::SocketSetFull
+        );
+        assert_eq!(
+            DhcpError::from(NetError::RouteTableFull),
+            DhcpError::RouteTableFull
+        );
+        assert_eq!(
+            DhcpError::from(NetError::InvalidHandle),
+            DhcpError::SocketSetFull,
+            "InvalidHandle has no DhcpError counterpart and must collapse to SocketSetFull"
+        );
+    }
+
+    #[test]
+    fn dhcp_client_new_fails_when_socket_set_is_full() {
+        // Done-when (finding 20): DhcpClient::new must surface
+        // DhcpError::SocketSetFull rather than panicking or silently
+        // succeeding when the stack's socket set is already at capacity.
+        let mut stack = make_stack();
+        for _ in 0..MAX_SOCKETS {
+            stack.add_tcp_socket().ok().unwrap(); // ok: test
+        }
+        assert_eq!(stack.socket_count(), MAX_SOCKETS);
+
+        let result = DhcpClient::new(&mut stack);
+        assert_eq!(
+            result.err(),
+            Some(DhcpError::SocketSetFull),
+            "DhcpClient::new must fail with SocketSetFull once MAX_SOCKETS is reached"
+        );
     }
 }

--- a/crates/thumos/src/elf.rs
+++ b/crates/thumos/src/elf.rs
@@ -238,10 +238,20 @@ fn validate(data: &[u8]) -> Result<(usize, ValidatedElf), ElfError> {
             _ => return Err(ElfError::InvalidSegment),
         };
 
-        if segments.count < 16 {
-            segments.segments[segments.count] = (vaddr, memsz, filesz, file_offset);
-            segments.count += 1;
+        // WHY (finding 2): the fixed-capacity `segments` array holds at
+        // most 16 PT_LOAD descriptors -- a 17th+ segment was previously
+        // dropped silently here while `total_pages` above still counted
+        // its page budget, so `load()` would report success while never
+        // writing that segment's bytes to memory. Reject the image
+        // outright instead; this coexists with the #327 budget check above
+        // and the finding-49 entry-in-segment check below, which still run
+        // against whatever segments were recorded before this one is
+        // rejected.
+        if segments.count >= 16 {
+            return Err(ElfError::InvalidSegment);
         }
+        segments.segments[segments.count] = (vaddr, memsz, filesz, file_offset);
+        segments.count += 1;
     }
 
     // WHY (finding 49): e_entry is a fully attacker-controlled u32 header
@@ -548,6 +558,37 @@ mod tests {
         buf[72..76].copy_from_slice(&0x0200_0000u32.to_le_bytes());
 
         assert_eq!(validate(&buf).unwrap_err(), ElfError::InvalidSegment);
+    }
+
+    /// finding 2: a 17th PT_LOAD segment must be rejected, not silently
+    /// dropped from the fixed 16-slot `segments` array while `total_pages`
+    /// still counted its budget -- the old behavior let `load()` report
+    /// success while never writing that segment's bytes to memory.
+    #[test]
+    fn parse_rejects_more_than_sixteen_pt_load_segments() {
+        const N: usize = 17;
+        let mut buf = [0u8; ELF32_EHDR_SIZE + N * ELF32_PHDR_SIZE];
+        let h = make_valid_ehdr();
+        buf[..ELF32_EHDR_SIZE].copy_from_slice(&h);
+        // e_phnum (offset 44, u16 LE): 17 program headers.
+        buf[44] = 17;
+        buf[45] = 0;
+
+        for i in 0..N {
+            let off = ELF32_EHDR_SIZE + i * ELF32_PHDR_SIZE;
+            // p_type = PT_LOAD (1).
+            buf[off..off + 4].copy_from_slice(&1u32.to_le_bytes());
+            // p_vaddr: inside the allowed load region.
+            buf[off + 8..off + 12].copy_from_slice(&0x4010_0000u32.to_le_bytes());
+            // p_memsz: 1 page, well under the MAX_ELF_PAGES budget even x17.
+            buf[off + 20..off + 24].copy_from_slice(&0x1000u32.to_le_bytes());
+        }
+
+        assert_eq!(
+            validate(&buf).unwrap_err(),
+            ElfError::InvalidSegment,
+            "a 17th PT_LOAD segment must be rejected, not silently dropped"
+        );
     }
 
     #[test]

--- a/crates/thumos/src/encryption.rs
+++ b/crates/thumos/src/encryption.rs
@@ -134,7 +134,15 @@ impl BlockDevice for EncryptedBlockDevice<'_> {
     /// Returns [`BlockError`] if the underlying device read fails or the
     /// sector range is invalid.
     fn read_sectors(&self, lba: u64, count: u32, buf: &mut [u8]) -> Result<(), BlockError> {
-        let expected_len = count as usize * SECTOR_SIZE;
+        // WHY (finding 3): count is caller-controlled and SECTOR_SIZE is a
+        // compile-time constant -- on a 32-bit target (usize == u32) count
+        // * SECTOR_SIZE can wrap, letting an oversized buf.len() slip past
+        // this check instead of being rejected. checked_mul rejects the
+        // wrap instead of silently admitting it.
+        let count_usize = usize::try_from(count).map_err(|_| BlockError::InvalidArgument)?;
+        let expected_len = count_usize
+            .checked_mul(SECTOR_SIZE)
+            .ok_or(BlockError::InvalidArgument)?;
         if buf.len() != expected_len {
             return Err(BlockError::InvalidArgument);
         }
@@ -200,7 +208,13 @@ impl BlockDevice for EncryptedBlockDevice<'_> {
     /// Returns [`BlockError`] if the underlying device I/O fails or the
     /// sector range is invalid.
     fn write_sectors(&mut self, lba: u64, count: u32, buf: &[u8]) -> Result<(), BlockError> {
-        let expected_len = count as usize * SECTOR_SIZE;
+        // WHY (finding 3): same overflow guard as read_sectors -- count is
+        // caller-controlled and SECTOR_SIZE is a compile-time constant; on
+        // a 32-bit target (usize == u32) count * SECTOR_SIZE can wrap.
+        let count_usize = usize::try_from(count).map_err(|_| BlockError::InvalidArgument)?;
+        let expected_len = count_usize
+            .checked_mul(SECTOR_SIZE)
+            .ok_or(BlockError::InvalidArgument)?;
         if buf.len() != expected_len {
             return Err(BlockError::InvalidArgument);
         }
@@ -278,9 +292,19 @@ impl BlockDevice for EncryptedBlockDevice<'_> {
 /// encryption layer.
 impl From<SecurityError> for BlockError {
     fn from(e: SecurityError) -> Self {
+        // WHY (finding 4): the old `_ => IoError` catch-all collapsed
+        // ZeroIterations, HkdfOutputTooLong, and InvalidBlockSize --
+        // caller/parameter validation failures, not I/O faults -- into the
+        // same opaque IoError as a genuine CipherError. Map each variant by
+        // its actual failure class: malformed/caller-controlled input maps
+        // to InvalidArgument, and only a true cipher-operation failure maps
+        // to IoError.
         match e {
-            SecurityError::InvalidKeyLength => BlockError::InvalidArgument,
-            _ => BlockError::IoError,
+            SecurityError::InvalidKeyLength
+            | SecurityError::ZeroIterations
+            | SecurityError::HkdfOutputTooLong
+            | SecurityError::InvalidBlockSize => BlockError::InvalidArgument,
+            SecurityError::CipherError => BlockError::IoError,
         }
     }
 }
@@ -495,6 +519,37 @@ mod tests {
         let enc = EncryptedBlockDevice::new(&mut dev, key);
         let mut buf = vec![0u8; SECTOR_SIZE];
         let result = enc.read_sectors(TEST_SECTORS, 1, &mut buf);
+        assert_eq!(result, Err(BlockError::OutOfBounds));
+    }
+
+    #[test]
+    fn write_sectors_length_mismatch_returns_error() {
+        // Done-when (finding 21): a buffer whose length doesn't match
+        // count * SECTOR_SIZE must be rejected before any write happens.
+        let mut dev = MemBlockDevice::new(TEST_SECTORS).expect("create device");
+        let key = sample_xts_key();
+        let mut enc = EncryptedBlockDevice::new(&mut dev, key);
+
+        let short_buf = vec![0u8; SECTOR_SIZE - 1];
+        let result = enc.write_sectors(0, 1, &short_buf);
+        assert_eq!(result, Err(BlockError::InvalidArgument));
+
+        let long_buf = vec![0u8; SECTOR_SIZE + 1];
+        let result = enc.write_sectors(0, 1, &long_buf);
+        assert_eq!(result, Err(BlockError::InvalidArgument));
+    }
+
+    #[test]
+    fn write_sectors_out_of_bounds_returns_error() {
+        // Done-when (finding 21): a write past the device's sector count
+        // must be rejected, mirroring the existing read_sectors OOB
+        // coverage.
+        let mut dev = MemBlockDevice::new(TEST_SECTORS).expect("create device");
+        let key = sample_xts_key();
+        let mut enc = EncryptedBlockDevice::new(&mut dev, key);
+
+        let buf = vec![0u8; SECTOR_SIZE];
+        let result = enc.write_sectors(TEST_SECTORS, 1, &buf);
         assert_eq!(result, Err(BlockError::OutOfBounds));
     }
 

--- a/crates/thumos/src/lfs.rs
+++ b/crates/thumos/src/lfs.rs
@@ -885,7 +885,8 @@ impl Lfs {
             | LfsError::Corrupt
             | LfsError::InvalidSuperblock
             | LfsError::InodeNotFound
-            | LfsError::CheckpointOverflow => VfsError::IoError,
+            | LfsError::CheckpointOverflow
+            | LfsError::NoCompactionCandidate => VfsError::IoError,
         }
     }
 

--- a/crates/thumos/src/lfs_checkpoint.rs
+++ b/crates/thumos/src/lfs_checkpoint.rs
@@ -13,7 +13,7 @@
 extern crate alloc;
 use alloc::vec::Vec;
 
-use crate::block::{BLOCK_SIZE, BlockDevice};
+use crate::block::{BLOCK_SIZE, BlockDevice, SECTORS_PER_BLOCK};
 use crate::cache::BlockCache;
 use crate::lfs_imap::LfsError;
 
@@ -209,7 +209,11 @@ pub(crate) fn write_checkpoint(
 /// # Errors
 ///
 /// - [`LfsError::BlockIo`] if the block read fails.
-/// - [`LfsError::Corrupt`] if the magic number does not match.
+/// - [`LfsError::Corrupt`] if the magic number does not match, or if the
+///   imap/segment-bitmap block pointers or counts resolve outside the
+///   device's actual block range (SECURITY, finding 18: a crafted or
+///   corrupted header must be rejected before its pointers are handed to
+///   the imap/segment-bitmap loaders).
 pub(crate) fn read_checkpoint(
     dev: &mut dyn BlockDevice,
     cache: &mut BlockCache,
@@ -217,7 +221,42 @@ pub(crate) fn read_checkpoint(
 ) -> Result<CheckpointHeader, LfsError> {
     let mut buf = [0u8; BLOCK_SIZE];
     cache.read(dev, slot_block, &mut buf)?;
-    CheckpointHeader::from_block(&buf)
+    let header = CheckpointHeader::from_block(&buf)?;
+    let device_blocks = dev.sector_count() / SECTORS_PER_BLOCK as u64;
+    validate_header_geometry(&header, device_blocks)?;
+    Ok(header)
+}
+
+/// Validate that a parsed checkpoint header's block pointers and counts
+/// resolve to ranges within the device's actual block count.
+///
+/// WHY (SECURITY, finding 18): [`CheckpointHeader::from_block`] only
+/// checks the magic number -- a crafted or corrupted header with an
+/// out-of-range `imap_block`/`segment_bitmap_block` or an oversized
+/// `*_count` would otherwise be accepted and handed straight to the imap
+/// and segment-bitmap loaders during mount. `write_checkpoint`'s #319
+/// check already treats an out-of-range payload as reject-worthy on the
+/// write side; this is the matching read-side check for whatever a slot
+/// is later found to contain, regardless of how it got there.
+fn validate_header_geometry(header: &CheckpointHeader, device_blocks: u64) -> Result<(), LfsError> {
+    let imap_end = header
+        .imap_block
+        .checked_add(u64::from(header.imap_block_count))
+        .ok_or(LfsError::Corrupt)?;
+    let segment_end = header
+        .segment_bitmap_block
+        .checked_add(u64::from(header.segment_bitmap_count))
+        .ok_or(LfsError::Corrupt)?;
+
+    if header.imap_block >= device_blocks
+        || imap_end > device_blocks
+        || header.segment_bitmap_block >= device_blocks
+        || segment_end > device_blocks
+    {
+        return Err(LfsError::Corrupt);
+    }
+
+    Ok(())
 }
 
 /// Read both checkpoint slots and return the one with the higher sequence.
@@ -568,5 +607,47 @@ mod tests {
         // Nothing should have been written for this rejected checkpoint.
         let mut cache2 = BlockCache::new();
         assert!(read_checkpoint(&mut dev, &mut cache2, slot_block).is_err());
+    }
+
+    #[test]
+    fn read_checkpoint_rejects_pointers_outside_device_geometry() {
+        // SECURITY (finding 18): a crafted or corrupted header claiming an
+        // imap/segment-bitmap pointer beyond the device's actual block
+        // count must be rejected -- write_checkpoint's #319 check only
+        // guards the write path; a checkpoint could reach disk through
+        // some other route (corruption, a crafted image) and must still
+        // be rejected on read, before its pointers are handed to the
+        // imap/segment-bitmap loaders.
+        let mut dev = block_device_for_checkpoint(); // 2048 blocks
+        let mut cache = BlockCache::new();
+
+        let header = CheckpointHeader {
+            magic: CHECKPOINT_MAGIC,
+            sequence: 1,
+            imap_block: 10,
+            imap_block_count: 1,
+            // segment_bitmap_block + count runs far past the device's 2048
+            // blocks. write_checkpoint's slot-capacity check would already
+            // reject this at write time, so write the header block
+            // directly to simulate a corrupted/crafted on-disk header
+            // reaching read.
+            segment_bitmap_block: 2000,
+            segment_bitmap_count: 100,
+            next_inode: 1,
+            last_segment_sequence: 1,
+        };
+
+        let header_buf = header.to_block();
+        cache
+            .write(&mut dev, 1, &header_buf)
+            .expect("write raw header block");
+        cache.flush(&mut dev).expect("flush");
+
+        let mut cache2 = BlockCache::new();
+        let result = read_checkpoint(&mut dev, &mut cache2, 1);
+        assert!(
+            matches!(result, Err(LfsError::Corrupt)),
+            "an out-of-geometry checkpoint header must be rejected as Corrupt"
+        );
     }
 }

--- a/crates/thumos/src/lfs_compact.rs
+++ b/crates/thumos/src/lfs_compact.rs
@@ -267,7 +267,12 @@ fn pick_candidate(
         }
     }
 
-    best.ok_or(LfsError::NoFreeSegments)
+    // WHY (finding 5): distinct from "no free segments" (the filesystem is
+    // completely full) -- this means no segment qualifies as a compaction
+    // candidate (every segment is either free already or is the writer's
+    // active segment), which can legitimately happen when compaction is
+    // triggered but nothing is actually reclaimable yet.
+    best.ok_or(LfsError::NoCompactionCandidate)
 }
 
 /// Collect all (inode_id, block_number) pairs from the imap.

--- a/crates/thumos/src/lfs_imap.rs
+++ b/crates/thumos/src/lfs_imap.rs
@@ -36,6 +36,11 @@ pub enum LfsError {
     /// A checkpoint's imap + segment-bitmap payload exceeds the slot's
     /// reserved capacity.
     CheckpointOverflow,
+    /// No segment is eligible for compaction (every segment is free or is
+    /// the writer's active segment) -- distinct from `NoFreeSegments`,
+    /// which means the filesystem is out of free segments entirely
+    /// (finding 5).
+    NoCompactionCandidate,
 }
 
 impl core::fmt::Display for LfsError {
@@ -49,6 +54,7 @@ impl core::fmt::Display for LfsError {
             Self::CheckpointOverflow => {
                 write!(f, "checkpoint payload exceeds reserved slot capacity")
             }
+            Self::NoCompactionCandidate => write!(f, "no segment eligible for compaction"),
         }
     }
 }

--- a/crates/thumos/src/lfs_writer.rs
+++ b/crates/thumos/src/lfs_writer.rs
@@ -286,6 +286,23 @@ impl LfsWriter {
         seg_mgr: &mut LfsSegmentManager,
         reserve_ok: bool,
     ) -> Result<(), LfsError> {
+        // WHY (finding 6): allocate the replacement segment BEFORE writing
+        // the header or advancing the sequence. The old order wrote the
+        // header (marking this segment sealed on disk) and incremented
+        // self.sequence first, then allocated -- if allocation failed, the
+        // caller saw NoFreeSegments but the writer had already mutated
+        // on-disk and in-memory state, so a retry re-wrote the same header
+        // with an already-advanced sequence number and incremented it
+        // again, drifting the persisted sequence away from what recovery
+        // expects. Allocating first means a failed seal leaves this
+        // writer's sequence/current_segment/write_position untouched.
+        let new_seg = if reserve_ok {
+            seg_mgr.allocate_for_compaction()
+        } else {
+            seg_mgr.allocate()
+        }
+        .ok_or(LfsError::NoFreeSegments)?;
+
         // The number of data blocks written is write_position - 1 (block 0 is header).
         let data_block_count = self.write_position.saturating_sub(1);
 
@@ -298,19 +315,14 @@ impl LfsWriter {
 
         let header_block = seg_mgr.segment_start_block(self.current_segment);
         let buf = header.to_block();
-        cache.write(dev, header_block, &buf)?;
+        if let Err(e) = cache.write(dev, header_block, &buf) {
+            // Roll back the allocation so a header-write failure does not
+            // leak the newly allocated segment as permanently used.
+            seg_mgr.free(new_seg);
+            return Err(LfsError::from(e));
+        }
 
         self.sequence += 1;
-
-        // Allocate a new segment for the next writes. The compaction path
-        // may take the reserved last-free segment; ordinary writers may
-        // not (#329).
-        let new_seg = if reserve_ok {
-            seg_mgr.allocate_for_compaction()
-        } else {
-            seg_mgr.allocate()
-        }
-        .ok_or(LfsError::NoFreeSegments)?;
         self.current_segment = new_seg;
         self.write_position = 1; // Skip header block.
 

--- a/crates/thumos/src/mic_audit.rs
+++ b/crates/thumos/src/mic_audit.rs
@@ -97,8 +97,12 @@ pub struct MicAuditEntry {
     pub start_tick: u64,
     /// Kernel tick (ms) when the mic was deactivated.
     ///
-    /// `0` if the session is still active (mic is currently on).
-    pub end_tick: u64,
+    /// `None` if the session is still active (mic is currently on). WHY
+    /// (finding 7): a bare `u64` with `0` doubling as "active" made a
+    /// session that genuinely ended at tick 0 (e.g. system boot), or a
+    /// caller passing `0` to `log_end`, indistinguishable from "still
+    /// running" -- `Option<u64>` has no such collision.
+    pub end_tick: Option<u64>,
     /// Audio session kind that triggered mic activation.
     pub session_kind: SessionKind,
     /// Identifier of the calling subsystem (e.g., "telephony", "voip").
@@ -117,7 +121,7 @@ impl MicAuditEntry {
     /// Return whether this session is still active (mic is on).
     #[must_use]
     pub(crate) fn is_active(&self) -> bool {
-        self.end_tick == 0
+        self.end_tick.is_none()
     }
 
     /// Return the duration of the session in milliseconds.
@@ -125,11 +129,7 @@ impl MicAuditEntry {
     /// Returns `None` if the session is still active.
     #[must_use]
     pub(crate) fn duration_ms(&self) -> Option<u64> {
-        if self.is_active() {
-            None
-        } else {
-            Some(self.end_tick.saturating_sub(self.start_tick))
-        }
+        self.end_tick.map(|end| end.saturating_sub(self.start_tick))
     }
 }
 
@@ -203,7 +203,7 @@ impl MicAuditLog {
         let entry = MicAuditEntry {
             id,
             start_tick: tick_ms,
-            end_tick: 0,
+            end_tick: None,
             session_kind: kind,
             caller: caller_buf,
             caller_len: copy_len as u8,
@@ -227,7 +227,7 @@ impl MicAuditLog {
             return Err(MicAuditError::AlreadyEnded);
         }
 
-        entry.end_tick = tick_ms;
+        entry.end_tick = Some(tick_ms);
         Ok(())
     }
 
@@ -298,7 +298,10 @@ mod tests {
         let entry = &log.entries()[0];
         assert_eq!(entry.id, 1);
         assert_eq!(entry.start_tick, 1000);
-        assert_eq!(entry.end_tick, 0, "active session must have end_tick 0");
+        assert_eq!(
+            entry.end_tick, None,
+            "active session must have end_tick None"
+        );
         assert_eq!(entry.session_kind, SessionKind::VoiceCall);
         assert_eq!(entry.caller(), b"telephony");
         assert!(entry.is_active(), "entry must be active before log_end");
@@ -312,7 +315,7 @@ mod tests {
         assert!(result.is_ok(), "log_end must succeed");
 
         let entry = &log.entries()[0];
-        assert_eq!(entry.end_tick, 5000);
+        assert_eq!(entry.end_tick, Some(5000));
         assert!(!entry.is_active(), "entry must not be active after log_end");
         assert_eq!(
             entry.duration_ms(),
@@ -344,6 +347,25 @@ mod tests {
             Err(MicAuditError::AlreadyEnded),
             "ending an already-ended entry must return AlreadyEnded"
         );
+    }
+
+    #[test]
+    fn log_end_at_tick_zero_is_not_confused_with_active() {
+        // finding 7: a session that legitimately ends at tick 0 must not
+        // be reported as still active -- the old end_tick: u64 sentinel
+        // (0 == "active") made this ambiguous. end_tick: Option<u64> has
+        // no such collision.
+        let mut log = MicAuditLog::new();
+        let id = log.log_start(SessionKind::VoiceCall, b"telephony", 0);
+        log.log_end(id, 0).ok();
+
+        let entry = &log.entries()[0];
+        assert!(
+            !entry.is_active(),
+            "a session ended at tick 0 must not read as active"
+        );
+        assert_eq!(entry.end_tick, Some(0));
+        assert_eq!(entry.duration_ms(), Some(0));
     }
 
     #[test]

--- a/crates/thumos/src/mmu.rs
+++ b/crates/thumos/src/mmu.rs
@@ -116,10 +116,15 @@ pub(crate) fn alloc_l2_table() -> Option<usize> {
 
 /// Free an L2 page table back to the pool.
 ///
+/// Returns `true` if `phys_addr` matched an allocated pool slot and was
+/// freed, `false` if it matched no slot -- WHY (finding 8): the caller can
+/// now detect a free of an unrecognized address instead of the prior
+/// silent no-op.
+///
 /// # Safety
 ///
 /// `phys_addr` must have been returned by `alloc_l2_table` and not yet freed.
-pub unsafe fn free_l2_table(phys_addr: usize) {
+pub unsafe fn free_l2_table(phys_addr: usize) -> bool {
     // WHY (#416): serializes with every other L2_ALLOC accessor (see
     // alloc_l2_table) so a concurrent alloc/free pair cannot corrupt a torn
     // bitmask update.
@@ -131,10 +136,11 @@ pub unsafe fn free_l2_table(phys_addr: usize) {
                 let alloc = core::ptr::addr_of_mut!(L2_ALLOC);
                 let mask = core::ptr::read_volatile(alloc);
                 core::ptr::write_volatile(alloc, mask & !(1u64 << i));
-                return;
+                return true;
             }
         }
     }
+    false
 }
 
 /// POSIX protection flag constants (from mman.h).
@@ -163,8 +169,15 @@ pub(crate) fn prot_to_l2_flags(prot_flags: u32) -> u32 {
         attrs |= page_flags::AP_KERNEL_ONLY; // no user access
     }
 
-    // Execute-never if exec permission not requested
-    if prot_flags & prot::PROT_EXEC == 0 {
+    // WHY (SECURITY, finding 19, W^X / #417): a page must never be both
+    // writable and executable -- that combination is a direct
+    // code-injection primitive (write shellcode, then execute it from the
+    // same mapping). PROT_WRITE always forces XN regardless of whether
+    // PROT_EXEC was also requested, so sys_mmap/sys_mprotect (the only two
+    // callers, in syscall.rs) can never install a WX page even though
+    // neither performs its own WX check before calling this function.
+    // Execute-never unless exec was requested AND write was not.
+    if prot_flags & prot::PROT_WRITE != 0 || prot_flags & prot::PROT_EXEC == 0 {
         attrs |= page_flags::XN;
     }
 
@@ -614,10 +627,15 @@ pub fn alloc_addr_space() -> Option<usize> {
 /// (`flags::SECTION`, bits [1:0] = 0b10), never `page_flags::L1_PAGE_TABLE`
 /// (0b01), so this walk never touches or frees the kernel's own mappings.
 ///
+/// Returns `true` if `phys_addr` matched an allocated pool slot and was
+/// freed, `false` if it matched no slot -- WHY (finding 8): the caller can
+/// now detect a free of an unrecognized address instead of the prior
+/// silent no-op.
+///
 /// # Safety
 ///
 /// `phys_addr` must have been returned by `alloc_addr_space` and not yet freed.
-pub unsafe fn free_addr_space(phys_addr: usize) {
+pub unsafe fn free_addr_space(phys_addr: usize) -> bool {
     // WHY (#416): serializes with every other ADDR_SPACE_ALLOC accessor (see
     // alloc_addr_space) so a concurrent alloc/free pair cannot corrupt a
     // torn bitmask update.
@@ -638,10 +656,11 @@ pub unsafe fn free_addr_space(phys_addr: usize) {
                 let alloc = core::ptr::addr_of_mut!(ADDR_SPACE_ALLOC);
                 let mask = core::ptr::read_volatile(alloc);
                 core::ptr::write_volatile(alloc, mask & !(1 << i));
-                return;
+                return true;
             }
         }
     }
+    false
 }
 
 /// Copy all 4096 L1 entries FROM the source address space INTO the destination.
@@ -701,6 +720,39 @@ mod tests {
 
     fn reset() {
         reset_addr_space_pool();
+    }
+
+    #[test]
+    fn prot_to_l2_flags_denies_write_plus_exec_wx_combo() {
+        // SECURITY (finding 19, W^X / #417): PROT_WRITE | PROT_EXEC must
+        // never yield a page that is both writable and executable -- the
+        // direct code-injection primitive (write shellcode, then execute
+        // it from the same mapping). Neither sys_mmap nor sys_mprotect
+        // perform their own WX check before calling prot_to_l2_flags, so
+        // this function is the sole enforcement point.
+        let attrs = prot_to_l2_flags(prot::PROT_READ | prot::PROT_WRITE | prot::PROT_EXEC);
+        assert_eq!(
+            attrs & page_flags::AP_FULL,
+            page_flags::AP_FULL,
+            "write access must still be granted"
+        );
+        assert_eq!(
+            attrs & page_flags::XN,
+            page_flags::XN,
+            "exec must be stripped (XN set) when write is also requested"
+        );
+    }
+
+    #[test]
+    fn prot_to_l2_flags_allows_exec_without_write() {
+        // A read+exec-only mapping (no write) is not a WX page and must
+        // remain executable.
+        let attrs = prot_to_l2_flags(prot::PROT_READ | prot::PROT_EXEC);
+        assert_eq!(
+            attrs & page_flags::XN,
+            0,
+            "read+exec without write must remain executable"
+        );
     }
 
     #[test]

--- a/crates/thumos/src/panic_wipe.rs
+++ b/crates/thumos/src/panic_wipe.rs
@@ -34,6 +34,7 @@ extern crate alloc;
 
 use core::fmt;
 
+use crate::irq;
 use crate::key_manager::KeyManager;
 use crate::page;
 
@@ -203,8 +204,24 @@ impl fmt::Display for DistressBeacon {
 pub struct WipeResult {
     /// Number of targets that completed successfully.
     pub targets_completed: usize,
+    /// Whether the primary encryption keys were zeroized in memory.
+    /// WHY (SECURITY, finding 14, info): tracked separately from
+    /// `failed_targets`'s entry for `WipeTarget::Keys`, which reflects
+    /// ONLY the on-disk key-file overwrite (defense-in-depth, currently
+    /// always fails per #324/#129) -- conflating the two under one bit
+    /// would let a reader mistake "Keys in failed_targets" for "the
+    /// encryption keys are still recoverable" when the in-memory keys
+    /// (the actual protection) are already destroyed. Set inside the
+    /// IRQ-masked critical section in Step 1 (finding 15).
+    pub keys_zeroized_in_memory: bool,
     /// Number of targets that failed.
     pub targets_failed: usize,
+    /// Which targets failed, in plan order (up to `PANIC_WIPE_TARGET_COUNT`
+    /// slots; unused slots are `None`). WHY (SECURITY, finding 9): the
+    /// caller needs to know WHICH category of sensitive data survived an
+    /// incomplete wipe, not just how many -- a bare count cannot
+    /// distinguish "WiFi credentials intact" from "message store intact".
+    pub failed_targets: [Option<WipeTarget>; PANIC_WIPE_TARGET_COUNT],
     /// Whether memory scrub was performed.
     pub memory_scrubbed: bool,
     /// Whether the distress beacon was emitted.
@@ -215,9 +232,20 @@ impl fmt::Display for WipeResult {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "WipeResult(completed={}, failed={}, scrubbed={}, beacon={})",
+            "WipeResult(completed={}, failed={}, scrubbed={}, beacon={}",
             self.targets_completed, self.targets_failed, self.memory_scrubbed, self.beacon_emitted,
-        )
+        )?;
+        if self.targets_failed > 0 {
+            write!(f, ", failed_targets=[")?;
+            for (i, target) in self.failed_targets.iter().flatten().enumerate() {
+                if i > 0 {
+                    write!(f, ", ")?;
+                }
+                write!(f, "{target}")?;
+            }
+            write!(f, "]")?;
+        }
+        write!(f, ")")
     }
 }
 
@@ -276,34 +304,51 @@ pub(crate) unsafe fn execute_panic_wipe(
 
     let mut completed: usize = 0;
     let mut failed: usize = 0;
+    let mut failed_targets: [Option<WipeTarget>; PANIC_WIPE_TARGET_COUNT] =
+        [None; PANIC_WIPE_TARGET_COUNT];
 
     // Step 1: Zeroize keys from memory — this is the critical action
-    // that makes all encrypted data unrecoverable.
-    key_manager.zeroize_all();
+    // that makes all encrypted data unrecoverable. WHY (SECURITY, finding
+    // 15): wrapped in a stop-the-world IRQ-masked critical section so no
+    // timer/scheduler-tick or other IRQ handler can preempt between "wipe
+    // triggered" and "keys destroyed" -- without this, an interrupt firing
+    // mid-zeroize could switch away to code that still observes the live
+    // keys for one or more scheduling quanta.
+    let keys_zeroized_in_memory = {
+        let _irq_guard = irq::IrqGuard::new();
+        key_manager.zeroize_all();
+        true
+    };
 
     for target in plan.targets() {
-        match target {
-            WipeTarget::Keys => {
-                // Already zeroized above; mark as complete.
-                // The filesystem key files are defense-in-depth.
-                if dry_run || wipe_target_path(target.path()) {
-                    completed = completed.saturating_add(1);
-                } else {
-                    failed = failed.saturating_add(1);
-                }
+        // WHY (SECURITY, finding 9): every target's on-disk tally comes
+        // from the same wipe_target_path() check -- WipeTarget::Keys' own
+        // in-memory zeroization already happened unconditionally in Step 1
+        // above and is tracked separately via `keys_zeroized_in_memory`
+        // (finding 14), so a failure recorded here must not be read as
+        // "the encryption keys are still recoverable".
+        if dry_run || wipe_target_path(target.path()) {
+            completed = completed.saturating_add(1);
+        } else {
+            // WHY (SECURITY, finding 9): record WHICH target failed, not
+            // just a bare count -- an operator needs to know whether it
+            // was WiFi credentials or the message store that survived an
+            // incomplete wipe.
+            if let Some(slot) = failed_targets.get_mut(failed) {
+                *slot = Some(*target);
             }
-            _ => {
-                if dry_run || wipe_target_path(target.path()) {
-                    completed = completed.saturating_add(1);
-                } else {
-                    failed = failed.saturating_add(1);
-                }
-            }
+            failed = failed.saturating_add(1);
         }
     }
 
-    // Step 2: Emit distress beacon.
+    // Step 2: Build the distress beacon payload. WHY (SECURITY, finding
+    // 10): emit_distress_beacon only constructs the in-memory payload --
+    // the actual mesh/LoRa transmission is not yet wired (same class as
+    // #129's wipe_target_path stub), so this function never hands the
+    // beacon to a radio driver. beacon_emitted below must report false
+    // rather than claiming a distress signal was actually transmitted.
     let _beacon = emit_distress_beacon(triggered_at, !key_manager.has_keys());
+    let beacon_emitted = false;
 
     // Step 3: Memory scrub.
     let memory_scrubbed = if dry_run {
@@ -317,9 +362,11 @@ pub(crate) unsafe fn execute_panic_wipe(
 
     WipeResult {
         targets_completed: completed,
+        keys_zeroized_in_memory,
         targets_failed: failed,
+        failed_targets,
         memory_scrubbed,
-        beacon_emitted: true,
+        beacon_emitted,
     }
 }
 
@@ -489,7 +536,10 @@ mod tests {
         );
         assert_eq!(result.targets_completed, PANIC_WIPE_TARGET_COUNT);
         assert_eq!(result.targets_failed, 0);
-        assert!(result.beacon_emitted);
+        assert!(
+            !result.beacon_emitted,
+            "beacon_emitted must be false until mesh transmission is actually wired (finding 10)"
+        );
     }
 
     #[test]
@@ -501,6 +551,27 @@ mod tests {
         assert!(
             result.memory_scrubbed,
             "dry-run must report memory as scrubbed"
+        );
+    }
+
+    #[test]
+    fn execute_panic_wipe_restores_irq_state_after_key_zeroization() {
+        // SECURITY (finding 15): the key-zeroization step in Step 1 runs
+        // inside an IrqGuard so no IRQ/scheduler-tick can preempt between
+        // "wipe triggered" and "keys destroyed". Verify the guard is
+        // correctly scoped: IRQ delivery must be back in its normal
+        // (enabled) state once execute_panic_wipe returns, not left
+        // masked.
+        crate::irq::reset_mock();
+        assert!(crate::irq::mock_enabled(), "starts unmasked");
+
+        let mut km = key_manager_with_derived_keys();
+        // SAFETY: dry_run = true performs no destructive I/O.
+        let _result = unsafe { execute_panic_wipe(&mut km, 6000, true) };
+
+        assert!(
+            crate::irq::mock_enabled(),
+            "IRQ delivery must be restored (guard dropped) after the wipe completes"
         );
     }
 
@@ -538,6 +609,29 @@ mod tests {
         assert!(beacon.keys_zeroized);
     }
 
+    #[test]
+    fn keys_zeroized_in_memory_is_tracked_separately_from_file_tally() {
+        // SECURITY (finding 14, info): WipeTarget::Keys' entry in
+        // failed_targets reflects ONLY the on-disk key-file overwrite
+        // (currently always fails: #324/#129's wipe_target_path stub).
+        // The in-memory zeroization in Step 1 is unconditional and
+        // infallible, and must be visible independent of that filesystem
+        // tally so a reader cannot mistake "Keys in failed_targets" for
+        // "the encryption keys are still recoverable".
+        let mut km = key_manager_with_derived_keys();
+        // SAFETY: this is the last action in this test.
+        let result = unsafe { execute_panic_wipe(&mut km, 5000, false) };
+
+        assert!(
+            result.keys_zeroized_in_memory,
+            "in-memory key zeroization must be reported true independent of the file tally"
+        );
+        assert!(
+            result.failed_targets.contains(&Some(WipeTarget::Keys)),
+            "the key-FILE overwrite is still expected to fail while wipe_target_path is a stub"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // Target paths
     // -----------------------------------------------------------------------
@@ -560,6 +654,22 @@ mod tests {
                 "{target} path must be under /data/: {path}"
             );
         }
+    }
+
+    #[test]
+    fn beacon_emitted_reports_false_while_transmission_is_unwired() {
+        // SECURITY (finding 10): emit_distress_beacon only builds the
+        // payload in memory -- execute_panic_wipe never hands it to a
+        // mesh/radio driver, so reporting beacon_emitted=true would tell
+        // the operator a distress signal went out over LoRa when nothing
+        // was actually transmitted.
+        let mut km = key_manager_with_derived_keys();
+        // SAFETY: dry_run = true performs no destructive I/O.
+        let result = unsafe { execute_panic_wipe(&mut km, 4000, true) };
+        assert!(
+            !result.beacon_emitted,
+            "beacon_emitted must be false until mesh transmission is actually wired"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -588,7 +698,9 @@ mod tests {
 
         let result = WipeResult {
             targets_completed: 5,
+            keys_zeroized_in_memory: true,
             targets_failed: 1,
+            failed_targets: [None; PANIC_WIPE_TARGET_COUNT],
             memory_scrubbed: true,
             beacon_emitted: true,
         };
@@ -608,6 +720,38 @@ mod tests {
         // targets it never actually overwrote.
         assert!(!wipe_target_path("/data/keys"));
         assert!(!wipe_target_path("/data/contacts"));
+    }
+
+    #[test]
+    fn execute_wipe_records_which_targets_failed() {
+        // SECURITY (finding 9): a bare failure count cannot tell an
+        // operator WHICH category of sensitive data survived an
+        // incomplete panic wipe. With the LFS wipe backend absent (#129),
+        // every filesystem target fails, so failed_targets must name each
+        // one individually.
+        let mut km = key_manager_with_derived_keys();
+        // SAFETY: this is the last action in this test.
+        let result = unsafe { execute_panic_wipe(&mut km, 3000, false) };
+
+        assert_eq!(result.targets_failed, PANIC_WIPE_TARGET_COUNT);
+        let named_count = result.failed_targets.iter().flatten().count();
+        assert_eq!(
+            named_count, PANIC_WIPE_TARGET_COUNT,
+            "every failed target must be individually named, not just counted"
+        );
+        for expected in [
+            WipeTarget::Keys,
+            WipeTarget::Contacts,
+            WipeTarget::Messages,
+            WipeTarget::CallHistory,
+            WipeTarget::WifiCredentials,
+            WipeTarget::BluetoothPairings,
+        ] {
+            assert!(
+                result.failed_targets.contains(&Some(expected)),
+                "{expected} must appear in failed_targets"
+            );
+        }
     }
 
     #[test]

--- a/crates/thumos/src/sim.rs
+++ b/crates/thumos/src/sim.rs
@@ -263,16 +263,22 @@ impl SimManager {
         match result {
             AtResponse::Ok if info_len > 0 => {
                 let line = &info_line[..info_len];
-                if let Some((rssi_raw, ber)) = telephony::parse_csq_response(line) {
-                    let dbm = rssi_to_dbm(rssi_raw);
-                    self.signal_info = SignalInfo {
-                        rssi: dbm,
-                        bars: dbm_to_bars(dbm),
-                        ber,
-                        rssi_raw,
-                    };
+                // WHY (finding 11): a +CSQ line that fails to parse must
+                // surface as an error, not silently return Ok with the
+                // previous (possibly stale) signal_info left unchanged.
+                match telephony::parse_csq_response(line) {
+                    Some((rssi_raw, ber)) => {
+                        let dbm = rssi_to_dbm(rssi_raw);
+                        self.signal_info = SignalInfo {
+                            rssi: dbm,
+                            bars: dbm_to_bars(dbm),
+                            ber,
+                            rssi_raw,
+                        };
+                        Ok(&self.signal_info)
+                    }
+                    None => Err(TelephonyError::ParseError),
                 }
-                Ok(&self.signal_info)
             }
             AtResponse::Ok => Ok(&self.signal_info),
             AtResponse::CmeError(code) => Err(TelephonyError::CmeError(code)),
@@ -283,12 +289,19 @@ impl SimManager {
 
     /// Poll signal strength if the polling interval has elapsed.
     ///
-    /// Returns the updated signal info if a poll was performed.
+    /// Returns `None` if the polling interval has not yet elapsed (no poll
+    /// was attempted). Returns `Some(Ok(..))` with the updated signal info
+    /// if the poll succeeded, or `Some(Err(..))` if a poll was attempted
+    /// but the modem query failed. WHY (finding 12): collapsing a failed
+    /// poll into the same `None` used for "not time yet" (via `.ok()`)
+    /// made a modem error indistinguishable from routine throttling,
+    /// mirroring the fix already applied to `Telephony::poll_signal`
+    /// (issue #282 finding 3).
     pub(crate) fn poll_signal<T: ModemTransport>(
         &mut self,
         transport: &mut T,
         current_tick: u64,
-    ) -> Option<&SignalInfo> {
+    ) -> Option<Result<&SignalInfo, TelephonyError>> {
         if let Some(last) = self.last_poll_tick {
             if current_tick.saturating_sub(last) < SIGNAL_POLL_INTERVAL_MS {
                 return None;
@@ -296,7 +309,7 @@ impl SimManager {
         }
 
         self.last_poll_tick = Some(current_tick);
-        self.query_signal(transport).ok()
+        Some(self.query_signal(transport))
     }
 
     // -----------------------------------------------------------------------
@@ -570,6 +583,22 @@ mod tests {
         transport.queue_info_ok(b"+CSQ: 25,0");
         let result = sim.poll_signal(&mut transport, 31_000);
         assert!(result.is_some(), "poll after interval must trigger");
+    }
+
+    #[test]
+    fn poll_signal_distinguishes_modem_error_from_interval_skip() {
+        // finding 12: a failed poll (modem/transport error) must be
+        // visible as Some(Err(..)), not collapsed into the same None used
+        // for "too soon to poll again".
+        let mut transport = MockModemTransport::new();
+        transport.send_ok = false;
+        let mut sim = SimManager::new();
+
+        let result = sim.poll_signal(&mut transport, 0);
+        assert!(
+            matches!(result, Some(Err(_))),
+            "a failed poll must surface as Some(Err(..)), not None"
+        );
     }
 
     #[test]

--- a/crates/thumos/src/telephony_parser.rs
+++ b/crates/thumos/src/telephony_parser.rs
@@ -26,14 +26,22 @@ pub(crate) fn parse_final_result(line: &[u8]) -> Option<AtResponse> {
         return Some(AtResponse::Error);
     }
     if let Some(rest) = strip_prefix(line, b"+CME ERROR: ") {
-        if let Some(code) = parse_u32(rest) {
-            return Some(AtResponse::CmeError(code));
-        }
+        // WHY (finding 13): a modem in verbose CME error mode (AT+CMEE=2,
+        // 3GPP TS 27.007 section 9.2) reports a text message here instead
+        // of a numeric code (e.g. "+CME ERROR: SIM not inserted"). Falling
+        // through unclassified left the caller's response loop treating
+        // the line as informational and eventually timing out, hiding a
+        // real modem-reported error behind a misleading Timeout.
+        return Some(match parse_u32(rest) {
+            Some(code) => AtResponse::CmeError(code),
+            None => AtResponse::Error,
+        });
     }
     if let Some(rest) = strip_prefix(line, b"+CMS ERROR: ") {
-        if let Some(code) = parse_u32(rest) {
-            return Some(AtResponse::CmsError(code));
-        }
+        return Some(match parse_u32(rest) {
+            Some(code) => AtResponse::CmsError(code),
+            None => AtResponse::Error,
+        });
     }
     None
 }
@@ -424,11 +432,26 @@ mod tests {
     }
 
     #[test]
-    fn parse_final_result_malformed_cme_code_returns_none() {
+    fn parse_final_result_verbose_cme_error_classifies_as_generic_error() {
+        // finding 13: a verbose (text) CME/CMS error -- e.g. AT+CMEE=2
+        // mode -- must still classify as a final result (AtResponse::Error)
+        // rather than falling through unclassified, which left the
+        // caller's response loop treating it as an info line until it
+        // eventually timed out.
         assert_eq!(
             parse_final_result(b"+CME ERROR: x"),
-            None,
-            "a non-numeric CME error code must not classify as any final result"
+            Some(AtResponse::Error),
+            "a non-numeric CME error code must classify as a generic Error, not fall through to None"
+        );
+        assert_eq!(
+            parse_final_result(b"+CME ERROR: SIM not inserted"),
+            Some(AtResponse::Error),
+            "a verbose CME ERROR message must classify as a generic Error, not time out unclassified"
+        );
+        assert_eq!(
+            parse_final_result(b"+CMS ERROR: SMS storage full"),
+            Some(AtResponse::Error),
+            "a verbose CMS ERROR message must classify as a generic Error, not time out unclassified"
         );
     }
 


### PR DESCRIPTION
First wave-3 batch (#337). **1 stale** (slab cap #405). **1 too-large** — the fixed global PBKDF2 salt (finding 17) is real + critical (all devices derive identical keys from the same salt) but a correct per-device salt needs an entropy-at-provisioning + plaintext on-disk-header seam that doesn't exist yet; flagged with a plan (refusing to substitute an attacker-readable device-id salt that would fake a fix).

## Security
- **W^X (#417)** — `prot_to_l2_flags` produced a writable+executable page for `PROT_WRITE|PROT_EXEC` (a direct code-injection primitive), and it's the *sole* enforcement point (neither mmap nor mprotect check WX). Now forces XN on any writable page.
- **panic-wipe integrity** — `beacon_emitted` was hardcoded `true` while the distress beacon is only built in memory and discarded (mesh transmit unwired) — a **misleading duress signal**; now false. Per-target failures recorded (which data survived, not just a count). Key zeroization runs inside an `IrqGuard` stop-the-world section. In-memory zeroization tallied separately from the key-file overwrite.
- **lfs_checkpoint** — read now validates header pointers/counts against device geometry (was magic-only); a crafted checkpoint's out-of-range pointers reached the loaders on mount.
- **encryption** — `count*SECTOR_SIZE` could wrap on 32-bit → checked_mul.

## Correctness
elf 17th-segment reject; lfs_writer allocate-before-seal; lfs_compact no-candidate vs no-space; mic_audit end_tick Option; sim CSQ-error + poll_signal Some(Err)/None; telephony verbose-CME classify; encryption error-map; dhcp gateway-route removal; mmu free-recognized bool. + coverage.

## Verification
- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — **2092 passed** (14 new; clean apply, no test fixups)
- `cargo build --release --target armv7a-none-eabi` — clean · `kanon lint` — clean

Partially addresses #337 (findings 1-21: 19 fixed + 1 stale; 1 too-large). ~21 remain.

_W^X + panic-wipe + checkpoint + salt reviewed at T0/Opus._