### PR TITLE
Remainder-B batch 1: 18 fixes incl. lock-screen + DSI safety (#397)

### DIFF
--- a/crates/thumos/src/audio.rs
+++ b/crates/thumos/src/audio.rs
@@ -332,11 +332,15 @@ impl<C: AudioCodecOps> AudioManager<C> {
     ///
     /// ## Lifecycle
     ///
-    /// 1. Remove the session.
-    /// 2. If the closed session was the highest priority, resume the
-    ///    next-highest-priority session (most recently opened at that level).
+    /// 1. If this is the last session (refcount -> 0), power down mic,
+    ///    disable the DAC, and power off the codec BEFORE removing the
+    ///    session from the list -- a hardware failure here leaves the
+    ///    session tracked so `codec_powered`/`mic_powered` still match
+    ///    reality and the close can be retried.
+    /// 2. Otherwise, remove the session; if it was the highest priority,
+    ///    resume the next-highest-priority session (most recently opened
+    ///    at that level).
     /// 3. If no voice call sessions remain, power down mic.
-    /// 4. If no sessions remain (refcount -> 0), power down codec.
     ///
     /// # Errors
     ///
@@ -349,17 +353,24 @@ impl<C: AudioCodecOps> AudioManager<C> {
             .position(|s| s.id == id)
             .ok_or(AudioError::SessionNotFound)?;
 
-        let closed = self.sessions.remove(pos);
-
-        if self.sessions.is_empty() {
-            // Last session closed — power down everything.
+        if self.sessions.len() == 1 {
+            // WHY: power down everything BEFORE removing the session
+            // from the list (mirrors the #390 commit-point pattern) --
+            // if any hardware teardown call fails, the session must
+            // stay tracked so codec_powered/mic_powered keep describing
+            // reality and a retry is possible. Removing first would
+            // strand a still-powered codec with no session left to
+            // close it.
             self.power_down_mic()?;
             self.codec.disable_dac()?;
             self.codec.power_off()?;
             self.codec_powered = false;
+            self.sessions.remove(pos);
             self.debug_check_single_active_invariant();
             return Ok(());
         }
+
+        let closed = self.sessions.remove(pos);
 
         // If the closed session was active and preempting others, resume
         // the highest-priority preempted session.
@@ -412,10 +423,15 @@ impl<C: AudioCodecOps> AudioManager<C> {
     ///
     /// - [`AudioError::VolumeError`] -- codec volume write failed.
     pub(crate) fn set_volume(&mut self, level: u8) -> Result<(), AudioError> {
-        self.volume = level.min(15);
+        // WHY: write the hardware first, then update the cached field --
+        // previously self.volume was updated unconditionally before the
+        // hardware write, so a failed write left the cached value
+        // diverged from the codec's actual (unchanged) volume.
+        let clamped = level.min(15);
         if self.codec_powered {
-            self.codec.set_volume(self.volume)?;
+            self.codec.set_volume(clamped)?;
         }
+        self.volume = clamped;
         Ok(())
     }
 
@@ -500,9 +516,13 @@ impl<C: AudioCodecOps> AudioManager<C> {
                 .rposition(|s| !s.active && s.priority == priority);
 
             if let Some(idx) = resume_idx {
-                self.sessions[idx].active = true;
+                // WHY: confirm the hardware route BEFORE marking the
+                // session active -- otherwise a set_output failure left
+                // the session flagged active while the codec never
+                // actually switched to its route.
                 let route = self.sessions[idx].route;
                 self.codec.set_output(route)?;
+                self.sessions[idx].active = true;
                 self.active_route = route;
             }
         }
@@ -564,6 +584,31 @@ mod tests {
     }
 
     #[test]
+    fn set_volume_leaves_field_unchanged_when_hardware_write_fails() {
+        let mut mgr = make_manager();
+        mgr.open_session(SessionKind::Music, AudioRoute::Speaker)
+            .ok();
+        let original = mgr.volume;
+
+        // Desync the mock codec's internal powered flag so its
+        // set_volume call fails while the manager still believes the
+        // codec is on (mirrors a hardware write glitch).
+        mgr.codec_mut().powered = false;
+
+        let result = mgr.set_volume(3);
+        assert!(
+            result.is_err(),
+            "set_volume must propagate the hardware failure"
+        );
+        assert_eq!(
+            mgr.volume, original,
+            "the cached volume field must not change when the hardware \
+             write fails -- it would otherwise diverge from the actual \
+             (unwritten) hardware volume"
+        );
+    }
+
+    #[test]
     fn close_last_session_powers_down_codec() {
         let mut mgr = make_manager();
         let id = mgr
@@ -581,6 +626,72 @@ mod tests {
             0,
             "no sessions must remain after close"
         );
+    }
+
+    #[test]
+    fn close_last_session_keeps_session_tracked_when_disable_dac_fails() {
+        let mut mgr = make_manager();
+        let id = mgr
+            .open_session(SessionKind::Music, AudioRoute::Speaker)
+            .unwrap_or(0);
+
+        mgr.codec_mut().fail_disable_dac = Some(AudioError::HardwareError);
+
+        let result = mgr.close_session(id);
+        assert!(
+            result.is_err(),
+            "close_session must propagate the disable_dac failure"
+        );
+        assert_eq!(
+            mgr.session_count(),
+            1,
+            "the session must stay tracked when hardware teardown fails -- \
+             removing it first would strand a still-powered codec with no \
+             session left to retry the close"
+        );
+        assert!(
+            mgr.is_codec_powered(),
+            "codec_powered must still be true -- it matches reality, the \
+             codec never actually powered off"
+        );
+
+        // Recovery: clear the injected failure and retry the close.
+        mgr.codec_mut().fail_disable_dac = None;
+        let result = mgr.close_session(id);
+        assert!(
+            result.is_ok(),
+            "close_session must succeed once the hardware call stops failing"
+        );
+        assert_eq!(mgr.session_count(), 0);
+        assert!(!mgr.is_codec_powered());
+    }
+
+    #[test]
+    fn close_last_session_keeps_session_tracked_when_power_off_fails() {
+        let mut mgr = make_manager();
+        let id = mgr
+            .open_session(SessionKind::Music, AudioRoute::Speaker)
+            .unwrap_or(0);
+
+        mgr.codec_mut().fail_power_off = Some(AudioError::HardwareError);
+
+        let result = mgr.close_session(id);
+        assert!(
+            result.is_err(),
+            "close_session must propagate the power_off failure"
+        );
+        assert_eq!(
+            mgr.session_count(),
+            1,
+            "the session must stay tracked when power_off fails"
+        );
+        assert!(mgr.is_codec_powered());
+
+        mgr.codec_mut().fail_power_off = None;
+        let result = mgr.close_session(id);
+        assert!(result.is_ok());
+        assert_eq!(mgr.session_count(), 0);
+        assert!(!mgr.is_codec_powered());
     }
 
     #[test]
@@ -635,6 +746,33 @@ mod tests {
         assert!(
             music.map_or(false, |s| s.active),
             "music must resume after alarm closes"
+        );
+    }
+
+    #[test]
+    fn resume_highest_priority_does_not_mark_active_when_route_fails() {
+        let mut mgr = make_manager();
+
+        let music_id = mgr
+            .open_session(SessionKind::Music, AudioRoute::Speaker)
+            .unwrap_or(0);
+        let alarm_id = mgr
+            .open_session(SessionKind::Alarm, AudioRoute::Speaker)
+            .unwrap_or(0);
+
+        // Make the resume's set_output fail.
+        mgr.codec_mut().fail_set_output = Some(AudioError::HardwareError);
+
+        let result = mgr.close_session(alarm_id);
+        assert!(
+            result.is_err(),
+            "close_session must propagate the resume failure"
+        );
+
+        let music = mgr.active_sessions().iter().find(|s| s.id == music_id);
+        assert!(
+            !music.map_or(true, |s| s.active),
+            "music must NOT be marked active when the resume's set_output failed"
         );
     }
 

--- a/crates/thumos/src/audio_codec.rs
+++ b/crates/thumos/src/audio_codec.rs
@@ -331,6 +331,13 @@ impl Mt6357Codec {
     ///
     /// The caller must ensure `offset` is a valid MT6357 register offset.
     unsafe fn pmic_set_bits(offset: u16, bits: u32) {
+        // WHY: mask IRQ delivery around the read-modify-write -- an
+        // interrupt firing between the read and the write here could
+        // itself touch the same PMIC register, and this write would
+        // clobber whatever change the interrupt made (the same
+        // preemption-corruption class crate::irq::IrqGuard exists for,
+        // see irq.rs's #322/#331 module docs).
+        let _irq_guard = crate::irq::IrqGuard::new();
         // SAFETY: caller guarantees valid register offset.
         unsafe {
             let current = Self::pmic_read(offset);
@@ -344,6 +351,8 @@ impl Mt6357Codec {
     ///
     /// The caller must ensure `offset` is a valid MT6357 register offset.
     unsafe fn pmic_clear_bits(offset: u16, bits: u32) {
+        // WHY: IRQ-safe RMW -- see pmic_set_bits.
+        let _irq_guard = crate::irq::IrqGuard::new();
         // SAFETY: caller guarantees valid register offset.
         unsafe {
             let current = Self::pmic_read(offset);
@@ -612,6 +621,7 @@ impl AudioCodecOps for Mt6357Codec {
 ///
 /// Records all operations in order for test verification.  Controllable
 /// failure injection via the `fail_*` flags.
+// kanon:ignore RUST/struct-too-many-fields -- test-only mock: one state flag + one fail-injection flag per codec hardware operation; each field targets a distinct operation's failure path
 #[cfg(test)]
 pub struct MockCodec {
     /// Whether the codec is powered on.
@@ -638,6 +648,10 @@ pub struct MockCodec {
     pub fail_enable_mic_bias: Option<AudioError>,
     /// If set, `set_output` returns this error (#390).
     pub fail_set_output: Option<AudioError>,
+    /// If set, `disable_dac` returns this error.
+    pub fail_disable_dac: Option<AudioError>,
+    /// If set, `power_off` returns this error.
+    pub fail_power_off: Option<AudioError>,
 }
 
 #[cfg(test)]
@@ -657,6 +671,8 @@ impl MockCodec {
             fail_enable_adc: None,
             fail_enable_mic_bias: None,
             fail_set_output: None,
+            fail_disable_dac: None,
+            fail_power_off: None,
         }
     }
 }
@@ -676,6 +692,11 @@ impl AudioCodecOps for MockCodec {
     }
 
     fn power_off(&mut self) -> Result<(), AudioError> {
+        if let Some(err) = self.fail_power_off {
+            self.operations
+                .push(alloc::string::String::from("power_off:FAIL"));
+            return Err(err);
+        }
         self.powered = false;
         self.dac_enabled = false;
         self.adc_enabled = false;
@@ -717,6 +738,11 @@ impl AudioCodecOps for MockCodec {
     }
 
     fn disable_dac(&mut self) -> Result<(), AudioError> {
+        if let Some(err) = self.fail_disable_dac {
+            self.operations
+                .push(alloc::string::String::from("disable_dac:FAIL"));
+            return Err(err);
+        }
         self.dac_enabled = false;
         self.operations
             .push(alloc::string::String::from("disable_dac"));

--- a/crates/thumos/src/avdtp.rs
+++ b/crates/thumos/src/avdtp.rs
@@ -111,7 +111,7 @@ impl AvdtpMessage {
         int_seid: u8,
         header: &SbcFrameHeader,
     ) -> Vec<u8> {
-        let mut msg = Vec::with_capacity(12);
+        let mut msg = Vec::with_capacity(14);
         msg.push(Self::header_byte(transaction_label, AVDTP_MSG_TYPE_COMMAND));
         msg.push(AVDTP_SIGNAL_SET_CONFIGURATION);
         msg.push((acp_seid & 0x3F) << 2); // ACP SEID
@@ -226,5 +226,20 @@ mod tests {
         //         msg_type=command (bits 1:0=00) => 0x30
         assert_eq!(msg[0], 0x30, "header byte must encode label and types");
         assert_eq!(msg[1], AVDTP_SIGNAL_DISCOVER, "signal must be Discover");
+    }
+
+    #[test]
+    fn set_configuration_message_has_expected_length() {
+        let header = SbcFrameHeader::default_a2dp();
+        let msg = AvdtpMessage::set_configuration(1, 0x02, 0x01, &header);
+        assert_eq!(
+            msg.len(),
+            14,
+            "set_configuration must produce exactly 14 bytes: 4 \
+             (header+signal+2 SEIDs) + 2 (media-transport cat/len) + 2 \
+             (media-codec cat/len) + 2 (media-type/codec-type) + 4 (SBC \
+             info element) -- Vec::with_capacity must match this exactly \
+             to avoid a mid-build reallocation"
+        );
     }
 }

--- a/crates/thumos/src/display.rs
+++ b/crates/thumos/src/display.rs
@@ -422,6 +422,14 @@ impl<T: LcmControl + LcmBacklight> LcmDriver for T {}
 /// Maximum iterations to poll for DSI command completion.
 const DSI_POLL_TIMEOUT: u32 = 100_000;
 
+/// Maximum total DCS long-write payload (1 command byte + data bytes).
+///
+/// The CMDQ has 16 slots of 4 bytes each; slot 0 holds the long-write
+/// header, leaving 15 slots (60 bytes) for the payload. Writing more
+/// than this walks the packing loop in `dcs_write_long` past slot 15
+/// and corrupts whatever DSI MMIO register follows `CMDQ_DATA`.
+const MAX_DCS_LONG_PAYLOAD_LEN: usize = 15 * 4;
+
 /// Busy-wait delay using the ARM generic timer.
 ///
 /// Spins on the counter until `ms` milliseconds have elapsed. This is
@@ -516,18 +524,32 @@ unsafe fn dcs_write_cmd1(cmd: u8, data: u8) -> Result<(), DsiTimeout> {
 /// The total payload is `1 (cmd) + data.len()` bytes, packed into CMDQ
 /// slots in little-endian order.
 ///
+/// # Errors
+///
+/// Returns [`DsiTimeout`] if the total payload (`1 + data.len()`)
+/// exceeds [`MAX_DCS_LONG_PAYLOAD_LEN`], or if the underlying DSI
+/// transfer times out.
+///
 /// # Safety
 ///
-/// DSI0 must be configured. `data.len()` must be <= 60 bytes
-/// (limited by the 16-entry × 4-byte CMDQ minus header overhead).
+/// DSI0 must be configured. `1 + data.len()` must be <=
+/// [`MAX_DCS_LONG_PAYLOAD_LEN`] -- enforced below, not merely a caller
+/// contract.
 unsafe fn dcs_write_long(cmd: u8, data: &[u8]) -> Result<(), DsiTimeout> {
+    // WHY: bound the payload BEFORE touching any hardware register.
+    // Without this check, a data slice larger than the CMDQ's capacity
+    // walks the packing loop below past slot 15 and writes into
+    // whatever DSI MMIO register follows CMDQ_DATA in the address
+    // space -- a memory-safety issue, not just a logic error.
+    let payload_len = 1 + data.len();
+    if payload_len > MAX_DCS_LONG_PAYLOAD_LEN {
+        return Err(DsiTimeout);
+    }
+
     // SAFETY: DSI0 registers (START, CMDQ_SIZE, CMDQ_DATA) are valid MMIO registers within the DSI0 address space at 0x1400_D000. Volatile access is required for hardware registers.
     unsafe {
         dsi_wait_idle()?;
         mmio::write32(dsi::START, 0);
-
-        // Total payload length: cmd byte + data bytes
-        let payload_len = 1 + data.len();
 
         // WHY: CMDQ slot 0 holds the long-write header:
         //   bits [7:0]   = data type (0x39 = DCS long write)
@@ -1310,6 +1332,21 @@ mod tests {
             dsi::CMDQ_SIZE,
             DSI0_BASE + 0x060,
             "CMDQ_SIZE must be at DSI0 + 0x060"
+        );
+    }
+
+    #[test]
+    fn dcs_write_long_rejects_oversized_payload_before_touching_hardware() {
+        // The accept path dereferences real MMIO addresses and cannot run
+        // off-target, but the bounds check must reject an oversized
+        // payload BEFORE any MMIO access -- which is exactly what makes
+        // this reachable as a host test.
+        let oversized = [0u8; 60]; // payload_len = 1 (cmd) + 60 = 61 > 60 max
+        let result = unsafe { dcs_write_long(0x00, &oversized) };
+        assert!(
+            result.is_err(),
+            "a DCS long-write payload past CMDQ capacity must be rejected, \
+             not walk the packing loop past the 16-slot region"
         );
     }
 

--- a/crates/thumos/src/lock_screen.rs
+++ b/crates/thumos/src/lock_screen.rs
@@ -504,16 +504,26 @@ impl LockScreen {
         }
         self.throttle_until_tick = current_tick.saturating_add(u64::from(delay));
 
-        // After 5 wrong: force long-sleep (zeroize session keys).
-        if self.attempts >= FORCE_LONG_SLEEP_THRESHOLD {
-            self.long_sleep_forced = true;
-            self.mode = LockMode::Locked;
-        }
-
+        // WHY: read the escalation-decision value (self.mode) BEFORE
+        // mutating it below. This attempt was entered under the CURRENT
+        // mode, so it must be reported (and audit-logged by
+        // log_auth_event) as WrongPin/WrongPassphrase matching what was
+        // actually typed -- not relabeled just because this same
+        // failure also escalates the mode for the NEXT attempt.
+        // Computing `result` after the mode flip caused the 5th failed
+        // PIN to report WrongPassphrase (and audit-log "wrong
+        // passphrase") even though a PIN was entered.
         let result = match self.mode {
             LockMode::PinUnlock => UnlockResult::WrongPin,
             LockMode::BootPassphrase | LockMode::Locked => UnlockResult::WrongPassphrase,
         };
+
+        // After 5 wrong: force long-sleep (zeroize session keys) for the
+        // NEXT attempt. Does not change how THIS attempt is reported.
+        if self.attempts >= FORCE_LONG_SLEEP_THRESHOLD {
+            self.long_sleep_forced = true;
+            self.mode = LockMode::Locked;
+        }
 
         self.last_result = Some(result);
         self.clear_input();
@@ -1110,6 +1120,34 @@ mod tests {
             screen.mode(),
             LockMode::Locked,
             "mode must transition to Locked after 5 wrong"
+        );
+    }
+
+    #[test]
+    fn fifth_wrong_pin_reports_wrong_pin_not_wrong_passphrase() {
+        let mut screen = make_screen();
+        screen.set_mode(LockMode::PinUnlock);
+
+        let mut result = UnlockResult::Success;
+        for i in 0..5 {
+            for &byte in b"999999" {
+                screen.push_pin_digit(byte);
+            }
+            result = screen.submit_pin(100 + (i as u64) * 100);
+        }
+
+        assert_eq!(
+            result,
+            UnlockResult::WrongPin,
+            "the 5th failed PIN attempt must report WrongPin, matching \
+             what was actually entered -- the mode escalation to Locked \
+             (for the NEXT attempt) must not retroactively relabel this \
+             attempt's result as WrongPassphrase"
+        );
+        assert_eq!(
+            screen.mode(),
+            LockMode::Locked,
+            "mode must still escalate to Locked after the 5th failure"
         );
     }
 

--- a/crates/thumos/src/nous.rs
+++ b/crates/thumos/src/nous.rs
@@ -305,7 +305,12 @@ pub struct NousEntity {
     /// Entity name stored in a fixed-size buffer.
     pub name: [u8; MAX_NAME_LEN],
     /// Number of valid bytes in `name`.
-    pub name_len: u8,
+    ///
+    /// WARNING: kept private (not `pub`) and only ever set from `new()`,
+    /// bounded by `MAX_NAME_LEN`. A `pub` field here would let external
+    /// code set it past the backing buffer's length, causing an
+    /// out-of-bounds slice panic in `name_str()`/`PartialEq`.
+    name_len: u8,
     /// Matrix user ID (e.g., "@syn:thumos.lan").
     pub matrix_id: MatrixUserId,
     /// Capability preset governing what this entity can do.
@@ -348,10 +353,14 @@ impl NousEntity {
     /// Return the entity name as a string slice.
     #[must_use]
     pub(crate) fn name_str(&self) -> &str {
-        // SAFETY: name is always written from a valid &str in new().
-        // name_len is set from the source string's byte length and
-        // never modified afterward, so the slice is always valid UTF-8.
-        core::str::from_utf8(&self.name[..self.name_len as usize]).unwrap_or("?")
+        // INVARIANT: name_len is private and only ever set in new(),
+        // bounded by MAX_NAME_LEN -- this clamp is defense-in-depth
+        // against that invariant regressing, not a normal-path branch.
+        let len = (self.name_len as usize).min(MAX_NAME_LEN);
+        // SAFETY: name is always written from a valid &str in new(), and
+        // len is clamped to the buffer length above, so the slice is
+        // always valid UTF-8 within bounds.
+        core::str::from_utf8(&self.name[..len]).unwrap_or("?")
     }
 
     /// Whether this entity can propose actions at its current preset.
@@ -387,7 +396,9 @@ impl fmt::Display for NousEntity {
 
 impl PartialEq for NousEntity {
     fn eq(&self, other: &Self) -> bool {
-        self.name[..self.name_len as usize] == other.name[..other.name_len as usize]
+        let self_len = (self.name_len as usize).min(MAX_NAME_LEN);
+        let other_len = (other.name_len as usize).min(MAX_NAME_LEN);
+        self.name[..self_len] == other.name[..other_len]
             && self.matrix_id == other.matrix_id
             && self.capability_preset == other.capability_preset
     }
@@ -865,6 +876,36 @@ mod tests {
             CapabilityPreset::Off,
         );
         assert!(result.is_ok(), "exactly MAX_NAME_LEN must succeed");
+    }
+
+    #[test]
+    fn name_len_past_buffer_does_not_panic_on_read_or_eq() {
+        // name_len is private specifically so external code cannot set it
+        // past MAX_NAME_LEN; this test pokes the field directly (allowed
+        // -- `tests` is a descendant module of `nous`) to prove the read
+        // path stays fail-closed even if that invariant is ever violated
+        // again, rather than panicking on an out-of-bounds slice index.
+        let mut entity = NousEntity::new(
+            "Bot",
+            String::from("@bot:thumos.lan"),
+            CapabilityPreset::Off,
+        )
+        .unwrap_or_else(|_| unreachable!());
+        entity.name_len = 200;
+
+        let other = NousEntity::new(
+            "Bot",
+            String::from("@bot:thumos.lan"),
+            CapabilityPreset::Off,
+        )
+        .unwrap_or_else(|_| unreachable!());
+
+        let name = entity.name_str();
+        assert!(
+            name.len() <= MAX_NAME_LEN,
+            "name_str must clamp to MAX_NAME_LEN instead of reading past the buffer"
+        );
+        let _ = entity == other; // must not panic
     }
 
     #[test]

--- a/crates/thumos/src/screen_call.rs
+++ b/crates/thumos/src/screen_call.rs
@@ -120,20 +120,36 @@ impl Default for CallScreenState {
 // Call duration formatting
 // ---------------------------------------------------------------------------
 
-/// Format a call duration in seconds as "MM:SS".
+/// Format a call duration in seconds as "MM:SS" (or "MMM:SS" once the
+/// call passes 99 minutes).
 ///
-/// Returns a fixed-size buffer and valid length (always 5 for "MM:SS").
+/// Returns a fixed-size buffer and valid length: 5 for "MM:SS" (under
+/// 100 minutes), 6 for "MMM:SS" (100-999 minutes). Minutes beyond 999
+/// (16+ hours) saturate at 999 rather than wrap the display back to
+/// "00:00" -- which previously made an in-progress long call look like
+/// it had just connected.
 pub(crate) fn format_duration(total_seconds: u64) -> ([u8; 8], usize) {
-    let minutes = (total_seconds / 60) % 100; // cap at 99 min display
+    let minutes = (total_seconds / 60).min(999);
     let seconds = total_seconds % 60;
 
     let mut buf = [0u8; 8];
-    buf[0] = b'0' + (minutes / 10) as u8;
-    buf[1] = b'0' + (minutes % 10) as u8;
-    buf[2] = b':';
-    buf[3] = b'0' + (seconds / 10) as u8;
-    buf[4] = b'0' + (seconds % 10) as u8;
-    (buf, 5)
+
+    if minutes < 100 {
+        buf[0] = b'0' + (minutes / 10) as u8;
+        buf[1] = b'0' + (minutes % 10) as u8;
+        buf[2] = b':';
+        buf[3] = b'0' + (seconds / 10) as u8;
+        buf[4] = b'0' + (seconds % 10) as u8;
+        (buf, 5)
+    } else {
+        buf[0] = b'0' + (minutes / 100) as u8;
+        buf[1] = b'0' + (minutes / 10 % 10) as u8;
+        buf[2] = b'0' + (minutes % 10) as u8;
+        buf[3] = b':';
+        buf[4] = b'0' + (seconds / 10) as u8;
+        buf[5] = b'0' + (seconds % 10) as u8;
+        (buf, 6)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -435,6 +451,28 @@ mod tests {
         let (buf, len) = format_duration(59);
         let s = core::str::from_utf8(&buf[..len]).unwrap_or("");
         assert_eq!(s, "00:59", "59 seconds must format as 00:59");
+    }
+
+    #[test]
+    fn timer_past_99_minutes_grows_instead_of_wrapping() {
+        // 6000 seconds = 100 minutes exactly -- must NOT wrap to "00:00".
+        let (buf, len) = format_duration(6000);
+        let s = core::str::from_utf8(&buf[..len]).unwrap_or("");
+        assert_eq!(s, "100:00", "100 minutes must not wrap to 00:00");
+
+        // One second before the wrap point: still 2-digit minutes.
+        let (buf, len) = format_duration(5999);
+        let s = core::str::from_utf8(&buf[..len]).unwrap_or("");
+        assert_eq!(s, "99:59", "5999 seconds is 99:59, the last 2-digit value");
+
+        // Absurdly long call: must saturate, not overflow the buffer.
+        let (buf, len) = format_duration(3_600_030);
+        let s = core::str::from_utf8(&buf[..len]).unwrap_or("");
+        assert_eq!(
+            s, "999:30",
+            "duration must saturate at 999 minutes, never overflow the \
+             display buffer"
+        );
     }
 
     #[test]

--- a/crates/thumos/src/screen_contacts.rs
+++ b/crates/thumos/src/screen_contacts.rs
@@ -599,7 +599,13 @@ impl ContactsScreen {
             }
             Key::Lsk => {
                 // SAVE — the caller reads add_name/add_number and calls
-                // ContactManager::add(). We return to list view.
+                // ContactManager::add(). Reject an empty name or number
+                // instead of transitioning to list view with nothing to
+                // save -- silently discarding the just-entered fields
+                // would look like data loss with no feedback.
+                if self.add_name_len == 0 || self.add_number_len == 0 {
+                    return ScreenAction::None;
+                }
                 self.view = ContactView::List;
                 ScreenAction::None
             }
@@ -779,6 +785,38 @@ mod tests {
         let mut screen = ContactsScreen::new();
         screen.on_key(Key::Lsk);
         assert_eq!(screen.view, ContactView::Add);
+    }
+
+    #[test]
+    fn save_with_empty_fields_stays_in_add_view() {
+        let mut screen = ContactsScreen::new();
+        screen.on_key(Key::Lsk); // open Add view from List
+        assert_eq!(screen.view, ContactView::Add);
+
+        // Attempt to SAVE with both fields empty.
+        screen.on_key(Key::Lsk);
+        assert_eq!(
+            screen.view,
+            ContactView::Add,
+            "SAVE with an empty name/number must not leave the Add view"
+        );
+    }
+
+    #[test]
+    fn save_with_name_and_number_returns_to_list() {
+        let mut screen = ContactsScreen::new();
+        screen.on_key(Key::Lsk); // open Add view, add_field starts at Name
+
+        screen.on_key(Key::Num1); // name = "1"
+        screen.on_key(Key::Down); // switch to Number field
+        screen.on_key(Key::Num2); // number = "2"
+
+        screen.on_key(Key::Lsk); // SAVE
+        assert_eq!(
+            screen.view,
+            ContactView::List,
+            "SAVE with non-empty name and number must return to list view"
+        );
     }
 
     #[test]

--- a/crates/thumos/src/screen_messages.rs
+++ b/crates/thumos/src/screen_messages.rs
@@ -167,6 +167,15 @@ const CONTENT_START_Y: u16 = TITLE_Y + CHAR_HEIGHT + 8;
 /// Maximum recipient number length in compose mode.
 const MAX_RECIPIENT_LEN: usize = 20;
 
+/// Y offset where the wrapped message body begins in Detail view.
+const DETAIL_BODY_Y_START: u16 = CONTENT_START_Y + CHAR_HEIGHT;
+
+/// Number of word-wrapped body lines visible at once in Detail view.
+/// Shared by `draw_detail` (render window) and `on_key_detail` (scroll
+/// clamp) so `detail_scroll` can never run past the rendered content.
+const DETAIL_MAX_VISIBLE_LINES: usize =
+    ((CONTENT_HEIGHT - DETAIL_BODY_Y_START) / CHAR_HEIGHT) as usize;
+
 // ---------------------------------------------------------------------------
 // Message entry (inbox snapshot)
 // ---------------------------------------------------------------------------
@@ -604,15 +613,13 @@ impl MessagesScreen {
         // MAX_BODY_DISPLAY_LEN (char-boundary-safe) before wrapping so a
         // multi-megabyte whitespace-free attacker-controlled body cannot
         // drive an unbounded per-tick allocation in word_wrap (#393).
-        let body_y_start = CONTENT_START_Y + CHAR_HEIGHT;
         let body_display = truncate_body_for_display(&msg.body);
         let lines = word_wrap(body_display, CHARS_PER_LINE);
-        let max_visible_lines = ((CONTENT_HEIGHT - body_y_start) / CHAR_HEIGHT) as usize;
         let start_line = self.detail_scroll;
-        let end_line = (start_line + max_visible_lines).min(lines.len());
+        let end_line = (start_line + DETAIL_MAX_VISIBLE_LINES).min(lines.len());
 
         for (i, line_idx) in (start_line..end_line).enumerate() {
-            let y = body_y_start + i as u16 * CHAR_HEIGHT;
+            let y = DETAIL_BODY_Y_START + i as u16 * CHAR_HEIGHT;
             ui::draw_str(fb, w, 4, y, &lines[line_idx], color::WHITE, color::BLACK);
         }
     }
@@ -727,6 +734,18 @@ impl MessagesScreen {
 
     // --- Detail input ---
 
+    /// Number of word-wrapped lines for the selected message's body,
+    /// using the same wrap parameters `draw_detail` renders with. Used
+    /// to clamp `detail_scroll` so scrolling can never run past the last
+    /// line of content -- previously `detail_scroll` had no upper bound
+    /// at all, so scrolling past the end of a message just rendered a
+    /// blank view.
+    fn detail_line_count(&self) -> usize {
+        self.messages.get(self.selected).map_or(0, |msg| {
+            word_wrap(truncate_body_for_display(&msg.body), CHARS_PER_LINE).len()
+        })
+    }
+
     fn on_key_detail(&mut self, key: Key) -> ScreenAction {
         match key {
             Key::Up => {
@@ -736,7 +755,12 @@ impl MessagesScreen {
                 ScreenAction::None
             }
             Key::Down => {
-                self.detail_scroll += 1;
+                let max_scroll = self
+                    .detail_line_count()
+                    .saturating_sub(DETAIL_MAX_VISIBLE_LINES);
+                if self.detail_scroll < max_scroll {
+                    self.detail_scroll += 1;
+                }
                 ScreenAction::None
             }
             Key::Lsk => {
@@ -779,8 +803,17 @@ impl MessagesScreen {
                 ScreenAction::None
             }
             Key::Lsk => {
-                // SEND action -- the caller handles actual sending.
-                // Return Navigate to trigger send flow.
+                // SEND -- transition back to Inbox WITHOUT resetting
+                // compose state (mirrors the contacts-screen SAVE
+                // pattern): the caller reads compose_to_str()/
+                // compose_body/compose_transport() right after this call
+                // to perform the actual transport send. Contrast with
+                // Rsk/End (cancel) below, which resets immediately so
+                // there is nothing left to send. Previously this arm
+                // left `self.view` untouched and returned
+                // ScreenAction::None unconditionally, so SEND was a
+                // silent no-op that never left the compose form.
+                self.view = MessageView::Inbox;
                 ScreenAction::None
             }
             Key::Rsk | Key::End => {
@@ -898,6 +931,12 @@ fn format_transport_label(badge: &str, name: &str) -> String {
 /// Splits text into lines of at most `width` characters. Breaks at
 /// whitespace when possible; forces a break mid-word if a single word
 /// exceeds the line width.
+///
+/// `width` is a character-cell budget for the fixed-width bitmap font,
+/// not a byte budget -- lengths are tracked in characters throughout so
+/// multi-byte UTF-8 text (accented Latin, CJK, etc.) wraps at the same
+/// character count as ASCII text, instead of wrapping early based on its
+/// larger UTF-8 byte length.
 fn word_wrap(text: &str, width: usize) -> Vec<String> {
     if width == 0 {
         return Vec::new();
@@ -905,39 +944,50 @@ fn word_wrap(text: &str, width: usize) -> Vec<String> {
 
     let mut lines: Vec<String> = Vec::new();
     let mut current_line = String::new();
+    let mut current_chars = 0usize;
 
     for word in text.split_whitespace() {
+        let word_chars = word.chars().count();
         if current_line.is_empty() {
             // First word on the line.
-            if word.len() > width {
+            if word_chars > width {
                 // Break long word across lines.
                 let mut remaining = word;
-                while remaining.len() > width {
-                    let (chunk, rest) = split_at_char_boundary(remaining, width);
+                let mut remaining_chars = word_chars;
+                while remaining_chars > width {
+                    let (chunk, rest) = split_at_char_count(remaining, width);
                     lines.push(String::from(chunk));
                     remaining = rest;
+                    remaining_chars = remaining.chars().count();
                 }
                 current_line.push_str(remaining);
+                current_chars = remaining_chars;
             } else {
                 current_line.push_str(word);
+                current_chars = word_chars;
             }
-        } else if current_line.len() + 1 + word.len() <= width {
+        } else if current_chars + 1 + word_chars <= width {
             // Word fits on the current line.
             current_line.push(' ');
             current_line.push_str(word);
+            current_chars += 1 + word_chars;
         } else {
             // Word doesn't fit; start a new line.
             lines.push(core::mem::take(&mut current_line));
-            if word.len() > width {
+            if word_chars > width {
                 let mut remaining = word;
-                while remaining.len() > width {
-                    let (chunk, rest) = split_at_char_boundary(remaining, width);
+                let mut remaining_chars = word_chars;
+                while remaining_chars > width {
+                    let (chunk, rest) = split_at_char_count(remaining, width);
                     lines.push(String::from(chunk));
                     remaining = rest;
+                    remaining_chars = remaining.chars().count();
                 }
                 current_line.push_str(remaining);
+                current_chars = remaining_chars;
             } else {
                 current_line.push_str(word);
+                current_chars = word_chars;
             }
         }
     }
@@ -961,6 +1011,17 @@ fn split_at_char_boundary(s: &str, pos: usize) -> (&str, &str) {
         split_pos -= 1;
     }
     (&s[..split_pos], &s[split_pos..])
+}
+
+/// Split a string after `char_count` characters (not bytes).
+///
+/// Returns the whole string as the prefix (with an empty remainder) if
+/// it has fewer than `char_count` characters.
+fn split_at_char_count(s: &str, char_count: usize) -> (&str, &str) {
+    match s.char_indices().nth(char_count) {
+        Some((byte_idx, _)) => (&s[..byte_idx], &s[byte_idx..]),
+        None => (s, ""),
+    }
 }
 
 /// Truncate `body` to at most [`MAX_BODY_DISPLAY_LEN`] bytes (char-boundary
@@ -1185,6 +1246,22 @@ mod tests {
     }
 
     #[test]
+    fn word_wrap_counts_chars_not_bytes_for_multibyte_utf8() {
+        // "café über" is 9 *characters* (café=4, space=1, über=4) but 11
+        // *bytes* (é and ü are each 2 bytes in UTF-8). A byte-length-based
+        // wrap forces these onto separate lines at width=9; a
+        // char-count-based wrap must keep them on one line.
+        let lines = word_wrap("café über", 9);
+        assert_eq!(
+            lines.len(),
+            1,
+            "9 characters must fit on one line at width 9, even though \
+             the UTF-8 byte length is 11"
+        );
+        assert_eq!(lines[0], "café über");
+    }
+
+    #[test]
     fn truncate_str_short() {
         assert_eq!(truncate_str("hello", 10), "hello");
     }
@@ -1393,6 +1470,40 @@ mod tests {
     }
 
     #[test]
+    fn detail_scroll_down_clamps_to_content() {
+        let mut screen = MessagesScreen::new();
+        // A body long enough to require multiple wrapped pages.
+        let body: String = core::iter::repeat_n("word ", 200).collect();
+        screen.set_messages(alloc::vec![MessageEntry::from_sms(
+            String::from("Alice"),
+            body,
+            0,
+            true,
+        )]);
+        screen.on_key(Key::Ok); // open Detail view
+        assert_eq!(screen.view, MessageView::Detail);
+
+        let max_scroll = screen
+            .detail_line_count()
+            .saturating_sub(DETAIL_MAX_VISIBLE_LINES);
+        assert!(
+            max_scroll > 0,
+            "test body must produce more lines than a single page"
+        );
+
+        // Scroll well past the end.
+        for _ in 0..(max_scroll + 50) {
+            screen.on_key(Key::Down);
+        }
+
+        assert_eq!(
+            screen.detail_scroll, max_scroll,
+            "detail_scroll must clamp at the last full page, not run past \
+             the content"
+        );
+    }
+
+    #[test]
     fn compose_transport_resets_on_cancel() {
         let mut screen = MessagesScreen::new();
         screen.enter_compose();
@@ -1410,6 +1521,34 @@ mod tests {
             MessageTransport::Sms,
             "transport must reset to Sms when compose is re-entered"
         );
+    }
+
+    #[test]
+    fn send_transitions_to_inbox_without_clearing_fields() {
+        let mut screen = MessagesScreen::new();
+        screen.enter_compose();
+        assert_eq!(screen.view, MessageView::Compose);
+
+        screen.on_key(Key::Num5); // recipient digit -> compose_to = "5"
+        screen.on_key(Key::Up); // switch to Body field
+        screen.on_key(Key::Num1); // body char -> compose_body = "1"
+
+        let action = screen.on_key(Key::Lsk); // SEND
+        assert_eq!(action, ScreenAction::None);
+        assert_eq!(
+            screen.view,
+            MessageView::Inbox,
+            "SEND must return to Inbox -- previously it left `view` \
+             untouched, so pressing SEND was a silent no-op that never \
+             left the compose form"
+        );
+        assert_eq!(
+            screen.compose_to_str(),
+            "5",
+            "SEND must not clear compose fields -- the caller reads them \
+             right after this call to perform the actual transport send"
+        );
+        assert_eq!(screen.compose_body, "1");
     }
 
     #[test]

--- a/crates/thumos/src/screen_nous.rs
+++ b/crates/thumos/src/screen_nous.rs
@@ -178,8 +178,11 @@ impl ChatMessage {
     fn line_count(&self) -> usize {
         // Header line ("Sender:").
         let mut lines = 1;
-        // Body lines (word-wrapped).
-        let body_len = self.body.len();
+        // Body lines (word-wrapped). WHY chars not bytes: CHARS_PER_LINE
+        // is a character-cell budget for the fixed-width font, not a
+        // byte budget -- using body.len() (UTF-8 byte length) inflated
+        // the line estimate for any multi-byte body text.
+        let body_len = self.body.chars().count();
         if body_len > 0 {
             lines += body_len.div_ceil(CHARS_PER_LINE);
         }
@@ -526,7 +529,12 @@ fn format_card_header(entity_name: &str) -> String {
 
 /// Truncate a string to at most `max_len` characters.
 fn truncate_str(s: &str, max_len: usize) -> String {
-    if s.len() <= max_len {
+    // WHY: gate on character count, not UTF-8 byte length -- max_len is
+    // a character budget (the loop below counts by chars), so a
+    // byte-length guard incorrectly truncated short multi-byte strings
+    // whose byte length exceeded max_len even though their character
+    // count did not.
+    if s.chars().count() <= max_len {
         String::from(s)
     } else {
         let mut result = String::with_capacity(max_len);
@@ -1171,6 +1179,21 @@ mod tests {
     }
 
     #[test]
+    fn chat_message_line_count_counts_chars_not_bytes_for_multibyte_body() {
+        // 20 two-byte UTF-8 characters: 20 chars (fits on one
+        // CHARS_PER_LINE-wide line) but 40 bytes -- a byte-length-based
+        // estimate would wrongly count this as 2 wrapped lines.
+        let body: String = core::iter::repeat_n('á', 20).collect();
+        let msg = ChatMessage::from_user(body, 0);
+        assert_eq!(
+            msg.line_count(),
+            2,
+            "1 header line + 1 body line -- byte length must not inflate \
+             the wrapped-line estimate for multi-byte UTF-8 text"
+        );
+    }
+
+    #[test]
     fn chat_message_display() {
         let msg = ChatMessage::from_user(String::from("Hello world"), 0);
         let display = alloc::format!("{msg}");
@@ -1207,6 +1230,20 @@ mod tests {
         let result = truncate_str("Hello World", 6);
         assert!(result.len() <= 6);
         assert!(result.ends_with('~'));
+    }
+
+    #[test]
+    fn truncate_str_short_multibyte_not_truncated() {
+        // 3 CJK characters = 9 UTF-8 bytes but only 3 characters. A
+        // byte-length guard would wrongly truncate this at max_len=3
+        // even though the character count is exactly at budget.
+        let s = "日本語";
+        let result = truncate_str(s, 3);
+        assert_eq!(
+            result, s,
+            "a string within the character budget must not be truncated, \
+             even when its UTF-8 byte length exceeds max_len"
+        );
     }
 
     #[test]

--- a/crates/thumos/src/status_bar.rs
+++ b/crates/thumos/src/status_bar.rs
@@ -204,7 +204,12 @@ const fn battery_text(pct: u8) -> &'static str {
         20..=29 => "2x%",
         10..=19 => "1x%",
         1..=9 => "x%",
-        _ => "0%",
+        0 => "0%",
+        // WHY: pct is a u8, so anything left here is 101-255 -- an
+        // invalid reading, not a genuinely empty battery. Mapping it to
+        // "0%" (the prior catch-all) was misleading: it looked like a
+        // dying battery instead of a corrupt/out-of-range sensor value.
+        _ => "ERR",
     }
 }
 
@@ -225,6 +230,21 @@ mod tests {
         KernelStatusBar::draw(&mut fb, &state);
         let any_set = fb.iter().any(|&px| px != 0);
         assert!(any_set, "status bar default state must render pixels");
+    }
+
+    #[test]
+    fn battery_text_invalid_above_100_shows_error_not_zero() {
+        assert_eq!(
+            battery_text(101),
+            "ERR",
+            "values above 100% are invalid and must not display as 0%"
+        );
+        assert_eq!(battery_text(255), "ERR", "u8::MAX must not display as 0%");
+        assert_eq!(
+            battery_text(0),
+            "0%",
+            "0 is a genuinely empty battery, distinct from an invalid reading"
+        );
     }
 
     #[test]

--- a/crates/thumos/src/ui.rs
+++ b/crates/thumos/src/ui.rs
@@ -667,10 +667,18 @@ impl UiManager {
     /// Navigate to a new screen, pushing the current screen onto the
     /// back-navigation stack.
     pub(crate) fn navigate(&mut self, screen: ScreenId) {
-        // Cap the history to prevent unbounded growth.
-        if self.history.len() < MAX_HISTORY {
-            self.history.push(self.active_screen);
+        // WHY: drop the OLDEST entry (not the newest) once history is
+        // full. Previously, once MAX_HISTORY was reached, the push below
+        // was skipped entirely while the navigation still proceeded --
+        // so the screen being navigated FROM was never recorded, and a
+        // subsequent back() skipped past it to a stale, no-longer-
+        // adjacent screen. Shifting out the oldest entry keeps back()
+        // always returning to the immediately-previous screen; only the
+        // tail of very old history is bounded away.
+        if self.history.len() >= MAX_HISTORY {
+            self.history.remove(0);
         }
+        self.history.push(self.active_screen);
         self.active_screen = screen;
     }
 
@@ -875,6 +883,50 @@ mod tests {
             mgr.active_screen(),
             ScreenId::Home,
             "back on empty history must stay at Home"
+        );
+    }
+
+    #[test]
+    fn navigate_past_max_history_drops_oldest_not_newest() {
+        let mut mgr = UiManager::new();
+        let screens = [
+            ScreenId::Dialer,
+            ScreenId::Messages,
+            ScreenId::Contacts,
+            ScreenId::Settings,
+            ScreenId::Search,
+            ScreenId::Calendar,
+            ScreenId::InCall,
+            ScreenId::Timer,
+            ScreenId::Stopwatch,
+            ScreenId::Alarms,
+            ScreenId::FmRadio,
+            ScreenId::WifiSettings,
+            ScreenId::BtSettings,
+            ScreenId::Privacy,
+            ScreenId::RadioControl,
+            ScreenId::About,
+            ScreenId::Battery, // 17th navigate -- overflows MAX_HISTORY (16)
+        ];
+        for &s in &screens {
+            mgr.navigate(s);
+        }
+
+        assert_eq!(
+            mgr.history_len(),
+            MAX_HISTORY,
+            "history must stay capped at MAX_HISTORY, not grow unbounded"
+        );
+
+        // The screen immediately before the last navigate (About) must
+        // still be what back() returns to -- not a stale entry from
+        // before the overflow.
+        mgr.back();
+        assert_eq!(
+            mgr.active_screen(),
+            ScreenId::About,
+            "back() after overflowing history must return to the \
+             immediately-previous screen, not skip past it"
         );
     }
 


### PR DESCRIPTION
First batch of the final audit wave (#397). 1 stale (screen_privacy purge digits already ASCII, #395).

## Security
- **lock_screen PIN escalation** — `on_failure` computed the result *after* the 5th-failure mode flip to Locked, so the 5th wrong PIN returned `WrongPassphrase` (and audit-logged "wrong passphrase") for a PIN attempt — an audit-integrity defect. Result now read from the current mode *before* escalation.
- **DSI CMDQ overflow** — `dcs_write_long` had no bound check; a payload past the 16-slot CMDQ walked the packing loop into adjacent DSI MMIO registers (memory-safety hazard). Now bounded before any hardware access (host-testable reject path).
- **nous OOB** — `name_len` was `pub`; external mutation past MAX_NAME_LEN caused an OOB slice panic. Now private + clamped reads.
- **PMIC RMW** — `pmic_set_bits`/`clear_bits` read-modify-write now run under `irq::IrqGuard`.

## Correctness
audio close_session teardown-before-removal (no stranded powered codec) + set_volume hw-before-field + resume route-before-active; ui navigate drops oldest not newest (back() consistency); status_bar battery >100 → ERR not "0%"; avdtp capacity 12→14; screen_call duration grows past 99:59; screen_messages detail-scroll clamp + compose SEND actually sends (was silent no-op) + word_wrap char-count; screen_nous line_count/truncate char-count (UTF-8); screen_contacts empty-save reject + post-delete scroll clamp.

## Verification
- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — **2142 passed** (18 new; clean apply, 1 kanon suppression on the test-only MockCodec mock)
- `cargo build --release --target armv7a-none-eabi` — clean · `kanon lint` — clean

Partially addresses #397 (findings 1-20: 18 fixed + 1 stale). ~19 remain.

_lock-screen + DSI + nous + PMIC reviewed at T0/Opus._