### PR TITLE
Structurally gate the debug console out of ship builds (#372)

### DIFF
--- a/crates/thumos/Cargo.toml
+++ b/crates/thumos/Cargo.toml
@@ -6,6 +6,23 @@ edition = "2024"
 license = "AGPL-3.0-only"
 repository = "https://github.com/forkwright/thumos"
 
+[features]
+# WHY (issue #372): dev-only kernel debug console (UART shell). Deliberately
+# absent from `default` -- a shipped/production build must not merely
+# *default* to excluding it, it must be structurally incapable of
+# containing it (see main.rs's `mod console` cfg gate + the
+# debug-console/production compile_error! there).
+debug-console = []
+# WHY (issue #372): marks a build as the shippable/flashable artifact.
+# Mutually exclusive with `debug-console` -- main.rs `compile_error!`s if
+# both are set, so an `--all-features` invocation (which enables both at
+# once) fails to compile instead of silently producing a console-carrying
+# release binary. The ship/bring-up build should pass `--features
+# production` (see design notes: CONTRIBUTING.md / ARCHITECTURE.md /
+# AGENTS.md / ci.yml kernel job need a companion update, out of scope for
+# this crate-local edit set).
+production = []
+
 [dependencies]
 aes = { version = "0.8", default-features = false }
 # WHY: Megolm needs AES-256-CBC (audit #231). Use the audited RustCrypto `cbc`

--- a/crates/thumos/src/console.rs
+++ b/crates/thumos/src/console.rs
@@ -16,6 +16,20 @@ use crate::uart::Uart;
 /// Maximum command line length.
 const MAX_CMD_LEN: usize = 128;
 
+/// Magic byte sequence required over UART before the console will start
+/// (issue #372 defense-in-depth: the console must not auto-start merely
+/// because a debug-console build booted and the boot-time gates passed --
+/// an operator must prove physical presence by typing this sequence).
+const PRESENCE_SEQUENCE: &[u8] = b"THUMOS-UNLOCK\r";
+
+/// Bound on presence-sequence idle polling, in iterations between bytes
+/// (not wall-clock time -- mirrors `uart::Uart`'s `UART_TX_TIMEOUT_SPINS`:
+/// this runs before any timer dependency is guaranteed available, so a raw
+/// iteration bound is the correct choice, not an elapsed-ticks check).
+/// TODO(#459)[deliberate-prudent]: the wall-clock window this represents is uncalibrated against
+/// real UART polling throughput; tune once measured on hardware.
+const PRESENCE_POLL_SPINS: u32 = 1_000_000;
+
 /// Kernel debug console.
 pub(crate) struct Console {
     serial: Uart,
@@ -31,6 +45,39 @@ impl Console {
             line_buf: [0; MAX_CMD_LEN],
             line_len: 0,
         }
+    }
+
+    /// Block (bounded) until `PRESENCE_SEQUENCE` is received over UART,
+    /// confirming a physically-present operator before the caller starts
+    /// the interactive shell (issue #372).
+    ///
+    /// Fails closed: if no byte arrives for `PRESENCE_POLL_SPINS`
+    /// iterations, or the caller never supplies the exact sequence,
+    /// returns `false` and the caller must not start the console. Any
+    /// mismatched byte resets the match (a typo requires retyping the
+    /// whole sequence, not just the wrong character).
+    pub(crate) fn wait_for_physical_presence(serial: &Uart) -> bool {
+        let mut matched = 0usize;
+        let mut idle_spins: u32 = 0;
+        while matched < PRESENCE_SEQUENCE.len() {
+            match serial.getc() {
+                Some(byte) if byte == PRESENCE_SEQUENCE[matched] => {
+                    matched += 1;
+                    idle_spins = 0; // NOTE: reset the idle bound on forward progress
+                }
+                Some(_) => {
+                    matched = 0; // NOTE: any mismatched byte resets the sequence
+                    idle_spins = 0;
+                }
+                None => {
+                    idle_spins += 1;
+                    if idle_spins >= PRESENCE_POLL_SPINS {
+                        return false;
+                    }
+                }
+            }
+        }
+        true
     }
 
     /// Print the prompt.
@@ -223,5 +270,15 @@ mod tests {
         }
         console.receive_byte(0x7F);
         assert_eq!(console.line_len, MAX_CMD_LEN - 2);
+    }
+
+    #[test]
+    fn wait_for_physical_presence_times_out_without_input() {
+        // WHY: the host-test `uart::Uart` stub never has RX data available
+        // (see uart_stub.rs), so this exercises the fail-closed path: no
+        // presence sequence arrives, and the bounded poll must return
+        // `false` rather than hang.
+        let serial = Uart::new();
+        assert!(!Console::wait_for_physical_presence(&serial));
     }
 }

