### PR TITLE
Wave-3 low-rollup batch 2: 32 coverage tests (#337 tail)

### DIFF
--- a/crates/thumos/src/encryption.rs
+++ b/crates/thumos/src/encryption.rs
@@ -607,4 +607,59 @@ mod tests {
             "display must contain type name"
         );
     }
+
+    #[test]
+    fn partial_block_write_preserves_untouched_neighbor_sectors() {
+        // Done-when (finding 22): a partial-block write (fewer than
+        // SECTORS_PER_BLOCK sectors) must read-modify-write -- sectors in
+        // the same 4 KiB block that were NOT part of this write must
+        // retain their prior plaintext content, not be zeroed or
+        // corrupted by the encrypt/decrypt round-trip.
+        let mut dev = MemBlockDevice::new(TEST_SECTORS).expect("create device");
+        let key = sample_xts_key();
+
+        // Fill the whole first block with a known pattern.
+        let full_block = [0x11u8; BLOCK_SIZE];
+        {
+            let mut enc = EncryptedBlockDevice::new(&mut dev, key);
+            enc.write_sectors(0, SECTORS_PER_BLOCK as u32, &full_block)
+                .expect("full block write failed");
+        }
+
+        // Overwrite only sectors 2-3 (partial, within the block) with a
+        // different pattern.
+        let partial_data = vec![0x22u8; 2 * SECTOR_SIZE];
+        {
+            let mut enc = EncryptedBlockDevice::new(&mut dev, key);
+            enc.write_sectors(2, 2, &partial_data)
+                .expect("partial write failed");
+        }
+
+        // Read back the whole block and verify neighbor sectors are
+        // untouched.
+        let mut readback = [0u8; BLOCK_SIZE];
+        {
+            let enc = EncryptedBlockDevice::new(&mut dev, key);
+            enc.read_sectors(0, SECTORS_PER_BLOCK as u32, &mut readback)
+                .expect("full block read failed");
+        }
+
+        // Sectors 0-1 (before the partial write) must be untouched.
+        assert!(
+            readback[..2 * SECTOR_SIZE].iter().all(|&b| b == 0x11),
+            "sectors before the partial write must retain original data"
+        );
+        // Sectors 2-3 (the partial write) must have the new pattern.
+        assert!(
+            readback[2 * SECTOR_SIZE..4 * SECTOR_SIZE]
+                .iter()
+                .all(|&b| b == 0x22),
+            "written sectors must reflect the new data"
+        );
+        // Sectors 4-7 (after the partial write) must be untouched.
+        assert!(
+            readback[4 * SECTOR_SIZE..].iter().all(|&b| b == 0x11),
+            "sectors after the partial write must retain original data"
+        );
+    }
 }

--- a/crates/thumos/src/gsm7.rs
+++ b/crates/thumos/src/gsm7.rs
@@ -277,4 +277,41 @@ mod tests {
         let count = count_gsm7_septets("Hi").unwrap_or(0);
         assert_eq!(count, 2, "'Hi' must count as 2 septets");
     }
+
+    #[test]
+    fn encode_gsm7_rejects_non_gsm7_char() {
+        // Done-when (finding 23): a character with no GSM-7
+        // representation (e.g. CJK) must be rejected via
+        // SmsError::Gsm7Encode, not silently dropped or substituted.
+        let result = encode_gsm7("中"); // CJK character, not in GSM-7
+        assert!(
+            matches!(result, Err(SmsError::Gsm7Encode(_))),
+            "a non-GSM-7 character must be rejected as Gsm7Encode"
+        );
+    }
+
+    #[test]
+    fn count_gsm7_septets_rejects_non_gsm7_char() {
+        // Done-when (finding 23): count_gsm7_septets must reject the same
+        // way encode_gsm7 does, not silently miscount.
+        let result = count_gsm7_septets("中");
+        assert!(
+            matches!(result, Err(SmsError::Gsm7Encode(_))),
+            "count_gsm7_septets must reject a non-GSM-7 character"
+        );
+    }
+
+    #[test]
+    fn decode_gsm7_rejects_truncated_pdu() {
+        // Done-when (finding 24): asking decode_gsm7 for more septets
+        // than the packed buffer actually contains must return
+        // SmsError::PduDecode, not panic or silently produce garbage/
+        // short output.
+        let encoded = encode_gsm7("Hi").unwrap_or_default(); // 2 septets, 2 bytes
+        let result = decode_gsm7(&encoded, 100);
+        assert!(
+            matches!(result, Err(SmsError::PduDecode)),
+            "a truncated PDU must be rejected as PduDecode"
+        );
+    }
 }

--- a/crates/thumos/src/key_manager.rs
+++ b/crates/thumos/src/key_manager.rs
@@ -539,4 +539,51 @@ mod tests {
             "same primary key must produce same audit key"
         );
     }
+
+    #[test]
+    fn derive_from_passphrase_production_entry_point() {
+        // Done-when (finding 25): exercise the actual production entry
+        // point -- 100k PBKDF2 iterations, the fixed on-disk salt -- not
+        // just the low-iteration derive_test_primary helper every other
+        // test in this module uses for speed.
+        let key1 = KeyManager::derive_from_passphrase(b"production entry point test")
+            .expect("derive_from_passphrase must succeed");
+        assert!(!key1.is_zero(), "derived primary key must not be all zeros");
+
+        let key2 = KeyManager::derive_from_passphrase(b"production entry point test")
+            .expect("derive_from_passphrase must succeed");
+        assert_eq!(
+            key1.as_bytes(),
+            key2.as_bytes(),
+            "the production entry point must be deterministic for the same passphrase"
+        );
+    }
+
+    #[test]
+    fn set_sleep_tier_short_preserves_keys() {
+        // Done-when (finding 26): set_sleep_tier's non-Long branch must
+        // leave loaded keys untouched -- only a transition TO Long
+        // triggers zeroize_all. The existing long_sleep_zeroizes_keys
+        // test only exercises the Long branch.
+        let primary = derive_test_primary(b"short tier preserves keys");
+        let mut km = KeyManager::new();
+        km.derive_partition_keys(&primary)
+            .expect("derive_partition_keys failed");
+        assert!(km.has_keys());
+
+        let data_before = *km.data_key().expect("data key missing").as_bytes();
+
+        km.set_sleep_tier(SleepTier::Short);
+
+        assert!(
+            km.has_keys(),
+            "transitioning to Short must not zeroize keys"
+        );
+        assert_eq!(km.sleep_tier(), SleepTier::Short);
+        assert_eq!(
+            km.data_key().expect("data key missing").as_bytes(),
+            &data_before,
+            "data key must be unchanged by a non-Long sleep-tier transition"
+        );
+    }
 }

