### PR TITLE
Remainder-B batch 2: 16 fixes incl. mic-audit + OOB guards (#397 tail)

### DIFF
--- a/crates/thumos/src/audio.rs
+++ b/crates/thumos/src/audio.rs
@@ -472,6 +472,17 @@ impl<C: AudioCodecOps> AudioManager<C> {
     }
 
     /// Return a mutable reference to the underlying codec.
+    ///
+    /// WHY test-only: production code must reach the codec ONLY through
+    /// the auditable session lifecycle (open_session/close_session/
+    /// set_route/set_volume) -- this raw accessor bypasses that entirely,
+    /// letting a caller flip enable_mic_bias()/enable_adc() with no
+    /// AudioSession ever recorded, defeating the "all mic activity is
+    /// auditable via the session log" invariant documented at the top of
+    /// this module. Grepped: every call site in the tree is this file's
+    /// own `#[cfg(test)] mod tests` (fault injection on MockCodec); no
+    /// production caller exists (#397).
+    #[cfg(test)]
     pub(crate) fn codec_mut(&mut self) -> &mut C {
         &mut self.codec
     }
@@ -1251,5 +1262,57 @@ mod tests {
             1,
             "the failed session must not be recorded"
         );
+    }
+
+    #[test]
+    fn power_down_mic_partial_failure_leaves_mic_powered_true_though_bias_already_off() {
+        // WHY: pins a genuine gap -- power_down_mic calls
+        // disable_mic_bias() then disable_adc(), each with `?`. If
+        // disable_mic_bias() succeeds but disable_adc() fails, the method
+        // returns before self.mic_powered is set false, so
+        // mgr.is_mic_powered() keeps reporting true even though the
+        // hardware mic bias is ALREADY off (only the ADC failed to power
+        // down) -- a state/reality divergence in the exact invariant this
+        // module's docs call "auditable via the session log" (#397).
+        let mut mgr = make_manager();
+        let call_id = mgr
+            .open_session(SessionKind::VoiceCall, AudioRoute::Earpiece)
+            .unwrap_or(0);
+        assert!(
+            mgr.is_mic_powered(),
+            "mic must be powered during voice call"
+        );
+
+        mgr.codec_mut().fail_disable_adc = Some(AudioError::HardwareError);
+
+        let result = mgr.close_session(call_id);
+        assert!(
+            result.is_err(),
+            "close_session must propagate the disable_adc failure"
+        );
+        assert!(
+            !mgr.codec().is_mic_bias_enabled(),
+            "mic bias hardware must already be off -- disable_mic_bias \
+             succeeded before disable_adc failed"
+        );
+        assert!(
+            mgr.is_mic_powered(),
+            "mgr.is_mic_powered() stays true because the `?` on the \
+             failed disable_adc short-circuits before self.mic_powered is \
+             set false -- this pins the current divergence, not asserted \
+             here as desired behavior"
+        );
+
+        // Recovery: clear the fault and retry -- disable_mic_bias is
+        // idempotent (MockCodec always succeeds and sets false), so the
+        // retry only needs disable_adc to succeed this time.
+        mgr.codec_mut().fail_disable_adc = None;
+        let result = mgr.close_session(call_id);
+        assert!(
+            result.is_ok(),
+            "retry must succeed once disable_adc recovers"
+        );
+        assert!(!mgr.is_mic_powered());
+        assert_eq!(mgr.session_count(), 0);
     }
 }

--- a/crates/thumos/src/audio_codec.rs
+++ b/crates/thumos/src/audio_codec.rs
@@ -561,6 +561,15 @@ impl AudioCodecOps for Mt6357Codec {
         if !self.powered {
             return Err(AudioError::CodecNotPowered);
         }
+        // WHY: enforce the documented precondition -- AudioError::AdcNotEnabled
+        // exists specifically for "mic bias requires ADC to be enabled", but
+        // no implementation actually checked it, so a caller reaching the
+        // codec directly (bypassing AudioManager's enable_adc-then-
+        // enable_mic_bias ordering) could power the mic bias FET preamp
+        // with the ADC never enabled (#397).
+        if !self.adc_enabled {
+            return Err(AudioError::AdcNotEnabled);
+        }
         if self.mic_bias {
             return Ok(());
         }
@@ -650,6 +659,10 @@ pub struct MockCodec {
     pub fail_set_output: Option<AudioError>,
     /// If set, `disable_dac` returns this error.
     pub fail_disable_dac: Option<AudioError>,
+    /// If set, `disable_adc` returns this error (#397) -- exercises the
+    /// power_down_mic partial-teardown path (disable_mic_bias succeeds,
+    /// disable_adc fails).
+    pub fail_disable_adc: Option<AudioError>,
     /// If set, `power_off` returns this error.
     pub fail_power_off: Option<AudioError>,
 }
@@ -672,6 +685,7 @@ impl MockCodec {
             fail_enable_mic_bias: None,
             fail_set_output: None,
             fail_disable_dac: None,
+            fail_disable_adc: None,
             fail_power_off: None,
         }
     }
