### PR TITLE
Userspace audit umbrellas: leipsanon + metaxu + pteron (#280 #281 #382)

### DIFF
--- a/crates/leipsanon/src/engine.rs
+++ b/crates/leipsanon/src/engine.rs
@@ -6,6 +6,8 @@
 
 use std::io::{self, Seek as _, SeekFrom, Write as _};
 use std::path::Path;
+use std::sync::mpsc;
+use std::thread;
 use std::time::{Duration, Instant};
 
 use snafu::Snafu;
@@ -23,6 +25,20 @@ use crate::targets::{WipeAction, WipeMethod};
 /// runtime-tunable entry point is [`Config::chunk_size`].
 pub(crate) const CHUNK_SIZE: usize = DEFAULT_CHUNK_SIZE;
 
+/// Upper bound on how long [`wipe_file`] waits FOR a single target's
+/// overwrite-and-sync to finish before giving up on it.
+///
+/// WHY(#280): `write_all`/`sync_all` on a `std::fs::File` have no OS-level
+/// cancellation available to this crate (no io_uring / async-I/O
+/// dependency) — a wedged block device can block either call
+/// indefinitely. The work runs on a detached worker thread; this is the
+/// deadline the ENGINE waits FOR before moving on, bounding how long one
+/// stuck target can stall the rest of the wipe plan. It does NOT stop the
+/// worker thread itself, which keeps running in the background — genuine
+/// syscall cancellation would need an async-I/O runtime this crate does
+/// not depend on (see `wipe_file`'s doc comment).
+const WIPE_TARGET_TIMEOUT: Duration = Duration::from_secs(60);
+
 // ----- Errors ---------------------------------------------------------------
 
 #[derive(Debug, Snafu)]
@@ -38,6 +54,11 @@ pub(crate) enum WipeError {
 
     #[snafu(display("failed to generate random fill for {path}: {source}"))]
     Random { path: String, source: MemoryError },
+
+    #[snafu(display(
+        "wipe of {path} exceeded the {timeout:?} bound; abandoning the wait (worker continues in the background)"
+    ))]
+    Timeout { path: String, timeout: Duration },
 }
 
 // ----- Types ----------------------------------------------------------------