--- a/crates/thumos/src/lfs_compact.rs
+++ b/crates/thumos/src/lfs_compact.rs
@@ -621,4 +621,158 @@ mod tests {
         let restored = DiskInode::read_from(&buf, 0).expect("parse relocated inode 1");
         assert_eq!(restored.size, 10);
     }
+
+    #[test]
+    fn compact_picks_the_fewest_live_blocks_among_multiple_candidates() {
+        // Done-when (finding 27): when more than one sealed segment is a
+        // compaction candidate, pick_candidate must select the one with
+        // the FEWEST live blocks, not merely the first one scanned. Sets
+        // up three distinct candidate segments with live counts 2, 1, and
+        // 0 and verifies the all-garbage segment (0 live) is the one
+        // reclaimed, while the other two are left completely untouched.
+        let mut dev = block_device_for_compact();
+        let mut cache = BlockCache::new();
+        let mut imap = LfsImap::new();
+        // Segments of 4 blocks (1 header + 3 data slots) so a segment can
+        // hold more than one live inode, letting live counts differ.
+        let mut seg_mgr = LfsSegmentManager::new(8, 4);
+        seg_mgr.mark_used(0);
+
+        let mut writer = LfsWriter::new(&mut seg_mgr).expect("create writer");
+        let seg1 = writer.current_segment();
+
+        // Segment 1: two live inodes (live_count = 2), sealed without
+        // filling its third slot.
+        let inode1 = new_file_inode(10);
+        let inode2 = new_file_inode(20);
+        writer
+            .write_inode(&mut dev, &mut cache, &mut imap, &mut seg_mgr, 1, &inode1)
+            .expect("write inode 1");
+        writer
+            .write_inode(&mut dev, &mut cache, &mut imap, &mut seg_mgr, 2, &inode2)
+            .expect("write inode 2");
+        writer
+            .seal_segment(&mut dev, &mut cache, &mut seg_mgr)
+            .expect("seal segment 1");
+
+        // Segment 2: one live inode (live_count = 1).
+        let seg2 = writer.current_segment();
+        assert_ne!(seg2, seg1, "writer must have moved to a new segment");
+        let inode3 = new_file_inode(30);
+        writer
+            .write_inode(&mut dev, &mut cache, &mut imap, &mut seg_mgr, 3, &inode3)
+            .expect("write inode 3");
+        writer
+            .seal_segment(&mut dev, &mut cache, &mut seg_mgr)
+            .expect("seal segment 2");
+
+        // Segment 3: one inode written and then sealed, so it starts with
+        // one live block.
+        let seg3 = writer.current_segment();
+        assert_ne!(seg3, seg2, "writer must have moved to a new segment");
+        let inode4_v1 = new_file_inode(40);
+        writer
+            .write_inode(&mut dev, &mut cache, &mut imap, &mut seg_mgr, 4, &inode4_v1)
+            .expect("write inode 4 v1");
+        writer
+            .seal_segment(&mut dev, &mut cache, &mut seg_mgr)
+            .expect("seal segment 3");
+
+        // Overwrite inode 4 from the NEW (writer's current) segment, so
+        // segment 3's only live block becomes garbage: segment 3 now has
+        // live_count = 0, the fewest of the three candidates.
+        let inode4_v2 = new_file_inode(41);
+        writer
+            .write_inode(&mut dev, &mut cache, &mut imap, &mut seg_mgr, 4, &inode4_v2)
+            .expect("write inode 4 v2");
+
+        let block1_before = imap.get(1).expect("inode 1 in imap");
+        let block2_before = imap.get(2).expect("inode 2 in imap");
+        let block3_before = imap.get(3).expect("inode 3 in imap");
+
+        let copied =
+            compact_one_segment(&mut dev, &mut cache, &mut writer, &mut imap, &mut seg_mgr)
+                .expect("compact");
+
+        assert_eq!(
+            copied, 0,
+            "the all-garbage segment (segment 3) has nothing live to relocate"
+        );
+        assert!(
+            seg_mgr.is_free(seg3),
+            "segment 3 (0 live blocks, the fewest) must be the one reclaimed"
+        );
+        assert!(
+            !seg_mgr.is_free(seg1),
+            "segment 1 (2 live blocks) must NOT have been reclaimed"
+        );
+        assert!(
+            !seg_mgr.is_free(seg2),
+            "segment 2 (1 live block) must NOT have been reclaimed"
+        );
+
+        // Segments 1 and 2's inodes must be completely untouched (same
+        // addresses as before compaction).
+        assert_eq!(imap.get(1), Some(block1_before));
+        assert_eq!(imap.get(2), Some(block2_before));
+        assert_eq!(imap.get(3), Some(block3_before));
+    }
+
+    #[test]
+    fn needs_compaction_triggers_below_threshold() {
+        // Done-when (finding 29): compaction must trigger once free
+        // segments drop below COMPACT_THRESHOLD_PERCENT of total, and
+        // must NOT trigger while comfortably above it. No existing test
+        // in this module calls needs_compaction at all.
+        let mut seg_mgr = LfsSegmentManager::new(100, 8);
+        seg_mgr.mark_used(0);
+        // 99 segments free (far above the 10% = 10 threshold).
+        assert!(
+            !needs_compaction(&seg_mgr),
+            "far above the free-segment threshold must not trigger compaction"
+        );
+
+        // Drain down to just below the threshold (9 free, threshold 10).
+        while seg_mgr.free_count() > 9 {
+            seg_mgr.allocate_for_compaction();
+        }
+        assert_eq!(seg_mgr.free_count(), 9);
+        assert!(
+            needs_compaction(&seg_mgr),
+            "free_count below the 10% threshold must trigger compaction"
+        );
+    }
+
+    #[test]
+    fn needs_compaction_requires_at_least_one_free_segment_floor() {
+        // A small filesystem where 10% of total rounds down to 0 must
+        // still require at least 1 free segment (the `.max(1)` floor), not
+        // treat "0 free required" as never needing compaction.
+        let mut seg_mgr = LfsSegmentManager::new(4, 8);
+        seg_mgr.mark_used(0);
+        // 3 segments free; threshold floors to 1, so this must not
+        // trigger yet.
+        assert!(
+            !needs_compaction(&seg_mgr),
+            "3 free segments (above the floor of 1) must not trigger compaction"
+        );
+
+        // Drain all free segments (bypassing the compaction-reserve floor
+        // via allocate_for_compaction) down to zero.
+        while seg_mgr.allocate_for_compaction().is_some() {}
+        assert_eq!(seg_mgr.free_count(), 0);
+        assert!(
+            needs_compaction(&seg_mgr),
+            "zero free segments must trigger compaction even when 10% of total rounds to 0"
+        );
+    }
+
+    #[test]
+    fn needs_compaction_zero_segments_is_false() {
+        let seg_mgr = LfsSegmentManager::new(0, 8);
+        assert!(
+            !needs_compaction(&seg_mgr),
+            "a filesystem with zero segments must not report needing compaction"
+        );
+    }
 }

