### PR TITLE
Boot the real kernel under QEMU + fix 2 latent boot bugs (#420, #461)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,3 +109,19 @@ jobs:
       - name: Kernel cross-compile (armv7a)
         working-directory: crates/thumos
         run: cargo build --release --target armv7a-none-eabi --jobs 8
+      - name: Install qemu-system-arm
+        run: sudo apt-get update && sudo apt-get install -y qemu-system-arm
+      - name: Kernel QEMU boot (real kinit -> boot-complete)
+        working-directory: crates/thumos
+        # WHY: the `qemu` feature retargets peripheral addresses to the QEMU
+        # `virt` board (UART/GIC) and boots the REAL kinit under
+        # qemu-system-arm, exiting via semihosting (0 = boot-complete). This
+        # is the "does the kernel boot" check -- verified in emulation without
+        # the physical MT6739. Failure modes are coded semihosting exits
+        # (1=panic, 2/3/4=aborts) or 124=hang (runner timeout).
+        run: |
+          set -euo pipefail
+          cargo build --release --target armv7a-none-eabi --features qemu --jobs 8
+          THUMOS_QEMU_TIMEOUT=60 ../../scripts/qemu-runner.sh target/armv7a-none-eabi/release/thumos | tee boot.log
+          grep -q 'THUMOS v0.1.0' boot.log
+          grep -q 'THUMOS-QEMU: boot-complete' boot.log

--- a/crates/thumos/Cargo.toml
+++ b/crates/thumos/Cargo.toml
@@ -22,6 +22,14 @@ debug-console = []
 # AGENTS.md / ci.yml kernel job need a companion update, out of scope for
 # this crate-local edit set).
 production = []
+# WHY: QEMU `-machine virt` bring-up harness -- remaps UART/GIC base constants
+# (kconfig.rs), swaps the MTK UART driver for a PL011 (uart_pl011.rs), no-ops
+# SoC-only MMIO on the timer-IRQ path (watchdog/DVFS/MCDI/DSI), skips init of
+# hardware virt does not model (eMMC/display/keypad/USB/CCCI), and reports
+# boot outcome via semihosting exit codes. Never enabled by default; the
+# MT6739 build is unchanged without it. Mutually exclusive with `production`
+# (see main.rs compile_error!).
+qemu = []
 
 [dependencies]
 aes = { version = "0.8", default-features = false }

--- a/crates/thumos/link.ld
+++ b/crates/thumos/link.ld
@@ -28,7 +28,10 @@ SECTIONS
     }
 
     . = ALIGN(4096);
-    __stack_top = . + 0x10000;
+    __stack_top = . + 0x10000;                  /* SVC boot stack (64 KB) */
+    __irq_stack_top = __stack_top + 0x1000;     /* IRQ banked stack (4 KB) */
+    __abt_stack_top = __irq_stack_top + 0x1000; /* ABT banked stack (4 KB) */
+    __und_stack_top = __abt_stack_top + 0x1000; /* UND banked stack (4 KB) */
 
     /DISCARD/ : {
         *(.comment)
@@ -36,3 +39,8 @@ SECTIONS
         *(.ARM.exidx*)
     }
 }
+
+/* Kernel image + all stacks must stay inside the reserved window ending at
+   kconfig::KERNEL_END (0x40100000): page::init hands out frames from there
+   up, so an oversized image would be silently overwritten by allocations. */
+ASSERT(__und_stack_top <= 0x40100000, "kernel image + stacks exceed KERNEL_RESERVED; grow kconfig::KERNEL_RESERVED/KERNEL_END and the memguard map together")

