### PR TITLE
boot->service handoff: KernelState + kardia superloop + reflex fast-path (#420)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,17 +111,25 @@ jobs:
         run: cargo build --release --target armv7a-none-eabi --jobs 8
       - name: Install qemu-system-arm
         run: sudo apt-get update && sudo apt-get install -y qemu-system-arm
-      - name: Kernel QEMU boot (real kinit -> boot-complete)
+      - name: Kernel QEMU boot + service loop (real kinit -> boot-complete -> loop)
         working-directory: crates/thumos
         # WHY: the `qemu` feature retargets peripheral addresses to the QEMU
         # `virt` board (UART/GIC) and boots the REAL kinit under
-        # qemu-system-arm, exiting via semihosting (0 = boot-complete). This
-        # is the "does the kernel boot" check -- verified in emulation without
-        # the physical MT6739. Failure modes are coded semihosting exits
-        # (1=panic, 2/3/4=aborts) or 124=hang (runner timeout).
+        # qemu-system-arm, hands off to the kardia service loop (PID 0), and
+        # exits via semihosting after QEMU_TICK_CAP serviced ticks (0 = the
+        # loop ran, not merely that boot reached its end). Verified in
+        # emulation without the physical MT6739. Runner exit codes: 0=loop
+        # ran; 5=service-loop stalled (#461 tick-source class); 1=panic;
+        # 2/3/4=aborts; 124=hang (runner timeout). boot.log is ALWAYS printed
+        # and the missing marker named, so a stall is a diagnostic, not a bare
+        # timeout.
         run: |
-          set -euo pipefail
+          set -uo pipefail
           cargo build --release --target armv7a-none-eabi --features qemu --jobs 8
-          THUMOS_QEMU_TIMEOUT=60 ../../scripts/qemu-runner.sh target/armv7a-none-eabi/release/thumos | tee boot.log
-          grep -q 'THUMOS v0.1.0' boot.log
-          grep -q 'THUMOS-QEMU: boot-complete' boot.log
+          rc=0
+          THUMOS_QEMU_TIMEOUT=60 ../../scripts/qemu-runner.sh target/armv7a-none-eabi/release/thumos | tee boot.log || rc=$?
+          echo "=== boot.log (runner rc=$rc) ==="; cat boot.log; echo "=== end boot.log ==="
+          test "$rc" -eq 0 || { echo "FAIL: runner exit $rc (0=ok 5=loop-stall#461 1=panic 2/3/4=abort 124=hang)"; exit 1; }
+          grep -q 'THUMOS v0.1.0' boot.log || { echo 'FAIL: missing banner'; exit 1; }
+          grep -q 'THUMOS-QEMU: boot-complete' boot.log || { echo 'FAIL: boot did not complete'; exit 1; }
+          grep -q 'THUMOS-QEMU: service-loop ticks=' boot.log || { echo 'FAIL: service loop never serviced a tick'; exit 1; }

--- a/crates/thumos/src/exceptions.rs
+++ b/crates/thumos/src/exceptions.rs
@@ -230,12 +230,13 @@ pub extern "C" fn irq_handler_rust() {
                 unsafe {
                     process::switch_to(next);
                 }
-            } else {
-                // REQ-19a: idle — no other runnable process, enter WFI.
-                // WHY: wfi suspends the core until the next interrupt, reducing
-                // power consumption in the idle path without affecting correctness.
-                power::idle();
             }
+            // WHY (REQ-19a, #420): the idle WFI moved to the PID-0 service
+            // loop (kardia.rs). A WFI here ran INSIDE the IRQ handler,
+            // stalling return-from-IRQ until the NEXT interrupt pended; the
+            // interrupted context (the service loop) is the correct idle
+            // point and issues power::idle() itself when no tick work
+            // remains.
         }
 
         // Check for pending signals on the current process.