--- a/crates/thumos/src/lfs_imap.rs
+++ b/crates/thumos/src/lfs_imap.rs
@@ -452,4 +452,44 @@ mod tests {
             "overflowing block_count must be rejected, not wrap into a tiny allocation"
         );
     }
+
+    #[test]
+    fn save_and_load_from_disk_round_trips_across_multiple_blocks() {
+        // Done-when (finding 30): an imap large enough to span more than
+        // one 4 KiB block must still round-trip correctly through
+        // save_to_disk / load_from_disk -- the existing
+        // save_and_load_from_disk_round_trips test only has 50 entries
+        // (604 bytes), which fits in a single block and never exercises
+        // the multi-block write/read loop.
+        let mut dev = MemBlockDevice::new(65536).expect("create device"); // 32 MiB
+        let mut cache = BlockCache::new();
+
+        let mut imap = LfsImap::new();
+        const ENTRY_COUNT: u32 = 1000;
+        for i in 0..ENTRY_COUNT {
+            imap.insert(i, u64::from(i) * 7 + 1000);
+        }
+
+        let start_block = 100;
+        let block_count = imap
+            .save_to_disk(&mut dev, &mut cache, start_block)
+            .expect("save should succeed");
+        assert!(
+            block_count > 1,
+            "test fixture must actually span multiple blocks, got {block_count}"
+        );
+
+        let mut cache2 = BlockCache::new();
+        let restored = LfsImap::load_from_disk(&mut dev, &mut cache2, start_block, block_count)
+            .expect("load should succeed");
+
+        assert_eq!(restored.len(), ENTRY_COUNT as usize);
+        for i in 0..ENTRY_COUNT {
+            assert_eq!(
+                restored.get(i),
+                Some(u64::from(i) * 7 + 1000),
+                "inode {i} mismatch across multi-block round-trip"
+            );
+        }
+    }
 }

--- a/crates/thumos/src/lfs_segment.rs
+++ b/crates/thumos/src/lfs_segment.rs
@@ -434,4 +434,34 @@ mod tests {
         mgr.mark_used(5);
         assert!(!mgr.is_free(5));
     }
+
+    #[test]
+    fn deserialize_rejects_header_too_short() {
+        // Done-when (finding 31): fewer than 8 header bytes
+        // (segment_count + segment_size, 4 bytes each) must be rejected
+        // as Corrupt before any bitmap parsing is attempted.
+        let result = LfsSegmentManager::deserialize(&[0u8; 4], 8, 256);
+        assert!(
+            matches!(result, Err(LfsError::Corrupt)),
+            "fewer than 8 header bytes must be rejected as Corrupt"
+        );
+    }
+
+    #[test]
+    fn deserialize_rejects_truncated_bitmap_data() {
+        // A correct 8-byte header but a bitmap payload shorter than the
+        // segment_count implies must be rejected as Corrupt, not read
+        // past the buffer.
+        let mgr = LfsSegmentManager::new(64, 256); // needs 8 bitmap bytes
+        let mut data = mgr.serialize();
+        // Truncate the bitmap portion so fewer bytes remain than
+        // byte_count requires (64 segments = 8 bitmap bytes; leave only 2).
+        data.truncate(8 + 2);
+
+        let result = LfsSegmentManager::deserialize(&data, 64, 256);
+        assert!(
+            matches!(result, Err(LfsError::Corrupt)),
+            "a bitmap shorter than segment_count requires must be rejected as Corrupt"
+        );
+    }
 }