@@ -750,6 +764,11 @@ impl AudioCodecOps for MockCodec {
     }
 
     fn disable_adc(&mut self) -> Result<(), AudioError> {
+        if let Some(err) = self.fail_disable_adc {
+            self.operations
+                .push(alloc::string::String::from("disable_adc:FAIL"));
+            return Err(err);
+        }
         self.adc_enabled = false;
         self.operations
             .push(alloc::string::String::from("disable_adc"));
@@ -786,6 +805,12 @@ impl AudioCodecOps for MockCodec {
     fn enable_mic_bias(&mut self) -> Result<(), AudioError> {
         if !self.powered {
             return Err(AudioError::CodecNotPowered);
+        }
+        // WHY: mirror the real Mt6357Codec's ADC-enabled precondition
+        // (#397) so a test exercising this invariant at the MockCodec
+        // level actually observes the enforced behavior.
+        if !self.adc_enabled {
+            return Err(AudioError::AdcNotEnabled);
         }
         if let Some(err) = self.fail_enable_mic_bias {
             self.operations
@@ -1024,6 +1049,35 @@ mod tests {
             Err(AudioError::CodecNotPowered),
             "enable_mic_bias without power must return CodecNotPowered"
         );
+    }
+
+    #[test]
+    fn mic_bias_requires_adc_enabled() {
+        let mut codec = MockCodec::new();
+        codec.power_on().ok();
+
+        // ADC not enabled yet.
+        let result = codec.enable_mic_bias();
+        assert_eq!(
+            result,
+            Err(AudioError::AdcNotEnabled),
+            "enable_mic_bias without ADC enabled must return \
+             AdcNotEnabled (#397)"
+        );
+        assert!(
+            !codec.is_mic_bias_enabled(),
+            "mic bias must not be marked enabled when the ADC \
+             precondition fails"
+        );
+
+        // Enable ADC, then mic bias must succeed.
+        codec.enable_adc().ok();
+        let result = codec.enable_mic_bias();
+        assert!(
+            result.is_ok(),
+            "enable_mic_bias must succeed once ADC is enabled"
+        );
+        assert!(codec.is_mic_bias_enabled());
     }
 
     #[test]

--- a/crates/thumos/src/fm_radio.rs
+++ b/crates/thumos/src/fm_radio.rs
@@ -497,6 +497,15 @@ impl<H: FmHwOps> FmRadio<H> {
         // Try hardware seek.
         match self.hw.seek_up() {
             Ok(freq) => {
+                // WHY: freq is hardware-returned and untrusted -- a
+                // glitched or malfunctioning combo-chip firmware could
+                // report a frequency outside the FM band, and storing it
+                // unchecked would let an out-of-band value flow into
+                // state, presets, and display code that all assume Tuned
+                // frequencies stay in-band (#397).
+                if !(FM_FREQ_MIN_KHZ..=FM_FREQ_MAX_KHZ).contains(&freq) {
+                    return Err(FmError::FrequencyOutOfRange);
+                }
                 self.state = FmState::Tuned {
                     frequency_khz: freq,
                 };
@@ -540,6 +549,11 @@ impl<H: FmHwOps> FmRadio<H> {
 
         match self.hw.seek_down() {
             Ok(freq) => {
+                // WHY: same untrusted-hardware-value guard as seek_up --
+                // see its comment (#397).
+                if !(FM_FREQ_MIN_KHZ..=FM_FREQ_MAX_KHZ).contains(&freq) {
+                    return Err(FmError::FrequencyOutOfRange);
+                }
                 self.state = FmState::Tuned {
                     frequency_khz: freq,
                 };
@@ -849,6 +863,54 @@ mod tests {
     }
 
     #[test]
+    fn seek_up_rejects_out_of_range_hardware_frequency() {
+        let mut hw = MockFmHw::new();
+        hw.seek_up_result = Some(50_000); // below FM_FREQ_MIN_KHZ
+        let mut radio = FmRadio::new(hw);
+        radio.power_on().ok();
+        radio.tune(90_000).ok();
+
+        let result = radio.seek_up();
+        assert_eq!(
+            result,
+            Err(FmError::FrequencyOutOfRange),
+            "seek_up must reject an out-of-band hardware-returned \
+             frequency (#397)"
+        );
+        assert_eq!(
+            radio.state(),
+            FmState::Tuned {
+                frequency_khz: 90_000
+            },
+            "state must be unchanged when the hardware result is rejected"
+        );
+    }
+
+    #[test]
+    fn seek_down_rejects_out_of_range_hardware_frequency() {
+        let mut hw = MockFmHw::new();
+        hw.seek_down_result = Some(200_000); // above FM_FREQ_MAX_KHZ
+        let mut radio = FmRadio::new(hw);
+        radio.power_on().ok();
+        radio.tune(90_000).ok();
+
+        let result = radio.seek_down();
+        assert_eq!(
+            result,
+            Err(FmError::FrequencyOutOfRange),
+            "seek_down must reject an out-of-band hardware-returned \
+             frequency (#397)"
+        );
+        assert_eq!(
+            radio.state(),
+            FmState::Tuned {
+                frequency_khz: 90_000
+            },
+            "state must be unchanged when the hardware result is rejected"
+        );
+    }
+
+    #[test]
     fn volume_control() {
         let mut radio = make_radio();
         assert_eq!(radio.volume(), FM_DEFAULT_VOLUME);
@@ -985,6 +1047,36 @@ mod tests {
             radio.preset_count(),
             4,
             "preset_count must reflect the highest used index + 1"
+        );
+    }
+
+    #[test]
+    fn recall_preset_uninitialized_non_contiguous_slot_returns_wrong_variant() {
+        // WHY: pins a mismatch between recall_preset's documented
+        // contract ("InvalidPreset -- slot index out of range or not
+        // set") and its actual behavior. preset_count only tracks the
+        // highest EVER-saved index + 1, not which individual slots were
+        // populated, so saving directly to slot 3 (skipping 0-2, as in
+        // preset_non_contiguous_index above) leaves slots 0-2 within the
+        // `index < preset_count` range yet never actually written (still
+        // 0). recall_preset falls through to the frequency-range check
+        // and returns FrequencyOutOfRange (0 is not in the FM band)
+        // instead of the documented InvalidPreset (#397 finding 32 --
+        // NOT fixed here; this pins current behavior for a follow-up).
+        let mut radio = make_radio();
+        radio.power_on().ok();
+        radio.tune(92_300).ok();
+        radio.save_preset(3).ok(); // non-contiguous; slots 0-2 stay unset
+        assert_eq!(radio.preset_count(), 4);
+
+        let result = radio.recall_preset(1); // never explicitly saved
+        assert_eq!(
+            result,
+            Err(FmError::FrequencyOutOfRange),
+            "current behavior: an unset-but-in-range slot surfaces \
+             FrequencyOutOfRange, not the documented \
+             InvalidPreset(\"...or not set\") -- a mismatch worth a \
+             follow-up fix, not asserted here as correct"
         );
     }
 

--- a/crates/thumos/src/lock_screen.rs
+++ b/crates/thumos/src/lock_screen.rs
@@ -1019,6 +1019,34 @@ mod tests {
     }
 
     #[test]
+    fn wrong_pin_via_on_key_reports_wrong_pin_not_success_or_duress() {
+        // Security-critical: drive a WRONG (neither real nor duress) PIN
+        // through the actual UI key-dispatch path (on_key), not
+        // submit_pin directly, and confirm both observable channels
+        // report failure -- not success and not a duress false-positive
+        // (#397).
+        let mut screen = make_screen();
+        screen.set_mode(LockMode::PinUnlock);
+
+        for &byte in b"000000" {
+            screen.on_key(digit_key(byte));
+        }
+        let action = screen.on_key(Key::Ok);
+
+        assert_eq!(
+            screen.last_result,
+            Some(UnlockResult::WrongPin),
+            "a wrong (non-duress) PIN entered via on_key must record WrongPin"
+        );
+        assert!(
+            matches!(action, ScreenAction::None),
+            "a wrong PIN must not surface ScreenAction::Duress or any \
+             navigation action"
+        );
+        assert_eq!(screen.attempts(), 1);
+    }
+
+    #[test]
     fn on_key_forwards_a_real_tick_so_unlock_recovers_after_throttle() {
         // Regression test for #388: on_key previously called
         // submit_pin(0)/submit_passphrase(0) unconditionally. Since

--- a/crates/thumos/src/nous.rs
+++ b/crates/thumos/src/nous.rs
@@ -1102,6 +1102,45 @@ mod tests {
     }
 
     #[test]
+    fn remove_entity_silently_shifts_active_when_removing_a_non_last_active_entity() {
+        // WHY: pins a genuine, currently-uncovered edge case in
+        // remove_entity's active-index adjustment. The existing branches
+        // (`entities.is_empty()`, `active_entity >= entities.len()`,
+        // `active_entity > index`) cover removing the active entity when
+        // it is the LAST one, or removing a non-active entity BEFORE the
+        // active one -- but not removing the ACTIVE entity itself from a
+        // non-last position. There, active_entity is left unchanged, but
+        // because Vec::remove shifts every later element down by one,
+        // that same numeric index now refers to a DIFFERENT entity --
+        // the active entity silently becomes whichever one used to sit
+        // immediately after the removed one, with no explicit selection
+        // by the caller (a silent capability-preset substitution, since
+        // each entity carries its own trust level) (#397).
+        let mut mgr = NousManager::new();
+        // Syn (Advisor) at 0, Phrouros (Observer) at 1, Paideia (Assistant) at 2.
+        mgr.switch(1).unwrap_or_else(|_| unreachable!()); // active = Phrouros
+        assert_eq!(mgr.active().map(|e| e.name_str()), Some("Phrouros"));
+
+        let removed = mgr.remove_entity(1); // remove the ACTIVE entity, non-last
+        assert_eq!(
+            removed.map(|e| String::from(e.name_str())),
+            Ok(String::from("Phrouros")),
+        );
+
+        // Current behavior: active_entity index (1) is left unchanged,
+        // but now refers to Paideia (which shifted down from index 2 to
+        // index 1) -- a different entity with a different capability
+        // preset, silently substituted for the one the caller had
+        // selected.
+        assert_eq!(
+            mgr.active().map(|e| e.name_str()),
+            Some("Paideia"),
+            "current behavior: the active pointer silently follows \
+             whatever entity shifted into the removed active entity's slot"
+        );
+    }
+
+    #[test]
     fn manager_remove_invalid_index() {
         let mut mgr = NousManager::new();
         let err = mgr.remove_entity(99);

--- a/crates/thumos/src/screen_messages.rs
+++ b/crates/thumos/src/screen_messages.rs
@@ -306,6 +306,14 @@ impl MessagesScreen {
         if self.selected >= self.messages.len() && !self.messages.is_empty() {
             self.selected = self.messages.len() - 1;
         }
+        // Clamp scroll_offset to the (possibly re-clamped) selection --
+        // otherwise a scroll_offset left pointing past the shrunk list's
+        // end makes draw_inbox's `(scroll_offset..scroll_offset+visible)
+        // .min(len)` window empty, so the inbox renders blank even though
+        // messages still exist (#397).
+        if self.scroll_offset > self.selected {
+            self.scroll_offset = self.selected;
+        }
     }
 
     /// Return the number of messages.
@@ -1124,6 +1132,38 @@ mod tests {
     }
 
     #[test]
+    fn split_at_char_boundary_backs_off_to_valid_boundary() {
+        // Each character is 2 bytes (U+00E9): char boundaries are at 0,
+        // 2, 4. Splitting at an odd byte offset must back off to the
+        // boundary at or before it, not split mid-codepoint (#397 --
+        // direct coverage of split_at_char_boundary itself, previously
+        // only exercised indirectly via truncate_body_for_display).
+        let s = "\u{00e9}\u{00e9}";
+        let (prefix, suffix) = split_at_char_boundary(s, 3);
+        assert_eq!(
+            prefix, "\u{00e9}",
+            "must back off to the boundary at byte 2, not 3"
+        );
+        assert_eq!(suffix, "\u{00e9}");
+    }
+
+    #[test]
+    fn split_at_char_boundary_pos_past_end_clamps_to_len() {
+        let s = "hi";
+        let (prefix, suffix) = split_at_char_boundary(s, 100);
+        assert_eq!(prefix, "hi");
+        assert_eq!(suffix, "");
+    }
+
+    #[test]
+    fn split_at_char_boundary_pos_zero() {
+        let s = "hi";
+        let (prefix, suffix) = split_at_char_boundary(s, 0);
+        assert_eq!(prefix, "");
+        assert_eq!(suffix, "hi");
+    }
+
+    #[test]
     fn draw_detail_bounds_word_wrap_allocation_for_huge_body() {
         let mut screen = MessagesScreen::new();
         // 1 MB whitespace-free body — worst case for word_wrap's per-line
@@ -1500,6 +1540,52 @@ mod tests {
             screen.detail_scroll, max_scroll,
             "detail_scroll must clamp at the last full page, not run past \
              the content"
+        );
+    }
+
+    #[test]
+    fn set_messages_clamps_scroll_offset_when_list_shrinks() {
+        // WHY: previously set_messages only clamped `selected`, not
+        // `scroll_offset` -- if the list shrinks while scrolled deep in,
+        // scroll_offset can be left pointing past the new (shorter)
+        // list's end, making draw_inbox's visible window
+        // `(scroll_offset..scroll_offset+visible).min(len)` empty even
+        // though messages still exist (#397).
+        let mut screen = MessagesScreen::new();
+        let long_messages: Vec<MessageEntry> = (0..20)
+            .map(|i| {
+                MessageEntry::from_sms(
+                    alloc::format!("+1555000{i:04}"),
+                    alloc::format!("message {i}"),
+                    i as u64,
+                    true,
+                )
+            })
+            .collect();
+        screen.set_messages(long_messages);
+        for _ in 0..15 {
+            screen.on_key(Key::Down);
+        }
+        assert!(
+            screen.scroll_offset > 0,
+            "scrolling down must advance scroll_offset"
+        );
+
+        // Shrink the list drastically while still scrolled.
+        screen.set_messages(make_test_messages()); // 3 messages
+        assert!(
+            screen.scroll_offset <= screen.selected_index(),
+            "scroll_offset must be clamped to the re-clamped selection \
+             after the list shrinks"
+        );
+
+        let mut fb = [0u16; CONTENT_PIXELS];
+        screen.draw(&mut fb);
+        let any_set = fb.iter().any(|&px| px != 0);
+        assert!(
+            any_set,
+            "inbox must still render visible content after shrinking \
+             while scrolled"
         );
     }
 

--- a/crates/thumos/src/screen_nous.rs
+++ b/crates/thumos/src/screen_nous.rs
@@ -299,7 +299,15 @@ impl NousChatScreen {
 
         self.messages.push(msg);
 
-        if has_proposal {
+        // WHY: a still-unresolved Pending proposal must not be silently
+        // displaced by a newer arrival -- previously this unconditionally
+        // repointed pending_proposal_msg_idx at the newest message, so the
+        // user's chance to confirm/cancel the FIRST pending action was
+        // lost with no record of its outcome (neither confirmed nor
+        // cancelled). The new proposal is still appended to history, but
+        // does not become "the" actionable proposal until the current one
+        // resolves (#397).
+        if has_proposal && self.pending_proposal != Some(ProposalState::Pending) {
             self.pending_proposal = Some(ProposalState::Pending);
             self.pending_proposal_msg_idx = Some(self.messages.len().saturating_sub(1));
         }
@@ -566,6 +574,37 @@ fn to_uppercase_truncated(s: &str, max_len: usize) -> String {
     result
 }
 
+/// Return the byte offset ending the next [`CHARS_PER_LINE`]-character
+/// chunk of `body` starting at byte offset `start`.
+///
+/// `start` must be a valid char boundary (0, or a value this function
+/// previously returned). Chunks by CHARACTER count, not byte count, and
+/// always returns a valid char boundary, so `&body[start..end]` is always
+/// valid UTF-8 -- even when a multi-byte codepoint would straddle a
+/// fixed-byte-offset cut (#397).
+fn next_body_line_end(body: &str, start: usize) -> usize {
+    body[start..]
+        .char_indices()
+        .nth(CHARS_PER_LINE)
+        .map_or(body.len(), |(idx, _)| start + idx)
+}
+
+/// Return the suffix of `s` containing at most the last `max_chars`
+/// characters, always landing on a UTF-8 char boundary.
+///
+/// WHY char-based: `s.len() - max_chars` (a byte-length computation) can
+/// land mid-codepoint for multi-byte UTF-8 content, and direct string
+/// indexing panics on an invalid char boundary -- unlike a fallible
+/// `from_utf8` (#397).
+fn last_n_chars(s: &str, max_chars: usize) -> &str {
+    let char_count = s.chars().count();
+    if char_count <= max_chars {
+        return s;
+    }
+    let skip = char_count - max_chars;
+    s.char_indices().nth(skip).map_or("", |(idx, _)| &s[idx..])
+}
+
 // ---------------------------------------------------------------------------
 // Screen trait implementation
 // ---------------------------------------------------------------------------
@@ -663,13 +702,19 @@ impl Screen for NousChatScreen {
                     MessageOrigin::User => USER_MSG_COLOR,
                 };
 
-                let body_bytes = msg.body.as_bytes();
+                // WHY: chunk by CHARACTER count via next_body_line_end,
+                // not a raw byte offset -- msg.body is untrusted (nous
+                // entity content over Matrix), and slicing at a fixed
+                // byte offset could land mid-codepoint for multi-byte
+                // UTF-8; the previous `.unwrap_or("")` on that invalid
+                // slice then silently rendered the WHOLE chunk --
+                // including any valid ASCII sharing that byte window --
+                // as an empty line (#397).
                 let mut offset = 0;
-                while offset < body_bytes.len() {
-                    let line_end = (offset + CHARS_PER_LINE).min(body_bytes.len());
+                while offset < msg.body.len() {
+                    let line_end = next_body_line_end(&msg.body, offset);
                     if render_y < msg_area_start + msg_area_height {
-                        let line_str =
-                            core::str::from_utf8(&body_bytes[offset..line_end]).unwrap_or("");
+                        let line_str = &msg.body[offset..line_end];
                         ui::draw_str(
                             fb,
                             w,
@@ -724,13 +769,10 @@ impl Screen for NousChatScreen {
                 color::BLACK,
             );
         } else {
-            // Show last CHARS_PER_LINE characters of input.
-            let display_start = if self.input_buffer.len() > CHARS_PER_LINE {
-                self.input_buffer.len() - CHARS_PER_LINE
-            } else {
-                0
-            };
-            let display_text = &self.input_buffer[display_start..];
+            // Show last CHARS_PER_LINE characters of input. See
+            // last_n_chars for why this must be char-based, not
+            // byte-based (#397).
+            let display_text = last_n_chars(&self.input_buffer, CHARS_PER_LINE);
             ui::draw_str(
                 fb,
                 w,
@@ -931,6 +973,41 @@ mod tests {
         let action = screen.pending_action();
         assert!(action.is_some());
         assert_eq!(action.map(|a| a.action.as_str()), Some("open_dialer"),);
+    }
+
+    #[test]
+    fn second_proposal_does_not_displace_unresolved_pending() {
+        let mut screen = NousChatScreen::new();
+        let body1 = String::from(
+            "```thumos-action\n{\"thumos_action\": \"open_dialer\", \"params\": {}, \"description\": \"First\"}\n```",
+        );
+        screen.push_message(ChatMessage::from_nous("Syn", body1, 1000));
+        assert_eq!(screen.pending_proposal(), Some(ProposalState::Pending));
+        let first_idx = screen.pending_proposal_msg_idx;
+
+        // A second proposal arrives before the user resolves the first.
+        let body2 = String::from(
+            "```thumos-action\n{\"thumos_action\": \"start_timer\", \"params\": {}, \"description\": \"Second\"}\n```",
+        );
+        screen.push_message(ChatMessage::from_nous("Syn", body2, 1001));
+
+        assert_eq!(screen.message_count(), 2, "both messages must be recorded");
+        assert_eq!(
+            screen.pending_proposal(),
+            Some(ProposalState::Pending),
+            "the FIRST proposal must remain pending, not silently dropped"
+        );
+        assert_eq!(
+            screen.pending_proposal_msg_idx, first_idx,
+            "the pending pointer must still reference the first \
+             (unresolved) proposal"
+        );
+        assert_eq!(
+            screen.pending_action().map(|a| a.description.as_str()),
+            Some("First"),
+            "the actionable proposal must still be the first one until it \
+             is resolved"
+        );
     }
 
     #[test]
@@ -1269,5 +1346,51 @@ mod tests {
     fn format_msg_header_output() {
         let header = format_msg_header("Syn");
         assert_eq!(header, "Syn:");
+    }
+
+    #[test]
+    fn next_body_line_end_is_char_boundary_safe_for_multibyte_utf8() {
+        // 28 ASCII bytes + a 2-byte codepoint + more ASCII. CHARS_PER_LINE
+        // counts *characters*; a raw byte-offset slice at CHARS_PER_LINE
+        // bytes would land mid-codepoint here (28 ASCII bytes + only the
+        // first byte of the 2-byte char), producing an invalid UTF-8
+        // slice (#397).
+        let mut body = "A".repeat(28);
+        body.push('\u{00e9}');
+        body.push_str(&"B".repeat(40));
+
+        let end = next_body_line_end(&body, 0);
+        assert!(
+            body.is_char_boundary(end),
+            "returned offset must land on a UTF-8 char boundary"
+        );
+        assert_eq!(
+            end,
+            28 + '\u{00e9}'.len_utf8(),
+            "must count CHARS_PER_LINE characters, not bytes"
+        );
+    }
+
+    #[test]
+    fn next_body_line_end_returns_body_len_when_shorter_than_chars_per_line() {
+        let body = "short";
+        assert_eq!(next_body_line_end(body, 0), body.len());
+    }
+
+    #[test]
+    fn last_n_chars_is_char_boundary_safe_for_multibyte_utf8() {
+        // 34 two-byte characters (68 bytes). A raw "last CHARS_PER_LINE
+        // bytes" cut (byte 68-29=39, odd) would land mid-codepoint and
+        // panic on direct string indexing (#397). last_n_chars must
+        // return exactly the last CHARS_PER_LINE characters instead.
+        let s: String = core::iter::repeat_n('\u{00e9}', 34).collect();
+        let result = last_n_chars(&s, CHARS_PER_LINE);
+        assert_eq!(result.chars().count(), CHARS_PER_LINE);
+        assert!(s.ends_with(result));
+    }
+
+    #[test]
+    fn last_n_chars_returns_whole_string_when_shorter_than_budget() {
+        assert_eq!(last_n_chars("hi", CHARS_PER_LINE), "hi");
     }
 }

--- a/crates/thumos/src/screen_settings.rs
+++ b/crates/thumos/src/screen_settings.rs
@@ -423,8 +423,14 @@ impl Screen for WifiSettingsScreen {
         // SSID (only if connected).
         ui::draw_str(fb, w, PADDING_X, y, "SSID:", color::DARK_GREY, color::BLACK);
         if self.state.connected && self.state.ssid_len > 0 {
-            let ssid_str =
-                core::str::from_utf8(&self.state.ssid[..self.state.ssid_len]).unwrap_or("<binary>");
+            // WHY: clamp before slicing -- ssid_len comes from the WiFi
+            // driver's state snapshot and is not validated against the
+            // 32-byte ssid buffer at the source; a malformed/corrupted
+            // driver report with ssid_len > ssid.len() would otherwise
+            // panic this OOB slice (#397). Fail-closed: render "<binary>"
+            // like an invalid-UTF8 SSID, rather than trusting the length.
+            let len = self.state.ssid_len.min(self.state.ssid.len());
+            let ssid_str = core::str::from_utf8(&self.state.ssid[..len]).unwrap_or("<binary>");
             ui::draw_str(
                 fb,
                 w,
@@ -864,6 +870,32 @@ mod tests {
         screen.draw(&mut fb);
         let any_set = fb.iter().any(|&px| px != 0);
         assert!(any_set, "wifi connected screen must render visible content");
+    }
+
+    #[test]
+    fn wifi_screen_clamps_oob_ssid_len_without_panicking() {
+        // ssid_len comes from a WiFi driver state snapshot that is not
+        // itself validated against the 32-byte ssid buffer -- a corrupted
+        // or malformed driver report with ssid_len > ssid.len() must not
+        // panic the draw path (#397).
+        let mut screen = WifiSettingsScreen::new();
+        let mut ssid = [0u8; 32];
+        ssid[..7].copy_from_slice(b"TestNet");
+        screen.update_state(WifiSettingsState {
+            connected: true,
+            ssid,
+            ssid_len: usize::MAX,
+            signal_percent: 85,
+            ip_addr: [192, 168, 0, 42],
+            scanning: false,
+        });
+        let mut fb = [0u16; CONTENT_PIXELS];
+        screen.draw(&mut fb); // must not panic
+        let any_set = fb.iter().any(|&px| px != 0);
+        assert!(
+            any_set,
+            "wifi screen must still render with a clamped OOB ssid_len"
+        );
     }
 
     #[test]

--- a/crates/thumos/src/t9.rs
+++ b/crates/thumos/src/t9.rs
@@ -788,6 +788,36 @@ mod tests {
     }
 
     #[test]
+    fn accept_falls_back_to_raw_digits_when_no_candidates_match() {
+        // 99999 has no dictionary match: every letter of a candidate
+        // word's first 5 characters would have to fall in {w,x,y,z} (key
+        // 9), which no word in DICTIONARY satisfies (#397).
+        let mut input = T9Input::new();
+        for _ in 0..5 {
+            input.press_key(9);
+        }
+        assert_eq!(
+            input.candidate_count(),
+            0,
+            "99999 must have no dictionary candidates"
+        );
+
+        let word = input.accept();
+        assert_eq!(
+            word, "99999",
+            "accept() must fall back to the raw digit string when there \
+             are no candidates"
+        );
+        assert_eq!(input.committed_text(), "99999");
+        assert_eq!(
+            input.key_count(),
+            0,
+            "key sequence must be cleared after accept, even on the \
+             fallback path"
+        );
+    }
+
+    #[test]
     fn toggle_mode_cycles() {
         let mut input = T9Input::new();
         assert_eq!(input.mode(), T9Mode::Predictive);

--- a/crates/thumos/src/ui.rs
+++ b/crates/thumos/src/ui.rs
@@ -392,14 +392,22 @@ pub(crate) fn draw_str_centered(
     fg: u16,
     bg: u16,
 ) {
-    let text_width = s.len() as u16 * CHAR_WIDTH;
+    let text_width = str_pixel_width(s);
     let x = region_x.saturating_add(region_width.saturating_sub(text_width) / 2);
     draw_str(fb, fb_width, x, y, s, fg, bg);
 }
 
 /// Return the pixel width of a string rendered with this font.
+///
+/// WHY chars not bytes: `draw_str` renders one glyph per *character*
+/// (`s.chars().enumerate()`), so the width budget must be a character
+/// count -- using the UTF-8 byte length overestimates the rendered width
+/// for multi-byte content (e.g., an accented contact name), mis-centering
+/// or mis-aligning text that draw_str_centered/status_bar/softkey
+/// right-alignment all depend on (#397).
 pub(crate) fn str_pixel_width(s: &str) -> u16 {
-    (s.len() as u16).saturating_mul(CHAR_WIDTH)
+    let char_count = u16::try_from(s.chars().count()).unwrap_or(u16::MAX);
+    char_count.saturating_mul(CHAR_WIDTH)
 }
 
 // ---------------------------------------------------------------------------
@@ -1016,6 +1024,31 @@ mod tests {
     }
 
     #[test]
+    fn draw_char_silently_skips_non_ascii_without_panicking() {
+        // draw_char intentionally has no glyph for codepoints outside the
+        // printable-ASCII font table (FONT_FIRST..=FONT_LAST, 0x20..=0x7E)
+        // -- FONT_DATA only covers that range. Pin the documented
+        // behavior: an out-of-range codepoint (e.g., U+00E9) is silently
+        // skipped (no panic, no pixels touched), rather than panicking on
+        // an out-of-bounds FONT_DATA index (#397, info).
+        let mut fb = [0u16; 8 * 16];
+        draw_char(&mut fb, 8, 0, 0, '\u{00e9}', color::WHITE, color::BLACK);
+        assert!(
+            fb.iter().all(|&px| px == 0),
+            "an out-of-font-range codepoint must leave the framebuffer \
+             untouched, not panic"
+        );
+
+        // A codepoint within range still renders normally.
+        let mut fb2 = [0u16; 8 * 16];
+        draw_char(&mut fb2, 8, 0, 0, 'A', color::WHITE, color::BLACK);
+        assert!(
+            fb2.iter().any(|&px| px != 0),
+            "an in-range ASCII codepoint must still render"
+        );
+    }
+
+    #[test]
     fn fill_rect_clips_to_bounds() {
         let mut fb = [0u16; 10 * 10];
         // Fill that extends past bounds must not panic.
@@ -1034,6 +1067,62 @@ mod tests {
     fn str_pixel_width_matches_char_count() {
         assert_eq!(str_pixel_width("Hello"), 40, "5 chars * 8px = 40");
         assert_eq!(str_pixel_width(""), 0, "empty string = 0 width");
+    }
+
+    #[test]
+    fn str_pixel_width_counts_chars_not_bytes_for_multibyte_utf8() {
+        // 4 characters, the last a 2-byte codepoint -- 5 UTF-8 bytes
+        // total. A byte-length-based width overestimates by one
+        // CHAR_WIDTH, mis-centering any string with multi-byte content
+        // (#397).
+        assert_eq!(
+            str_pixel_width("caf\u{00e9}"),
+            4 * CHAR_WIDTH,
+            "width must reflect 4 characters, not 5 UTF-8 bytes"
+        );
+    }
+
+    #[test]
+    fn draw_str_centered_centers_by_char_count_for_multibyte_utf8() {
+        // Regression for #397: draw_str_centered previously used the
+        // UTF-8 byte length to compute centering, which would shift a
+        // multi-byte string off-center relative to an equal-character
+        // ASCII string.
+        let mut fb_multibyte = [0u16; 240 * 16];
+        draw_str_centered(
+            &mut fb_multibyte,
+            240,
+            0,
+            240,
+            0,
+            "caf\u{00e9}",
+            color::WHITE,
+            color::BLACK,
+        );
+
+        let mut fb_ascii = [0u16; 240 * 16];
+        draw_str_centered(
+            &mut fb_ascii,
+            240,
+            0,
+            240,
+            0,
+            "cafe",
+            color::WHITE,
+            color::BLACK,
+        );
+
+        // Both are 4 characters, so both must start at the same column --
+        // find the first set pixel column in each and compare.
+        let first_set_col = |fb: &[u16]| -> Option<usize> {
+            (0..240).find(|&x| (0..16).any(|y| fb[y * 240 + x] != 0))
+        };
+        assert_eq!(
+            first_set_col(&fb_multibyte),
+            first_set_col(&fb_ascii),
+            "a 4-char multi-byte string must center identically to a \
+             4-char ASCII string"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Final batch of the final audit wave (#397, findings 21-39). 3 stale (batch-1 #450 added the resume-fail/empty-save/compose-SEND tests). 2 coverage findings pin a known-wrong behavior + flag follow-ups (recall_preset wrong variant, nous remove-active silent substitution) — filed as issues.

## Security
- **codec_mut mic-audit bypass** — was `pub(crate)`, letting raw codec control skip the auditable session lifecycle (mic biased with no AudioSession recorded). Every caller is test-only; now `#[cfg(test)]`-gated.
- **enable_mic_bias ADC invariant** — now enforces the documented AdcNotEnabled precondition (was powering the mic-bias preamp with ADC never enabled).
- **screen_settings ssid_len OOB** — clamped before slicing; a malformed WiFi driver snapshot (ssid_len > 32) was a reachable panic.
- **screen_nous UTF-8** — body + input buffer sliced on char boundaries; a byte-offset cut on attacker-controlled multi-byte content dropped whole lines / panicked.

## Correctness
fm_radio seek validates hardware frequency vs FM band; screen_nous preserves an unresolved Pending proposal; screen_messages set_messages scroll clamp; ui str_pixel_width/draw_str_centered char-count.

## Coverage
power_down_mic partial failure, recall_preset unset-slot, lock_screen on_key wrong-PIN, nous remove-active, t9 fallback, draw_char skip, split_at_char_boundary.

## Verification
- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — **2163 passed** (21 new; clean apply)
- `cargo build --release --target armv7a-none-eabi` — clean · `kanon lint` — clean

Completes #397 (findings 21-39). With batch-1 (#450), all 39 remainder-B findings addressed.

_codec_mut + ssid-OOB + screen_nous-UTF8 + enable_mic_bias + on_key reviewed at T0/Opus._