### PR TITLE
Zero-warning gate + unsafe/dead-code policy (#431, closes #12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,12 @@ jobs:
       - name: Kernel host tests (i686)
         working-directory: crates/thumos
         run: cargo nextest run --bin thumos --target i686-unknown-linux-gnu --build-jobs 8 --test-threads 8
-      - name: Kernel cross-compile (armv7a)
+      - name: Kernel cross-compile (armv7a) + zero-warning gate (#431)
         working-directory: crates/thumos
+        # WHY (#431): the zero-warning gate (-D warnings) lives in
+        # crates/thumos/.cargo/config.toml's armv7a rustflags (always-on, dev +
+        # CI, and it does not clobber the linker-script flag the way an env
+        # RUSTFLAGS would). This step just builds; a new warning fails it.
         run: cargo build --release --target armv7a-none-eabi --jobs 8
       - name: Trust-anchor build guard (#233)
         working-directory: crates/thumos

--- a/crates/thumos/.cargo/config.toml
+++ b/crates/thumos/.cargo/config.toml
@@ -2,7 +2,13 @@
 target = "armv7a-none-eabi"
 
 [target.armv7a-none-eabi]
-rustflags = ["-C", "link-arg=-Tlink.ld"]
+# WHY (#431): -D warnings holds the SHIPPED kernel to zero warnings, always-on
+# (dev + CI), scoped to armv7a so the i686 host-test target is unaffected.
+# unsafe_code is `allow` (a bare-metal kernel is inherently unsafe; the
+# discipline is per-block SAFETY comments + kanon) and dead_code is a
+# crate-level `expect` (the tracked compiled-but-unwired surface, #145/#420);
+# every OTHER warning class is denied. cargo caps dependency lints to allow.
+rustflags = ["-C", "link-arg=-Tlink.ld", "-D", "warnings"]
 # WHY: `cargo run` and `cargo test` for the bare-metal kernel target dispatch
 # each built binary through the QEMU runner so kernel code can be exercised
 # in an emulated ARM environment. The runner translates QEMU's semihosting

--- a/crates/thumos/Cargo.toml
+++ b/crates/thumos/Cargo.toml
@@ -74,10 +74,13 @@ xts-mode = { version = "0.5", default-features = false }
 ed25519-dalek = { version = "2", default-features = false }
 
 # WHY: the kernel crate is excluded from the workspace (bare-metal target)
-# but must still enforce the same lint quality floor. These match the
-# workspace lints in the root Cargo.toml.
+# but still enforces the same lint floor -- EXCEPT unsafe_code. A bare-metal
+# kernel is inherently unsafe (MMIO, global_asm!, raw register access);
+# `unsafe_code = "warn"` fired ~484 non-actionable warnings (one per unsafe
+# block) and blocked a `-D warnings` gate. The real safety discipline is the
+# per-block `// SAFETY:` comments, enforced by kanon RUST/unsafe-needs-safety.
 [lints.rust]
-unsafe_code = "warn"
+unsafe_code = "allow"
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/crates/thumos/src/bt_audio.rs
+++ b/crates/thumos/src/bt_audio.rs
@@ -41,13 +41,15 @@ use crate::avdtp::{
     AVDTP_SIGNAL_OPEN, AVDTP_SIGNAL_SET_CONFIGURATION, AVDTP_SIGNAL_START, AvdtpMessage,
 };
 use crate::bluetooth::{BtError, BtHwOps, hci_acl_data};
+// WHY cfg(test): the avdtp/sbc glob re-exports are used only by this
+// module's tests (via super::*); unused in the shipped build.
+#[cfg(test)]
+pub(crate) use crate::avdtp::*;
 use crate::sbc::{
     SBC_FREQ_44100, SBC_FREQ_48000, SBC_MAX_FRAME_SIZE, SbcEncoder, SbcFrameHeader, StubSbcEncoder,
 };
 
 // Re-export SBC and AVDTP types so external callers can still use crate::bt_audio::*.
-pub(crate) use crate::avdtp::*;
-pub(crate) use crate::sbc::*;
 
 // ---------------------------------------------------------------------------
 // Error type

--- a/crates/thumos/src/exceptions.rs
+++ b/crates/thumos/src/exceptions.rs
@@ -56,7 +56,7 @@ pub unsafe fn init() {
     unsafe {
         core::arch::asm!(
             "mcr p15, 0, {}, c12, c0, 0", // VBAR
-            in(reg) (vector_table as usize),
+            in(reg) (vector_table as *const () as usize),
         );
 
         // Enable IRQs (clear I bit in CPSR)

--- a/crates/thumos/src/fd.rs
+++ b/crates/thumos/src/fd.rs
@@ -2705,7 +2705,7 @@ mod tests {
         // Create a file through VFS, open it, write through sys_write
         let mt = unsafe { get_mount_table_mut() }.expect("mount table");
         let fs = mt.get_mut(0).expect("root fs");
-        let file_id = fs
+        let _file_id = fs
             .create(0, "writable.txt", InodeType::RegularFile)
             .expect("create");
         drop(fs);

--- a/crates/thumos/src/futex.rs
+++ b/crates/thumos/src/futex.rs
@@ -279,8 +279,7 @@ mod tests {
         // function-local static lands inside that window (see fd.rs tests
         // for the same pattern).
         static mut WORD: u32 = 42;
-        // SAFETY: test-only static; single-threaded per test.
-        let addr = unsafe { core::ptr::addr_of!(WORD) as u32 };
+        let addr = core::ptr::addr_of!(WORD) as u32;
 
         // val != *addr → should return EAGAIN immediately without blocking.
         let result = sys_futex_wait(addr, 99);
@@ -378,8 +377,7 @@ mod tests {
         // WHY function-local `static mut`: mirrors futex_wait_returns_eagain_on_mismatch
         // -- lands inside the validated user-address window on this host binary.
         static mut WORD: u32 = 42;
-        // SAFETY: test-only static; single-threaded per test.
-        let addr = unsafe { core::ptr::addr_of!(WORD) as u32 };
+        let addr = core::ptr::addr_of!(WORD) as u32;
 
         // *addr == val, so this would normally proceed to register a
         // waiter -- but the table is full.

--- a/crates/thumos/src/harmostes.rs
+++ b/crates/thumos/src/harmostes.rs
@@ -1349,7 +1349,6 @@ fn push_u32(s: &mut String, val: u32) {
 
 #[cfg(test)]
 mod tests {
-    use alloc::string::ToString;
 
     use super::*;
 

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -13,7 +13,9 @@ extern crate alloc;
 
 use core::fmt::Write;
 use core::slice;
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::AtomicBool;
+#[cfg(not(feature = "qemu"))]
+use core::sync::atomic::Ordering;
 
 #[cfg(not(feature = "qemu"))]
 use crate::ccci::CcciDriver;
@@ -24,9 +26,11 @@ use crate::csprng;
 use crate::device::DeviceRegistry;
 #[cfg(not(feature = "qemu"))]
 use crate::device::{self, DeviceRegistry};
+#[cfg(not(feature = "qemu"))]
 use crate::dhcp::{DhcpClient, DhcpEvent};
 #[cfg(not(feature = "qemu"))]
 use crate::display::{DisplayDriver, Gc9306};
+#[cfg(not(feature = "qemu"))]
 use crate::dns::{DnsResolver, LAN_DNS, MULLVAD_DNS};
 use crate::elf;
 use crate::exceptions;
@@ -37,9 +41,9 @@ use crate::kconfig;
 #[cfg(not(feature = "qemu"))]
 use crate::mmio;
 use crate::mmu;
-use crate::net::{
-    self, FirewallDevice, LoopbackDevice, NetworkReadiness, NetworkStack, WifiDevice,
-};
+use crate::net::{self, NetworkReadiness, WifiDevice};
+#[cfg(not(feature = "qemu"))]
+use crate::net::{FirewallDevice, LoopbackDevice, NetworkStack};
 use crate::page;
 use crate::power::PowerManager;
 use crate::process;

--- a/crates/thumos/src/main.rs
+++ b/crates/thumos/src/main.rs
@@ -6,9 +6,20 @@
 
 #![no_std]
 #![cfg_attr(not(test), no_main)]
+// WHY (#431): the kernel carries a large compiled-and-tested surface that is
+// not yet boot-wired (radio/messaging/UI subsystems built ahead of the boot
+// path). That is a deliberate, tracked state (#145 wiring audit, #420
+// boot-wiring), not cruft, so dead_code is expected crate-wide rather than
+// annotated at ~715 sites. WHY expect not allow: the wiring waves progressively
+// consume the surface, and once it is fully wired this expectation goes
+// unfulfilled and prompts its own removal. All OTHER warning classes stay live
+// under the -D warnings gate.
+#![expect(dead_code, reason = "compiled-but-unwired surface, tracked #145/#420")]
 extern crate alloc;
 
+#[cfg(not(test))]
 use core::fmt::Write;
+#[cfg(not(test))]
 use core::panic::PanicInfo;
 
 mod audio;

--- a/crates/thumos/src/mmu.rs
+++ b/crates/thumos/src/mmu.rs
@@ -43,7 +43,7 @@ mod flags {
     pub(crate) const NORMAL_WB_WA: u32 = (0b001 << 12) | (1 << 3) | (1 << 2);
     /// Device memory, strongly ordered.
     /// TEX[2:0] = 0b000, C = 0, B = 1 (for device/shared).
-    pub(crate) const DEVICE: u32 = (1 << 2);
+    pub(crate) const DEVICE: u32 = 1 << 2;
     /// Execute never (XN, bit 4).
     pub(crate) const XN: u32 = 1 << 4;
 }
@@ -563,7 +563,7 @@ unsafe fn program_translation() {}
 
 /// Return the physical address of the L1 page table.
 pub fn table_base() -> usize {
-    unsafe { core::ptr::addr_of!(L1) as usize }
+    core::ptr::addr_of!(L1) as usize
 }
 
 // --- Per-process address space pool ---

--- a/crates/thumos/src/page.rs
+++ b/crates/thumos/src/page.rs
@@ -248,13 +248,7 @@ pub unsafe fn try_free_page(addr: usize) -> bool {
         // under test changes nothing the bitmap-level free tests observe.
         #[cfg(not(test))]
         {
-            #[expect(
-                unsafe_code,
-                reason = "zeroing a page immediately before freeing it, per this function's own SAFETY analysis above"
-            )]
-            unsafe {
-                zero_page(addr);
-            }
+            zero_page(addr);
         }
         bitmap[word] &= !(1 << bit);
         FREE_PAGES += 1;

--- a/crates/thumos/src/pipe.rs
+++ b/crates/thumos/src/pipe.rs
@@ -646,8 +646,7 @@ mod tests {
         }
 
         static mut FDS: [u32; 2] = [0, 0];
-        // SAFETY: test-only static; single-threaded per test.
-        let fds_ptr = unsafe { core::ptr::addr_of_mut!(FDS) as u32 };
+        let fds_ptr = core::ptr::addr_of_mut!(FDS) as u32;
         assert_eq!(sys_pipe(fds_ptr), 0, "pipe() should succeed");
         // SAFETY: test-only static; single-threaded per test.
         let (read_fd, write_fd) = unsafe {

--- a/crates/thumos/src/power.rs
+++ b/crates/thumos/src/power.rs
@@ -44,10 +44,6 @@ const MCDI_BASE: usize = 0x1000_DC00;
 
 /// MCDI_CORE_EN: per-core power-down enable register.
 /// Bit N = 1 → core N is powered down.
-#[expect(
-    dead_code,
-    reason = "reserved for per-core power-down; wired in follow-up"
-)]
 const MCDI_CORE_EN: usize = MCDI_BASE + 0x04;
 
 // ---------------------------------------------------------------------------
@@ -360,10 +356,6 @@ unsafe fn display_wake() {
 ///
 /// DSI0 CMD_FIFO register: 0x1400_D000 + offset 0x200.
 /// Format: bits [7:0] = DCS opcode, bit 8 = last-byte flag.
-#[expect(
-    dead_code,
-    reason = "DSI0 init helper; invoked by panel bring-up in follow-up"
-)]
 unsafe fn dcs_cmd0(cmd: u8) {
     // WHY(qemu): virt models no DSI0 block; the FIFO write would data-abort
     // inside the timer IRQ (backlight-timeout path).

--- a/crates/thumos/src/screen_messages.rs
+++ b/crates/thumos/src/screen_messages.rs
@@ -45,8 +45,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 use crate::ui::{
-    self, CHAR_HEIGHT, CHAR_WIDTH, CONTENT_HEIGHT, Key, SCREEN_WIDTH, Screen, ScreenAction,
-    ScreenId, color,
+    self, CHAR_HEIGHT, CHAR_WIDTH, CONTENT_HEIGHT, Key, SCREEN_WIDTH, Screen, ScreenAction, color,
 };
 
 // ---------------------------------------------------------------------------
@@ -233,7 +232,7 @@ impl MessageEntry {
 
 /// Current view state of the messages screen.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum MessageView {
+pub(crate) enum MessageView {
     /// Inbox list view.
     Inbox,
     /// Full message detail view.

--- a/crates/thumos/src/screen_privacy.rs
+++ b/crates/thumos/src/screen_privacy.rs
@@ -26,8 +26,7 @@
 use crate::lock_screen::constant_time_eq;
 use crate::security::{self, SHA256_DIGEST_LEN};
 use crate::ui::{
-    self, CHAR_HEIGHT, CHAR_WIDTH, CONTENT_HEIGHT, Key, SCREEN_WIDTH, Screen, ScreenAction,
-    ScreenId, color,
+    self, CHAR_HEIGHT, CHAR_WIDTH, CONTENT_HEIGHT, Key, SCREEN_WIDTH, Screen, ScreenAction, color,
 };
 
 // ---------------------------------------------------------------------------

--- a/crates/thumos/src/screen_threat.rs
+++ b/crates/thumos/src/screen_threat.rs
@@ -724,8 +724,6 @@ mod tests {
 
     #[test]
     fn alert_type_display() {
-        use alloc::format;
-
         assert_eq!(ThreatAlertType::ImsiCatcher.to_string(), "IMSI_CATCHER");
         assert_eq!(ThreatAlertType::BleTracker.to_string(), "BLE_TRACKER");
         assert_eq!(ThreatAlertType::DeauthAttack.to_string(), "DEAUTH_ATTACK");
@@ -819,8 +817,6 @@ mod tests {
 
     #[test]
     fn threat_level_display() {
-        use alloc::format;
-
         assert_eq!(ThreatLevel::Low.to_string(), "LOW");
         assert_eq!(ThreatLevel::Medium.to_string(), "MEDIUM");
         assert_eq!(ThreatLevel::High.to_string(), "HIGH");
@@ -829,8 +825,6 @@ mod tests {
 
     #[test]
     fn firewall_mode_display() {
-        use alloc::format;
-
         assert_eq!(FirewallMode::Open.to_string(), "OPEN");
         assert_eq!(FirewallMode::Restricted.to_string(), "RESTRICTED");
         assert_eq!(FirewallMode::Blocked.to_string(), "BLOCKED");

--- a/crates/thumos/src/security_mode.rs
+++ b/crates/thumos/src/security_mode.rs
@@ -36,7 +36,10 @@ use subtle::ConstantTimeEq;
 
 use crate::audit::{AuditEventType, AuditLog};
 use crate::key_manager::KeyManager;
-use crate::power::{PowerManager, PowerState, Radio};
+use crate::power::PowerManager;
+// WHY cfg(test): PowerState/Radio are named only in this module's tests.
+#[cfg(test)]
+use crate::power::{PowerState, Radio};
 use crate::security::{KEY_SIZE, SleepTier};
 
 // ---------------------------------------------------------------------------

--- a/crates/thumos/src/sms.rs
+++ b/crates/thumos/src/sms.rs
@@ -35,7 +35,7 @@ extern crate alloc;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-use crate::telephony::{AtResponse, MAX_LINE_LEN, ModemTransport, TelephonyError};
+use crate::telephony::{AtResponse, MAX_LINE_LEN, ModemTransport};
 
 // Re-export GSM-7 codec so callers can still use crate::sms::*.
 pub(crate) use crate::gsm7::*;

--- a/crates/thumos/src/syscall.rs
+++ b/crates/thumos/src/syscall.rs
@@ -27,6 +27,7 @@ use crate::capability;
 use crate::fd;
 use crate::futex;
 use crate::ipc;
+#[cfg(test)]
 use crate::kconfig;
 use crate::memguard::validate_user_buffer;
 use crate::mmu;
@@ -441,9 +442,7 @@ pub(crate) fn dispatch(num: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> 
             // runnable_count() and any Sleeping-aware scheduler logic see
             // this process as blocked for the sleep window, not spuriously
             // Running.
-            let Ok(ms) = u64::try_from(arg0) else {
-                return EINVAL;
-            };
+            let ms = u64::from(arg0);
             const TICK_MS: u64 = 10;
             let ticks_needed = ms.saturating_add(TICK_MS - 1) / TICK_MS;
             let wake_tick = crate::exceptions::ticks().saturating_add(ticks_needed);
@@ -504,9 +503,7 @@ pub(crate) fn dispatch(num: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> 
         // ---- Process management ----
         Syscall::Fork => match process::fork() {
             Some(child_pid) => {
-                let Ok(pid_u32) = u32::try_from(child_pid) else {
-                    return EINVAL;
-                };
+                let pid_u32 = u32::from(child_pid);
                 pid_u32
             }
             None => u32::MAX,
@@ -642,7 +639,7 @@ fn sys_write_dispatch(fd: u32, buf_ptr: u32, count: u32) -> u32 {
             // SAFETY: validate_user_buffer confirmed [ptr, ptr+len) is within
             // user-accessible DRAM.
             let slice = unsafe { core::slice::from_raw_parts(ptr as *const u8, len) };
-            let mut serial = Uart::new();
+            let serial = Uart::new();
             for &byte in slice {
                 serial.putc(byte);
             }

--- a/crates/thumos/src/wifi.rs
+++ b/crates/thumos/src/wifi.rs
@@ -33,7 +33,7 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 use crate::csprng;
-use crate::security::{SHA1_DIGEST_LEN, hmac_sha1, pbkdf2_hmac_sha1, prf_384};
+use crate::security::{hmac_sha1, pbkdf2_hmac_sha1, prf_384};
 
 // ---------------------------------------------------------------------------
 // MT6739 WiFi hardware constants


### PR DESCRIPTION
1335 armv7a warnings -> **0** on every shipped build, with a  gate now always-on.

**Policy (operator-decided):** `unsafe_code = allow` (a bare-metal kernel is inherently unsafe; SAFETY comments + kanon are the discipline, not this ~484-warning lint); crate-level `#![expect(dead_code)]` for the ~700 items that are the tracked compiled-but-unwired surface (#145/#420) - `expect` is self-correcting, flagging itself once the surface is wired. Then ~20 genuinely-actionable warnings fixed (unused imports cfg-gated/removed, unnecessary unsafe, irrefutable let-else, private-in-public, needless mut/parens, stale expects).

**Gate:** `-D warnings` in `.cargo/config.toml` armv7a rustflags (always-on dev+CI, scoped to armv7a so the i686 test target is untouched; doesn't clobber the linker flag the way an env RUSTFLAGS would).

**Scope:** covers the shipped armv7a builds. The host-test build has a separate pre-existing warning tail (unfulfilled item-expects, must_use drops in tests, unsafe-op-in-unsafe-fn) - a follow-up. W^X (#417) is designed on the issue, separate.

Verified: default/qemu/debug-console 0 warnings under the gate; host nextest **2182**; qemu boots ticks=50 exit 0; kanon + fmt clean.

Closes #431, #12.