--- a/crates/thumos/src/lfs_writer.rs
+++ b/crates/thumos/src/lfs_writer.rs
@@ -658,4 +658,89 @@ mod tests {
             "writer should have moved to a new segment after fill"
         );
     }
+
+    #[test]
+    fn write_checkpoint_odd_sequence_routes_to_slot_b() {
+        // Done-when (finding 32): an ODD checkpoint_sequence must land in
+        // slot B (checkpoint_slots.1), mirroring the existing
+        // checkpoint_round_trips test which only exercises the even
+        // (slot A) path.
+        let mut dev = block_device_for_writer();
+        let mut cache = BlockCache::new();
+        let mut imap = LfsImap::new();
+        let mut seg_mgr = LfsSegmentManager::new(8, 256);
+        seg_mgr.mark_used(0);
+
+        let mut writer = LfsWriter::new(&mut seg_mgr).expect("create writer");
+
+        let inode = new_file_inode(7);
+        writer
+            .write_inode(&mut dev, &mut cache, &mut imap, &mut seg_mgr, 0, &inode)
+            .expect("write inode 0");
+
+        let checkpoint_slots = (1u64, 2u64); // slot A at block 1, slot B at block 2
+        let checkpoint_seq = 3u64; // odd -> slot B
+
+        writer
+            .write_checkpoint(
+                &mut dev,
+                &mut cache,
+                &imap,
+                &seg_mgr,
+                checkpoint_slots,
+                checkpoint_seq,
+                1, // next_inode
+            )
+            .expect("write checkpoint");
+
+        cache.flush(&mut dev).expect("flush");
+
+        // Reading slot B (block 2) must find the checkpoint we just wrote.
+        let mut cache2 = BlockCache::new();
+        let header = lfs_checkpoint::read_checkpoint(&mut dev, &mut cache2, 2)
+            .expect("read checkpoint from slot B");
+        assert_eq!(header.magic, CHECKPOINT_MAGIC);
+        assert_eq!(header.sequence, checkpoint_seq);
+        assert_eq!(header.next_inode, 1);
+
+        // Slot A (block 1) must NOT have been written -- reading it as a
+        // checkpoint must fail (no valid magic there).
+        let mut cache3 = BlockCache::new();
+        let slot_a_result = lfs_checkpoint::read_checkpoint(&mut dev, &mut cache3, 1);
+        assert!(
+            slot_a_result.is_err(),
+            "an odd sequence must not touch slot A"
+        );
+    }
+
+    #[test]
+    fn with_sequence_resumes_from_the_given_sequence_number() {
+        // Done-when (finding 33): LfsWriter::with_sequence is the
+        // checkpoint-resume constructor -- it must start the writer's
+        // sequence counter at the CALLER-SUPPLIED value (e.g. loaded from
+        // a checkpoint header), not the fixed sequence=1 that
+        // LfsWriter::new always uses. No existing test calls
+        // with_sequence at all.
+        let mut seg_mgr = LfsSegmentManager::new(8, 256);
+        seg_mgr.mark_used(0);
+
+        let mut writer = LfsWriter::with_sequence(&mut seg_mgr, 42).expect("create writer");
+        assert_eq!(
+            writer.sequence(),
+            42,
+            "with_sequence must start at the supplied sequence number"
+        );
+
+        let mut dev = block_device_for_writer();
+        let mut cache = BlockCache::new();
+        // Sealing must advance from the resumed sequence, not from 1.
+        writer
+            .seal_segment(&mut dev, &mut cache, &mut seg_mgr)
+            .expect("seal");
+        assert_eq!(
+            writer.sequence(),
+            43,
+            "sealing must increment the resumed sequence, not reset it"
+        );
+    }
 }

--- a/crates/thumos/src/mic_audit.rs
+++ b/crates/thumos/src/mic_audit.rs
@@ -551,4 +551,59 @@ mod tests {
         assert_eq!(msg, "audit log full", "LogFull display must match");
         assert_eq!(err, MicAuditError::LogFull, "LogFull must be Eq");
     }
+
+    #[test]
+    fn eviction_of_an_active_session_does_not_corrupt_active_tracking() {
+        // Done-when (finding 34): when the entry being evicted (the
+        // oldest, at capacity) is a session that is STILL ACTIVE (never
+        // ended), the active-session bookkeeping (is_mic_active /
+        // active_sessions) must reflect the eviction correctly, not
+        // retain a dangling reference to the evicted entry or miscount.
+        // eviction_at_capacity checks the log stays capped and the
+        // evicted entry is gone, but never checks active-session
+        // bookkeeping around an eviction where the victim was active.
+        let mut log = MicAuditLog::new();
+        for i in 0..MAX_ENTRIES {
+            log.log_start(SessionKind::VoiceCall, b"active", i as u64 * 10);
+        }
+        assert_eq!(log.len(), MAX_ENTRIES);
+        assert!(
+            log.is_mic_active(),
+            "all sessions are active before eviction"
+        );
+        assert_eq!(
+            log.active_sessions().len(),
+            MAX_ENTRIES,
+            "every entry must be active before the evicting call"
+        );
+
+        let victim_id = log.entries()[0].id;
+
+        // This log_start evicts the oldest entry -- which is itself an
+        // active (never-ended) session -- to make room.
+        let new_id = log.log_start(SessionKind::VoiceCall, b"newest", 999_999);
+
+        assert_eq!(
+            log.len(),
+            MAX_ENTRIES,
+            "log must stay capped at MAX_ENTRIES"
+        );
+        assert!(
+            log.is_mic_active(),
+            "mic must still read active: the new entry is active even though the victim was evicted"
+        );
+        assert_eq!(
+            log.active_sessions().len(),
+            MAX_ENTRIES,
+            "active-session count must reflect exactly MAX_ENTRIES live entries, not double-count or leak the evicted one"
+        );
+        assert!(
+            !log.entries().iter().any(|e| e.id == victim_id),
+            "the evicted victim's id must no longer appear anywhere in the log"
+        );
+        assert!(
+            log.entries().iter().any(|e| e.id == new_id),
+            "the newly started session must be present"
+        );
+    }
 }

