### PR TITLE
3 operator-decided fixes: recall_preset InvalidPreset, nous deselect, pteron alloc (#452 #453 #456)

### DIFF
--- a/crates/pteron/src/transport.rs
+++ b/crates/pteron/src/transport.rs
@@ -710,15 +710,19 @@ impl BtHciTransport {
 
     /// Set a pre-generated random address by sending `HCI_LE_Set_Random_Address`.
     ///
-    /// The HCI command bytes are placed INTO the TX ring buffer via [`send_raw`].
+    /// The HCI command bytes are STP-framed into a fixed-size stack buffer
+    /// and placed INTO the TX ring buffer.
     ///
     /// # Errors
     ///
     /// Returns [`Error::BufferOverflow`] if the TX ring buffer is full.
     pub(crate) fn set_random_address(&mut self, addr: BdAddr) -> Result<usize> {
         let pkt = build_le_set_random_address_cmd(&addr);
-        let frame_size = STP_DELIMITER_LEN + STP_HEADER_LEN + pkt.len();
-        let mut frame_buf = vec![0u8; frame_size];
+        // WHY: HCI_LE_Set_Random_Address is a fixed 10-byte command, well
+        // under MAX_COMMAND_FRAME_LEN -- a fixed-size stack buffer replaces
+        // the second per-call heap allocation this used to require
+        // (`vec![0u8; frame_size]`), matching send_command's framing.
+        let mut frame_buf = [0u8; MAX_COMMAND_FRAME_LEN];
         let written = stp_encode(self.tx_seq, &pkt, &mut frame_buf)?;
         if !self.tx.push(&frame_buf[..written]) {
             return Err(Error::BufferOverflow {
@@ -1274,5 +1278,39 @@ mod tests {
             0xAA,
             "last address byte in HCI packet must be the MSB (0xAA)"
         );
+    }
+
+    #[test]
+    fn set_random_address_round_trips_through_fixed_frame_buffer() -> Result<()> {
+        // WHY: set_random_address now frames the STP header into a
+        // fixed-size stack buffer (MAX_COMMAND_FRAME_LEN), the same
+        // pattern send_command uses, instead of a second per-call heap
+        // allocation (`vec![0u8; frame_size]`); this proves that refactor
+        // still produces a correct, decodable STP frame (#456).
+        let mut transport = BtHciTransport::new();
+        let addr = BdAddr::from_bytes([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]);
+        transport.set_random_address(addr)?;
+
+        let mut raw = vec![0u8; RING_BUF_SIZE];
+        let drained = transport.drain_tx(&mut raw);
+        assert!(drained > 0, "TX buffer must contain the encoded frame");
+
+        let (payload, frame_len) = stp_decode(&raw[..drained])?;
+        assert_eq!(
+            frame_len, drained,
+            "decoded frame length must match the drained byte count"
+        );
+        assert_eq!(
+            payload.len(),
+            10,
+            "HCI_LE_Set_Random_Address HCI payload must be 10 bytes \
+             (H4 + opcode + param_len + 6-byte address)"
+        );
+        assert_eq!(
+            payload.get(9).copied().ok_or(Error::RxUnderrun)?,
+            0xAA,
+            "last address byte in the framed payload must be the MSB (0xAA)"
+        );
+        Ok(())
     }
 }

--- a/crates/thumos/src/fm_radio.rs
+++ b/crates/thumos/src/fm_radio.rs
@@ -354,8 +354,9 @@ impl FmHwOps for MockFmHw {
 pub struct FmRadio<H: FmHwOps> {
     /// Current FM state.
     state: FmState,
-    /// Preset frequencies in kHz (6 slots).
-    presets: [u32; FM_PRESET_COUNT],
+    /// Preset frequencies in kHz (6 slots). `None` marks an unset slot,
+    /// distinguishing 'never saved' from a saved frequency (#452).
+    presets: [Option<u32>; FM_PRESET_COUNT],
     /// Number of populated preset slots.
     preset_count: u8,
     /// Current volume level (0-15).
@@ -370,7 +371,7 @@ impl<H: FmHwOps> FmRadio<H> {
     pub fn new(hw: H) -> Self {
         Self {
             state: FmState::Off,
-            presets: [0u32; FM_PRESET_COUNT],
+            presets: [None; FM_PRESET_COUNT],
             preset_count: 0,
             volume: FM_DEFAULT_VOLUME,
             hw,
@@ -398,9 +399,9 @@ impl<H: FmHwOps> FmRadio<H> {
         }
     }
 
-    /// Return the preset frequencies.
+    /// Return the preset frequencies. `None` marks an unset slot.
     #[must_use]
-    pub fn presets(&self) -> &[u32] {
+    pub fn presets(&self) -> &[Option<u32>] {
         &self.presets[..self.preset_count as usize]
     }
 
@@ -594,7 +595,7 @@ impl<H: FmHwOps> FmRadio<H> {
             _ => return Err(FmError::InvalidState),
         };
 
-        self.presets[index] = freq;
+        self.presets[index] = Some(freq);
         if index >= self.preset_count as usize {
             self.preset_count = (index + 1) as u8;
         }
@@ -616,7 +617,14 @@ impl<H: FmHwOps> FmRadio<H> {
             return Err(FmError::InvalidPreset);
         }
 
-        let freq = self.presets[index];
+        // WHY(#452): preset_count only tracks the highest EVER-saved index
+        // + 1, not which individual slots were populated, so a slot within
+        // the `index < preset_count` range can still be unset if it was
+        // skipped by a non-contiguous save_preset call. Per-slot occupancy
+        // (Option<u32>) lets that case return InvalidPreset as documented,
+        // instead of falling through to a frequency-range check against an
+        // arbitrary default value.
+        let freq = self.presets[index].ok_or(FmError::InvalidPreset)?;
         if !(FM_FREQ_MIN_KHZ..=FM_FREQ_MAX_KHZ).contains(&freq) {
             return Err(FmError::FrequencyOutOfRange);
         }
@@ -1051,18 +1059,17 @@ mod tests {
     }
 
     #[test]
-    fn recall_preset_uninitialized_non_contiguous_slot_returns_wrong_variant() {
-        // WHY: pins a mismatch between recall_preset's documented
-        // contract ("InvalidPreset -- slot index out of range or not
-        // set") and its actual behavior. preset_count only tracks the
-        // highest EVER-saved index + 1, not which individual slots were
-        // populated, so saving directly to slot 3 (skipping 0-2, as in
-        // preset_non_contiguous_index above) leaves slots 0-2 within the
-        // `index < preset_count` range yet never actually written (still
-        // 0). recall_preset falls through to the frequency-range check
-        // and returns FrequencyOutOfRange (0 is not in the FM band)
-        // instead of the documented InvalidPreset (#397 finding 32 --
-        // NOT fixed here; this pins current behavior for a follow-up).
+    fn recall_preset_uninitialized_non_contiguous_slot_returns_invalid_preset() {
+        // WHY(#452): recall_preset's documented contract is
+        // "InvalidPreset -- slot index out of range or not set".
+        // preset_count only tracks the highest EVER-saved index + 1, not
+        // which individual slots were populated, so saving directly to
+        // slot 3 (skipping 0-2, as in preset_non_contiguous_index above)
+        // leaves slots 0-2 within the `index < preset_count` range yet
+        // never actually written. Per-slot occupancy (Option<u32>) now
+        // lets recall_preset distinguish that from a genuinely saved
+        // frequency and return InvalidPreset as documented, fixing the
+        // FrequencyOutOfRange mismatch this test used to pin.
         let mut radio = make_radio();
         radio.power_on().ok();
         radio.tune(92_300).ok();
@@ -1072,11 +1079,9 @@ mod tests {
         let result = radio.recall_preset(1); // never explicitly saved
         assert_eq!(
             result,
-            Err(FmError::FrequencyOutOfRange),
-            "current behavior: an unset-but-in-range slot surfaces \
-             FrequencyOutOfRange, not the documented \
-             InvalidPreset(\"...or not set\") -- a mismatch worth a \
-             follow-up fix, not asserted here as correct"
+            Err(FmError::InvalidPreset),
+            "an unset-but-in-range slot must return the documented \
+             InvalidPreset, not FrequencyOutOfRange"
         );
     }
 

--- a/crates/thumos/src/nous.rs
+++ b/crates/thumos/src/nous.rs
@@ -464,8 +464,9 @@ pub(crate) fn default_paideia() -> Result<NousEntity, NousError> {
 pub(crate) struct NousManager {
     /// Registered nous entities.
     entities: Vec<NousEntity>,
-    /// Index of the currently active entity.
-    active_entity: usize,
+    /// Index of the currently active entity, or `None` if no entity is
+    /// currently selected (#453).
+    active_entity: Option<usize>,
 }
 
 impl NousManager {
@@ -484,7 +485,7 @@ impl NousManager {
             .collect();
         Self {
             entities,
-            active_entity: 0,
+            active_entity: Some(0),
         }
     }
 
@@ -495,7 +496,7 @@ impl NousManager {
     pub(crate) fn empty() -> Self {
         Self {
             entities: Vec::new(),
-            active_entity: 0,
+            active_entity: None,
         }
     }
 
@@ -504,19 +505,21 @@ impl NousManager {
     /// Returns `None` if no entities are registered.
     #[must_use]
     pub(crate) fn active(&self) -> Option<&NousEntity> {
-        self.entities.get(self.active_entity)
+        self.entities.get(self.active_entity?)
     }
 
     /// Return a mutable reference to the currently active entity.
     ///
     /// Returns `None` if no entities are registered.
     pub(crate) fn active_mut(&mut self) -> Option<&mut NousEntity> {
-        self.entities.get_mut(self.active_entity)
+        self.entities.get_mut(self.active_entity?)
     }
 
     /// Return the index of the currently active entity.
+    ///
+    /// Returns `None` if no entity is currently selected (#453).
     #[must_use]
-    pub(crate) fn active_index(&self) -> usize {
+    pub(crate) fn active_index(&self) -> Option<usize> {
         self.active_entity
     }
 
@@ -551,17 +554,22 @@ impl NousManager {
                 count: self.entities.len(),
             });
         }
-        self.active_entity = index;
+        self.active_entity = Some(index);
         Ok(())
     }
 
     /// Cycle to the next entity (wraps around).
     ///
-    /// Does nothing if no entities are registered.
+    /// Does nothing if no entities are registered. If no entity is
+    /// currently selected, selects the first entity (#453).
     pub(crate) fn cycle_next(&mut self) {
-        if !self.entities.is_empty() {
-            self.active_entity = (self.active_entity + 1) % self.entities.len();
+        if self.entities.is_empty() {
+            return;
         }
+        self.active_entity = Some(match self.active_entity {
+            Some(idx) => (idx + 1) % self.entities.len(),
+            None => 0,
+        });
     }
 
     /// Add a new entity to the manager.
@@ -589,8 +597,12 @@ impl NousManager {
 
     /// Remove an entity by index.
     ///
-    /// Adjusts the active entity index if needed. Cannot remove the last
-    /// entity (the manager must always have at least one, or be empty).
+    /// If the removed entity was the currently active one, the active
+    /// selection is cleared (`None`) regardless of its position -- fail-
+    /// closed, so no privileged action is ever silently attributed to
+    /// whichever entity shifted into the vacated slot (#453). Otherwise
+    /// the active index shifts down to keep pointing at the same
+    /// surviving entity.
     ///
     /// # Errors
     ///
@@ -605,13 +617,19 @@ impl NousManager {
 
         let removed = self.entities.remove(index);
 
-        // Adjust active entity if needed.
-        if self.entities.is_empty() {
-            self.active_entity = 0;
-        } else if self.active_entity >= self.entities.len() {
-            self.active_entity = self.entities.len() - 1;
-        } else if self.active_entity > index {
-            self.active_entity -= 1;
+        // WHY(#453): deselect outright when the removed entity was the
+        // active one (fail-closed) instead of leaving the numeric index
+        // unchanged to silently point at whatever entity shifted down
+        // into the vacated slot; otherwise shift the index down by one
+        // to keep tracking the same surviving entity.
+        match self.active_entity {
+            Some(active) if active == index => self.active_entity = None,
+            Some(active) if active > index => self.active_entity = Some(active - 1),
+            _ => {
+                // WHY: nothing selected (None), or the active entity sits
+                // BEFORE the removed one (active < index) — the active index
+                // still points at the same surviving entity; no adjustment.
+            }
         }
 
         Ok(removed)
@@ -977,7 +995,7 @@ mod tests {
     fn manager_defaults() {
         let mgr = NousManager::new();
         assert_eq!(mgr.entity_count(), 3, "must have 3 default entities");
-        assert_eq!(mgr.active_index(), 0, "Syn must be active by default");
+        assert_eq!(mgr.active_index(), Some(0), "Syn must be active by default");
 
         let active = mgr.active();
         assert!(active.is_some());
@@ -1025,23 +1043,23 @@ mod tests {
     #[test]
     fn manager_cycle_next() {
         let mut mgr = NousManager::new();
-        assert_eq!(mgr.active_index(), 0);
+        assert_eq!(mgr.active_index(), Some(0));
 
         mgr.cycle_next();
-        assert_eq!(mgr.active_index(), 1);
+        assert_eq!(mgr.active_index(), Some(1));
 
         mgr.cycle_next();
-        assert_eq!(mgr.active_index(), 2);
+        assert_eq!(mgr.active_index(), Some(2));
 
         mgr.cycle_next();
-        assert_eq!(mgr.active_index(), 0, "must wrap around");
+        assert_eq!(mgr.active_index(), Some(0), "must wrap around");
     }
 
     #[test]
     fn manager_cycle_next_empty() {
         let mut mgr = NousManager::empty();
         mgr.cycle_next(); // Must not panic.
-        assert_eq!(mgr.active_index(), 0);
+        assert_eq!(mgr.active_index(), None);
     }
 
     #[test]
@@ -1091,31 +1109,26 @@ mod tests {
         let mut mgr = NousManager::new();
         // Switch to last entity (index 2 = Paideia).
         mgr.switch(2).unwrap_or_else(|_| unreachable!());
-        assert_eq!(mgr.active_index(), 2);
+        assert_eq!(mgr.active_index(), Some(2));
 
-        // Remove entity at index 2.
+        // Remove entity at index 2 (the active entity, and the last one).
         let _ = mgr.remove_entity(2);
-        assert!(
-            mgr.active_index() < mgr.entity_count(),
-            "active index must be clamped after removal"
+        assert_eq!(
+            mgr.active_index(),
+            None,
+            "removing the active entity must deselect, not silently \
+             clamp to a different entity (#453)"
         );
     }
 
     #[test]
-    fn remove_entity_silently_shifts_active_when_removing_a_non_last_active_entity() {
-        // WHY: pins a genuine, currently-uncovered edge case in
-        // remove_entity's active-index adjustment. The existing branches
-        // (`entities.is_empty()`, `active_entity >= entities.len()`,
-        // `active_entity > index`) cover removing the active entity when
-        // it is the LAST one, or removing a non-active entity BEFORE the
-        // active one -- but not removing the ACTIVE entity itself from a
-        // non-last position. There, active_entity is left unchanged, but
-        // because Vec::remove shifts every later element down by one,
-        // that same numeric index now refers to a DIFFERENT entity --
-        // the active entity silently becomes whichever one used to sit
-        // immediately after the removed one, with no explicit selection
-        // by the caller (a silent capability-preset substitution, since
-        // each entity carries its own trust level) (#397).
+    fn remove_entity_deselects_when_removing_a_non_last_active_entity() {
+        // WHY(#453): removing the currently-active entity must clear the
+        // selection (fail-closed) rather than leaving active_entity's
+        // numeric index unchanged and letting it silently refer to
+        // whatever entity Vec::remove shifted down into that slot --
+        // that would substitute a different entity's capability preset
+        // for a selection the caller never made.
         let mut mgr = NousManager::new();
         // Syn (Advisor) at 0, Phrouros (Observer) at 1, Paideia (Assistant) at 2.
         mgr.switch(1).unwrap_or_else(|_| unreachable!()); // active = Phrouros
@@ -1127,17 +1140,13 @@ mod tests {
             Ok(String::from("Phrouros")),
         );
 
-        // Current behavior: active_entity index (1) is left unchanged,
-        // but now refers to Paideia (which shifted down from index 2 to
-        // index 1) -- a different entity with a different capability
-        // preset, silently substituted for the one the caller had
-        // selected.
         assert_eq!(
             mgr.active().map(|e| e.name_str()),
-            Some("Paideia"),
-            "current behavior: the active pointer silently follows \
-             whatever entity shifted into the removed active entity's slot"
+            None,
+            "removing the active entity must deselect -- no entity is \
+             active until one is explicitly selected"
         );
+        assert_eq!(mgr.active_index(), None);
     }
 
     #[test]

--- a/crates/thumos/src/screen_nous.rs
+++ b/crates/thumos/src/screen_nous.rs
@@ -268,10 +268,20 @@ impl NousChatScreen {
     }
 
     /// Update the cached entity info from a nous manager.
+    ///
+    /// If no entity is currently selected (#453), the cache reflects that
+    /// explicitly rather than keeping a stale prior selection's name and
+    /// capability label.
     pub(crate) fn sync_from_manager(&mut self, manager: &NousManager) {
-        if let Some(entity) = manager.active() {
-            self.active_entity_name = String::from(entity.name_str());
-            self.active_preset_label = entity.capability_label();
+        match manager.active() {
+            Some(entity) => {
+                self.active_entity_name = String::from(entity.name_str());
+                self.active_preset_label = entity.capability_label();
+            }
+            None => {
+                self.active_entity_name = String::from("(none)");
+                self.active_preset_label = CapabilityPreset::Off.label();
+            }
         }
     }
 
@@ -1242,6 +1252,18 @@ mod tests {
         screen.sync_from_manager(&mgr);
         assert_eq!(screen.active_entity_name, "Syn");
         assert_eq!(screen.active_preset_label, "ADVISOR");
+    }
+
+    #[test]
+    fn sync_from_manager_no_active_entity() {
+        let mut screen = NousChatScreen::new();
+        let mut mgr = NousManager::new();
+        // WHY: discard the removed entity -- only the deselect side
+        // effect on the manager's active selection matters here (#453).
+        let _ = mgr.remove_entity(0); // removes the active entity (Syn)
+        screen.sync_from_manager(&mgr);
+        assert_eq!(screen.active_entity_name, "(none)");
+        assert_eq!(screen.active_preset_label, "OFF");
     }
 
     #[test]


### PR DESCRIPTION
Three small operator-decided fixes (from the unblock interview).

- **#452 fm_radio** — preset store is now `[Option<u32>; N]`, so `recall_preset` returns the documented `InvalidPreset` for an in-range-but-never-saved slot instead of falling through to a frequency-range check. Pinning test flipped to assert InvalidPreset.
- **#453 nous** — `remove_entity` now **deselects** (`active_entity: Option<usize>` → None) when the removed entity is the active one, regardless of position. Fail-closed: no privileged action silently attributed to whichever entity shifted into the vacated slot (a different capability/trust preset). The one external caller (screen_nous) resets its cached name/label to "(none)"/OFF on no-active. Pinning test flipped to assert deselect.
- **#456 pteron** — `set_random_address` frames into a fixed stack buffer (MAX_COMMAND_FRAME_LEN) instead of a second heap Vec, matching send_command; fixed a dead `send_raw` doc link.

## Verification
- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — **2164 passed**
- `cargo build --release --target armv7a-none-eabi` — clean
- `cargo nextest run -p pteron` — **69 passed** · `cargo clippy -p pteron --all-targets -- -D warnings` — clean · `kanon lint` — clean

Closes #452, #453, #456.