@@ -49,6 +70,12 @@ pub(crate) struct WipeResult {
     pub(crate) actions_completed: usize,
     /// Number of actions that encountered an I/O error.
     pub(crate) actions_failed: usize,
+    /// Number of actions whose target path did not exist on the filesystem.
+    /// Distinct FROM `actions_completed` — a missing target was never
+    /// destroyed BY this run, so counting it as a completed wipe would let
+    /// a caller believe a panic-wipe succeeded when the data may simply be
+    /// at a different (unwiped) path (#280).
+    pub(crate) actions_missing: usize,
     /// Number of PRIORITY-1 (key-wipe) actions that failed. Destroying key
     /// material is what actually renders encrypted data unrecoverable, so
     /// this must be checked independently of `actions_failed` — a caller
@@ -112,12 +139,14 @@ impl WipeEngine {
     /// sorted by ascending priority (as returned by [`crate::targets::plan`]).
     ///
     /// In dry-run mode all actions are counted as completed with zero bytes
-    /// wiped. In real mode, actions on paths that do not exist are silently
-    /// skipped (not counted as failures).
+    /// wiped. In real mode, actions on paths that do not exist are counted
+    /// in `actions_missing` — NOT as completed and NOT as failed, because a
+    /// missing target was never destroyed by this run (#280).
     pub(crate) fn execute(&mut self, plan: &[WipeAction]) -> WipeResult {
         let start = Instant::now();
         let mut completed: usize = 0;
         let mut failed: usize = 0;
+        let mut missing: usize = 0;
         let mut critical_failed: usize = 0;
         let mut bytes_wiped: u64 = 0;
 
@@ -132,10 +161,17 @@ impl WipeEngine {
                 completed = completed.saturating_add(1);
             } else {
                 match wipe_path(&action.path, action.method, self.chunk_size) {
-                    Ok(bytes) => {
+                    Ok(Some(bytes)) => {
                         log::info!("wiped {} bytes FROM {}", bytes, action.path.display());
                         completed = completed.saturating_add(1);
                         bytes_wiped = bytes_wiped.saturating_add(bytes);
+                    }
+                    Ok(None) => {
+                        log::warn!(
+                            "wipe target missing FROM {} (not counted as wiped)",
+                            action.path.display()
+                        );
+                        missing = missing.saturating_add(1);
                     }
                     Err(ref e) => {
                         log::error!("wipe failed for {}: {}", action.path.display(), e);
@@ -151,6 +187,7 @@ impl WipeEngine {
         WipeResult {
             actions_completed: completed,
             actions_failed: failed,
+            actions_missing: missing,
             critical_failures: critical_failed,
             bytes_wiped,
             elapsed: start.elapsed(),
@@ -160,8 +197,11 @@ impl WipeEngine {
 
 // ----- Free functions -------------------------------------------------------
 
-/// Wipe `path` using `method`. Returns bytes written. Missing paths return 0.
-fn wipe_path(path: &Path, method: WipeMethod, chunk_size: usize) -> Result<u64, WipeError> {
+/// Wipe `path` using `method`. Returns `Ok(Some(bytes))` when the target
+/// existed and was wiped, or `Ok(None)` when `path` does not exist — a
+/// missing target has nothing to destroy, so it is NOT reported as bytes
+/// written (#280).
+fn wipe_path(path: &Path, method: WipeMethod, chunk_size: usize) -> Result<Option<u64>, WipeError> {
     let path_str = path.display().to_string();
 
     let mut file = match std::fs::OpenOptions::new()
@@ -172,7 +212,7 @@ fn wipe_path(path: &Path, method: WipeMethod, chunk_size: usize) -> Result<u64, 
         Ok(f) => f,
         Err(e) if e.kind() == io::ErrorKind::NotFound => {
             log::warn!("wipe target not found (skipping): {path_str}");
-            return Ok(0);
+            return Ok(None);
         }
         Err(e) => {
             return Err(WipeError::Open {
@@ -192,12 +232,62 @@ fn wipe_path(path: &Path, method: WipeMethod, chunk_size: usize) -> Result<u64, 
         source: e,
     })?;
 
-    wipe_file(file, len, method, &path_str, chunk_size)
+    wipe_file(file, len, method, &path_str, chunk_size).map(Some)
+}
+
+/// Run `f` on a detached worker thread, waiting up to `timeout` FOR it to
+/// finish. Returns `None` if the deadline elapses first.
+///
+/// WHY(#280): this is the seam that lets [`wipe_file`] bound a blocking
+/// `write_all`/`sync_all` without needing an async-I/O runtime. The
+/// worker is NOT force-stopped on timeout — Rust/std has no mechanism to
+/// cancel an in-flight blocking syscall — it keeps running in the
+/// background and its eventual result (if any) is dropped along with the
+/// disconnected channel. This bounds how long the CALLER waits, not how
+/// long the underlying I/O actually takes.
+fn run_with_timeout<T, F>(timeout: Duration, f: F) -> Option<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let _ = tx.send(f()); // WHY: send fails only if the receiver already timed out and dropped rx; the worker result is then unobservable by design, nothing to recover.
+    });
+    rx.recv_timeout(timeout).ok()
 }
 
 /// Overwrite `file` (of known `len`) using `method`, then sync.
+///
+/// Bounded by [`WIPE_TARGET_TIMEOUT`] via [`run_with_timeout`]: if the
+/// worker has not finished by the deadline this returns
+/// [`WipeError::Timeout`] rather than blocking the wipe engine
+/// indefinitely on one stuck target (#280). See `run_with_timeout`'s doc
+/// comment for why the worker itself cannot be force-cancelled.
 fn wipe_file(
     mut file: std::fs::File,
+    len: u64,
+    method: WipeMethod,
+    path: &str,
+    chunk_size: usize,
+) -> Result<u64, WipeError> {
+    let path_owned = path.to_owned();
+    run_with_timeout(WIPE_TARGET_TIMEOUT, move || {
+        wipe_file_blocking(&mut file, len, method, &path_owned, chunk_size)
+    })
+    .unwrap_or_else(|| {
+        Err(WipeError::Timeout {
+            path: path.to_owned(),
+            timeout: WIPE_TARGET_TIMEOUT,
+        })
+    })
+}
+
+/// The actual overwrite-and-sync loop, run on [`wipe_file`]'s worker
+/// thread. Split out so [`run_with_timeout`] can be unit-tested against a
+/// plain closure without needing real (potentially slow) file I/O.
+fn wipe_file_blocking(
+    file: &mut std::fs::File,
     len: u64,
     method: WipeMethod,
     path: &str,
@@ -349,6 +439,44 @@ mod tests {
             engine.chunk_size(),
             CHUNK_SIZE,
             "default engine must use DEFAULT_CHUNK_SIZE"
+        );
+    }
+
+    #[test]
+    fn wipe_target_timeout_is_positive() {
+        assert!(
+            WIPE_TARGET_TIMEOUT > Duration::from_secs(0),
+            "WIPE_TARGET_TIMEOUT must be a real bound, not disabled/zero (#280)"
+        );
+    }
+
+    #[test]
+    fn run_with_timeout_returns_none_when_worker_exceeds_deadline() {
+        // WHY(#280): this is the seam wipe_file uses to bound a blocking
+        // write_all/sync_all — the caller must not block past the deadline
+        // even though the worker itself keeps running in the background.
+        // The worker blocks on a channel we hold open so it deterministically
+        // outlives the deadline WITHOUT a wall-clock sleep; dropping block_tx
+        // after the assertion lets the worker exit cleanly (no leaked thread).
+        let (block_tx, block_rx) = std::sync::mpsc::channel::<()>();
+        let result = run_with_timeout(Duration::from_millis(20), move || {
+            block_rx.recv().ok();
+            42u32
+        });
+        assert_eq!(
+            result, None,
+            "a worker slower than the deadline must yield None, not block the caller"
+        );
+        drop(block_tx);
+    }
+
+    #[test]
+    fn run_with_timeout_returns_result_when_worker_finishes_in_time() {
+        let result = run_with_timeout(Duration::from_secs(1), || 7u32);
+        assert_eq!(
+            result,
+            Some(7),
+            "a worker finishing within the deadline must return its result"
         );
     }
 
@@ -543,11 +671,12 @@ mod tests {
     }
 
     #[test]
-    fn missing_wipe_target_counts_as_completed_with_zero_bytes() {
-        // WHY: locks in the documented `execute` contract (see its doc
-        // comment) that a wipe target absent FROM the filesystem is treated
-        // as a benign no-op — not a failure, and counted as completed with
-        // zero bytes wiped — rather than surfacing as an I/O error.
+    fn missing_wipe_target_counts_as_missing_not_completed() {
+        // WHY(#280): a wipe target absent FROM the filesystem must NOT be
+        // reported as a completed wipe — the panic-wipe contract is that
+        // `actions_completed` means data was actually destroyed. A missing
+        // target is counted in `actions_missing` instead, distinct FROM
+        // both success and I/O failure.
         let missing = std::env::temp_dir().join(format!(
             "leipsanon_missing_wipe_target_{}_{}",
             std::process::id(),
@@ -561,12 +690,16 @@ mod tests {
         let mut engine = WipeEngine::new(false);
         let result = engine.execute(&plan);
         assert_eq!(
-            result.actions_completed, 1,
-            "a missing wipe target must still be counted as completed"
+            result.actions_completed, 0,
+            "a missing wipe target must NOT be counted as completed"
+        );
+        assert_eq!(
+            result.actions_missing, 1,
+            "a missing wipe target must be counted in actions_missing"
         );
         assert_eq!(
             result.actions_failed, 0,
-            "a missing wipe target must not be counted as a failure"
+            "a missing wipe target is not an I/O failure either"
         );
         assert_eq!(
             result.bytes_wiped, 0,

--- a/crates/leipsanon/src/engine.rs
+++ b/crates/leipsanon/src/engine.rs
@@ -29,7 +29,7 @@ pub(crate) const CHUNK_SIZE: usize = DEFAULT_CHUNK_SIZE;
 /// overwrite-and-sync to finish before giving up on it.
 ///
 /// WHY(#280): `write_all`/`sync_all` on a `std::fs::File` have no OS-level
-/// cancellation available to this crate (no io_uring / async-I/O
+/// cancellation available to this crate (no `io_uring` / async-I/O
 /// dependency) — a wedged block device can block either call
 /// indefinitely. The work runs on a detached worker thread; this is the
 /// deadline the ENGINE waits FOR before moving on, bounding how long one

--- a/crates/metaxu/src/client.rs
+++ b/crates/metaxu/src/client.rs
@@ -30,6 +30,8 @@ mod tests {
     }
 
     impl BridgeTransport for InMemoryRuntime {
+        type Error = crate::Error;
+
         fn exchange(&mut self, request_frame: &[u8]) -> Result<Vec<u8>> {
             let request = decode_request(request_frame)?;
             let response = match &request {
@@ -52,7 +54,7 @@ mod tests {
     }
 
     #[test]
-    fn sms_request_round_trips_through_in_memory_runtime() -> Result<()> {
+    fn sms_request_round_trips_through_in_memory_runtime() -> Result<(), crate::Error> {
         let request_id = Ulid::from_bytes([1; 16]);
         let request = TaskRequest::SendSms {
             request_id,
@@ -115,6 +117,8 @@ mod tests {
     struct MismatchedResponseRuntime;
 
     impl BridgeTransport for MismatchedResponseRuntime {
+        type Error = crate::Error;
+
         fn exchange(&mut self, request_frame: &[u8]) -> Result<Vec<u8>> {
             let _request = decode_request(request_frame)?;
             let response = TaskResponse::accepted(Ulid::from_bytes([99; 16]), DeviceAction::None);

--- a/crates/metaxu/src/error.rs
+++ b/crates/metaxu/src/error.rs
@@ -1,19 +1,30 @@
 //! Error types for the Aletheia bridge.
 
-use compact_str::CompactString;
 use snafu::{GenerateImplicitData as _, Location, Snafu};
 use ulid::Ulid;
 
 use crate::protocol::Capability;
 
 /// Result type for bridge operations.
-pub type Result<T> = std::result::Result<T, Error>; // kanon:ignore RUST/pub-visibility -- public API
+///
+/// `E` is the transport-specific failure type carried by [`Error::Transport`];
+/// call sites that can never produce a transport error (encode/decode paths)
+/// use the `Infallible` default so the source chain is preserved without
+/// forcing every caller to name a transport error type.
+pub type Result<T, E = core::convert::Infallible> = std::result::Result<T, Error<E>>; // kanon:ignore RUST/pub-visibility -- public API
 
 /// Aletheia bridge errors.
+///
+/// Generic over `E`, the transport-specific failure type carried by
+/// [`Error::Transport`]. `E` defaults to [`core::convert::Infallible`] for
+/// call sites that can never produce a transport error.
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
 #[non_exhaustive]
-pub enum Error {
+pub enum Error<E = core::convert::Infallible>
+where
+    E: std::error::Error + 'static,
+{
     /// Failed to serialize a bridge message.
     #[snafu(display("failed to encode bridge message at {location}: {source}"))]
     Encode {
@@ -63,23 +74,121 @@ pub enum Error {
     },
 
     /// Transport-level failure.
-    #[snafu(display("bridge transport error at {location}: {message}"))]
+    ///
+    /// `source` preserves the concrete failure produced by the
+    /// [`crate::BridgeTransport`] implementation in use, so the cause is
+    /// walkable and downcastable instead of collapsed into a message string.
+    #[snafu(display("bridge transport error at {location}: {source}"))]
     Transport {
-        /// Transport-specific failure message.
-        message: CompactString,
+        /// Underlying transport failure.
+        source: E,
         /// Source location where the error was attached.
         #[snafu(implicit)]
         location: Location,
     },
 }
 
-impl Error {
-    /// Build a transport error from an implementation-specific message.
+impl<E> Error<E>
+where
+    E: std::error::Error + 'static,
+{
+    /// Build a transport error from an implementation-specific cause.
     #[must_use]
-    pub fn transport(message: impl Into<CompactString>) -> Self {
+    pub fn transport(source: E) -> Self {
         Self::Transport {
-            message: message.into(),
+            source,
             location: Location::generate(),
         }
+    }
+}
+
+impl Error<core::convert::Infallible> {
+    // WHY: encode/decode/capability call sites are fixed at the
+    // `Infallible` placeholder so they never name a transport error type;
+    // widen() composes their result with a caller's transport-typed
+    // `Error<E>` via `.map_err(|err| err.widen())` at the `?` site. A plain
+    // blanket `From<Error<Infallible>> for Error<E>` impl would conflict
+    // with core's reflexive `impl<T> From<T> for T` at `E = Infallible`
+    // (E0119), so this is an inherent method instead of a trait impl.
+    pub(crate) fn widen<E>(self) -> Error<E>
+    where
+        E: std::error::Error + 'static,
+    {
+        match self {
+            Self::Encode { source, location } => Error::Encode { source, location },
+            Self::Decode { source, location } => Error::Decode { source, location },
+            Self::MissingCapability {
+                request_id,
+                capability,
+                location,
+            } => Error::MissingCapability {
+                request_id,
+                capability,
+                location,
+            },
+            Self::ResponseRequestMismatch {
+                request_id,
+                response_id,
+                location,
+            } => Error::ResponseRequestMismatch {
+                request_id,
+                response_id,
+                location,
+            },
+            Self::Transport { source, .. } => match source {},
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use snafu::GenerateImplicitData as _;
+
+    use super::*;
+
+    #[test]
+    fn transport_error_preserves_concrete_source() {
+        let cause = std::io::Error::other("socket reset by peer");
+        let cause_message = cause.to_string();
+        let error = Error::transport(cause);
+
+        let source = std::error::Error::source(&error);
+        let downcast = source.and_then(|inner| inner.downcast_ref::<std::io::Error>());
+
+        assert!(
+            downcast.is_some(),
+            "concrete io::Error must survive through Error::Transport unstringified"
+        );
+        assert_eq!(
+            downcast.map(std::string::ToString::to_string),
+            Some(cause_message)
+        );
+    }
+
+    #[test]
+    fn transport_variant_matches_on_typed_source() {
+        let error = Error::transport(std::io::Error::other("connection reset"));
+
+        assert!(matches!(
+            error,
+            Error::Transport { source, .. } if source.kind() == std::io::ErrorKind::Other
+        ));
+    }
+
+    #[test]
+    fn widen_preserves_non_transport_variant_shape() {
+        let request_id = Ulid::from_bytes([1; 16]);
+        let narrow: Error = Error::MissingCapability {
+            request_id,
+            capability: Capability::ContactsRead,
+            location: Location::generate(),
+        };
+
+        let widened: Error<std::io::Error> = narrow.widen();
+
+        assert!(matches!(
+            widened,
+            Error::MissingCapability { request_id: seen, .. } if seen == request_id
+        ));
     }
 }

--- a/crates/metaxu/src/error.rs
+++ b/crates/metaxu/src/error.rs
@@ -110,7 +110,7 @@ impl Error<core::convert::Infallible> {
     // blanket `From<Error<Infallible>> for Error<E>` impl would conflict
     // with core's reflexive `impl<T> From<T> for T` at `E = Infallible`
     // (E0119), so this is an inherent method instead of a trait impl.
-    pub(crate) fn widen<E>(self) -> Error<E>
+    pub(crate) const fn widen<E>(self) -> Error<E>
     where
         E: std::error::Error + 'static,
     {

--- a/crates/metaxu/src/lib.rs
+++ b/crates/metaxu/src/lib.rs
@@ -12,7 +12,7 @@ mod error;
 mod protocol;
 mod transport;
 
-use snafu::OptionExt as _;
+use snafu::{OptionExt as _, ResultExt as _};
 
 pub use client::BridgeClient; // kanon:ignore RUST/pub-visibility -- public API
 pub use error::{Error, Result};
@@ -45,11 +45,12 @@ where
     ///
     /// Returns [`Error::MissingCapability`] when local preflight does not find
     /// a grant claim for the required capability, [`Error::Transport`] for
-    /// transport failures,
+    /// transport failures (wrapping `T::Error` so the concrete transport
+    /// cause is preserved rather than stringified),
     /// [`Error::Decode`] for malformed responses, and
     /// [`Error::ResponseRequestMismatch`] when the runtime answers another
     /// request id.
-    pub fn submit(&mut self, request: &TaskRequest) -> Result<TaskResponse> {
+    pub fn submit(&mut self, request: &TaskRequest) -> Result<TaskResponse, T::Error> {
         request
             .has_required_capability()
             .then_some(())
@@ -59,9 +60,12 @@ where
             })?;
 
         let request_id = request.request_id();
-        let request_frame = encode_request(request)?;
-        let response_frame = self.transport.exchange(&request_frame)?;
-        let response = decode_response(&response_frame)?;
+        let request_frame = encode_request(request).map_err(|err| err.widen())?;
+        let response_frame = self
+            .transport
+            .exchange(&request_frame)
+            .context(error::TransportSnafu)?;
+        let response = decode_response(&response_frame).map_err(|err| err.widen())?;
 
         (response.request_id == request_id).then_some(()).context(
             error::ResponseRequestMismatchSnafu {

--- a/crates/metaxu/src/lib.rs
+++ b/crates/metaxu/src/lib.rs
@@ -60,12 +60,12 @@ where
             })?;
 
         let request_id = request.request_id();
-        let request_frame = encode_request(request).map_err(|err| err.widen())?;
+        let request_frame = encode_request(request).map_err(error::Error::widen)?;
         let response_frame = self
             .transport
             .exchange(&request_frame)
             .context(error::TransportSnafu)?;
-        let response = decode_response(&response_frame).map_err(|err| err.widen())?;
+        let response = decode_response(&response_frame).map_err(error::Error::widen)?;
 
         (response.request_id == request_id).then_some(()).context(
             error::ResponseRequestMismatchSnafu {

--- a/crates/metaxu/src/transport.rs
+++ b/crates/metaxu/src/transport.rs
@@ -1,13 +1,18 @@
 //! Transport abstraction for bridge frames.
 
-use crate::Result;
-
 /// Synchronous request/response transport for serialized bridge frames.
 ///
 /// Implementations may be in-memory, IPC-backed, socket-backed, or any other
 /// Menos-facing mechanism. This trait is byte-oriented so tests can exercise
 /// serialization without requiring a live runtime connection.
 pub trait BridgeTransport /* kanon:ignore RUST/pub-visibility -- public API */ {
+    /// Transport-specific failure type.
+    ///
+    /// Preserved as the [`crate::Error::Transport`] source when
+    /// [`crate::BridgeClient::submit`] wraps it, so the concrete cause
+    /// survives instead of collapsing into a message string.
+    type Error: std::error::Error + 'static;
+
     /// Exchange one serialized task request for one serialized task response.
-    fn exchange(&mut self, request_frame: &[u8]) -> Result<Vec<u8>>;
+    fn exchange(&mut self, request_frame: &[u8]) -> core::result::Result<Vec<u8>, Self::Error>;
 }

--- a/crates/pteron/src/transport.rs
+++ b/crates/pteron/src/transport.rs
@@ -51,7 +51,7 @@ pub(crate) const RING_BUF_SIZE: usize = 2048;
 const MAX_HCI_COMMAND_PARAMS_LEN: usize = 255;
 
 /// Maximum size of an H4-framed HCI command: type(1) + opcode(2) +
-/// param_len(1) + up to [`MAX_HCI_COMMAND_PARAMS_LEN`] parameter bytes.
+/// `param_len`(1) + up to [`MAX_HCI_COMMAND_PARAMS_LEN`] parameter bytes.
 const MAX_HCI_COMMAND_LEN: usize = 4 + MAX_HCI_COMMAND_PARAMS_LEN;
 
 /// Maximum size of an STP-framed HCI command (delimiter + header + the

--- a/crates/pteron/src/transport.rs
+++ b/crates/pteron/src/transport.rs
@@ -43,6 +43,26 @@ const STP_FUNC_BT: u8 = 0;
 /// decode share this tighter bound instead of the raw protocol maximum.
 pub(crate) const RING_BUF_SIZE: usize = 2048;
 
+/// Maximum size of an HCI command's parameter block.
+///
+/// WHY: HCI bounds command parameters to a single `u8` length field (see
+/// `encode_command`'s INVARIANT in `hci.rs`), so 255 bytes is the true
+/// protocol ceiling regardless of which [`HciCommand`] variant is encoded.
+const MAX_HCI_COMMAND_PARAMS_LEN: usize = 255;
+
+/// Maximum size of an H4-framed HCI command: type(1) + opcode(2) +
+/// param_len(1) + up to [`MAX_HCI_COMMAND_PARAMS_LEN`] parameter bytes.
+const MAX_HCI_COMMAND_LEN: usize = 4 + MAX_HCI_COMMAND_PARAMS_LEN;
+
+/// Maximum size of an STP-framed HCI command (delimiter + header + the
+/// largest possible HCI command payload).
+///
+/// WHY: [`BtHciTransport::send_command`] only ever frames [`HciCommand`]
+/// values, whose encoded size is bounded well under [`RING_BUF_SIZE`]; a
+/// fixed-size stack buffer of this length replaces a second per-call heap
+/// allocation that used to size itself dynamically to the command length.
+const MAX_COMMAND_FRAME_LEN: usize = STP_DELIMITER_LEN + STP_HEADER_LEN + MAX_HCI_COMMAND_LEN;
+
 /// Default address-rotation interval: 15 minutes in seconds, matching BLE spec
 /// recommendation.
 ///
@@ -416,17 +436,30 @@ pub(crate) const fn generate_nrpa(entropy: &[u8; 6]) -> BdAddr {
     BdAddr::from_bytes([b0, b1, b2, b3, b4, b5])
 }
 
-/// Generate a Resolvable Private Address (RPA) preamble.
+/// Generate an address with RPA type bits SET (two MSBs = 0b01).
 ///
-/// RPA bit format: two MSBs of byte 5 (the address MSB) are 0b01.
-/// The lower 22 bits are a random prand; the upper 24 bits (bytes 0-2 in
-/// display ORDER) would normally be the hash(IRK, prand) in a full
-/// implementation.  This function returns the address with the prand portion
-/// SET and the hash portion filled FROM `entropy`, sufficient for address
-/// rotation without a full IRK implementation.
+/// SECURITY GAP (too large for a mechanical fix; tracked separately): this
+/// does NOT compute a spec-conformant Resolvable Private Address. Per BT
+/// Core Spec Vol 6, Part B §1.3.2.2, an RPA's lower 24 bits MUST equal
+/// `ah(IRK, prand)` — an AES-128 hash of the upper 22-bit prand under the
+/// bonded peer's Identity Resolving Key — so a bonded peer can resolve the
+/// address back to our identity. This function fills BOTH the prand region
+/// AND the hash region FROM raw `entropy`, with no relation to any IRK. The
+/// result:
+/// - is NOT resolvable by any bonded peer (defeats reconnection, bonded
+///   auto-connect, and directed-advertising use cases that rely on RPA
+///   resolution), and
+/// - is NOT a valid RPA per spec, while still asserting via the type bits
+///   that it is one — worse than an NRPA for any caller that branches on
+///   the address-type bits and assumes resolvability.
 ///
-/// WHY: used when bonding is established; allows the bonded peer to resolve
-/// the address via their stored IRK while remaining opaque to others.
+/// A conformant implementation needs an `ah()` AES-128 primitive (this
+/// crate has no AES dependency and no raw-ECB usage pattern anywhere), an
+/// IRK generation/storage seam (zeroized, persistent across our own address
+/// rotations), and an SMP (Security Manager Protocol) bonding flow to
+/// exchange IRKs with peers (this crate has no L2CAP/SMP layer at all —
+/// HCI/STP transport only). None of those seams exist yet; do not treat
+/// this function's output as a real RPA.
 pub(crate) const fn generate_rpa(entropy: &[u8; 6]) -> BdAddr {
     let [mut b0, b1, b2, b3, b4, b5] = *entropy;
     // Force two MSBs to 0b01 in the most-significant byte (index 0 = display MSB)
@@ -527,10 +560,18 @@ impl BtHciTransport {
     /// When advancing to `ResetCompleteEventDelivered`, this method injects the
     /// Hardware Error event `{0x04, 0x10, 0x01, 0x00}` INTO the RX ring buffer
     /// so that callers see the same event that real hardware would produce.
+    /// The transition only completes once that injection succeeds — a state
+    /// named `ResetCompleteEventDelivered` must never be reachable without the
+    /// event actually landing in the RX path.
     ///
     /// # Errors
     ///
     /// Returns [`Error::UnexpectedResetState`] if the transition is not valid.
+    ///
+    /// Returns [`Error::BufferOverflow`] if the RX ring buffer has no room for
+    /// the Hardware Error event; `rstflag` remains
+    /// [`RstFlag::ResetCompleteEventPending`] so the caller can retry the
+    /// transition once the RX buffer drains.
     pub(crate) fn advance_reset(&mut self) -> Result<RstFlag> {
         let next = match self.rstflag {
             RstFlag::Normal => RstFlag::ResetStart,
@@ -539,7 +580,16 @@ impl BtHciTransport {
                 // Inject HCI Hardware Error event INTO RX path per DRIVER-INTERFACES.md §4.4.
                 // Event: H4=0x04, code=0x10, param_len=0x01, hw_code=0x00
                 let hw_error_event: [u8; 4] = [0x04, 0x10, 0x01, 0x00];
-                let _ = self.rx.push(&hw_error_event); // WHY: best-effort RX injection; ring buffer may be full during reset storm.
+                // WHY: ResetCompleteEventDelivered is a contract that the event
+                // reached RX; on injection failure stay in
+                // ResetCompleteEventPending and surface the error instead of
+                // silently losing the event, so the caller can retry.
+                if !self.rx.push(&hw_error_event) {
+                    return Err(Error::BufferOverflow {
+                        need: hw_error_event.len(),
+                        have: RING_BUF_SIZE - self.rx.len(),
+                    });
+                }
                 RstFlag::ResetCompleteEventDelivered
             }
             RstFlag::ResetCompleteEventDelivered => RstFlag::Normal,
@@ -570,8 +620,10 @@ impl BtHciTransport {
     /// enough space for the encoded frame.
     pub(crate) fn send_command(&mut self, cmd: &HciCommand) -> Result<usize> {
         let hci_bytes = encode_command(cmd);
-        let frame_size = STP_DELIMITER_LEN + STP_HEADER_LEN + hci_bytes.len();
-        let mut frame_buf = vec![0u8; frame_size];
+        // WHY: HCI command frames are bounded by MAX_COMMAND_FRAME_LEN, so a
+        // fixed-size stack buffer replaces the second per-call heap
+        // allocation this used to require (`vec![0u8; frame_size]`).
+        let mut frame_buf = [0u8; MAX_COMMAND_FRAME_LEN];
         let written = stp_encode(self.tx_seq, &hci_bytes, &mut frame_buf)?;
         if !self.tx.push(&frame_buf[..written]) {
             return Err(Error::BufferOverflow {
@@ -960,11 +1012,12 @@ mod tests {
     }
 
     #[test]
-    fn reset_state3_advances_even_when_rx_injection_fails() -> Result<()> {
+    fn reset_state3_does_not_advance_when_rx_injection_fails() -> Result<()> {
         let mut transport = BtHciTransport::new();
         // WHY: fill the RX ring to capacity so the Hardware Error event
         // injection at state 3 has no room to land, exercising the
-        // documented best-effort-injection failure path.
+        // failure path that must surface an error instead of silently
+        // advancing past a state whose name promises delivery.
         let filler = vec![0u8; RING_BUF_SIZE - 1];
         assert!(
             transport.rx.push(&filler),
@@ -973,12 +1026,16 @@ mod tests {
 
         transport.advance_reset()?;
         transport.advance_reset()?;
-        let s3 = transport.advance_reset()?;
+        let result = transport.advance_reset();
 
+        assert!(
+            matches!(result, Err(Error::BufferOverflow { .. })),
+            "injection failure must surface as an error, not a silent state advance"
+        );
         assert_eq!(
-            s3,
-            RstFlag::ResetCompleteEventDelivered,
-            "reset state machine must still advance even when best-effort RX injection fails"
+            transport.rstflag(),
+            RstFlag::ResetCompleteEventPending,
+            "rstflag must remain ResetCompleteEventPending so a retry can occur once RX drains"
         );
         Ok(())
     }
@@ -1159,6 +1216,34 @@ mod tests {
         assert_eq!(
             own_addr_type, OWN_ADDR_TYPE_RANDOM,
             "LE_Set_Scan_Parameters must always use Own_Address_Type = 0x01 (Random)"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn send_command_round_trips_through_fixed_frame_buffer() -> Result<()> {
+        // WHY: send_command frames the STP header into a fixed-size stack
+        // buffer (MAX_COMMAND_FRAME_LEN) instead of a second per-call heap
+        // allocation; this proves that refactor still produces a correct,
+        // decodable STP frame for a command near the larger end of the
+        // HciCommand payload range (SetEventMask's 8-byte mask).
+        let mut transport = BtHciTransport::new();
+        let cmd = HciCommand::SetEventMask { mask: [0xFF; 8] };
+        transport.send_command(&cmd)?;
+
+        let mut raw = vec![0u8; RING_BUF_SIZE];
+        let drained = transport.drain_tx(&mut raw);
+        assert!(drained > 0, "TX buffer must contain the encoded frame");
+
+        let (payload, frame_len) = stp_decode(&raw[..drained])?;
+        assert_eq!(
+            frame_len, drained,
+            "decoded frame length must match the drained byte count"
+        );
+        assert_eq!(
+            payload.len(),
+            4 + 8,
+            "SetEventMask HCI payload must be H4+opcode+param_len(4 bytes) + 8 mask bytes"
         );
         Ok(())
     }


### PR DESCRIPTION
Three userspace-crate audit umbrellas swept together. Several findings stale (fixed by the #278 rollup / prior work); substantive fixes:

## leipsanon (#280)
- **Missing wipe target counted as completed** — false assurance a panic-wipe destroyed data that never existed at that path. `wipe_path` returns `Ok(None)` for missing; `WipeResult.actions_missing` is distinct from completed/failed.
- **Unbounded write_all/sync_all** — a wedged block device blocked the whole wipe engine forever. Now worker-thread + WIPE_TARGET_TIMEOUT deadline (true syscall cancel needs io_uring, not a dep; non-cancellable worker documented).

## metaxu (#281)
- **Transport error dropped its source chain** (stringified). Fixed the **kanon-compliant** way (no `Box<dyn Error>`): `Error<E = Infallible>` generic over the transport error type + `BridgeTransport::Error` associated type, so the concrete cause is walkable/downcastable. `widen()` bridges the Infallible encode/decode paths without a coherence-conflicting blanket `From`.

## pteron (#382)
- **advance_reset** advanced to `ResetCompleteEventDelivered` even when the HW-error RX injection failed — now returns BufferOverflow, stays Pending for retry.
- **send_command** double-allocated; STP frame now builds into a fixed stack buffer.
- **generate_rpa** fills the RPA hash field with raw entropy instead of `ah(IRK,prand)` — a real LE-Privacy defect, but a conformant fix needs an AES-128 ah() + IRK storage + SMP bonding flow (none exist). Doc-only clarification here; full fix tracked separately.

## Verification
- `cargo nextest run -p leipsanon -p metaxu -p pteron` — **133 passed** (leipsanon 54 + metaxu 11 + pteron 68)
- `cargo build --workspace` clean (no metaxu consumer breaks on the signature change) · `kanon lint` clean

Addresses #280, #281, #382. pteron generate_rpa (RPA subsystem) + set_random_address double-alloc split to follow-ups.

_metaxu generic-error refactor + pteron RPA/reset reviewed at T0/Opus._