--- a/crates/thumos/src/mmu.rs
+++ b/crates/thumos/src/mmu.rs
@@ -1108,4 +1108,241 @@ mod tests {
             "outer drop restores IRQ delivery"
         );
     }
+
+    #[test]
+    fn prot_to_l2_flags_translates_the_non_wx_permission_combinations() {
+        // Done-when (finding 35): batch-1 added the W^X-specific cases
+        // (write+exec denial, exec-without-write). This covers every
+        // remaining POSIX-to-ARM AP/XN translation those didn't:
+        // read-only, read+write (no exec), no permissions at all, and
+        // exec-only (no read/write).
+        let ap_mask = page_flags::AP_FULL | page_flags::AP_READ_ONLY | page_flags::AP_KERNEL_ONLY;
+
+        // Read-only: AP_READ_ONLY, not executable (no PROT_EXEC requested).
+        let ro = prot_to_l2_flags(prot::PROT_READ);
+        assert_eq!(
+            ro & ap_mask,
+            page_flags::AP_READ_ONLY,
+            "read-only must set AP_READ_ONLY"
+        );
+        assert_eq!(
+            ro & page_flags::XN,
+            page_flags::XN,
+            "read-only (no exec) must set XN"
+        );
+
+        // Read+write, no exec: AP_FULL, XN set (write forces XN regardless).
+        let rw = prot_to_l2_flags(prot::PROT_READ | prot::PROT_WRITE);
+        assert_eq!(
+            rw & page_flags::AP_FULL,
+            page_flags::AP_FULL,
+            "read+write must set AP_FULL"
+        );
+        assert_eq!(
+            rw & page_flags::XN,
+            page_flags::XN,
+            "write without exec must still set XN"
+        );
+
+        // No permissions requested at all: AP_KERNEL_ONLY (no PL0 access), XN set.
+        let none = prot_to_l2_flags(0);
+        assert_eq!(
+            none & ap_mask,
+            page_flags::AP_KERNEL_ONLY,
+            "no permissions must set AP_KERNEL_ONLY"
+        );
+        assert_eq!(
+            none & page_flags::XN,
+            page_flags::XN,
+            "no permissions must set XN"
+        );
+
+        // Exec-only (no read, no write requested): AP_KERNEL_ONLY (neither
+        // write nor read branch taken), but XN must NOT be set since exec
+        // was requested and write was not.
+        let exec_only = prot_to_l2_flags(prot::PROT_EXEC);
+        assert_eq!(
+            exec_only & ap_mask,
+            page_flags::AP_KERNEL_ONLY,
+            "exec-only (no read/write) must set AP_KERNEL_ONLY"
+        );
+        assert_eq!(
+            exec_only & page_flags::XN,
+            0,
+            "exec-only must remain executable (XN unset)"
+        );
+    }
+
+    #[test]
+    fn map_page_fails_closed_when_l2_pool_is_exhausted() {
+        // Done-when (finding 36): if alloc_l2_table() cannot supply a new
+        // L2 table (pool exhausted), map_page must fail closed (return
+        // false), not silently install a partial/garbage mapping.
+        reset();
+        reset_l2_pool();
+        let l1 = alloc_addr_space().unwrap_or_default();
+        let attrs = page_flags::SMALL_PAGE | page_flags::AP_FULL;
+        unsafe {
+            // Exhaust the L2 pool by mapping L2_POOL_SIZE distinct 1 MB
+            // regions (each consumes one pool slot) without ever
+            // unmapping. Region 0 is deliberately skipped so it can be
+            // used below as the "one more" attempt after exhaustion.
+            for region in 0..L2_POOL_SIZE {
+                let virt = (region + 1) << 20;
+                assert!(
+                    map_page(l1, virt, 0x5000_0000, attrs),
+                    "map must succeed while the pool still has capacity"
+                );
+            }
+            assert!(alloc_l2_table().is_none(), "pool must be fully exhausted");
+
+            let virt_new = 0usize; // region 0, not yet touched above
+            assert!(
+                !map_page(l1, virt_new, 0x5000_0000, attrs),
+                "map_page must fail closed (false) when the L2 pool is exhausted"
+            );
+
+            free_addr_space(l1);
+        }
+    }
+
+    #[test]
+    fn map_page_fails_closed_over_an_existing_section_mapping() {
+        // A virtual address already covered by an L1 SECTION descriptor
+        // (1 MB granularity, e.g. the kernel identity map) must never be
+        // overlaid with a page-granularity mapping -- map_page must
+        // refuse, not corrupt the L1 entry.
+        reset();
+        unsafe {
+            init_and_enable(); // populates the kernel L1 with SECTION descriptors
+            let table_phys = table_base();
+            // 0x400 MB is the start of the DRAM identity-mapped region:
+            // a SECTION descriptor, not a page table.
+            let virt = 0x400usize << 20;
+            let attrs = page_flags::SMALL_PAGE | page_flags::AP_FULL;
+            assert!(
+                !map_page(table_phys, virt, 0x5000_0000, attrs),
+                "map_page must fail closed over an existing section mapping"
+            );
+        }
+    }
+
+    #[test]
+    fn update_page_prot_fails_closed_when_no_l2_table_is_installed() {
+        // Done-when (finding 36): update_page_prot on a virtual address
+        // whose L1 index has never had an L2 table installed must fail
+        // closed. No existing test calls update_page_prot at all.
+        reset();
+        let l1 = alloc_addr_space().unwrap_or_default();
+        unsafe {
+            let virt = 0x3000_0000usize;
+            assert!(
+                !update_page_prot(l1, virt, page_flags::SMALL_PAGE | page_flags::AP_READ_ONLY),
+                "update_page_prot must fail closed when no L2 table is installed"
+            );
+            free_addr_space(l1);
+        }
+    }
+
+    #[test]
+    fn update_page_prot_fails_closed_on_an_unmapped_page_within_an_installed_l2_table() {
+        // An L2 table can be installed (via a sibling mapping in the same
+        // 1 MB region) while the SPECIFIC page being updated is still
+        // unmapped -- update_page_prot must fail closed for that page too.
+        reset();
+        reset_l2_pool();
+        let l1 = alloc_addr_space().unwrap_or_default();
+        let attrs = page_flags::SMALL_PAGE | page_flags::AP_FULL;
+        unsafe {
+            let mapped_virt = 0x2000_0000usize;
+            let unmapped_virt = mapped_virt + 0x1000; // same 1 MB region, next page
+            assert!(map_page(l1, mapped_virt, 0x5000_0000, attrs));
+
+            assert!(
+                !update_page_prot(
+                    l1,
+                    unmapped_virt,
+                    page_flags::SMALL_PAGE | page_flags::AP_READ_ONLY
+                ),
+                "update_page_prot must fail closed on an unmapped page even though the L2 table exists"
+            );
+
+            free_addr_space(l1);
+        }
+    }
+
+    #[test]
+    fn update_page_prot_succeeds_and_preserves_the_physical_frame() {
+        // Success path: update_page_prot must change only the attribute
+        // bits, never the physical frame address.
+        reset();
+        reset_l2_pool();
+        let l1 = alloc_addr_space().unwrap_or_default();
+        let virt = 0x2100_0000usize;
+        let phys = 0x5000_0000usize;
+        unsafe {
+            assert!(map_page(
+                l1,
+                virt,
+                phys,
+                page_flags::SMALL_PAGE | page_flags::AP_FULL
+            ));
+            assert!(update_page_prot(
+                l1,
+                virt,
+                page_flags::SMALL_PAGE | page_flags::AP_READ_ONLY
+            ));
+            assert_eq!(
+                read_l2_phys(l1, virt),
+                Some(phys),
+                "update_page_prot must preserve the mapped physical frame"
+            );
+            free_addr_space(l1);
+        }
+    }
+
+    #[test]
+    fn alloc_l2_table_pool_exhaustion_and_reuse() {
+        // Done-when (finding 37): the L2 table pool's OWN
+        // allocate/exhaust/free/reuse cycle, exercised directly via
+        // alloc_l2_table/free_l2_table -- mirroring the dedicated
+        // alloc_addr_space_pool_exhaustion / free_addr_space_allows_reuse
+        // coverage that already exists for the address-space pool; the L2
+        // pool itself only ever received this exercise INDIRECTLY (via
+        // map_page/unmap_page) until now.
+        reset_l2_pool();
+        let mut addrs = [0usize; L2_POOL_SIZE];
+        for slot in &mut addrs {
+            *slot = alloc_l2_table().expect("pool must have capacity for L2_POOL_SIZE allocations");
+        }
+
+        let overflow = alloc_l2_table();
+        assert!(
+            overflow.is_none(),
+            "the (L2_POOL_SIZE + 1)th allocation must return None"
+        );
+
+        // Free one slot and confirm it becomes available for reuse at the
+        // SAME address.
+        let freed = addrs[0];
+        assert!(
+            unsafe { free_l2_table(freed) },
+            "freeing a previously allocated slot must report true"
+        );
+        let reused = alloc_l2_table().expect("freed slot must be available for reuse");
+        assert_eq!(
+            reused, freed,
+            "reused allocation must return the just-freed address"
+        );
+
+        // Clean up the rest.
+        for &addr in addrs.iter().skip(1) {
+            unsafe {
+                free_l2_table(addr);
+            }
+        }
+        unsafe {
+            free_l2_table(reused);
+        }
+    }
 }