--- a/crates/thumos/src/kardia.rs
+++ b/crates/thumos/src/kardia.rs
@@ -1,0 +1,263 @@
+//! Kardia -- the kernel heartbeat: post-boot KernelState + service loop.
+//!
+//! `kinit::run()` hands its fn-scope subsystem state to [`KernelState`], and
+//! the boot context (PID 0, the kernel/idle process created by
+//! `process::init`) becomes [`service_loop`]. Each wake: drain the reflex
+//! fast-path FIRST (reflex.rs), then on a new 100 Hz tick poll every
+//! persisted subsystem non-blockingly, render if dirty, then idle until the
+//! next interrupt. Userspace runs by PREEMPTING this loop -- the timer IRQ's
+//! scheduler round-robins away from PID 0 and back; the loop itself never
+//! calls `process::schedule()`.
+//!
+//! WARNING (coexistence is UNVERIFIED): the "timer IRQ preempts PID 0 and
+//! round-robins back" model is correct by construction, but has zero runtime
+//! coverage -- `process::switch_to`'s taken branch is `cfg(target_arch=arm)`
+//! asm (a no-op on host tests) and no userspace ELF has ever run (`/init`
+//! and `/shell` are missing from the ramfs). The qemu tick-cap below
+//! exercises only the solo-PID-0 path. TODO(#420)[deliberate-prudent]: once a userspace ELF
+//! exists in the qemu ramfs, add a two-process qemu soak that forces
+//! `schedule() -> switch_to() -> round-robin back to PID 0` before phone
+//! bring-up depends on preemption.
+//!
+//! WHY WFI (not WFE) for the phone idle (#461): WFE has no configured event
+//! source (no SEV/SEVONPEND) and parks forever under qemu-virt; WFI wakes on
+//! the 100 Hz timer IRQ on both targets. The idle WFI is issued IRQ-masked
+//! (see [`service_loop`]) so a reflex IRQ that fires+retires in the check ->
+//! idle window cannot be lost. WHY `exceptions::ticks()`, not
+//! `timer::elapsed_ms()`, as the tick source (#461): the CNTPCT-backed
+//! elapsed_ms does not advance under qemu-virt, while the IRQ-incremented
+//! tick counter does.
+
+use core::fmt::Write;
+
+use crate::device::DeviceRegistry;
+use crate::exceptions;
+use crate::kinit::BootState;
+use crate::power::PowerManager;
+use crate::reflex;
+use crate::security_mode::ModeManager;
+use crate::uart::Uart;
+
+/// Timer ticks per wall-clock second (exceptions.rs TICK_MS = 10).
+const TICKS_PER_SECOND: u64 = 100;
+
+/// QEMU CI cap: serviced ticks before a clean semihosting-exit 0. Proves the
+/// service loop RUNS -- ticks advance and the loop body executes repeatedly
+/// -- not merely that boot reached its end.
+///
+/// NOTE: this is 50 *serviced ticks*, NOT a wall-clock duration. Under
+/// qemu-virt the generic-timer CNTFRQ is uncalibrated (#461), so the tick
+/// rate is not a true 100 Hz; do not read this as "500 ms".
+#[cfg(feature = "qemu")]
+const QEMU_TICK_CAP: u32 = 50;
+
+/// QEMU stall escape: a hard ceiling on total loop wakes. Under qemu the idle
+/// is a busy-poll (not WFI -- see [`service_loop`]) so the loop always keeps
+/// spinning; if `exceptions::ticks()` ever stalls (the #461 class: timer IRQ
+/// stops / a frozen counter), the serviced-tick cap can never be reached, so
+/// this ceiling forces a FAST exit with a distinct diagnostic code instead of
+/// a 60 s runner timeout (which is indistinguishable from CI infra flake).
+/// Far above `QEMU_TICK_CAP` so healthy runs never hit it.
+#[cfg(feature = "qemu")]
+const QEMU_WAKE_CEILING: u32 = 5_000_000;
+
+/// Owned post-boot kernel state: every subsystem that must outlive
+/// `kinit::run()`'s init blocks lives here, moved in at the boot->service
+/// handoff and owned exclusively by the service loop.
+///
+/// INVARIANT (load-bearing -- the whole point of this struct): a subsystem
+/// may be a `KernelState` field ONLY if it is never mutated in IRQ context.
+/// Single-ownership by the loop is what makes plain (unsynchronized) access
+/// race-free. An IRQ-fed subsystem (the CCCI modem's CLDMA RX, a RING URC, a
+/// network device's RX -- i.e. exactly #398/#402) MUST NOT be a bare field:
+/// it hands data to the loop through an `IrqSpinlock`-guarded structure (the
+/// [`reflex`] mechanism, generalised to carry payloads), not by the loop and
+/// an ISR both touching the same object. IRQ handlers communicate with this
+/// struct through reflex flags ONLY.
+///
+/// Follow-on wirings (#398, #400-#404) each add their subsystem as a field
+/// plus one non-blocking step in [`Self::poll_all`] -- subject to the
+/// invariant above.
+///
+/// NOTE (power split-brain, #404): `power` is persisted here, but the timer
+/// IRQ independently drives DVFS/core-parking/backlight on `power`-module
+/// statics. #404 must unify these into a single owner (loop-owned here, IRQ
+/// enqueuing) rather than double-managing two `PowerManager`s.
+pub(crate) struct KernelState {
+    pub(crate) boot: BootState,
+    #[expect(
+        dead_code,
+        reason = "device lifecycle steps land with the subsystem wirings (#398, #400-#404)"
+    )]
+    pub(crate) devices: DeviceRegistry,
+    #[expect(
+        dead_code,
+        reason = "radio-policy service steps land with the security-mode wiring (#404)"
+    )]
+    pub(crate) power: PowerManager,
+    #[expect(
+        dead_code,
+        reason = "duress/panic mode transitions land with the security-mode wiring (#404)"
+    )]
+    pub(crate) mode: ModeManager,
+    /// Last whole second observed, for once-per-second dirty marking.
+    last_second: u64,
+}
+
+impl KernelState {
+    /// Take ownership of the boot-built subsystem state.
+    pub(crate) fn new(
+        boot: BootState,
+        devices: DeviceRegistry,
+        power: PowerManager,
+        mode: ModeManager,
+    ) -> Self {
+        Self {
+            boot,
+            devices,
+            power,
+            mode,
+            last_second: 0,
+        }
+    }
+
+    /// Poll every persisted subsystem once for tick `now`. Returns true when
+    /// the active screen should re-render.
+    ///
+    /// INVARIANT: no step may block or wait -- poll(now)/tick(now)-style calls
+    /// only; anything slower belongs in a budgeted state machine inside its
+    /// subsystem.
+    pub(crate) fn poll_all(&mut self, now: u64) -> bool {
+        // NOTE(foundation): the home clock (once per second) is the only
+        // persisted render input; each subsystem wiring adds its step here.
+        let second = now / TICKS_PER_SECOND;
+        if second != self.last_second {
+            self.last_second = second;
+            return true;
+        }
+        false
+    }
+
+    /// Render the active screen when marked dirty.
+    ///
+    /// TODO(#400)[deliberate-prudent]: screen-registry dispatch + framebuffer render; until then
+    /// this is the seam where the frame is produced. Rendering is skipped when
+    /// no display was brought up.
+    pub(crate) fn render_if_dirty(&mut self) {
+        if !self.boot.display_ok {
+            return;
+        }
+        // TODO(#400)[deliberate-prudent]: dispatch to the active screen's draw().
+    }
+
+    /// Execute pending reflex fast-path events in privileged (loop) context.
+    pub(crate) fn handle_reflex(&mut self, pending: reflex::Pending, serial: &mut Uart) {
+        if pending.panic_wipe {
+            let _ = serial.write_str("[kardia] REFLEX panic-wipe\r\n"); // WHY: best-effort loop diagnostic; must not block on a failed UART write
+            // TODO(#404)[deliberate-prudent]: invoke panic_wipe via the persisted key manager.
+        }
+        if pending.duress {
+            let _ = serial.write_str("[kardia] REFLEX duress\r\n"); // WHY: best-effort loop diagnostic; must not block on a failed UART write
+            // TODO(#404)[deliberate-prudent]: duress transition via self.mode + wipe policy.
+        }
+        if pending.incoming_ring {
+            let _ = serial.write_str("[kardia] REFLEX incoming-ring\r\n"); // WHY: best-effort loop diagnostic; must not block on a failed UART write
+            // TODO(#398)[deliberate-prudent]: ring UI + audio route via persisted telephony.
+        }
+    }
+}
+
+/// The kernel service loop -- PID 0's body. Never returns (on the phone).
+///
+/// INVARIANT: entered with scheduling already enabled (kinit calls
+/// `process::enable_scheduling()` first); everything here tolerates preemption
+/// at any instruction outside an `IrqSpinlock` critical section.
+pub(crate) fn service_loop(mut kernel: KernelState, mut serial: Uart) -> ! {
+    let _ = serial.write_str("[kardia] service loop running\r\n"); // WHY: best-effort loop diagnostic; must not block on a failed UART write
+    let mut last_tick = exceptions::ticks();
+    #[cfg(feature = "qemu")]
+    let mut serviced: u32 = 0;
+    #[cfg(feature = "qemu")]
+    let mut wakes: u32 = 0;
+    loop {
+        #[cfg(feature = "qemu")]
+        {
+            wakes += 1;
+            if wakes >= QEMU_WAKE_CEILING {
+                // ticks() stalled before QEMU_TICK_CAP -- fail FAST with a
+                // distinct code rather than let the runner time out (#461).
+                let _ = write!(
+                    serial,
+                    "THUMOS-QEMU: service-loop STALLED wakes={wakes} ticks={serviced}\r\n"
+                );
+                crate::qemu::request_exit(5);
+            }
+        }
+
+        // Reflex fast-path FIRST -- drained on every wake, ahead of the tick
+        // test, so a raised flag is handled promptly. Re-loop after handling
+        // so a reflex handler that raises another is serviced immediately.
+        let pending = reflex::drain();
+        if pending.any() {
+            kernel.handle_reflex(pending, &mut serial);
+            continue;
+        }
+
+        let now = exceptions::ticks();
+        if now != last_tick {
+            // NOTE: a preemption gap of K ticks collapses to ONE service pass
+            // with the latest `now` -- poll(now) interfaces are time-based, so
+            // catch-up replay is unnecessary.
+            last_tick = now;
+            // TODO(#400)[deliberate-prudent]: poll_input() -> key events -> active-screen dispatch.
+            if kernel.poll_all(now) {
+                kernel.render_if_dirty();
+            }
+            #[cfg(feature = "qemu")]
+            {
+                serviced += 1;
+                if serviced >= QEMU_TICK_CAP {
+                    let _ = write!(serial, "THUMOS-QEMU: service-loop ticks={serviced}\r\n"); // WHY: best-effort CI marker; exit follows regardless
+                    crate::qemu::request_exit(0);
+                }
+            }
+            continue;
+        }
+
+        // Idle: no reflex, no new tick.
+        idle(last_tick);
+    }
+}
+
+/// Idle until the next interrupt.
+///
+/// On the phone: IRQ-masked WFI. WHY masked (closes the lost-wakeup window):
+/// a reflex IRQ that fires+retires between the unmasked `drain` above and the
+/// WFI would, with IRQs enabled, leave WFI waiting for an interrupt that
+/// already passed -- degrading the fast-path to the 10 ms tick cadence it
+/// exists to beat, and hiding a dependency on the timer never being gated (a
+/// future tickless idle would then hang). Masking + re-checking under the
+/// mask + WFI-while-masked (ARM WFI wakes on a GIC-pending interrupt
+/// regardless of CPSR.I) closes it: either the re-check sees the flag/tick, or
+/// the pending IRQ wakes the WFI; unmasking on guard drop takes it.
+///
+/// Under qemu: a busy-poll (`spin_loop`), NOT WFI, so the loop keeps spinning
+/// and [`QEMU_WAKE_CEILING`] can always fire a fast diagnostic exit if ticks
+/// stall (#461) -- termination must not itself depend on WFI waking.
+fn idle(last_tick: u64) {
+    #[cfg(feature = "qemu")]
+    {
+        let _ = last_tick;
+        core::hint::spin_loop();
+    }
+    #[cfg(not(feature = "qemu"))]
+    {
+        let _guard = crate::irq::IrqGuard::new();
+        // Re-check under the mask: a reflex flag set by an IRQ that already
+        // retired, or a tick that advanced, means there is work -- skip WFI.
+        if !reflex::peek_pending() && exceptions::ticks() == last_tick {
+            crate::power::idle();
+        }
+        // _guard drops here -> IRQs unmask -> any GIC-pending IRQ is taken.
+    }
+}

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -1271,15 +1271,13 @@ pub unsafe fn run() -> ! {
     process::enable_scheduling();
 
     // -----------------------------------------------------------------------
-    // QEMU milestone: full boot sequence attempted -- exit via semihosting
+    // QEMU milestone: full boot sequence attempted
     // -----------------------------------------------------------------------
-    // WHY(qemu): CI asserts on this marker and on exit code 0; without an
-    // explicit exit the idle loop below runs until the runner timeout.
+    // WHY(qemu): CI asserts on this marker. The semihosting exit 0 moved
+    // into the service loop (kardia::QEMU_TICK_CAP), so a green run proves
+    // the loop serviced real ticks, not merely that boot reached its end.
     #[cfg(feature = "qemu")]
-    {
-        let _ = serial.write_str("THUMOS-QEMU: boot-complete\r\n");
-        crate::qemu::request_exit(0);
-    }
+    let _ = serial.write_str("THUMOS-QEMU: boot-complete\r\n");
 
     // -----------------------------------------------------------------------
     // Debug console or idle
@@ -1298,20 +1296,17 @@ pub unsafe fn run() -> ! {
             console.prompt();
         }
     } else {
-        // No console  -  just idle
-        let _ = serial.write_str("[init] No debug console this boot; idling\r\n");
+        let _ = serial.write_str("[init] No debug console this boot; entering service loop\r\n");
     }
 