--- a/crates/thumos/src/kconfig.rs
+++ b/crates/thumos/src/kconfig.rs
@@ -20,7 +20,15 @@ pub(crate) static mut UART_BAUD: u32 = 921_600;
 pub(crate) static mut VERBOSE_BOOT: bool = true;
 
 /// Enable kernel debug console on UART.
-pub(crate) static mut DEBUG_CONSOLE: bool = true;
+///
+/// WARNING: defaults `false` (issue #372) -- the console is a dev-only
+/// UART shell with no authentication. The former `console=` cmdline arm
+/// that let a boot-args attacker force this to `true` has been deleted;
+/// flipping this back to `true` is now a deliberate, reviewable source
+/// edit, not a runtime toggle. See `kinit`'s `debug_console_gate` for the
+/// full gate (this flag is one layer of three, alongside the
+/// `debug-console` compile-time feature and the physical-presence check).
+pub(crate) static mut DEBUG_CONSOLE: bool = false;
 
 /// Panic behavior: 0 = halt, N = reboot after N seconds.
 pub(crate) static mut PANIC_TIMEOUT: u32 = 0;
@@ -98,11 +106,12 @@ pub(crate) fn parse_cmdline(cmdline: &str) {
                 "verbose" => unsafe {
                     VERBOSE_BOOT = value != "0";
                 },
-                // SAFETY: parse_cmdline is called once during early boot before
-                // any concurrent access to these static mut config globals.
-                "console" => unsafe {
-                    DEBUG_CONSOLE = value != "0";
-                },
+                // WHY (issue #372): the `console=` key is deliberately NOT
+                // handled -- it falls through to the `_` (ignored) arm
+                // below. A boot-args attacker must not be able to force
+                // the debug console on; `DEBUG_CONSOLE` is now a
+                // compile-time-fixed default (see its doc comment) with no
+                // runtime cmdline path.
                 "tick_ms" => {
                     if let Ok(v) = value.parse::<u32>() {
                         // SAFETY: parse_cmdline is called once during early boot before
@@ -131,7 +140,7 @@ mod tests {
 
     #[test]
     fn parse_cmdline_sets_tick_rate_and_security_flags() {
-        parse_cmdline("tick_ms=25 verbose=0 console=0 panic=5");
+        parse_cmdline("tick_ms=25 verbose=0 console=1 panic=5");
 
         // SAFETY: single-threaded test (nextest process-isolates per test);
         // addr_of!().read() avoids a shared reference to the static mut.
@@ -145,7 +154,12 @@ mod tests {
         };
         assert_eq!(tick, 25);
         assert!(!verbose);
-        assert!(!console);
+        // WHY (issue #372): `console=` is deliberately a no-op (see
+        // parse_cmdline) -- a boot-args attacker must not be able to force
+        // the debug console on. `console=1` here proves that: DEBUG_CONSOLE
+        // stays at its compile-time default (false) regardless of cmdline
+        // input.
+        assert!(!console, "console= must not be settable from the cmdline");
         assert_eq!(panic, 5);
     }
 

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -16,6 +16,7 @@ use core::slice;
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use crate::ccci::CcciDriver;
+#[cfg(feature = "debug-console")]
 use crate::console::Console;
 use crate::csprng;
 use crate::device::{self, DeviceRegistry};
@@ -353,6 +354,58 @@ fn plan_userspace_spawn_from_vfs(path: &str) -> UserspaceSpawnPlan<'static> {
         Some(elf_data) => UserspaceSpawnPlan::Elf(elf_data),
         None => UserspaceSpawnPlan::Missing,
     }
+}
+
+/// Decide whether the dev-only debug console should start this boot
+/// (issue #372 hardening layers, defense-in-depth beyond the
+/// `debug-console` compile-time feature that makes the console
+/// structurally absent from any build that lacks it).
+///
+/// Fails closed: any unmet condition returns `false`.
+#[cfg(feature = "debug-console")]
+fn debug_console_gate(serial: &mut Uart, mode_mgr: &crate::security_mode::ModeManager) -> bool {
+    // WHY: `kconfig::DEBUG_CONSOLE`'s cmdline arm was deleted (issue #372 --
+    // a boot-args attacker must not be able to force the console on) and its
+    // default flipped to `false`. Reaching a live console now requires BOTH
+    // `--features debug-console` at build time (this function only exists
+    // under that cfg) AND a deliberate source edit flipping
+    // `kconfig::DEBUG_CONSOLE`'s default back to `true` -- neither can
+    // happen by accident via a build flag alone (e.g. `--all-features`),
+    // and the latter is reviewable in a diff.
+    // SAFETY: DEBUG_CONSOLE is a compile-time-fixed default; nothing writes
+    // it after boot now that the cmdline arm is gone.
+    if !unsafe { kconfig::DEBUG_CONSOLE } {
+        return false;
+    }
+
+    // WARNING (defense-in-depth): refuse to start under Sentinel/Panic.
+    // NOTE: `mode_mgr` is freshly `ModeManager::default()`-constructed at
+    // Step 8f and nothing between there and here transitions it, so this
+    // currently always evaluates to Daily -- see the Step 8f WHY comment
+    // above. Kept as the structural check point so it becomes load-bearing
+    // the moment mode state is threaded through boot instead of re-derived
+    // fresh every time (e.g. a mode persisted across a warm restart).
+    if mode_mgr.mode() != crate::security_mode::SecurityMode::Daily {
+        let _ = serial.write_str("[init] Debug console refused: security mode is not Daily\r\n");
+        return false;
+    }
+
+    // WARNING (defense-in-depth): the console must not auto-start. Require
+    // an explicit entry sequence typed over UART before the interactive
+    // prompt appears, so merely compiling and booting a debug-console build
+    // does not hand a shell to whoever has a serial cable.
+    //
+    // TODO(#459)[deliberate-prudent]: `Console::wait_for_physical_presence` depends on
+    // `Uart::getc`, whose RX "data ready" bit position is unverified
+    // against the MT6739 TRM (see uart.rs) -- confirm on real hardware.
+    let _ =
+        serial.write_str("[init] Debug console armed -- awaiting physical-presence sequence\r\n");
+    if !Console::wait_for_physical_presence(serial) {
+        let _ = serial.write_str("[init] Debug console presence sequence not received\r\n");
+        return false;
+    }
+
+    true
 }
 
 // ---------------------------------------------------------------------------
@@ -781,6 +834,11 @@ pub unsafe fn run() -> ! {
     // -----------------------------------------------------------------------
     let _ = serial.write_str("[init] Security mode (Daily)\r\n");
     let mut pm = PowerManager::new();
+    // WHY: hoisted to function scope (was block-local) so the
+    // debug-console hardening gate near the end of boot (issue #372) can
+    // read the live security mode via this same `ModeManager` instance,
+    // rather than re-deriving a second, independent one.
+    let mode_mgr = crate::security_mode::ModeManager::default();
     {
         // WHY (finding 46): the radio policy must be established here,
         // BEFORE USB ACM (Step 9) and the CCCI modem (Step 10) bring
@@ -798,7 +856,6 @@ pub unsafe fn run() -> ! {
         // NOTE: BFU (Before First Unlock) timer wiring is separate,
         // unrelated work -- not part of this radio-policy fix.
         // let bfu = BfuTimer::new(SecurityMode::Daily);
-        let mode_mgr = crate::security_mode::ModeManager::default();
         crate::power::apply_mode_policy(&mode_mgr.effective_policy(), &mut pm);
         state.security_mode_ok = true;
         let _ = serial.write_str("       Security mode: Daily policy applied\r\n");
@@ -1147,32 +1204,32 @@ pub unsafe fn run() -> ! {
     // -----------------------------------------------------------------------
     // Debug console or idle
     // -----------------------------------------------------------------------
-    // SAFETY: DEBUG_CONSOLE is a compile-time or boot-time constant; reading it
-    // is safe here as it is never written after boot.
-    if unsafe { kconfig::DEBUG_CONSOLE } {
+    #[cfg(feature = "debug-console")]
+    let start_console = debug_console_gate(&mut serial, &mode_mgr);
+    #[cfg(not(feature = "debug-console"))]
+    let start_console = false;
+
+    if start_console {
         let _ = serial.write_str("[init] Starting debug console\r\n");
         let _ = serial.write_str("       Type 'help' for commands\r\n\r\n");
-        let mut console = Console::new();
-        console.prompt();
-
-        // NOTE: in a real implementation, UART RX would be interrupt-driven.
-        // For now, we poll. This gets replaced when the UART driver has
-        // proper RX interrupt support.
-        loop {
-            // SAFETY: WFE is a hint instruction available in all ARM privilege levels.
-            // No memory is accessed; the CPU enters a low-power wait state.
-            unsafe {
-                core::arch::asm!("wfe");
-            }
+        #[cfg(feature = "debug-console")]
+        {
+            let mut console = Console::new();
+            console.prompt();
         }
     } else {
         // No console  -  just idle
-        loop {
-            // SAFETY: WFE is a hint instruction available in all ARM privilege levels.
-            // No memory is accessed; the CPU enters a low-power wait state.
-            unsafe {
-                core::arch::asm!("wfe");
-            }
+        let _ = serial.write_str("[init] No debug console this boot; idling\r\n");
+    }
+
+    // NOTE: in a real implementation, UART RX would be interrupt-driven.
+    // For now, we poll (when a console is active) or just idle. This gets
+    // replaced when the UART driver has proper RX interrupt support.
+    loop {
+        // SAFETY: WFE is a hint instruction available in all ARM privilege levels.
+        // No memory is accessed; the CPU enters a low-power wait state.
+        unsafe {
+            core::arch::asm!("wfe");
         }
     }
 }

--- a/crates/thumos/src/main.rs
+++ b/crates/thumos/src/main.rs
@@ -27,7 +27,29 @@ mod capability;
 mod ccci;
 mod ccci_logger;
 mod clock;
-#[cfg(not(test))]
+
+// WHY (issue #372): `debug-console` and `production` are structurally
+// mutually exclusive -- the dev-only kernel shell (unauthenticated UART
+// command execution, no capability check) must never be compiled into a
+// shippable/production image. A CI grep on a diff cannot catch a future
+// `--all-features` invocation (security.yml's cargo-deny job already runs
+// one, though today scoped to the workspace, which excludes this crate);
+// this compile_error! does, because --all-features enables both features
+// at once regardless of workspace membership.
+#[cfg(all(feature = "debug-console", feature = "production"))]
+compile_error!(
+    "debug-console and production are mutually exclusive (issue #372): the dev-only kernel UART shell must never ship. Build with --features debug-console (no --features production) for a bring-up/dev image, or --features production (no --features debug-console) for the ship/flash artifact."
+);
+
+// WHY (issue #372): also gated `not(test)` — the console's command methods
+// (cmd_mem/cmd_ps/…) read kernel state via `crate::heap`/`page`/`process`,
+// several of which are themselves `#[cfg(not(test))]`, so the module cannot
+// compile under the host-test cfg. Making the console host-testable (to
+// resurrect the #337 receive_byte tests + the new presence test) needs
+// heap/page/process host stubs — tracked separately; out of #372's
+// structural-gate scope. The armv7a `--features debug-console` build proves
+// the console compiles for its real target.
+#[cfg(all(feature = "debug-console", not(test)))]
 mod console;
 mod contacts;
 mod csprng;

--- a/crates/thumos/src/uart.rs
+++ b/crates/thumos/src/uart.rs
@@ -8,6 +8,8 @@
 //! - 0x00: RBR/THR (receive buffer / transmit holding)
 //! - 0x04: IER (interrupt enable)
 //! - 0x14: LSR (line status)
+//!   - bit 0: DR (receiver data ready) -- TODO(#459)[deliberate-prudent]: unverified against the
+//!     MT6739 TRM, see `Uart::getc`
 //!   - bit 5: THRE (transmit holding register empty)
 //!   - bit 6: TEMT (transmitter empty)
 
@@ -19,11 +21,21 @@ const UART0_BASE: usize = 0x1100_2000;
 /// Transmit holding register OFFSET.
 const THR: usize = 0x00;
 
+/// Receive buffer register OFFSET.
+/// NOTE: shares the THR offset, per the standard 16550-style register
+/// layout this module's TX side already follows (RBR on read, THR on
+/// write) -- see the module doc's register map.
+const RBR: usize = 0x00;
+
 /// Line status register OFFSET.
 const LSR: usize = 0x14;
 
 /// LSR bit: transmit holding register empty.
 const LSR_THRE: u32 = 1 << 5;
+
+/// LSR bit: receiver data ready.
+/// TODO(#459)[deliberate-prudent]: unverified against the MT6739 TRM -- see `Uart::getc`.
+const LSR_DR: u32 = 1 << 0;
 
 /// Bound on `putc`'s TX-ready poll, in iterations (not wall-clock time --
 /// see `putc`'s doc comment). Generous enough to never trip under normal
@@ -85,6 +97,29 @@ impl Uart {
     pub(crate) fn write_str_raw(&self, s: &str) {
         for byte in s.bytes() {
             self.putc(byte);
+        }
+    }
+
+    /// Non-blocking receive: returns the next byte if the RX FIFO has one
+    /// ready, `None` otherwise.
+    ///
+    /// TODO(#459)[deliberate-prudent]: `LSR_DR` (bit 0, "data ready") is the standard 16550-style
+    /// position and matches this module's existing THR/LSR offset layout,
+    /// but has not been independently confirmed against the MT6739 TRM for
+    /// this UART instance -- verify on real hardware before any boot-path
+    /// behavior depends on RX timing (issue #372,
+    /// `console::wait_for_physical_presence`).
+    pub(crate) fn getc(&self) -> Option<u8> {
+        // SAFETY: MMIO register access at known physical address. The UART
+        // is already initialized by the bootloader.
+        unsafe {
+            let lsr = (self.base + LSR) as *const u32;
+            if core::ptr::read_volatile(lsr) & LSR_DR == 0 {
+                return None;
+            }
+            let rbr = (self.base + RBR) as *const u32;
+            let raw = core::ptr::read_volatile(rbr) & 0xFF;
+            u8::try_from(raw).ok()
         }
     }
 }

--- a/crates/thumos/src/uart_stub.rs
+++ b/crates/thumos/src/uart_stub.rs
@@ -21,6 +21,11 @@ impl Uart {
 
     /// Discard a single byte.
     pub(crate) fn putc(&self, _byte: u8) {}
+
+    /// Host-test RX stub: no real UART, so no bytes are ever available.
+    pub(crate) fn getc(&self) -> Option<u8> {
+        None
+    }
 }
 
 impl fmt::Write for Uart {


### PR DESCRIPTION
#372: DEBUG_CONSOLE booted an **unauthenticated UART command shell**, defaulted ON, with destructive `reboot` (unconditional watchdog reset) and `panic` commands. Operator decision: **structural compile-time dev-only gate** (not a CI grep).

## Profile fork — T0-decided
Gate on the `debug-console` feature **alone**, not `debug_assertions` — because bring-up's flashed armv7a artifact IS built with `--release` (verified: CONTRIBUTING/ARCHITECTURE/AGENTS/ci.yml), so a `debug_assertions` gate would strip the console from exactly the builds bring-up needs.

## What lands
- `debug-console` feature (never in `default`) gates `mod console` + the kinit boot branch (also `not(test)` — see #459).
- a mutually-exclusive `production` marker feature + `compile_error!` when both are set → **`--all-features` fails to compile** rather than silently shipping a console-carrying binary.
- `DEBUG_CONSOLE` default → false; the `console=` cmdline arm **deleted** (no boot-args force-on).
- dev-console hardening (defense-in-depth): 3-layer gate — source-default-false + Daily-mode-only + a **typed physical-presence sequence** over UART before the prompt (fail-closed bounded poll).

## Verified matrix
| build | console | result |
|---|---|---|
| default | absent | nextest 2164, armv7a clean |
| `--features debug-console` | present | armv7a clean, host 2164 |
| `--features production` | absent | armv7a clean |
| `debug-console,production` | — | **compile_error** (exit 101) |

kanon + fmt clean.

## Honest limits (tracked in #459)
Daily-mode check is vacuous today (mode never transitions before the check); `Uart::getc` reads LSR bit 0 unverified vs the MT6739 TRM (fail-safe, `TODO(#459)`); the console's own tests stay dead until host-testability lands (#459 — heap/page/process host stubs + CI `--features debug-console` step).

Closes #372.

_T0-reviewed: profile fork, structural ship-guard, dev-hardening, and the honest-limit scoping._