--- a/crates/thumos/src/page.rs
+++ b/crates/thumos/src/page.rs
@@ -451,4 +451,128 @@ mod tests {
             "outer drop restores IRQ delivery"
         );
     }
+
+    #[test]
+    fn init_computes_bitmap_boundaries_from_unaligned_inputs() {
+        // Done-when (finding 38): kernel_end must round UP to the next
+        // page boundary (so a kernel ending mid-page never bleeds into
+        // the free pool) and ram_end must round DOWN to a page boundary;
+        // init must then mark exactly [start_page, end_page) free and
+        // every other page allocated.
+        //
+        // WHY calling page::init() here (unlike this file's other tests,
+        // which deliberately avoid it to prevent intra-file races): this
+        // is the ONLY test in this module touching PAGE_BITMAP/
+        // FREE_PAGES, so there is no race within this file -- the same
+        // accepted pattern process.rs's tests already use for
+        // page::init() with fabricated (never-dereferenced) addresses.
+        const RAM_START: usize = 0x1000_0000;
+        // kernel_end lands inside page index 1 (not aligned) -> must
+        // round UP to page index 2.
+        const KERNEL_END: usize = RAM_START + 4660;
+        // ram_end lands just past page index 10's start (not aligned) ->
+        // must round DOWN to page index 10.
+        const RAM_END: usize = RAM_START + 10 * PAGE_SIZE + 5;
+
+        // SAFETY: test-only; RAM_START/RAM_END/KERNEL_END are never
+        // dereferenced by init() -- it only computes page-index
+        // bookkeeping.
+        unsafe {
+            init(RAM_START, RAM_END, KERNEL_END);
+
+            // addr_of!().read() avoids a shared reference to the static mut.
+            let first = core::ptr::addr_of!(FIRST_PAGE).read();
+            let usable_start = core::ptr::addr_of!(USABLE_START_PAGE).read();
+            let usable_end = core::ptr::addr_of!(USABLE_END_PAGE).read();
+            let free = core::ptr::addr_of!(FREE_PAGES).read();
+            assert_eq!(first, RAM_START);
+            assert_eq!(usable_start, 2, "kernel_end must round UP to page index 2");
+            assert_eq!(usable_end, 10, "ram_end must round DOWN to page index 10");
+            assert_eq!(free, 8, "8 usable pages (index 2..10) must be free");
+
+            let bitmap = &*core::ptr::addr_of!(PAGE_BITMAP);
+            let is_allocated = |page: usize| bitmap[page / 32] & (1 << (page % 32)) != 0;
+
+            assert!(
+                is_allocated(0),
+                "page 0 (below usable start) must be allocated"
+            );
+            assert!(
+                is_allocated(1),
+                "page 1 (below usable start) must be allocated"
+            );
+            for page in 2..10 {
+                assert!(
+                    !is_allocated(page),
+                    "page {page} (within the usable range) must be free"
+                );
+            }
+            assert!(
+                is_allocated(10),
+                "page 10 (at usable end, exclusive) must be allocated"
+            );
+            assert!(
+                is_allocated(11),
+                "page 11 (past usable end) must be allocated"
+            );
+        }
+    }
+
+    #[test]
+    fn alloc_and_free_round_trip_yields_distinct_pages_and_rejects_double_free() {
+        // Done-when (finding 39): alloc_page/try_free_page/free_count
+        // have zero coverage in this module (the file's other tests only
+        // exercise zero_page/zero_page_range/PAGE_LOCK to avoid
+        // page::init() races). This is the second (and only other) test
+        // here to call page::init(); like
+        // init_computes_bitmap_boundaries_from_unaligned_inputs it is the
+        // only test touching PAGE_BITMAP/FREE_PAGES via this specific
+        // call, and process.rs's tests already independently call
+        // page::init() with fabricated addresses, so this does not
+        // introduce a new class of risk.
+        const RAM_START: usize = 0x2000_0000;
+        const RAM_END: usize = RAM_START + 4 * PAGE_SIZE;
+        const KERNEL_END: usize = RAM_START; // entire range usable
+
+        // SAFETY: test-only; fabricated addresses are never dereferenced
+        // by the allocator's bookkeeping in a `#[cfg(test)]` build (the
+        // zero-on-free memory scrub is `#[cfg(not(test))]`-gated; see
+        // try_free_page's own WHY comment).
+        unsafe {
+            init(RAM_START, RAM_END, KERNEL_END);
+            assert_eq!(free_count(), 4, "4 whole pages must be free after init");
+
+            let a = alloc_page().expect("first allocation must succeed");
+            let b = alloc_page().expect("second allocation must succeed");
+            assert_ne!(a, b, "two allocations must never return the same page");
+            assert_eq!(
+                free_count(),
+                2,
+                "free_count must drop by 2 after 2 allocations"
+            );
+
+            assert!(try_free_page(a), "freeing an allocated page must succeed");
+            assert_eq!(free_count(), 3, "free_count must rise by 1 after freeing");
+
+            // Double-free of the same address must be rejected, not
+            // double-increment free_count.
+            assert!(
+                !try_free_page(a),
+                "double-freeing the same page must be rejected"
+            );
+            assert_eq!(
+                free_count(),
+                3,
+                "a rejected double-free must not change free_count"
+            );
+
+            // The freed page must be handed out again on the next
+            // allocation (bitmap correctly reflects the free bit).
+            let c = alloc_page().expect("third allocation must succeed");
+            assert_eq!(c, a, "the freed page must be reusable");
+
+            try_free_page(b);
+            try_free_page(c);
+        }
+    }
 }