-    // NOTE: in a real implementation, UART RX would be interrupt-driven.
-    // For now, we poll (when a console is active) or just idle. This gets
-    // replaced when the UART driver has proper RX interrupt support.
-    loop {
-        // SAFETY: WFE is a hint instruction available in all ARM privilege levels.
-        // No memory is accessed; the CPU enters a low-power wait state.
-        unsafe {
-            core::arch::asm!("wfe");
-        }
-    }
+    // WHY (#420): boot -> service handoff. The fn-scope state kinit built
+    // moves into KernelState and the boot context (PID 0) becomes the
+    // kernel service loop. Scheduling was enabled above, at the same point
+    // as before -- the loop never calls process::schedule() itself;
+    // userspace runs by the timer IRQ preempting PID 0 and round-robining
+    // back.
+    let kernel = crate::kardia::KernelState::new(state, devices, pm, mode_mgr);
+    crate::kardia::service_loop(kernel, serial)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/thumos/src/main.rs
+++ b/crates/thumos/src/main.rs
@@ -110,6 +110,11 @@ mod http_client;
 mod ipc;
 mod irq;
 mod json_mini;
+// WHY (#420): post-boot service loop + persisted KernelState. Test-gated
+// like kinit -- it consumes kinit::BootState and device::DeviceRegistry,
+// both cfg(not(test)).
+#[cfg(not(test))]
+mod kardia;
 mod kconfig;
 mod key_manager;
 #[cfg(not(test))]