--- a/crates/thumos/src/csprng.rs
+++ b/crates/thumos/src/csprng.rs
@@ -156,6 +156,22 @@ impl EntropyPool {
     fn is_seeded(&self) -> bool {
         self.entropy_bits >= SEED_ENTROPY_BITS
     }
+
+    /// Deterministically seed the pool for QEMU bring-up (feature `qemu`).
+    ///
+    /// WHY(qemu): a deterministic emulator has no hardware entropy source --
+    /// timer-jitter is the entire entropy model, and QEMU's CP15 counter
+    /// advances predictably, so `add_timer_sample` never credits
+    /// `SEED_ENTROPY_BITS` and `init`'s seed loop cannot make progress. This
+    /// fills the pool from a fixed vector and marks it seeded so the boot
+    /// proceeds. NOT cryptographically secure; compiled ONLY under
+    /// `--features qemu`, which is mutually exclusive with `production`
+    /// (main.rs compile_error!) and so can never reach a shippable image.
+    #[cfg(feature = "qemu")]
+    fn seed_deterministic_qemu(&mut self) {
+        self.pool = *b"thumos-qemu-deterministic-seed!!";
+        self.entropy_bits = SEED_ENTROPY_BITS;
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -278,6 +294,16 @@ pub unsafe fn init() -> bool {
     // registers; no state is mutated.
     #[cfg(not(test))]
     let deadline_start = crate::timer::elapsed_ms();
+
+    // WHY(qemu): deterministic emulator has no hardware entropy; inject a
+    // fixed seed so is_seeded() passes on the first check below and boot
+    // proceeds instead of spinning on jitter that never accumulates.
+    // SAFETY: ENTROPY is written only from the timer IRQ handler; this runs
+    // before IRQs deliver entropy and is non-reentrant on single-core ARMv7.
+    #[cfg(feature = "qemu")]
+    unsafe {
+        (*core::ptr::addr_of_mut!(ENTROPY)).seed_deterministic_qemu();
+    }
 
     // Spin until the entropy pool has accumulated a full seed estimate,
     // or until CSPRNG_INIT_TIMEOUT_MS elapses.

--- a/crates/thumos/src/exceptions.rs
+++ b/crates/thumos/src/exceptions.rs
@@ -217,19 +217,25 @@ pub extern "C" fn irq_handler_rust() {
         let now = ticks();
         power::check_backlight_timeout(now);
 
-        // Run scheduler
-        let next = process::schedule();
-        if next != process::current_pid() {
-            // SAFETY: next is a valid PID returned by schedule(), which only
-            // returns PIDs for processes in the READY state.
-            unsafe {
-                process::switch_to(next);
+        // Run scheduler -- only once boot has enabled scheduling. WHY: during
+        // kinit the boot runs in the bare boot context (not a scheduled
+        // process), so a context switch here would abandon the boot
+        // mid-init; process::enable_scheduling() is called once at the end of
+        // kinit, after userspace spawn.
+        if process::scheduling_enabled() {
+            let next = process::schedule();
+            if next != process::current_pid() {
+                // SAFETY: next is a valid PID returned by schedule(), which only
+                // returns PIDs for processes in the READY state.
+                unsafe {
+                    process::switch_to(next);
+                }
+            } else {
+                // REQ-19a: idle — no other runnable process, enter WFI.
+                // WHY: wfi suspends the core until the next interrupt, reducing
+                // power consumption in the idle path without affecting correctness.
+                power::idle();
             }
-        } else {
-            // REQ-19a: idle — no other runnable process, enter WFI.
-            // WHY: wfi suspends the core until the next interrupt, reducing
-            // power consumption in the idle path without affecting correctness.
-            power::idle();
         }
 
         // Check for pending signals on the current process.
@@ -257,6 +263,10 @@ pub extern "C" fn data_abort_handler_rust() {
     let _ = write!(serial, "\r\n!!! DATA ABORT !!!\r\n"); // WHY: best-effort serial write in exception handler; cannot recover from UART failure
     let _ = write!(serial, "DFAR: {dfar:#010x} (fault address)\r\n"); // WHY: best-effort serial write in exception handler; cannot recover from UART failure
     let _ = write!(serial, "DFSR: {dfsr:#010x} (fault status)\r\n"); // WHY: best-effort serial write in exception handler; cannot recover from UART failure
+    // WHY(qemu): distinct exit code lets CI tell a data abort from a panic
+    // or a hang; the asm wrapper otherwise parks in `b .` until timeout.
+    #[cfg(feature = "qemu")]
+    crate::qemu::request_exit(2);
 }
 
 /// Prefetch abort handler.
@@ -275,6 +285,9 @@ pub extern "C" fn prefetch_abort_handler_rust() {
     let _ = write!(serial, "\r\n!!! PREFETCH ABORT !!!\r\n"); // WHY: best-effort serial write in exception handler; cannot recover from UART failure
     let _ = write!(serial, "IFAR: {ifar:#010x}\r\n"); // WHY: best-effort serial write in exception handler; cannot recover from UART failure
     let _ = write!(serial, "IFSR: {ifsr:#010x}\r\n"); // WHY: best-effort serial write in exception handler; cannot recover from UART failure
+    // WHY(qemu): distinct exit code for CI (3 = prefetch abort).
+    #[cfg(feature = "qemu")]
+    crate::qemu::request_exit(3);
 }
 
 /// Undefined instruction handler.
@@ -284,6 +297,9 @@ pub extern "C" fn undefined_handler_rust() {
     serial
         .write_str("\r\n!!! UNDEFINED INSTRUCTION !!!\r\n")
         .ok();
+    // WHY(qemu): distinct exit code for CI (4 = undefined instruction).
+    #[cfg(feature = "qemu")]
+    crate::qemu::request_exit(4);
 }
 
 /// SVC handler (placeholder for future syscall implementation).

--- a/crates/thumos/src/gic.rs
+++ b/crates/thumos/src/gic.rs
@@ -7,11 +7,10 @@
 //! These addresses come FROM the MT6739 device tree (intc node).
 //! The GIC handles all hardware interrupts and routes them to cores.
 
-/// GIC Distributor base address.
-const GICD_BASE: usize = 0x0C00_0000;
-
-/// GIC CPU Interface base address.
-const GICC_BASE: usize = 0x0C00_2000;
+// NOTE: GIC base addresses live in kconfig (single source of truth); the
+// qemu feature remaps them to the virt board's GICv2. The register-level
+// driver below is plain architectural GICv2 and works unchanged on both.
+use crate::kconfig::{GICC_BASE, GICD_BASE};
 
 // Distributor registers
 mod gicd {

--- a/crates/thumos/src/kconfig.rs
+++ b/crates/thumos/src/kconfig.rs
@@ -51,14 +51,31 @@ pub(crate) const KERNEL_RESERVED: usize = 0xF_8000;
 /// Kernel end address (load + reserved).
 pub(crate) const KERNEL_END: usize = KERNEL_LOAD + KERNEL_RESERVED;
 
-/// UART0 base address.
+/// UART0 base address (MT6739 ttyMT0, MTK 8250-style register map).
+#[cfg(not(feature = "qemu"))]
 pub(crate) const UART0_BASE: usize = 0x1100_2000;
 
-/// GIC distributor base address.
+/// UART0 base address (PL011 on QEMU `-machine virt`).
+/// NOTE: consumed by uart_pl011.rs, which main.rs swaps in under the qemu
+/// feature -- the register map differs, not just the base.
+#[cfg(feature = "qemu")]
+pub(crate) const UART0_BASE: usize = 0x0900_0000;
+
+/// GIC distributor base address (MT6739 device tree, intc node).
+#[cfg(not(feature = "qemu"))]
 pub(crate) const GICD_BASE: usize = 0x0C00_0000;
 
-/// GIC CPU interface base address.
+/// GIC distributor base address (QEMU `-machine virt`, GICv2).
+#[cfg(feature = "qemu")]
+pub(crate) const GICD_BASE: usize = 0x0800_0000;
+
+/// GIC CPU interface base address (MT6739).
+#[cfg(not(feature = "qemu"))]
 pub(crate) const GICC_BASE: usize = 0x0C00_2000;
+
+/// GIC CPU interface base address (QEMU `-machine virt`, GICv2).
+#[cfg(feature = "qemu")]
+pub(crate) const GICC_BASE: usize = 0x0801_0000;
 
 /// Display framebuffer base (set by LK bootloader).
 pub(crate) const FB_BASE: usize = 0x77EE_0000;

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -15,12 +15,17 @@ use core::fmt::Write;
 use core::slice;
 use core::sync::atomic::{AtomicBool, Ordering};
 
+#[cfg(not(feature = "qemu"))]
 use crate::ccci::CcciDriver;
 #[cfg(feature = "debug-console")]
 use crate::console::Console;
 use crate::csprng;
+#[cfg(feature = "qemu")]
+use crate::device::DeviceRegistry;
+#[cfg(not(feature = "qemu"))]
 use crate::device::{self, DeviceRegistry};
 use crate::dhcp::{DhcpClient, DhcpEvent};
+#[cfg(not(feature = "qemu"))]
 use crate::display::{DisplayDriver, Gc9306};
 use crate::dns::{DnsResolver, LAN_DNS, MULLVAD_DNS};
 use crate::elf;
@@ -29,6 +34,7 @@ use crate::fd;
 use crate::gic;
 use crate::heap;
 use crate::kconfig;
+#[cfg(not(feature = "qemu"))]
 use crate::mmio;
 use crate::mmu;
 use crate::net::{
@@ -43,6 +49,7 @@ use crate::screen_home::{HomeScreen, HomeScreenState, OperatingMode};
 use crate::status_bar::{KernelStatusBar, StatusBarState};
 use crate::uart::Uart;
 use crate::ui::{self, UiManager};
+#[cfg(not(feature = "qemu"))]
 use crate::usb::UsbController;
 use crate::watchdog;
 
@@ -54,9 +61,17 @@ use crate::watchdog;
 pub(crate) static DISPLAY_AVAILABLE: AtomicBool = AtomicBool::new(false);
 
 /// USB ACM serial link established.
+#[cfg_attr(
+    feature = "qemu",
+    expect(dead_code, reason = "set by the USB init step, which is qemu-gated")
+)]
 pub(crate) static USB_SERIAL_AVAILABLE: AtomicBool = AtomicBool::new(false);
 
 /// Modem CCCI link established.
+#[cfg_attr(
+    feature = "qemu",
+    expect(dead_code, reason = "set by the CCCI init step, which is qemu-gated")
+)]
 pub(crate) static MODEM_AVAILABLE: AtomicBool = AtomicBool::new(false);
 
 // ---------------------------------------------------------------------------
@@ -265,6 +280,13 @@ impl BootState {
 // ---------------------------------------------------------------------------
 
 /// Maximum time (ms) to wait for modem boot before declaring failure.
+#[cfg_attr(
+    feature = "qemu",
+    expect(
+        dead_code,
+        reason = "consumed by the CCCI init step, which is qemu-gated"
+    )
+)]
 const MODEM_BOOT_TIMEOUT_MS: u64 = 10_000;
 
 /// Framebuffer RGB565 colour: solid red (panic indicator).
@@ -547,7 +569,12 @@ pub unsafe fn run() -> ! {
     unsafe {
         watchdog::init();
     }
+    #[cfg(not(feature = "qemu"))]
     let _ = serial.write_str("       WDT armed (5s timeout)\r\n");
+    // WHY(qemu): watchdog is a no-op stub (watchdog_qemu.rs); say so rather
+    // than log a hardware claim that is not true under the emulator.
+    #[cfg(feature = "qemu")]
+    let _ = serial.write_str("       WDT skipped (qemu: no MT6739 WDT model)\r\n");
 
     // -----------------------------------------------------------------------
     // Step 6: Device registry
@@ -565,6 +592,12 @@ pub unsafe fn run() -> ! {
     // Step 7: eMMC block device
     // -----------------------------------------------------------------------
     let _ = serial.write_str("[init] eMMC (MSDC0)\r\n");
+    // WHY(qemu): virt models no MSDC controller at 0x1123_0000; the first
+    // register access would data-abort. emmc_ok stays false, so the
+    // filesystem step degrades to the ramfs root (existing path).
+    #[cfg(feature = "qemu")]
+    let _ = serial.write_str("       Skipped (qemu: no MSDC model)\r\n");
+    #[cfg(not(feature = "qemu"))]
     {
         let mut emmc = crate::emmc::MsdcController::new();
         match unsafe { emmc.init() } {
@@ -687,6 +720,12 @@ pub unsafe fn run() -> ! {
     // Step 8: Display pipeline (DDP → GC9306)
     // -----------------------------------------------------------------------
     let _ = serial.write_str("[init] Display (GC9306 240x320)\r\n");
+    // WHY(qemu): virt models no MT6739 DDP/DSI pipeline at 0x1400_0000; the
+    // init writes would data-abort. display_ok stays false, so boot degrades
+    // to serial-only (existing path) and the panic handler never touches FB.
+    #[cfg(feature = "qemu")]
+    let _ = serial.write_str("       Skipped (qemu: no DDP/DSI model)\r\n");
+    #[cfg(not(feature = "qemu"))]
     {
         let gc9306 = Gc9306::new();
         let mut display = DisplayDriver::new(gc9306);
@@ -727,6 +766,12 @@ pub unsafe fn run() -> ! {
     // (Step 6) and has no dependency on display/USB/modem, so moving it
     // earlier is safe.
     let _ = serial.write_str("[init] GPIO keypad\r\n");
+    // WHY(qemu): virt models no MT6739 KPD block at 0x1001_0000; the enable
+    // write would data-abort. input_ok stays false, so passphrase entry
+    // reports its skip path (existing behavior).
+    #[cfg(feature = "qemu")]
+    let _ = serial.write_str("       Skipped (qemu: no KPD model)\r\n");
+    #[cfg(not(feature = "qemu"))]
     {
         // NOTE: Full keypad driver is in crates/haphe. Here we enable the
         // KPD hardware so interrupt-driven scanning can start.
@@ -865,6 +910,11 @@ pub unsafe fn run() -> ! {
     // Step 9: USB ACM serial (primary debug console)
     // -----------------------------------------------------------------------
     let _ = serial.write_str("[init] USB ACM serial\r\n");
+    // WHY(qemu): virt models no MUSB controller at 0x1121_0000; the init
+    // would data-abort. usb_ok stays false (existing degradation path).
+    #[cfg(feature = "qemu")]
+    let _ = serial.write_str("       Skipped (qemu: no MUSB model)\r\n");
+    #[cfg(not(feature = "qemu"))]
     {
         let mut usb = UsbController::new();
         // SAFETY: usb.init() programs the MUSB MMIO registers at their known
@@ -887,6 +937,13 @@ pub unsafe fn run() -> ! {
     // Step 10: CCCI modem boot (fault-tolerant with timeout)
     // -----------------------------------------------------------------------
     let _ = serial.write_str("[init] CCCI modem\r\n");
+    // WHY(qemu): virt models no CCCI/CLDMA block at 0x200F_0000 (nor the MD
+    // boot registers at 0x2000_xxxx); boot_modem would data-abort. modem_ok
+    // stays false -- phone functions disabled (existing degradation path).
+    #[cfg(feature = "qemu")]
+    let _ = serial
+        .write_str("       Skipped (qemu: no CCCI/CLDMA model); phone functions disabled\r\n");
+    #[cfg(not(feature = "qemu"))]
     {
         let mut ccci = CcciDriver::new();
         let boot_start = crate::timer::elapsed_ms();
@@ -956,6 +1013,14 @@ pub unsafe fn run() -> ! {
     }
 
     let _ = serial.write_str("[init] Network loopback smoke (DHCP + DNS)\r\n");
+    // WHY(qemu): the DHCP poll loop below is bounded by an elapsed_ms()
+    // deadline + a wfe-gated yield, neither of which terminates under QEMU
+    // (#461); and a loopback DHCP/DNS self-test verifies nothing under an
+    // emulator with no network model. Skipped under qemu; production path
+    // unchanged.
+    #[cfg(feature = "qemu")]
+    let _ = serial.write_str("       Skipped (qemu: no network model -- #461)\r\n");
+    #[cfg(not(feature = "qemu"))]
     {
         // WHY: In production, the WiFi driver provides the Device impl.
         // Until WiFi hardware init is wired in, we use LoopbackDevice to
@@ -1078,11 +1143,8 @@ pub unsafe fn run() -> ! {
     // Boot status summary
     // -----------------------------------------------------------------------
     let _ = serial.write_str("\r\n");
-    let _ = write!(
-        serial,
-        "[init] Boot complete at {} ms\r\n",
-        crate::timer::elapsed_ms()
-    );
+    let boot_ms = crate::timer::elapsed_ms();
+    let _ = write!(serial, "[init] Boot complete at {boot_ms} ms\r\n");
     let _ = write!(
         serial,
         "       {} / {} subsystems OK\r\n",
@@ -1199,6 +1261,24 @@ pub unsafe fn run() -> ! {
                 state.userspace_entries_missing
             );
         }
+    }
+
+    // Boot is complete; the boot context now becomes the idle loop. Enable
+    // scheduler context switches so the timer IRQ can run spawned userspace
+    // (scheduling is gated OFF throughout kinit -- see
+    // process::scheduling_enabled -- because the boot context is not a
+    // scheduled process and a mid-init switch would abandon it).
+    process::enable_scheduling();
+
+    // -----------------------------------------------------------------------
+    // QEMU milestone: full boot sequence attempted -- exit via semihosting
+    // -----------------------------------------------------------------------
+    // WHY(qemu): CI asserts on this marker and on exit code 0; without an
+    // explicit exit the idle loop below runs until the runner timeout.
+    #[cfg(feature = "qemu")]
+    {
+        let _ = serial.write_str("THUMOS-QEMU: boot-complete\r\n");
+        crate::qemu::request_exit(0);
     }
 
     // -----------------------------------------------------------------------

--- a/crates/thumos/src/main.rs
+++ b/crates/thumos/src/main.rs
@@ -41,6 +41,15 @@ compile_error!(
     "debug-console and production are mutually exclusive (issue #372): the dev-only kernel UART shell must never ship. Build with --features debug-console (no --features production) for a bring-up/dev image, or --features production (no --features debug-console) for the ship/flash artifact."
 );
 
+// WHY: the qemu feature remaps peripheral base addresses and no-ops SoC-only
+// MMIO -- structurally incompatible with a shippable image. Fails an
+// --all-features build loudly instead of producing a kernel that cannot run
+// on the phone.
+#[cfg(all(feature = "qemu", feature = "production"))]
+compile_error!(
+    "qemu and production are mutually exclusive: the QEMU bring-up harness remaps MT6739 peripheral addresses and must never ship."
+);
+
 // WHY (issue #372): also gated `not(test)` — the console's command methods
 // (cmd_mem/cmd_ps/…) read kernel state via `crate::heap`/`page`/`process`,
 // several of which are themselves `#[cfg(not(test))]`, so the module cannot
@@ -120,6 +129,10 @@ mod pipe;
 mod power;
 mod process;
 mod provision;
+// WHY(qemu): semihosting exit codes + early host-console writes for the
+// QEMU runner (see scripts/qemu-runner.sh).
+#[cfg(all(not(test), feature = "qemu"))]
+mod qemu;
 mod ramfs;
 mod sbc;
 mod screen_alarm;
@@ -161,7 +174,12 @@ mod timer;
 #[cfg(test)]
 #[path = "timer_stub.rs"]
 mod timer;
-#[cfg(not(test))]
+#[cfg(all(not(test), not(feature = "qemu")))]
+mod uart;
+// WHY(qemu): virt has a PL011 at kconfig::UART0_BASE, not the MTK 8250-style
+// UART; same module surface, different register map (see uart_pl011.rs).
+#[cfg(all(not(test), feature = "qemu"))]
+#[path = "uart_pl011.rs"]
 mod uart;
 mod ui;
 // WHY(host-test): syscall's stdout (fd 1) and unknown-syscall debug paths
@@ -172,7 +190,12 @@ mod ui;
 mod uart;
 mod usb;
 mod vfs;
-#[cfg(not(test))]
+#[cfg(all(not(test), not(feature = "qemu")))]
+mod watchdog;
+// WHY(qemu): virt models no MT6739 WDT; a no-op stub keeps the timer-IRQ
+// pet path and kinit call sites identical without touching MMIO.
+#[cfg(all(not(test), feature = "qemu"))]
+#[path = "watchdog_qemu.rs"]
 mod watchdog;
 mod wifi;
 
@@ -187,7 +210,19 @@ core::arch::global_asm!(
     ".global _start",
     ".arm",
     "_start:",
-    "    cpsid   if",               // Disable interrupts
+    "    cpsid   if", // Disable interrupts
+    // WHY: banked-mode stacks. Reset leaves SP_irq/SP_abt/SP_und UNKNOWN;
+    // the first timer IRQ (or any abort) pushes {r0-r12,lr} through them
+    // (exceptions.rs asm wrappers), so without this setup the first tick
+    // corrupts memory or double-faults silently. Latent on every target --
+    // QEMU bring-up is simply the first place the timer IRQ has ever fired.
+    "    msr     cpsr_c, #0xD2", // IRQ mode (I+F masked)
+    "    ldr     sp, =__irq_stack_top",
+    "    msr     cpsr_c, #0xD7", // ABT mode (I+F masked)
+    "    ldr     sp, =__abt_stack_top",
+    "    msr     cpsr_c, #0xDB", // UND mode (I+F masked)
+    "    ldr     sp, =__und_stack_top",
+    "    msr     cpsr_c, #0xD3",    // back to SVC (I+F masked)
     "    ldr     sp, =__stack_top", // Set stack pointer
     "    ldr     r0, =__bss_start", // Zero BSS
     "    ldr     r1, =__bss_end",
@@ -204,6 +239,10 @@ core::arch::global_asm!(
 #[cfg(not(test))]
 #[unsafe(no_mangle)]
 pub extern "C" fn kernel_main() -> ! {
+    // WHY(qemu): earliest possible liveness marker -- proves _start ran and
+    // semihosting works even when the UART path is broken.
+    #[cfg(feature = "qemu")]
+    qemu::write0(c"thumos-qemu: kernel_main reached\n");
     // WHY: delegate everything to kinit::run() which handles the full
     // boot sequence with fault isolation and driver integration.
     // SAFETY: called exactly once from the boot stub (_start) on the boot
@@ -245,6 +284,11 @@ fn panic(info: &PanicInfo) -> ! {
     if kinit::DISPLAY_AVAILABLE.load(core::sync::atomic::Ordering::Relaxed) {
         serial.write_str("(display: red screen rendered)\r\n").ok();
     }
+
+    // WHY(qemu): report exit code 1 via semihosting so a panic fails the
+    // run immediately instead of hanging to the runner timeout.
+    #[cfg(feature = "qemu")]
+    qemu::request_exit(1);
 
     loop {
         // SAFETY: WFE is a hint instruction available in all ARM privilege levels.

--- a/crates/thumos/src/power.rs
+++ b/crates/thumos/src/power.rs
@@ -30,6 +30,13 @@
 /// Bits [21:0] = PCW (integer + fractional divider).
 /// The four values below are approximate; production firmware reads them
 /// from the efuse-calibrated OPP table.
+#[cfg_attr(
+    feature = "qemu",
+    expect(
+        dead_code,
+        reason = "the ARMPLL write is qemu-gated; virt models no MT6739 CMU"
+    )
+)]
 const ARMPLL_CON1: usize = 0x1000_C104;
 
 /// MCDI (Multi-Core Deep Idle) base address.
@@ -208,6 +215,9 @@ pub(crate) fn evaluate_dvfs(load_percent: u8) {
     let new_freq = gov.apply_dvfs(load_percent);
 
     if new_freq != prev_freq {
+        // WHY(qemu): virt models no MT6739 CMU; the ARMPLL write would
+        // data-abort inside the timer IRQ. Governor state still updates.
+        #[cfg(not(feature = "qemu"))]
         // SAFETY: ARMPLL_CON1 is a valid MMIO register on the MT6739 CMU
         // block at 0x1000_C104.  Volatile write is required for hardware
         // registers.  Called with IRQs disabled so no torn write.
@@ -241,10 +251,15 @@ pub(crate) fn evaluate_core_parking(runnable_count: usize) {
         // Write inverse mask to MCDI_CORE_EN: bit N=1 → power down core N.
         // Core 0 is never set here (bit 0 of the inverse is always 0).
         let park_mask = u32::from(!new_mask & 0b0000_1110);
+        // WHY(qemu): virt models no MT6739 MCDI block; the write would
+        // data-abort inside the timer IRQ. Governor state still updates.
+        #[cfg(feature = "qemu")]
+        let _ = park_mask;
         // SAFETY: MCDI_CORE_EN is a valid MMIO register on the MT6739 MCDI
         // block at 0x1000_DC04.  Stub write — production MCDI handshake
         // requires additional synchronisation with each core's reset handler,
         // which is not yet wired.
+        #[cfg(not(feature = "qemu"))]
         unsafe {
             crate::mmio::write32(MCDI_CORE_EN, park_mask);
         }
@@ -350,11 +365,18 @@ unsafe fn display_wake() {
     reason = "DSI0 init helper; invoked by panel bring-up in follow-up"
 )]
 unsafe fn dcs_cmd0(cmd: u8) {
-    // SAFETY: DSI0_CMD_FIFO is a valid MMIO register within the DSI0
-    // address space at 0x1400_D000.  Volatile access required for hardware.
-    const DSI0_CMD_FIFO: usize = 0x1400_D200;
-    unsafe {
-        crate::mmio::write32(DSI0_CMD_FIFO, u32::from(cmd) | 0x100);
+    // WHY(qemu): virt models no DSI0 block; the FIFO write would data-abort
+    // inside the timer IRQ (backlight-timeout path).
+    #[cfg(feature = "qemu")]
+    let _ = cmd;
+    #[cfg(not(feature = "qemu"))]
+    {
+        // SAFETY: DSI0_CMD_FIFO is a valid MMIO register within the DSI0
+        // address space at 0x1400_D000.  Volatile access required for hardware.
+        const DSI0_CMD_FIFO: usize = 0x1400_D200;
+        unsafe {
+            crate::mmio::write32(DSI0_CMD_FIFO, u32::from(cmd) | 0x100);
+        }
     }
 }
 

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -162,6 +162,26 @@ static mut PROCS: [Option<Process>; MAX_PROCS] = {
 /// Currently running process ID.
 static mut CURRENT: Pid = 0;
 
+/// Whether the scheduler may context-switch. WHY: `kinit` runs in the bare
+/// boot context (not a scheduled process), so a timer-IRQ context switch
+/// during init would abandon the boot mid-sequence -- a timing-dependent
+/// hang (the tick lands at a non-deterministic point). Boot enables
+/// scheduling via `enable_scheduling()` once userspace has been spawned and
+/// the boot context becomes the idle loop.
+static SCHEDULING_ENABLED: core::sync::atomic::AtomicBool =
+    core::sync::atomic::AtomicBool::new(false);
+
+/// Enable scheduler context switches. Called exactly once from `kinit`, after
+/// userspace spawn, before the boot context enters the idle loop.
+pub(crate) fn enable_scheduling() {
+    SCHEDULING_ENABLED.store(true, core::sync::atomic::Ordering::Release);
+}
+
+/// Whether the scheduler may context-switch (false throughout `kinit`).
+pub(crate) fn scheduling_enabled() -> bool {
+    SCHEDULING_ENABLED.load(core::sync::atomic::Ordering::Acquire)
+}
+
 /// Stack size per process: 16 KB (4 pages).
 const STACK_PAGES: usize = 4;
 

--- a/crates/thumos/src/qemu.rs
+++ b/crates/thumos/src/qemu.rs
@@ -1,0 +1,67 @@
+//! QEMU semihosting harness for the `qemu` bring-up feature.
+//!
+//! AArch32 semihosting (`svc #0x123456`) against `qemu-system-arm
+//! -semihosting-config enable=on,target=native`. Mirrors the calls proven
+//! by `examples/qemu_smoke.rs`. Compiled only under `--features qemu`.
+//!
+//! Exit-code contract (asserted by CI): 0 = boot-complete, 1 = panic,
+//! 2 = data abort, 3 = prefetch abort, 4 = undefined instruction.
+
+/// SYS_EXIT_EXTENDED semihosting operation.
+///
+/// WHY: plain SYS_EXIT (0x18) on AArch32 takes the reason code directly in
+/// r1 and cannot carry an exit status; the extended form takes a
+/// [reason, status] block, so pass/fail/abort codes reach the runner.
+const SYS_EXIT_EXTENDED: u32 = 0x20;
+
+/// SYS_WRITE0 semihosting operation (write NUL-terminated string).
+const SYS_WRITE0: u32 = 0x04;
+
+/// ADP_Stopped_ApplicationExit reason code.
+const ADP_STOPPED_APPLICATION_EXIT: u32 = 0x2_0026;
+
+/// Terminate the guest; `status` becomes the QEMU process exit code.
+fn exit(status: u32) -> ! {
+    let params = [ADP_STOPPED_APPLICATION_EXIT, status];
+    // SAFETY: `svc #0x123456` is the architecturally-defined A32 semihosting
+    // trap. QEMU services it host-side and terminates the guest, so control
+    // never returns; `params` outlives the call because the call never
+    // returns.
+    unsafe {
+        core::arch::asm!(
+            "svc #0x123456",
+            in("r0") SYS_EXIT_EXTENDED,
+            in("r1") params.as_ptr(),
+            options(noreturn, nostack),
+        );
+    }
+}
+
+/// Unit-typed wrapper over [`exit`].
+///
+/// WHY: callers sit at points where the non-qemu build continues (idle
+/// loops, exception hang loops). A `-> !` call there marks the shared tail
+/// unreachable and trips `unreachable_code` whenever the feature is on;
+/// this wrapper never returns at runtime but does not poison the caller's
+/// control-flow analysis.
+pub(crate) fn request_exit(status: u32) {
+    exit(status);
+}
+
+/// Write a NUL-terminated string to the QEMU host console.
+///
+/// Works before UART/MMU init -- the only dependency is the semihosting
+/// trap, so it is the earliest available boot instrumentation.
+pub(crate) fn write0(msg: &core::ffi::CStr) {
+    // SAFETY: msg is NUL-terminated (CStr invariant) and lives in mapped
+    // kernel memory; QEMU reads it host-side up to the NUL. r0 carries the
+    // semihosting result on return and is declared clobbered.
+    unsafe {
+        core::arch::asm!(
+            "svc #0x123456",
+            inlateout("r0") SYS_WRITE0 => _,
+            in("r1") msg.as_ptr(),
+            options(nostack, readonly),
+        );
+    }
+}

--- a/crates/thumos/src/uart_pl011.rs
+++ b/crates/thumos/src/uart_pl011.rs
@@ -1,0 +1,94 @@
+//! PL011 UART driver for QEMU `-machine virt` (bring-up feature `qemu`).
+//!
+//! Same module surface as the MT6739 driver in `uart.rs` (main.rs swaps this
+//! in via `#[path]` under the qemu feature) so kernel call sites are
+//! identical. PL011 register map (ARM DDI 0183):
+//! - 0x00: DR (data; read = RX, write = TX)
+//! - 0x18: FR (flags; bit 4 = RXFE rx-fifo-empty, bit 5 = TXFF tx-fifo-full)
+
+use core::fmt;
+
+use crate::kconfig::UART0_BASE;
+
+/// Data register OFFSET.
+const DR: usize = 0x00;
+
+/// Flag register OFFSET.
+const FR: usize = 0x18;
+
+/// FR bit: receive FIFO empty.
+const FR_RXFE: u32 = 1 << 4;
+
+/// FR bit: transmit FIFO full.
+const FR_TXFF: u32 = 1 << 5;
+
+/// Bound on `putc`'s TX-ready poll, in iterations (not wall-clock time).
+/// QEMU drains the PL011 FIFO promptly; the bound exists so a wedged device
+/// model cannot hang the kernel (mirrors the MT6739 driver's contract).
+const UART_TX_TIMEOUT_SPINS: u32 = 1_000_000;
+
+/// UART driver for the QEMU virt PL011 console.
+pub(crate) struct Uart {
+    base: usize,
+}
+
+impl Uart {
+    /// Create a UART driver for the QEMU virt debug console.
+    pub(crate) fn new() -> Self {
+        Self { base: UART0_BASE }
+    }
+
+    /// Write a single byte, waiting (bounded) for TX FIFO space.
+    pub(crate) fn putc(&self, byte: u8) {
+        // SAFETY: DR/FR are PL011 MMIO registers at UART0_BASE on the QEMU
+        // virt board; volatile access is required for hardware registers.
+        unsafe {
+            let fr = (self.base + FR) as *const u32;
+            let dr = (self.base + DR) as *mut u32;
+
+            let mut spins: u32 = 0;
+            #[expect(
+                clippy::while_immutable_condition,
+                reason = "volatile MMIO read sees hardware-driven changes the compiler cannot observe"
+            )]
+            while core::ptr::read_volatile(fr) & FR_TXFF != 0 {
+                spins += 1;
+                if spins >= UART_TX_TIMEOUT_SPINS {
+                    return;
+                }
+            }
+
+            core::ptr::write_volatile(dr, u32::from(byte));
+        }
+    }
+
+    /// Write a string to the UART.
+    pub(crate) fn write_str_raw(&self, s: &str) {
+        for byte in s.bytes() {
+            self.putc(byte);
+        }
+    }
+
+    /// Non-blocking receive: returns the next byte if the RX FIFO has one
+    /// ready, `None` otherwise. Surface parity with `uart.rs::getc`.
+    pub(crate) fn getc(&self) -> Option<u8> {
+        // SAFETY: DR/FR are PL011 MMIO registers at UART0_BASE on the QEMU
+        // virt board; volatile access is required for hardware registers.
+        unsafe {
+            let fr = (self.base + FR) as *const u32;
+            if core::ptr::read_volatile(fr) & FR_RXFE != 0 {
+                return None;
+            }
+            let dr = (self.base + DR) as *const u32;
+            let raw = core::ptr::read_volatile(dr) & 0xFF;
+            u8::try_from(raw).ok()
+        }
+    }
+}
+
+impl fmt::Write for Uart {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.write_str_raw(s);
+        Ok(())
+    }
+}

--- a/crates/thumos/src/watchdog_qemu.rs
+++ b/crates/thumos/src/watchdog_qemu.rs
@@ -1,0 +1,27 @@
+//! Watchdog no-op stub for QEMU `-machine virt` (bring-up feature `qemu`).
+//!
+//! virt models no MT6739 WDT block at 0x1000_7000 -- any register write
+//! would data-abort (and `pet()` runs on EVERY timer IRQ). Same module
+//! surface as `watchdog.rs`; QEMU runs are bounded by the runner timeout
+//! instead of a hardware watchdog.
+
+/// No-op init: no WDT hardware exists under QEMU virt.
+///
+/// # Safety
+///
+/// No preconditions; performs no operation.
+pub unsafe fn init() {}
+
+/// No-op pet: keeps the timer-IRQ call site identical.
+///
+/// # Safety
+///
+/// No preconditions; performs no operation.
+pub unsafe fn pet() {}
+
+/// No-op disable.
+///
+/// # Safety
+///
+/// No preconditions; performs no operation.
+pub unsafe fn disable() {}

--- a/scripts/qemu-runner.sh
+++ b/scripts/qemu-runner.sh
@@ -62,8 +62,13 @@ EOF
 fi
 
 # -machine virt  : generic ARM virtual platform with PL011 UART at 0x09000000,
-#                  memory at 0x40000000. The kernel link script (link.ld)
-#                  loads .text at 0x40000000, matching this layout.
+#                  GICv2 at 0x08000000/0x08010000, RAM at 0x40000000. The
+#                  kernel link script (link.ld) loads .text at 0x40008000,
+#                  inside that RAM window.
+# -m 1024M       : match kconfig::RAM_END (RAM_START + 1 GB) so the page
+#                  allocator's whole range is backed by real RAM -- a frame
+#                  handed out beyond the emulated RAM size would data-abort
+#                  on first touch.
 # -cpu cortex-a7 : matches thumos target CPU (MT6739 is quad Cortex-A53 but
 #                  the kernel is built for armv7a-none-eabi, so we pick a
 #                  compatible v7-A core QEMU supports in 32-bit mode).
@@ -82,7 +87,7 @@ exec timeout --kill-after=5 "${TIMEOUT_SECS}" \
   qemu-system-arm \
     -machine virt \
     -cpu cortex-a7 \
-    -m 256M \
+    -m 1024M \
     -nographic \
     -semihosting-config enable=on,target=native \
     -kernel "${BINARY}" \


### PR DESCRIPTION
## The kernel boots — in emulation, on metis, verified in CI

First time `kinit::run()` has ever *executed* (it was compile-checked + host-unit-tested only). Under `qemu-system-arm -machine virt`: banner → MMU → GIC → scheduler → **first timer IRQ** → CSPRNG → every subsystem degrading correctly → userspace spawn → **`THUMOS-QEMU: boot-complete`** → semihosting exit 0. The new CI "Kernel QEMU boot" step asserts the banner + boot-complete markers, so **"does the kernel boot" is now a green check — no phone required** (the autonomy enabler behind #420).

## Two MAINLINE latent bugs it surfaced (fixed, not qemu-gated)

Both would hit the phone; it just never ran a timer tick before:
- **Banked stacks**: `_start` only set the SVC stack pointer. The first timer IRQ pushed registers through `SP_irq`=UNKNOWN → memory corruption / double-fault. Fixed in `_start` + link.ld (3 banked stacks + a KERNEL_END `ASSERT`).
- **Scheduler-during-boot race**: the timer IRQ ran `schedule()`+`switch_to()` every tick, but `kinit` runs in the bare boot context — a mid-init switch abandoned the boot (a non-deterministic hang whose point moved between runs). Fixed: scheduling gated OFF throughout `kinit`, enabled once after userspace spawn.

## QEMU harness (feature `qemu`, mutually exclusive with `production`; MT6739 build unchanged without it)

kconfig remaps UART/GIC to `virt`; `gic.rs` now consumes kconfig's bases (kills a 3-copy drift); `uart_pl011.rs` swapped via `#[path]`; WDT no-op'd; SoC-only timer-IRQ MMIO cfg-gated; the 5 unmodeled device inits skipped onto existing degradation paths; `qemu.rs` semihosting exit codes (0/1/2/3/4). csprng seeds deterministically (emulator has no entropy); DHCP loopback smoke skipped (its waits don't terminate under QEMU — #461).

## Verification
- default armv7a build clean · host nextest **2164** · `--features qemu` boots to **exit 0** · kanon + fmt clean
- CI: new QEMU-boot step (build `--features qemu` → run → assert banner + boot-complete)

Advances #420 (the boot path now runs + is CI-verifiable). Follow-ups: #461 (elapsed_ms/wfe under QEMU); minor cruft (unused modem/USB statics, gic/device GIC-base consolidation) to be filed.

_T0-reviewed: the two mainline boot fixes, the feature-gated harness, and the deterministic-seed / DHCP-skip qemu band-aids (both tracked in #461)._