--- a/crates/thumos/src/panic_wipe.rs
+++ b/crates/thumos/src/panic_wipe.rs
@@ -779,4 +779,31 @@ mod tests {
             "every target, including keys' filesystem copy, must be reported failed/unverified"
         );
     }
+
+    #[test]
+    fn execute_wipe_real_run_reports_memory_scrub_and_beacon_state() {
+        // Done-when (finding 40): the REAL (non-dry-run) path's own
+        // memory_scrubbed and beacon_emitted fields are untested by the
+        // existing real-run tests (execute_wipe_records_which_targets_failed,
+        // keys_zeroized_in_memory_is_tracked_separately_from_file_tally,
+        // execute_wipe_real_run_reports_filesystem_targets_as_failed all
+        // check targets/keys but never these two fields on a
+        // dry_run=false call).
+        let mut km = key_manager_with_derived_keys();
+        // SAFETY: this is the last action in this test -- nothing reads
+        // page/heap-backed memory afterward.
+        let result = unsafe { execute_panic_wipe(&mut km, 7000, false) };
+
+        // No test in this file ever calls page::init(), so the usable
+        // page range is empty in this process and the real scrub has
+        // nothing to zero.
+        assert!(
+            !result.memory_scrubbed,
+            "memory_scrubbed must be false: the usable page range is empty in this test process"
+        );
+        assert!(
+            !result.beacon_emitted,
+            "beacon_emitted must be false on the real path too -- mesh transmission is still unwired"
+        );
+    }
 }

--- a/crates/thumos/src/sim.rs
+++ b/crates/thumos/src/sim.rs
@@ -628,4 +628,64 @@ mod tests {
             "must not recognize READY as SIM PIN"
         );
     }