@@ -134,6 +139,7 @@ mod provision;
 #[cfg(all(not(test), feature = "qemu"))]
 mod qemu;
 mod ramfs;
+mod reflex;
 mod sbc;
 mod screen_alarm;
 mod screen_calendar;

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -167,12 +167,12 @@ static mut CURRENT: Pid = 0;
 /// during init would abandon the boot mid-sequence -- a timing-dependent
 /// hang (the tick lands at a non-deterministic point). Boot enables
 /// scheduling via `enable_scheduling()` once userspace has been spawned and
-/// the boot context becomes the idle loop.
+/// the boot context becomes the kardia service loop (PID 0's body).
 static SCHEDULING_ENABLED: core::sync::atomic::AtomicBool =
     core::sync::atomic::AtomicBool::new(false);
 
 /// Enable scheduler context switches. Called exactly once from `kinit`, after
-/// userspace spawn, before the boot context enters the idle loop.
+/// userspace spawn, before the boot context enters the kardia service loop.
 pub(crate) fn enable_scheduling() {
     SCHEDULING_ENABLED.store(true, core::sync::atomic::Ordering::Release);
 }

--- a/crates/thumos/src/reflex.rs
+++ b/crates/thumos/src/reflex.rs
@@ -1,0 +1,165 @@
+//! Reflex -- the IRQ fast-path: a deliberately tiny allowlist of events an
+//! interrupt handler may flag for immediate service-loop attention, ahead of
+//! the normal 100 Hz poll cadence.
+//!
+//! ADMISSION RULE: an entry must justify why a 10 ms poll-cadence response is
+//! unacceptable. Current allowlist: duress key, panic-wipe trigger,
+//! incoming-call ring. Everything else goes through `KernelState::poll_all`.
+//! Adding an entry is a reviewable diff to this one small file, not a
+//! scattered pattern.
+//!
+//! Concurrency CONTRACT (single-core): setters run in IRQ context;
+//! [`drain`]/[`peek_pending`] run in the service loop (PID 0). All take the
+//! same [`IrqSpinlock`], which masks IRQ delivery for the critical section, so
+//! a drain's read-and-clear can never interleave with a setter (#322/#331
+//! class), and a setter in IRQ context nests correctly via the `IrqGuard`
+//! save/restore. `static mut PENDING` is never touched off-lock.
+//!
+//! WHY booleans, not payloads: reflex is a WAKE-HINT channel -- the loop
+//! fetches any associated data (ring caller-ID, which key) from the owning
+//! subsystem's state after the hint. This keeps IRQ handlers minimal; a
+//! future payload need extends [`Pending`] to small `Copy` fields under the
+//! same lock without changing the concurrency story.
+
+use crate::irq::IrqSpinlock;
+
+/// Pending reflex flags, drained atomically by the service loop.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct Pending {
+    pub(crate) duress: bool,
+    pub(crate) panic_wipe: bool,
+    pub(crate) incoming_ring: bool,
+}
+
+impl Pending {
+    /// True when any reflex is pending.
+    pub(crate) const fn any(&self) -> bool {
+        self.duress || self.panic_wipe || self.incoming_ring
+    }
+}
+
+static LOCK: IrqSpinlock = IrqSpinlock::new();
+
+/// Guarded by [`LOCK`] -- never touch without holding it.
+static mut PENDING: Pending = Pending {
+    duress: false,
+    panic_wipe: false,
+    incoming_ring: false,
+};
+
+fn set(mutate: impl FnOnce(&mut Pending)) {
+    let _guard = LOCK.lock();
+    // SAFETY: PENDING is only accessed under LOCK, whose IrqSpinlock masks IRQ
+    // delivery for the critical section -- no IRQ-vs-loop interleaving is
+    // possible on this single-core kernel.
+    unsafe { mutate(&mut *core::ptr::addr_of_mut!(PENDING)) }
+}
+
+/// Raise the duress-key reflex.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "raised by the keypad IRQ wiring (#400/#404)")
+)]
+pub(crate) fn raise_duress() {
+    set(|p| p.duress = true);
+}
+
+/// Raise the panic-wipe reflex.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "raised by the panic-wipe trigger wiring (#404)")
+)]
+pub(crate) fn raise_panic_wipe() {
+    set(|p| p.panic_wipe = true);
+}
+
+/// Raise the incoming-call-ring reflex.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "raised by the CCCI RING URC wiring (#398)")
+)]
+pub(crate) fn raise_incoming_ring() {
+    set(|p| p.incoming_ring = true);
+}
+
+/// True if any reflex is pending, WITHOUT clearing it.
+///
+/// WHY: the service loop's IRQ-masked idle (`kardia::idle`) re-checks this
+/// under the mask before committing to WFI, so a flag raised by an IRQ that
+/// already retired in the drain->idle window is seen rather than slept
+/// through. Unused under the qemu idle (busy-poll, no WFI).
+#[cfg_attr(
+    all(feature = "qemu", not(test)),
+    expect(
+        dead_code,
+        reason = "the qemu idle busy-polls; peek is the phone masked-WFI re-check"
+    )
+)]
+pub(crate) fn peek_pending() -> bool {
+    let _guard = LOCK.lock();
+    // SAFETY: as in `set` -- exclusive access under LOCK.
+    unsafe { (*core::ptr::addr_of!(PENDING)).any() }
+}
+
+/// Take and clear all pending reflex flags in one critical section.
+pub(crate) fn drain() -> Pending {
+    let _guard = LOCK.lock();
+    // SAFETY: as in `set` -- exclusive access under LOCK.
+    unsafe { core::mem::take(&mut *core::ptr::addr_of_mut!(PENDING)) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // WHY not #[test]-parallel-safe individually: PENDING is a shared static;
+    // nextest process-isolates each test (its own process), so these do not
+    // race each other. Each drains at the end to leave a clean slate.
+
+    #[test]
+    fn pending_any_reflects_flags() {
+        assert!(!Pending::default().any());
+        assert!(
+            Pending {
+                duress: true,
+                ..Pending::default()
+            }
+            .any()
+        );
+    }
+
+    #[test]
+    fn raise_then_drain_returns_the_flag_and_clears() {
+        let _ = drain(); // clean slate
+        raise_duress();
+        assert!(
+            peek_pending(),
+            "peek must see the raised flag without clearing"
+        );
+        let p = drain();
+        assert!(p.duress && !p.panic_wipe && !p.incoming_ring);
+        assert!(
+            !peek_pending(),
+            "drain must clear -- a second peek sees nothing"
+        );
+        assert!(!drain().any(), "second drain is empty");
+    }
+
+    #[test]
+    fn multiple_raises_coalesce_into_one_drain() {
+        let _ = drain();
+        raise_duress();
+        raise_panic_wipe();
+        raise_incoming_ring();
+        let p = drain();
+        assert_eq!(
+            p,
+            Pending {
+                duress: true,
+                panic_wipe: true,
+                incoming_ring: true,
+            }
+        );
+        assert!(!drain().any());
+    }
+}


### PR DESCRIPTION
## The kernel stops booting and starts living

Before this, kinit ran to the end and spun in a bare `loop { wfe }`. Now it hands its fn-scope subsystem state to an owned `KernelState` and the boot context (PID 0) **becomes the kardia service loop**: each wake drains the reflex IRQ fast-path first, then on a new 100 Hz tick polls every persisted subsystem non-blockingly, renders if dirty, idles. This is the **#420 foundation** — the six subsystem wirings (#398/#400-#404) each become a `add a field + one poll_all step` unit on top of it.

**Proven under QEMU** (CI now asserts the loop RUNS, not just that boot reached its end):
```
THUMOS-QEMU: boot-complete
[kardia] service loop running
THUMOS-QEMU: service-loop ticks=50   → semihosting exit 0
```

## Design → adversarial review → fold (not defer)

Fable designed the architecture; three Opus judges attacked it (race/lock, boot->service transition, qemu-boot preservation). Their must-fixes are **folded in**:
- **Masked-WFI phone idle** — the idle WFI runs under an IRQ-masked critical section that re-checks reflex+tick first (ARM WFI wakes on GIC-pending even with I masked), closing the drain->WFI lost-wakeup window and removing a hidden "timer must never be gated" dependency.
- **Unconditional qemu termination** — under `qemu` the idle busy-polls and a hard wake-ceiling force-exits with a distinct code (5) if `ticks()` ever stalls (#461), so a tick-source regression fails FAST with a diagnostic instead of a 60 s CI timeout.
- **Hard KernelState invariant** — a subsystem may be a field ONLY if never mutated in IRQ context; IRQ-fed subsystems (CCCI/#398, network/#402) MUST hand off through the reflex-generalised `IrqSpinlock` structure. Power split-brain named for #404.
- **Honest prose** — the timer-preempts-PID-0 coexistence is correct-by-construction but **unverified** (`switch_to`'s taken branch is ARM-only asm, never run with a 2nd process). A two-process qemu soak is a required follow-up (filed) once a userspace ELF exists in the ramfs.

Companion mainline fix: the idle WFI is removed from the timer IRQ handler (a WFI *inside* the handler stalled return-from-IRQ) and re-homed in the loop.

## Verification
default armv7a clean · host nextest **2167** (3 new reflex tests) · `--features qemu` boots -> loop -> ticks=50 -> exit 0 · kanon + fmt clean · CI always prints boot.log + names the missing marker.

Foundation only; the 6 wirings are follow-on (some blocked on PENDING kinit steps, noted in the design).