+
+    #[test]
+    fn query_operator_extracts_name_from_valid_response() {
+        // Done-when (finding 41): SimManager::query_operator has zero
+        // existing coverage in this module.
+        let mut transport = MockModemTransport::new();
+        transport.queue_info_ok(b"+COPS: 0,0,\"Vodafone\"");
+
+        let mut name = [0u8; 32];
+        let result = SimManager::query_operator(&mut transport, &mut name);
+        assert_eq!(result, Ok(8), "operator name length must be 8");
+        assert_eq!(&name[..8], b"Vodafone", "operator name must be Vodafone");
+    }
+
+    #[test]
+    fn query_operator_ok_with_no_info_line_returns_zero() {
+        let mut transport = MockModemTransport::new();
+        transport.queue_ok();
+
+        let mut name = [0u8; 32];
+        let result = SimManager::query_operator(&mut transport, &mut name);
+        assert_eq!(
+            result,
+            Ok(0),
+            "an OK with no info line must return length 0"
+        );
+    }
+
+    #[test]
+    fn query_operator_maps_at_error_branches() {
+        // Done-when (finding 41): every AT error-branch mapping in
+        // query_operator -- CmeError, CmsError (which collapses to the
+        // SAME TelephonyError::CmeError variant, not a distinct one), and
+        // the bare generic Error -> ModemError.
+        let mut name = [0u8; 32];
+
+        let mut transport = MockModemTransport::new();
+        transport.queue_response(b"+CME ERROR: 10");
+        assert_eq!(
+            SimManager::query_operator(&mut transport, &mut name),
+            Err(TelephonyError::CmeError(10)),
+            "a +CME ERROR must map to TelephonyError::CmeError with its code"
+        );
+
+        let mut transport = MockModemTransport::new();
+        transport.queue_response(b"+CMS ERROR: 302");
+        assert_eq!(
+            SimManager::query_operator(&mut transport, &mut name),
+            Err(TelephonyError::CmeError(302)),
+            "a +CMS ERROR must ALSO map to TelephonyError::CmeError (no distinct CmsError variant)"
+        );
+
+        let mut transport = MockModemTransport::new();
+        transport.queue_response(b"ERROR");
+        assert_eq!(
+            SimManager::query_operator(&mut transport, &mut name),
+            Err(TelephonyError::ModemError),
+            "a bare ERROR must map to TelephonyError::ModemError"
+        );
+    }
 }

--- a/crates/thumos/src/telephony_parser.rs
+++ b/crates/thumos/src/telephony_parser.rs
@@ -538,4 +538,56 @@ mod tests {
             "a line matching no known URC prefix must dispatch to None"
         );
     }
+
+    #[test]
+    fn parse_u8_rejects_overflowing_value() {
+        // Done-when (finding 42): a decimal field within u8 range must
+        // parse normally, but a value exceeding u8::MAX (255) must be
+        // rejected via the checked_mul/checked_add overflow guards, not
+        // silently wrap. parse_u8 is private but has no direct test at
+        // all -- existing coverage is only indirect, via in-range fields
+        // in parse_csq_response/parse_creg_response/parse_final_result.
+        assert_eq!(parse_u8(b"255"), Some(255), "255 (u8::MAX) must parse");
+        assert_eq!(
+            parse_u8(b"256"),
+            None,
+            "256 (one past u8::MAX) must be rejected, not wrap to 0"
+        );
+        assert_eq!(
+            parse_u8(b"999"),
+            None,
+            "a value far exceeding u8::MAX must be rejected"
+        );
+    }
+
+    #[test]
+    fn parse_u32_rejects_overflowing_value() {
+        assert_eq!(
+            parse_u32(b"4294967295"),
+            Some(u32::MAX),
+            "u32::MAX must parse"
+        );
+        assert_eq!(
+            parse_u32(b"4294967296"),
+            None,
+            "one past u32::MAX must be rejected, not wrap to 0"
+        );
+        assert_eq!(
+            parse_u32(b"99999999999999999999"),
+            None,
+            "a value far exceeding u32::MAX must be rejected"
+        );
+    }
+
+    #[test]
+    fn csq_response_with_overflowing_rssi_field_is_rejected() {
+        // Integration-level check: an over-range AT field must propagate
+        // the parse_u8 overflow rejection all the way up through the
+        // public parser, not just at the private helper.
+        assert_eq!(
+            parse_csq_response(b"+CSQ: 999,0"),
+            None,
+            "an out-of-range rssi field must reject the whole +CSQ line"
+        );
+    }
 }


### PR DESCRIPTION
Final wave-3 batch (#337, findings 22-42) — coverage for untested paths, no functional change. 1 stale (lfs_compact data-relocation already covered).

## Coverage
- **mmu** — full `prot_to_l2_flags` POSIX→ARM translation (non-W^X cases); `map_page`/`update_page_prot` fail-closed branches (L2 exhaustion, section-overlay, unmapped page); L2 table pool alloc/exhaust/free/reuse.
- **page** — `init()` bitmap boundary arithmetic (round-up/round-down); allocator alloc/free round-trip + distinct-page invariant + double-free rejection.
- **lfs** — fewest-live-blocks victim selection; `needs_compaction` policy + `.max(1)` floor; multi-block imap round-trip; segment-bitmap truncation reject; odd-sequence slot-B routing; `with_sequence` resume.
- **crypto/telephony** — `derive_from_passphrase` production entry point + non-Long sleep-tier key preservation; gsm7 reject/truncated-decode; sim `query_operator` + AT error mapping; `parse_u8/u32` overflow reject; encryption partial-block neighbor preservation; mic_audit active-session eviction; panic_wipe real-path fields.

## Verification
- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — **2124 passed** (32 new; 1 apply-surfaced fix: page.rs static_mut_refs → addr_of!().read())
- `cargo build --release --target armv7a-none-eabi` — clean · `kanon lint` — clean

Completes #337 (findings 22-42 covered; 1 stale). With batch-1 (#447), all 42 wave-3 findings are addressed except the fixed-salt remnant (needs per-device provisioning infrastructure).