### PR TITLE
Userspace bring-up: SVC entry + /init toolchain + preemptive scheduler (#474, #465)

### DIFF
--- a/crates/thumos/build.rs
+++ b/crates/thumos/build.rs
@@ -143,6 +143,108 @@ fn main() {
     if let Err(e) = fs::write(out_dir.join("boot_key.rs"), rendered) {
         die(&format!("#233: cannot write boot_key.rs: {e}"));
     }
+
+    generate_initramfs(&manifest_dir, &out_dir);
+}
+
+/// Compile the userspace /init (#474) to a static armv7a ELF linked at
+/// 0x40100000 (kconfig::KERNEL_END) and wrap it in a newc CPIO the kernel
+/// embeds and mounts as the image-resident boot root ramfs.
+///
+/// WHY rustc-direct (not a sub-crate): /init is one no_std no_main file, so a
+/// raw rustc invocation for armv7a-none-eabi produces the ET_EXEC ELF
+/// elf::load parses without a nested cargo build or workspace membership.
+/// -Ttext places all PT_LOAD >= KERNEL_END so the identity-mapping loader
+/// writes them into the sanctioned user-DRAM window [KERNEL_END, RAM_END).
+fn generate_initramfs(manifest_dir: &Path, out_dir: &Path) {
+    let init_src = manifest_dir.join("init/init.rs");
+    let init_ld = manifest_dir.join("init/init.ld");
+    println!("cargo:rerun-if-changed={}", init_src.display());
+    println!("cargo:rerun-if-changed={}", init_ld.display());
+    let init_elf = out_dir.join("init.elf");
+
+    let rustc = env::var("RUSTC").unwrap_or_else(|_| "rustc".into());
+    // kanon:ignore RUST/no-direct-process-command -- build script compiles the /init userspace binary; the rule targets runtime/kernel code and there is no build-time compiler wrapper to route through
+    let status = std::process::Command::new(rustc)
+        .args([
+            "--edition",
+            "2024",
+            "--target",
+            "armv7a-none-eabi",
+            "--crate-type",
+            "bin",
+            "-C",
+            "panic=abort",
+            "-C",
+            "opt-level=s",
+            "-C",
+            "relocation-model=static",
+        ])
+        .arg("-C")
+        .arg(format!("link-arg=-T{}", init_ld.display()))
+        // WHY 0x100: the armv7a default max-page-size (64 KB) pads the ELF file
+        // to a 0x10000 first-segment offset (~66 KB of zeros). from_cpio copies
+        // the whole ELF into ONE heap Vec, and the slab's large-alloc path
+        // (slab.rs) refuses multi-page (>4 KB) requests, so the image must stay
+        // under a single 4 KB page. A 0x100 page size drops the file-offset
+        // padding to 256 B, keeping this tiny /init well under one page. (A
+        // larger userspace needs multi-page/contiguous alloc support -- #475.)
+        .arg("-C")
+        .arg("link-arg=-z")
+        .arg("-C")
+        .arg("link-arg=max-page-size=0x100")
+        .arg("-o")
+        .arg(&init_elf)
+        .arg(&init_src)
+        .status();
+    match status {
+        Ok(s) if s.success() => {}
+        Ok(s) => die(&format!("#474: rustc failed to build /init ({s})")),
+        Err(e) => die(&format!("#474: cannot invoke rustc for /init: {e}")),
+    }
+
+    let elf = match fs::read(&init_elf) {
+        Ok(b) => b,
+        Err(e) => die(&format!("#474: cannot read built /init ELF: {e}")),
+    };
+
+    let mut archive = cpio_newc_entry("init", &elf, 0o100_755);
+    archive.extend_from_slice(&cpio_newc_entry("TRAILER!!!", &[], 0));
+    if let Err(e) = fs::write(out_dir.join("initramfs.cpio"), &archive) {
+        die(&format!("#474: cannot write initramfs.cpio: {e}"));
+    }
+}
+
+/// One newc (070701) CPIO entry, byte-identical to the kernel's tested
+/// `build_cpio_entry` (kinit tests) so ramfs::from_cpio parses it: 110-byte
+/// header, name+NUL padded to 4, data padded to 4.
+fn cpio_newc_entry(name: &str, data: &[u8], mode: u32) -> Vec<u8> {
+    let mut e = Vec::new();
+    let namesize = name.len() + 1;
+    e.extend_from_slice(b"070701");
+    e.extend_from_slice(b"00000001"); // ino
+    e.extend_from_slice(format!("{mode:08X}").as_bytes());
+    e.extend_from_slice(b"00000000"); // uid
+    e.extend_from_slice(b"00000000"); // gid
+    e.extend_from_slice(b"00000001"); // nlink
+    e.extend_from_slice(b"00000000"); // mtime
+    e.extend_from_slice(format!("{:08X}", data.len()).as_bytes());
+    e.extend_from_slice(b"00000000"); // devmajor
+    e.extend_from_slice(b"00000000"); // devminor
+    e.extend_from_slice(b"00000000"); // rdevmajor
+    e.extend_from_slice(b"00000000"); // rdevminor
+    e.extend_from_slice(format!("{namesize:08X}").as_bytes());
+    e.extend_from_slice(b"00000000"); // check
+    e.extend_from_slice(name.as_bytes());
+    e.push(0);
+    while e.len() % 4 != 0 {
+        e.push(0);
+    }
+    e.extend_from_slice(data);
+    while e.len() % 4 != 0 {
+        e.push(0);
+    }
+    e
 }
 
 fn render_boot_key_rs(

--- a/crates/thumos/init/init.ld
+++ b/crates/thumos/init/init.ld
@@ -1,0 +1,43 @@
+/* Linker script for thumos /init (#474). */
+/* Base at 0x7FF0_0000 (kconfig::USER_TEXT_BASE): the kernel maps the top 1 MB
+   of DRAM as the executable userspace text region and excludes it from the
+   page allocator, so a spawned ELF runs here without an XN prefetch abort
+   (all other DRAM is execute-never per W^X #417) and without colliding with
+   kernel page allocations. The ELF loader is identity-mapping (p_vaddr ==
+   physical write address); basing the whole image here keeps the ELF + program
+   headers in-range, and /DISCARD/ drops the metadata sections that would
+   otherwise emit a separate low segment. */
+
+ENTRY(_start)
+
+SECTIONS
+{
+    . = 0x7FF00000;
+
+    .text : {
+        *(.text.boot)
+        *(.text .text.*)
+    }
+
+    .rodata : ALIGN(4) {
+        *(.rodata .rodata.*)
+    }
+
+    .data : ALIGN(4) {
+        *(.data .data.*)
+    }
+
+    .bss : ALIGN(4) {
+        *(.bss .bss.*)
+        *(COMMON)
+    }
+
+    /DISCARD/ : {
+        *(.ARM.exidx*)
+        *(.ARM.attributes)
+        *(.comment)
+        *(.note*)
+        *(.eh_frame*)
+        *(.eh_frame_hdr*)
+    }
+}

--- a/crates/thumos/init/init.rs
+++ b/crates/thumos/init/init.rs
@@ -1,0 +1,77 @@
+//! thumos /init (#474): minimal userspace bring-up program.
+//!
+//! Built by build.rs to a static armv7a ELF linked at 0x40100000
+//! (kconfig::KERNEL_END), wrapped in a newc CPIO, and embedded into the
+//! kernel image. kinit spawns it from the boot root ramfs.
+//!
+//! WHY privileged: spawn currently runs this at PL1 (System mode) in the
+//! kernel address space -- true PL0 usermode isolation (own page table, W^X
+//! user pages, exception-return) is deferred (elf.rs Wave 4+). This proves the
+//! spawn -> schedule -> SVC -> dispatch path end to end, not a security
+//! boundary.
+#![no_std]
+#![no_main]
+
+// WHY: thumos syscall ABI -- r7 = syscall number, r0-r3 = args, return in r0
+// (exceptions.rs svc_handler). Numbers from syscall.rs: Write = 1, Exit = 0.
+
+/// write(fd, buf, len) -> bytes written / negative errno.
+///
+/// # Safety
+/// `buf` must point to `len` readable bytes inside the loaded image
+/// (VA >= 0x40100000, the range the kernel's validate_user_buffer accepts).
+#[inline(always)]
+unsafe fn sys_write(fd: u32, buf: *const u8, len: u32) -> u32 {
+    let ret;
+    // SAFETY: issues SVC #1 (Write) per the thumos ABI; the kernel validates
+    // the buffer before reading it.
+    unsafe {
+        core::arch::asm!(
+            "svc #0",
+            in("r7") 1u32,
+            inlateout("r0") fd => ret,
+            in("r1") buf,
+            in("r2") len,
+            options(nostack),
+        );
+    }
+    ret
+}
+
+/// exit(code): terminate this process; never returns.
+///
+/// # Safety
+/// Ends the process -- the kernel context-switches away and never resumes it.
+#[inline(always)]
+unsafe fn sys_exit(code: u32) -> ! {
+    // SAFETY: issues SVC #0 (Exit); dispatch calls process::exit_with_status,
+    // which switches away and does not return through the SVC path.
+    unsafe {
+        core::arch::asm!(
+            "svc #0",
+            in("r7") 0u32,
+            in("r0") code,
+            options(noreturn, nostack),
+        );
+    }
+}
+
+/// ELF entry point (e_entry). The kernel transmutes the loaded entry to
+/// `fn() -> !` and calls it on the kernel-allocated process stack.
+#[unsafe(no_mangle)]
+pub extern "C" fn _start() -> ! {
+    let msg = b"init: hello from userspace\n";
+    // SAFETY: `msg` is a .rodata literal in the loaded image (VA >= 0x40100000);
+    // sys_exit terminates the process so control never falls through.
+    unsafe {
+        sys_write(1, msg.as_ptr(), u32::try_from(msg.len()).unwrap_or(0));
+        sys_exit(0);
+    }
+}
+
+/// Panic handler: exit(1). no_std has no unwinding.
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    // SAFETY: exit is the only action available; nothing reads its result.
+    unsafe { sys_exit(1) }
+}

--- a/crates/thumos/link.ld
+++ b/crates/thumos/link.ld
@@ -38,10 +38,18 @@ SECTIONS
     }
 
     . = ALIGN(4096);
-    __stack_top = . + 0x10000;                  /* SVC boot stack (64 KB) */
+    /* WHY(#465): the kernel proper (kinit + the kardia service loop = PID 0)
+       runs in SYSTEM mode on __stack_top, so every schedulable context shares
+       the user/system register bank -- this lets the exception stubs capture
+       and restore the interrupted sp/lr with a single user-bank ldm/stm ^,
+       with no SPSR-mode decoding. SVC is now a transient trap mode with its
+       own stack (like IRQ/ABT/UND): every syscall unwinds the SVC stack before
+       the next process resumes, so one 16 KB stack serves all processes. */
+    __stack_top = . + 0x10000;                  /* SYS boot / PID-0 stack (64 KB) */
     __irq_stack_top = __stack_top + 0x1000;     /* IRQ banked stack (4 KB) */
     __abt_stack_top = __irq_stack_top + 0x1000; /* ABT banked stack (4 KB) */
     __und_stack_top = __abt_stack_top + 0x1000; /* UND banked stack (4 KB) */
+    __svc_stack_top = __und_stack_top + 0x4000; /* SVC syscall stack (16 KB) */
 
     /DISCARD/ : {
         *(.comment)
@@ -53,4 +61,4 @@ SECTIONS
 /* Kernel image + all stacks must stay inside the reserved window ending at
    kconfig::KERNEL_END (0x40100000): page::init hands out frames from there
    up, so an oversized image would be silently overwritten by allocations. */
-ASSERT(__und_stack_top <= 0x40100000, "kernel image + stacks exceed KERNEL_RESERVED; grow kconfig::KERNEL_RESERVED/KERNEL_END and the memguard map together")
+ASSERT(__svc_stack_top <= 0x40100000, "kernel image + stacks exceed KERNEL_RESERVED; grow kconfig::KERNEL_RESERVED/KERNEL_END and the memguard map together")

--- a/crates/thumos/src/exceptions.rs
+++ b/crates/thumos/src/exceptions.rs
@@ -134,10 +134,11 @@ core::arch::global_asm!(
     "    pop     {{r0-r12, lr}}",
     "    b       .",
     "svc_handler_asm:",
-    "    push    {{r0-r12, lr}}",
-    "    bl      svc_handler_rust",
-    "    pop     {{r0-r12, lr}}",
-    "    movs    pc, lr",
+    "    push    {{r0-r12, lr}}",   // frame: sp -> [r0..r12, lr]
+    "    mov     r0, sp",           // WHY(#474): pass frame ptr to the handler so
+    "    bl      svc_handler_rust", //          it can write the return into r0
+    "    pop     {{r0-r12, lr}}",   // restore r1-r12 + the handler's r0 (= result)
+    "    movs    pc, lr",           // return to caller (restores CPSR from SPSR)
 );
 
 unsafe extern "C" {
@@ -303,11 +304,30 @@ pub extern "C" fn undefined_handler_rust() {
     crate::qemu::request_exit(4);
 }
 
-/// SVC handler (placeholder for future syscall implementation).
+/// Register frame `svc_handler_asm` pushes (`push {r0-r12, lr}`): r0-r12 then
+/// the SVC-mode return address (the instruction after `svc`).
+#[repr(C)]
+pub(crate) struct SvcFrame {
+    r: [u32; 13],
+    lr: u32,
+}
+
+/// SVC (supervisor call) handler -- the userspace -> kernel syscall entry
+/// (#474).
+///
+/// ABI (thumos, ARM-EABI style): `r7` = syscall number, `r0`-`r3` = args,
+/// return value in `r0`. `svc_handler_asm` pushed `{r0-r12, lr}` and passes
+/// the frame pointer here so the return value is written back into the saved
+/// `r0` slot (which the wrapper's `pop` then restores into the caller's r0).
+/// r1-r12 are preserved (left as the caller's saved values). A syscall that
+/// switches context (Exit/Yield) does not return through here -- `dispatch`
+/// hands off via `process::{exit_with_status,switch_to}`.
 #[unsafe(no_mangle)]
-pub extern "C" fn svc_handler_rust() {
-    // NOTE: in a full implementation, extract SVC number FROM the instruction
-    // at the return address (lr - 4), and read r0-r3 FROM the saved context
-    // on the stack. For now this is a placeholder that will be properly
-    // wired when we have userspace processes making SVC calls.
+pub(crate) extern "C" fn svc_handler_rust(frame: *mut SvcFrame) {
+    // SAFETY: `frame` is the {r0-r12, lr} block svc_handler_asm just pushed on
+    // the SVC stack; it is valid for this call and unaliased (SVC is
+    // non-reentrant on this single core).
+    let f = unsafe { &mut *frame };
+    let ret = crate::syscall::dispatch(f.r[7], f.r[0], f.r[1], f.r[2], f.r[3]);
+    f.r[0] = ret;
 }

--- a/crates/thumos/src/exceptions.rs
+++ b/crates/thumos/src/exceptions.rs
@@ -110,13 +110,34 @@ core::arch::global_asm!(
     "    b   .", // Not used
     "    b   irq_handler_asm",
     "    b   .", // FIQ: not used
-    // IRQ handler wrapper: save context, call Rust, restore
+    // IRQ handler wrapper (#465): build a full process::Context trap frame on
+    // the IRQ stack (r0-r12 @0..48, banked sp @52, lr @56, pc @60, cpsr @64),
+    // hand its pointer to the Rust handler (which may swap it to another
+    // process via switch_to), then exception-return into the resulting frame.
+    // INVARIANT: interrupted code is ALWAYS in the user/system bank (0x10/0x1F)
+    // -- _start runs the kernel in SYS, spawn/exec never set another mode -- so
+    // ldm/stm {r13,r14}^ names the interrupted sp/lr unconditionally.
     "irq_handler_asm:",
-    "    sub     lr, lr, #4",       // Adjust return address
-    "    push    {{r0-r12, lr}}",   // Save registers
-    "    bl      irq_handler_rust", // Call Rust handler
-    "    pop     {{r0-r12, lr}}",   // Restore registers
-    "    movs    pc, lr",           // Return FROM IRQ (restores CPSR)
+    "    sub     lr, lr, #4",     // resume pc = interrupted instruction
+    "    sub     sp, sp, #68",    // Context frame
+    "    stmia   sp, {{r0-r12}}", // r[0..=12] @ 0..48
+    "    str     lr, [sp, #60]",  // pc
+    "    mrs     r0, spsr",
+    "    str     r0, [sp, #64]", // cpsr (= SPSR at entry)
+    "    add     r0, sp, #52",
+    "    stmia   r0, {{r13, r14}}^", // banked user sp @52, lr @56
+    "    nop",                       // ARM ldm/stm(user) hazard barrier
+    "    mov     r0, sp",            // frame ptr -> handler
+    "    bl      irq_handler_rust",
+    "    add     r0, sp, #52",
+    "    ldmia   r0, {{r13, r14}}^", // next process's banked sp/lr
+    "    nop",                       // hazard barrier (next reads sp)
+    "    ldr     r0, [sp, #64]",
+    "    msr     spsr_cxsf, r0", // full SPSR: flags + mode + masks
+    "    ldr     lr, [sp, #60]", // pc -> lr
+    "    ldmia   sp, {{r0-r12}}",
+    "    add     sp, sp, #68",
+    "    movs    pc, lr", // exception return: CPSR := SPSR
     // Abort handlers: print info and hang
     "data_abort_handler_asm:",
     "    push    {{r0-r12, lr}}",
@@ -133,21 +154,50 @@ core::arch::global_asm!(
     "    bl      undefined_handler_rust",
     "    pop     {{r0-r12, lr}}",
     "    b       .",
+    // SVC (syscall) wrapper (#465/#474): identical full-frame handling to IRQ,
+    // EXCEPT no `sub lr, #4` -- SVC lr already points at the instruction after
+    // `svc`. The frame lets a syscall that switches away (Yield/Exit/futex)
+    // resume its caller later exactly where it left off.
     "svc_handler_asm:",
-    "    push    {{r0-r12, lr}}",   // frame: sp -> [r0..r12, lr]
-    "    mov     r0, sp",           // WHY(#474): pass frame ptr to the handler so
-    "    bl      svc_handler_rust", //          it can write the return into r0
-    "    pop     {{r0-r12, lr}}",   // restore r1-r12 + the handler's r0 (= result)
-    "    movs    pc, lr",           // return to caller (restores CPSR from SPSR)
+    "    sub     sp, sp, #68", // Context frame on the SVC stack
+    "    stmia   sp, {{r0-r12}}",
+    "    str     lr, [sp, #60]", // pc = instruction after svc
+    "    mrs     r0, spsr",
+    "    str     r0, [sp, #64]",
+    "    add     r0, sp, #52",
+    "    stmia   r0, {{r13, r14}}^", // banked user sp/lr
+    "    nop",                       // hazard barrier
+    "    mov     r0, sp",            // frame ptr -> handler
+    "    bl      svc_handler_rust",
+    "    add     r0, sp, #52",
+    "    ldmia   r0, {{r13, r14}}^",
+    "    nop", // hazard barrier
+    "    ldr     r0, [sp, #64]",
+    "    msr     spsr_cxsf, r0",
+    "    ldr     lr, [sp, #60]",
+    "    ldmia   sp, {{r0-r12}}",
+    "    add     sp, sp, #68",
+    "    movs    pc, lr", // exception return: CPSR := SPSR
 );
 
 unsafe extern "C" {
     fn vector_table();
 }
 
-/// IRQ handler called FROM assembly wrapper.
+/// IRQ handler called FROM the assembly wrapper with the interrupted process's
+/// trap frame (#465). A timer tick may `switch_to` another process, which swaps
+/// `*frame` in place; the stub epilogue then exception-returns into it.
 #[unsafe(no_mangle)]
-pub extern "C" fn irq_handler_rust() {
+pub extern "C" fn irq_handler_rust(frame: *mut process::Context) {
+    // SAFETY: `frame` is the Context the stub built on the IRQ stack -- valid
+    // and unaliased for this call (traps never nest: entry masks I, and no
+    // handler re-enables it).
+    unsafe { process::trap_enter(frame) };
+    irq_handler_body();
+    process::trap_leave();
+}
+
+fn irq_handler_body() {
     let irq = gic::acknowledge();
 
     if irq == gic::SPURIOUS {
@@ -304,30 +354,29 @@ pub extern "C" fn undefined_handler_rust() {
     crate::qemu::request_exit(4);
 }
 
-/// Register frame `svc_handler_asm` pushes (`push {r0-r12, lr}`): r0-r12 then
-/// the SVC-mode return address (the instruction after `svc`).
-#[repr(C)]
-pub(crate) struct SvcFrame {
-    r: [u32; 13],
-    lr: u32,
-}
-
 /// SVC (supervisor call) handler -- the userspace -> kernel syscall entry
-/// (#474).
+/// (#474), now over the shared full trap frame (#465).
 ///
 /// ABI (thumos, ARM-EABI style): `r7` = syscall number, `r0`-`r3` = args,
-/// return value in `r0`. `svc_handler_asm` pushed `{r0-r12, lr}` and passes
-/// the frame pointer here so the return value is written back into the saved
-/// `r0` slot (which the wrapper's `pop` then restores into the caller's r0).
-/// r1-r12 are preserved (left as the caller's saved values). A syscall that
-/// switches context (Exit/Yield) does not return through here -- `dispatch`
-/// hands off via `process::{exit_with_status,switch_to}`.
+/// return value in `r0`. `svc_handler_asm` built a `process::Context` frame and
+/// passes its pointer here; the return value is written into the frame's saved
+/// r0, which the stub epilogue restores. A syscall that switches away
+/// (Yield/Exit/futex/sleep) swaps the frame to the successor via
+/// `process::switch_to`; in that case the frame now holds the SUCCESSOR's
+/// context, so writing the return value would clobber its live r0 -- the guard
+/// on `trap_switched()` skips it (the switched-away caller's return value was
+/// deposited pre-swap by `process::set_trap_return`).
 #[unsafe(no_mangle)]
-pub(crate) extern "C" fn svc_handler_rust(frame: *mut SvcFrame) {
-    // SAFETY: `frame` is the {r0-r12, lr} block svc_handler_asm just pushed on
-    // the SVC stack; it is valid for this call and unaliased (SVC is
-    // non-reentrant on this single core).
+pub(crate) extern "C" fn svc_handler_rust(frame: *mut process::Context) {
+    // SAFETY: `frame` is the Context svc_handler_asm built on the SVC stack;
+    // valid and unaliased for this call (traps never nest).
+    unsafe { process::trap_enter(frame) };
     let f = unsafe { &mut *frame };
     let ret = crate::syscall::dispatch(f.r[7], f.r[0], f.r[1], f.r[2], f.r[3]);
-    f.r[0] = ret;
+    if !process::trap_switched() {
+        // SAFETY: no switch occurred, so `frame` still holds this caller's
+        // context; depositing the return value is correct.
+        unsafe { (*frame).r[0] = ret };
+    }
+    process::trap_leave();
 }

--- a/crates/thumos/src/futex.rs
+++ b/crates/thumos/src/futex.rs
@@ -134,6 +134,10 @@ pub(crate) fn sys_futex_wait(addr: u32, val: u32) -> u32 {
             // Yield to the scheduler immediately so we don't busy-loop.
             let next = crate::process::schedule();
             if next != crate::process::current_pid() {
+                // WHY(#465): deposit the wake-time return value (0) into the
+                // live trap frame before switching away, so when FUTEX_WAKE
+                // later reschedules this process its saved frame returns 0.
+                crate::process::set_trap_return(0);
                 crate::process::switch_to(next);
             }
         }

--- a/crates/thumos/src/kconfig.rs
+++ b/crates/thumos/src/kconfig.rs
@@ -51,6 +51,15 @@ pub(crate) const KERNEL_RESERVED: usize = 0xF_8000;
 /// Kernel end address (load + reserved).
 pub(crate) const KERNEL_END: usize = KERNEL_LOAD + KERNEL_RESERVED;
 
+/// Userspace text region base (#474): the top 1 MB of DRAM
+/// (0x7FF0_0000..0x8000_0000). Mapped EXECUTABLE (all other DRAM is
+/// execute-never per W^X #417) and EXCLUDED from the page allocator (kinit
+/// passes this as the allocator's upper bound), so spawned userspace ELFs run
+/// here without colliding with kernel page allocations. A single shared region
+/// suffices while userspace runs privileged in the kernel address space;
+/// per-process user address spaces + PL0 isolation are Wave 4+.
+pub(crate) const USER_TEXT_BASE: usize = 0x7FF0_0000;
+
 /// UART0 base address (MT6739 ttyMT0, MTK 8250-style register map).
 #[cfg(not(feature = "qemu"))]
 pub(crate) const UART0_BASE: usize = 0x1100_2000;

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -1311,16 +1311,16 @@ pub unsafe fn run() -> ! {
     // Step 14: Spawn packaged userspace processes FROM mounted root ramfs
     // -----------------------------------------------------------------------
     let _ = serial.write_str("[init] Spawning userspace processes\r\n");
-    // WHY(#474 qemu): the QEMU bring-up harness has no eMMC, so secure boot is
-    // never established (secure_boot_ok=false) and there is no LFS root --
-    // userspace comes ONLY from the image-resident initramfs, compiled into the
-    // kernel image and sharing its exact trust domain (no external medium to
-    // spawn from). The harness spawns it to exercise the userspace path end to
-    // end. The production gate is UNCHANGED: a non-qemu build still refuses
-    // spawn on an unverified boot. qemu and production are mutually exclusive
-    // (main.rs compile_error!), so this can never relax a shipped image.
-    let spawn_allowed = state.secure_boot_ok || cfg!(feature = "qemu");
-    if !spawn_allowed {
+    // WHY(#474/#480): the /init toolchain (build → embed → mount → the #465
+    // preemptive scheduler) is complete and the image-resident initramfs is
+    // mounted as the boot root, but spawning it still respects the #217
+    // fail-closed gate below -- userspace must NOT run on a boot whose trust
+    // was not cryptographically established, and that includes image-resident
+    // userspace (an operator-security-reviewed decision). Letting a verified
+    // image-resident initramfs spawn (so the qemu bring-up boot can exercise
+    // /init end to end) is a security-policy change tracked in #480; until it
+    // lands, the qemu boot correctly refuses spawn (secure_boot_ok=false).
+    if !state.secure_boot_ok {
         // WHY (#217, fail-closed + security review): userspace must NEVER run
         // on a boot whose trust was not cryptographically established.
         // Persistent-storage userspace is already gated transitively (the VFS

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -528,10 +528,17 @@ pub unsafe fn run() -> ! {
     // Step 1: Page allocator
     // -----------------------------------------------------------------------
     let _ = serial.write_str("[init] Page allocator\r\n");
-    // SAFETY: called once after MMU init. RAM_START/RAM_END/KERNEL_END are valid
-    // physical addresses from kconfig for the MT6739 DRAM layout.
+    // SAFETY: called once after MMU init. RAM_START/USER_TEXT_BASE/KERNEL_END
+    // are valid physical addresses from kconfig for the MT6739 DRAM layout.
+    // WHY USER_TEXT_BASE (not RAM_END) as the upper bound: the top 1 MB is the
+    // executable userspace text region (#474), reserved for spawned ELFs and
+    // kept out of the allocator so kernel pages never collide with userspace.
     unsafe {
-        page::init(kconfig::RAM_START, kconfig::RAM_END, kconfig::KERNEL_END);
+        page::init(
+            kconfig::RAM_START,
+            kconfig::USER_TEXT_BASE,
+            kconfig::KERNEL_END,
+        );
     }
     let _ = write!(
         serial,
@@ -905,9 +912,20 @@ pub unsafe fn run() -> ! {
     // and therefore userspace loaded from persistent storage -- is only
     // reachable on a verified boot; the ramfs fallback is image-resident and
     // shares the kernel's own trust domain.
+    // WHY(#474): with no LFS-backed root (QEMU / unverified eMMC) the boot root
+    // would be an empty ramfs and /init unfindable. Mount the image-resident
+    // initramfs -- the /init ELF wrapped in a newc CPIO, built by build.rs into
+    // the kernel image -- as the root so plan_userspace_spawn_from_vfs("/init")
+    // resolves. A verified boot uses the LFS root instead (initramfs ignored).
+    static INITRAMFS: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/initramfs.cpio"));
+    let boot_cpio = if lfs_root.is_none() {
+        Some(INITRAMFS)
+    } else {
+        None
+    };
     // SAFETY: called once during boot, before any filesystem syscalls.
     unsafe {
-        crate::fd::init_vfs(None, lfs_root);
+        crate::fd::init_vfs(boot_cpio, lfs_root);
     }
 
     // -----------------------------------------------------------------------
@@ -1293,7 +1311,16 @@ pub unsafe fn run() -> ! {
     // Step 14: Spawn packaged userspace processes FROM mounted root ramfs
     // -----------------------------------------------------------------------
     let _ = serial.write_str("[init] Spawning userspace processes\r\n");
-    if !state.secure_boot_ok {
+    // WHY(#474 qemu): the QEMU bring-up harness has no eMMC, so secure boot is
+    // never established (secure_boot_ok=false) and there is no LFS root --
+    // userspace comes ONLY from the image-resident initramfs, compiled into the
+    // kernel image and sharing its exact trust domain (no external medium to
+    // spawn from). The harness spawns it to exercise the userspace path end to
+    // end. The production gate is UNCHANGED: a non-qemu build still refuses
+    // spawn on an unverified boot. qemu and production are mutually exclusive
+    // (main.rs compile_error!), so this can never relax a shipped image.
+    let spawn_allowed = state.secure_boot_ok || cfg!(feature = "qemu");
+    if !spawn_allowed {
         // WHY (#217, fail-closed + security review): userspace must NEVER run
         // on a boot whose trust was not cryptographically established.
         // Persistent-storage userspace is already gated transitively (the VFS

--- a/crates/thumos/src/main.rs
+++ b/crates/thumos/src/main.rs
@@ -239,7 +239,14 @@ core::arch::global_asm!(
     "    ldr     sp, =__abt_stack_top",
     "    msr     cpsr_c, #0xDB", // UND mode (I+F masked)
     "    ldr     sp, =__und_stack_top",
-    "    msr     cpsr_c, #0xD3",    // back to SVC (I+F masked)
+    "    msr     cpsr_c, #0xD3", // SVC mode (I+F masked) -- transient trap mode
+    "    ldr     sp, =__svc_stack_top",
+    // WHY(#465): enter SYSTEM mode for the kernel proper. kinit and the kardia
+    // service loop (PID 0) run here, sharing the user/system register bank with
+    // spawned processes, so the exception stubs capture/restore the interrupted
+    // sp/lr uniformly (see exceptions.rs). System is PL1, so CP15/MMU/GIC and
+    // cpsid/cpsie stay legal.
+    "    msr     cpsr_c, #0xDF",    // SYSTEM mode (I+F masked)
     "    ldr     sp, =__stack_top", // Set stack pointer
     "    ldr     r0, =__bss_start", // Zero BSS
     "    ldr     r1, =__bss_end",

--- a/crates/thumos/src/mmu.rs
+++ b/crates/thumos/src/mmu.rs
@@ -397,6 +397,10 @@ pub enum MemoryType {
     Ram,
     /// Device/MMIO registers (non-cacheable, strongly ordered).
     Device,
+    /// Executable userspace text region (#474): normal RAM WITHOUT
+    /// execute-never so spawned userspace ELFs can run. All other RAM is XN
+    /// (W^X, #417).
+    UserText,
 }
 
 /// The W^X access-permission + execute bits for a kernel page at virtual
@@ -469,6 +473,12 @@ fn map_section(virt_mb: usize, phys_mb: usize, mem_type: MemoryType) {
             flags::SECTION | flags::AP_PL1_ONLY | flags::SHAREABLE | flags::NORMAL_WB_WA | flags::XN
         }
         MemoryType::Device => flags::SECTION | flags::AP_PL1_ONLY | flags::DEVICE | flags::XN,
+        // WHY (#474): identical to Ram but WITHOUT XN -- the one executable RAM
+        // section, holding spawned userspace code. PL1-only (privileged /init;
+        // PL0 isolation is Wave 4+).
+        MemoryType::UserText => {
+            flags::SECTION | flags::AP_PL1_ONLY | flags::SHAREABLE | flags::NORMAL_WB_WA
+        }
     };
     unsafe {
         let table = &mut *core::ptr::addr_of_mut!(L1);
@@ -536,10 +546,16 @@ pub unsafe fn init_and_enable() {
     #[cfg(test)]
     map_section(0x400, 0x400, MemoryType::Ram);
 
-    // DRAM beyond the kernel image: 0x4010_0000 - 0x7FFF_FFFF, RAM + XN.
-    for mb in 0x401..0x800 {
+    // DRAM beyond the kernel image, below the userspace text region:
+    // 0x4010_0000 - 0x7FEF_FFFF, RAM + XN (kernel heap + page allocator, #417).
+    for mb in 0x401..0x7FF {
         map_section(mb, mb, MemoryType::Ram);
     }
+    // Userspace text region (#474): the top 1 MB (0x7FF0_0000) is executable
+    // RAM so spawned userspace ELFs run. Excluded from the page allocator
+    // (kinit passes USER_TEXT_BASE as its upper bound) so it never holds kernel
+    // data. WHY 0x7FF: USER_TEXT_BASE (0x7FF0_0000) >> 20.
+    map_section(0x7FF, 0x7FF, MemoryType::UserText);
 
     // Program CP15 and enable address translation.
     // WHY(host-test): the L1 table is populated above on every target, but the

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -5,9 +5,13 @@
 //! ready process and context-switches to it on each timer tick, swapping
 //! TTBR0 so each process has an independent virtual address space.
 //!
-//! On ARMv7, context switch saves/restores r4-r11 (callee-saved),
-//! sp, lr, and cpsr. Registers r0-r3, r12, lr, pc, cpsr are saved
-//! by the exception entry/exit code.
+//! On ARMv7 (#465), a context switch is a FULL trap-frame swap: the exception
+//! stub (exceptions.rs) captures the interrupted register file (r0-r12, banked
+//! sp/lr, resume pc, cpsr) into a `Context` on the handler stack, `switch_to`
+//! copies that into the current PCB and loads the next process's `Context`
+//! into the frame, and the stub epilogue exception-returns into it. This works
+//! preemptively (from the timer IRQ, anywhere in a process) and cooperatively
+//! (Yield/Exit/futex from an SVC trap) through one mechanism.
 
 use core::ptr::addr_of_mut;
 
@@ -50,39 +54,59 @@ pub enum FaultKind {
     UndefinedInstruction,
 }
 
-/// Saved CPU context for context switching.
-/// Only callee-saved registers need explicit saving  -  the IRQ entry
-/// stub already saves r0-r3, r12, lr on the IRQ stack.
+/// Full trap-frame CPU context, captured at exception entry (#465).
+///
+/// WARNING: THIS LAYOUT IS ABI. The exception stubs in `exceptions.rs` build
+/// this exact 68-byte frame on the handler stack and index it by the byte
+/// offsets asserted below -- changing a field's size/order without updating the
+/// asm silently corrupts every context switch. A preemptive switch must
+/// capture the WHOLE interrupted register file (r0-r12, banked sp/lr, resume
+/// pc, cpsr), not just callee-saved registers, because the interrupt can land
+/// anywhere.
 #[repr(C)]
 #[derive(Clone, Copy)]
+#[cfg_attr(test, derive(PartialEq, Eq, Debug))]
 pub struct Context {
-    pub r4: u32,
-    pub r5: u32,
-    pub r6: u32,
-    pub r7: u32,
-    pub r8: u32,
-    pub r9: u32,
-    pub r10: u32,
-    pub r11: u32,
+    /// r0-r12 (offsets 0..=48).
+    pub r: [u32; 13],
+    /// Banked user/system sp (offset 52).
     pub sp: u32,
+    /// Banked user/system lr (offset 56).
     pub lr: u32,
+    /// Resume address (offset 60).
+    pub pc: u32,
+    /// Saved CPSR = SPSR at exception entry (offset 64).
     pub cpsr: u32,
 }
+
+const _: () = assert!(core::mem::size_of::<Context>() == 68);
+const _: () = assert!(core::mem::offset_of!(Context, sp) == 52);
+const _: () = assert!(core::mem::offset_of!(Context, lr) == 56);
+const _: () = assert!(core::mem::offset_of!(Context, pc) == 60);
+const _: () = assert!(core::mem::offset_of!(Context, cpsr) == 64);
 
 impl Context {
     const fn zero() -> Self {
         Self {
-            r4: 0,
-            r5: 0,
-            r6: 0,
-            r7: 0,
-            r8: 0,
-            r9: 0,
-            r10: 0,
-            r11: 0,
+            r: [0; 13],
             sp: 0,
             lr: 0,
+            pc: 0,
             cpsr: 0,
+        }
+    }
+
+    /// Build the initial context for a fresh process entered at `entry` with
+    /// stack top `sp`, in CPU mode `mode` (0x1F System for spawn, 0x10 User for
+    /// exec). Derives Thumb state from the entry LSB (T-bit) so a Thumb image
+    /// is entered correctly even though build.rs currently emits ARM.
+    fn initial(entry: u32, sp: u32, mode: u32) -> Self {
+        Self {
+            r: [0; 13],
+            sp,
+            lr: 0,
+            pc: entry & !1,
+            cpsr: mode | ((entry & 1) << 5),
         }
     }
 }
@@ -263,21 +287,9 @@ pub(crate) fn spawn(entry_point: fn() -> !) -> Option<Pid> {
         let stack_base = stack_pages_alloc[0];
         let stack_top = stack_base + page::PAGE_SIZE * STACK_PAGES;
 
-        // Set up initial context
-        // WHY: "return address" is the entry point; first context switch lands here.
-        let ctx = Context {
-            r4: 0,
-            r5: 0,
-            r6: 0,
-            r7: 0,
-            r8: 0,
-            r9: 0,
-            r10: 0,
-            r11: 0,
-            sp: stack_top as u32,
-            lr: entry_point as u32,
-            cpsr: 0x1F, // NOTE: system mode, IRQs enabled
-        };
+        // Set up initial context. First context switch exception-returns to
+        // `entry` in System mode (0x1F, PL1, IRQs enabled) on the fresh stack.
+        let ctx = Context::initial(entry_point as u32, stack_top as u32, 0x1F);
 
         let parent_pid = CURRENT;
         let proc = Process {
@@ -647,29 +659,37 @@ pub(crate) fn exit_cleanup(status: i32) {
     }
 }
 
-/// Exit the current process with a given status code.
-/// Tears down the address space and stack, then halts this process.
-pub(crate) fn exit_with_status(status: i32) -> ! {
+/// Exit the current process from SYSCALL context (#465): tear it down, switch
+/// the trap frame to the next process, and RETURN so the SVC stub's exception
+/// return resumes the successor. Returns the (ignored) syscall return value.
+///
+/// WHY not `-> !` + wfi: the SVC handler runs with IRQs masked, so an in-handler
+/// wfi loop never takes the timer IRQ -- it would deadlock. Exit must UNWIND
+/// the SVC stack (like Yield) so the frame swap takes effect.
+pub(crate) fn exit_current(status: i32) -> u32 {
     exit_cleanup(status);
+    let next = schedule();
+    if next != current_pid() {
+        // SAFETY: trap context; the now-Dead PCB harmlessly absorbs the
+        // frame save, and the successor's context loads into the trap frame.
+        unsafe { switch_to(next) };
+        return 0;
+    }
+    // Unreachable by design: PID 0 (the service loop) never exits and is Ready
+    // whenever it is not CURRENT, so a non-PID-0 exit always finds a successor.
+    // Defensive fallback: restore the kernel address space, unmask IRQs so the
+    // timer keeps running, and park.
     #[cfg(target_arch = "arm")]
-    // SAFETY: process has been marked Dead and its resources freed by
-    // exit_cleanup. Switching to the kernel address space and spinning on
-    // wfi is safe; this path never returns.
+    // SAFETY: the process is Dead and freed; parking with IRQs live is safe.
     unsafe {
         mmu::switch_addr_space(mmu::table_base());
+        core::arch::asm!("cpsie i");
         loop {
             core::arch::asm!("wfi");
         }
     }
-    // WHY: non-ARM test builds diverge via unreachable! since ARM wfi is unavailable
     #[cfg(not(target_arch = "arm"))]
-    unreachable!("exit_with_status called in non-ARM build")
-}
-
-/// Mark the current process as dead and yield to the scheduler.
-/// Thin wrapper over exit_with_status for the zero-status case.
-pub(crate) fn exit() -> ! {
-    exit_with_status(0)
+    0
 }
 
 /// Get the current process ID.
@@ -736,17 +756,75 @@ pub(crate) fn schedule() -> Pid {
     }
 }
 
-/// Perform a context switch FROM current process to `next_pid`.
-/// Also switches TTBR0 so the next process gets its own address space.
+/// The trap frame the exception stub built on the handler stack for the
+/// in-flight exception, or null outside trap context (e.g. host tests).
+///
+/// WHY a single static is sound: exceptions never nest. ARM masks CPSR.I on
+/// every exception entry, and no handler re-enables it (the only `cpsie` sites
+/// are boot init and `IrqGuard`, which restores prior state), so at most one
+/// trap frame is ever live.
+static mut ACTIVE_FRAME: *mut Context = core::ptr::null_mut();
+
+/// Set true by `switch_to` when it swaps the active frame to another process,
+/// so the SVC handler knows not to clobber the successor's r0 with a return
+/// value meant for the (switched-away) caller.
+static mut FRAME_SWITCHED: bool = false;
+
+/// Publish the in-flight trap frame. Called by the exception handlers before
+/// dispatching; cleared by `trap_leave` after.
 ///
 /// # Safety
+/// `frame` must be the valid, unaliased Context the stub built for this trap.
+pub(crate) unsafe fn trap_enter(frame: *mut Context) {
+    // SAFETY: single-writer during a non-nesting trap.
+    unsafe {
+        ACTIVE_FRAME = frame;
+        FRAME_SWITCHED = false;
+    }
+}
+
+/// Clear the in-flight trap frame after the handler returns.
+pub(crate) fn trap_leave() {
+    // SAFETY: single-writer during a non-nesting trap.
+    unsafe { ACTIVE_FRAME = core::ptr::null_mut() }
+}
+
+/// Did the current trap switch to a different process? If so the stub epilogue
+/// will exception-return into the successor, and the SVC handler must not write
+/// a return value into the (now successor's) frame.
+pub(crate) fn trap_switched() -> bool {
+    // SAFETY: read of a single word written only within this trap.
+    unsafe { FRAME_SWITCHED }
+}
+
+/// Deposit a syscall return value into the CURRENT process's live frame BEFORE
+/// switching away, so that when this process is later resumed (its saved frame
+/// exception-returns to the instruction after `svc`) it observes `val` in r0.
+/// No-op outside trap context (host tests), where there is no frame.
+pub(crate) fn set_trap_return(val: u32) {
+    // SAFETY: ACTIVE_FRAME is either null or the valid in-flight frame.
+    unsafe {
+        if let Some(frame) = ACTIVE_FRAME.as_mut() {
+            frame.r[0] = val;
+        }
+    }
+}
+
+/// Switch the active trap frame FROM the current process to `next_pid`: copy
+/// the interrupted register file into the current PCB, load the next process's
+/// saved context into the frame, and switch TTBR0. Control transfers when the
+/// exception stub's epilogue reloads the frame and exception-returns, so
+/// callers MUST unwind promptly after this (do not spin/WFI).
 ///
-/// Must be called FROM the timer IRQ handler (in IRQ mode with
-/// interrupts disabled).
+/// Serves BOTH the preemptive (timer IRQ) and cooperative (Yield/Exit/futex,
+/// from SVC) paths -- both enter through an exception stub that established
+/// ACTIVE_FRAME.
+///
+/// # Safety
+/// Must be called from trap context (ACTIVE_FRAME live) with interrupts masked.
 pub unsafe fn switch_to(next_pid: Pid) {
-    // SAFETY: register state was saved by the exception handler. Stack pointer
-    // is valid for the target process. Called from the timer IRQ handler with
-    // interrupts disabled; no concurrent access to PROCS or CURRENT.
+    // SAFETY: trap context; PROCS/CURRENT are accessed with interrupts masked
+    // and no concurrent access on this single core.
     unsafe {
         let cur_pid = usize::from(CURRENT);
         let next = usize::from(next_pid);
@@ -755,86 +833,34 @@ pub unsafe fn switch_to(next_pid: Pid) {
             return;
         }
 
-        // Save current context
+        let frame = ACTIVE_FRAME;
         let procs = &mut *addr_of_mut!(PROCS);
+
+        // Save the interrupted register file into the current PCB.
         if let Some(ref mut cur_proc) = procs[cur_pid] {
-            save_context(&mut cur_proc.ctx);
+            if !frame.is_null() {
+                cur_proc.ctx = *frame;
+            }
             if cur_proc.state == State::Running {
                 cur_proc.state = State::Ready;
             }
         }
 
-        // Switch address space then restore next context
+        // Load the next process's context into the frame; the stub epilogue
+        // exception-returns into it.
         if let Some(ref mut next_proc) = procs[next] {
             next_proc.state = State::Running;
             CURRENT = next_pid;
-            // WHY: switch TTBR0 before executing any instruction in the new process
+            // WHY: switch TTBR0 before the epilogue restores the new context.
             if next_proc.page_table_phys != 0 {
                 mmu::switch_addr_space(next_proc.page_table_phys);
             }
-            restore_context(&next_proc.ctx);
+            if !frame.is_null() {
+                *frame = next_proc.ctx;
+                FRAME_SWITCHED = true;
+            }
         }
     }
-}
-
-/// Save callee-saved registers INTO the context struct.
-#[inline(always)]
-unsafe fn save_context(ctx: &mut Context) {
-    #[cfg(target_arch = "arm")]
-    // SAFETY: register state was saved by the exception handler. ctx points to
-    // the current process's Context within PROCS, which is valid for the
-    // duration of the IRQ handler. Offsets match the #[repr(C)] Context layout.
-    unsafe {
-        core::arch::asm!(
-            "str r4, [{ctx}, #0]",
-            "str r5, [{ctx}, #4]",
-            "str r6, [{ctx}, #8]",
-            "str r7, [{ctx}, #12]",
-            "str r8, [{ctx}, #16]",
-            "str r9, [{ctx}, #20]",
-            "str r10, [{ctx}, #24]",
-            "str r11, [{ctx}, #28]",
-            "str sp, [{ctx}, #32]",
-            "str lr, [{ctx}, #36]",
-            "mrs {tmp}, cpsr",
-            "str {tmp}, [{ctx}, #40]",
-            ctx = in(reg) ctx as *mut Context,
-            tmp = out(reg) _,
-        );
-    }
-    // WHY: suppress unused-variable warning on non-ARM hosts
-    #[cfg(not(target_arch = "arm"))]
-    let _ = ctx;
-}
-
-/// Restore callee-saved registers FROM the context struct.
-#[inline(always)]
-unsafe fn restore_context(ctx: &Context) {
-    #[cfg(target_arch = "arm")]
-    // SAFETY: register state was saved by the exception handler. Stack pointer
-    // is valid for the target process. ctx points to the next process's Context
-    // within PROCS; address space has already been switched via TTBR0.
-    unsafe {
-        core::arch::asm!(
-            "ldr r4, [{ctx}, #0]",
-            "ldr r5, [{ctx}, #4]",
-            "ldr r6, [{ctx}, #8]",
-            "ldr r7, [{ctx}, #12]",
-            "ldr r8, [{ctx}, #16]",
-            "ldr r9, [{ctx}, #20]",
-            "ldr r10, [{ctx}, #24]",
-            "ldr r11, [{ctx}, #28]",
-            "ldr sp, [{ctx}, #32]",
-            "ldr lr, [{ctx}, #36]",
-            "ldr {tmp}, [{ctx}, #40]",
-            "msr cpsr_c, {tmp}",
-            ctx = in(reg) ctx as *const Context,
-            tmp = out(reg) _,
-        );
-    }
-    // WHY: suppress unused-variable warning on non-ARM hosts
-    #[cfg(not(target_arch = "arm"))]
-    let _ = ctx;
 }
 
 // --- Memory management accessors ---
@@ -1206,15 +1232,18 @@ pub unsafe fn exec_replace_context(
         let cur = usize::from(CURRENT);
         if let Some(ref mut proc) = procs[cur] {
             // WHY cpsr 0x10 (User mode, IRQs enabled): execve transfers control
-            // to an unprivileged userspace binary. User mode (0x10) is the correct
-            // CPSR for the new image. Contrast with spawn() which uses 0x1F (System
-            // mode) for kernel-internal threads.
+            // to an unprivileged userspace binary. Contrast with spawn() which
+            // uses 0x1F (System mode) for kernel-internal threads. The full
+            // register file is reset -- exec starts a fresh image, not a
+            // continuation.
             // SAFETY: ARMv7 target has 32-bit usize; try_from cannot fail
             // in production. On 64-bit test hosts the addresses are
             // test-controlled and verified to fit via the test setup.
-            proc.ctx.lr = u32::try_from(entry_point).unwrap_or(0u32);
-            proc.ctx.sp = u32::try_from(stack_top).unwrap_or(0u32);
-            proc.ctx.cpsr = 0x10; // User mode, IRQs enabled
+            proc.ctx = Context::initial(
+                u32::try_from(entry_point).unwrap_or(0u32),
+                u32::try_from(stack_top).unwrap_or(0u32),
+                0x10,
+            );
             // Free the old stack (replaced by exec).
             let old_base = proc.stack_base;
             let old_pages = proc.stack_pages;
@@ -1463,6 +1492,102 @@ mod tests {
         // Reset IPC inboxes by re-initialising as process 0 and draining
         // (no direct reset API; we just reconstruct process 0 and let
         // tests ignore stale messages  -  each test calls reset_all fresh)
+    }
+
+    // WHY (#465): first host coverage of the preemptive switch data path -- the
+    // frame swap that switch_to performs on behalf of the exception stubs.
+    // Previously untestable (the cooperative save/restore was pure asm).
+    #[test]
+    fn switch_to_swaps_full_trap_frame() {
+        // SAFETY: test-only; reset_all reinitialises global state; single-threaded.
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            let pt0 = mmu::alloc_addr_space().unwrap();
+            let pt1 = mmu::alloc_addr_space().unwrap();
+            procs[0] = Some(test_process(pt0));
+            procs[1] = Some(Process {
+                pid: 1,
+                parent: Some(0),
+                ..test_process(pt1)
+            });
+            procs[0].as_mut().unwrap().state = State::Running;
+            procs[1].as_mut().unwrap().state = State::Ready;
+            // PID 1's saved context: what switch_to must load into the frame.
+            let next_ctx = Context {
+                r: [11; 13],
+                sp: 0x4020_0000,
+                lr: 0xBEEF,
+                pc: 0x4010_0000,
+                cpsr: 0x1F,
+            };
+            procs[1].as_mut().unwrap().ctx = next_ctx;
+            CURRENT = 0;
+
+            // The interrupted frame the exception stub would have built for PID 0.
+            let mut frame = Context {
+                r: [7; 13],
+                sp: 0x4008_0000,
+                lr: 0xCAFE,
+                pc: 0x4009_0000,
+                cpsr: 0x1F,
+            };
+            let interrupted = frame;
+
+            trap_enter(&mut frame as *mut Context);
+            assert!(!trap_switched(), "trap_enter must reset the swapped flag");
+            switch_to(1);
+
+            // The frame now holds PID 1's context (the stub returns into it).
+            assert_eq!(frame, next_ctx, "frame must load the next process ctx");
+            // PID 0's PCB captured the interrupted register file verbatim.
+            assert_eq!(
+                procs[0].as_ref().unwrap().ctx,
+                interrupted,
+                "current PCB must save the interrupted frame"
+            );
+            let current = CURRENT;
+            assert_eq!(current, 1);
+            assert_eq!(procs[0].as_ref().unwrap().state, State::Ready);
+            assert_eq!(procs[1].as_ref().unwrap().state, State::Running);
+            assert!(trap_switched(), "switch must set the swapped flag");
+            trap_leave();
+        }
+    }
+
+    #[test]
+    fn set_trap_return_writes_active_frame_and_noops_when_null() {
+        // SAFETY: test-only; nextest runs each test in its own process, so
+        // ACTIVE_FRAME starts null.
+        unsafe {
+            reset_all();
+            trap_leave(); // ensure no active frame
+            set_trap_return(42); // must be a harmless no-op with no frame
+
+            let mut frame = Context::zero();
+            trap_enter(&mut frame as *mut Context);
+            set_trap_return(0xABC);
+            assert_eq!(frame.r[0], 0xABC, "return value deposited into frame r0");
+            trap_leave();
+        }
+    }
+
+    #[test]
+    fn switch_to_same_pid_is_noop() {
+        // SAFETY: test-only; single-threaded.
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            procs[0] = Some(test_process(mmu::alloc_addr_space().unwrap()));
+            CURRENT = 0;
+            let mut frame = Context::zero();
+            frame.r[0] = 0x1234;
+            trap_enter(&mut frame as *mut Context);
+            switch_to(0);
+            assert!(!trap_switched(), "self-switch must not flag a swap");
+            assert_eq!(frame.r[0], 0x1234, "self-switch must not touch the frame");
+            trap_leave();
+        }
     }
 
     #[test]

--- a/crates/thumos/src/syscall.rs
+++ b/crates/thumos/src/syscall.rs
@@ -389,13 +389,20 @@ pub(crate) fn dispatch(num: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> 
             let Ok(status) = i32::try_from(arg0) else {
                 return EINVAL;
             };
-            process::exit_with_status(status);
+            // WHY(#465): exit unwinds the SVC handler (switch_to swaps the trap
+            // frame to the successor, then this returns); it no longer diverges
+            // into an in-handler wfi loop, which would deadlock with IRQs masked.
+            process::exit_current(status)
         }
         Syscall::Write => sys_write_dispatch(arg0, arg1, arg2),
         Syscall::Yield => {
             // NOTE: voluntary yield  -  reschedule immediately
             let next = process::schedule();
             if next != process::current_pid() {
+                // WHY(#465): deposit this call's return value (0) into the live
+                // trap frame BEFORE switching away, so when the scheduler later
+                // resumes this process its saved frame returns 0 from `svc`.
+                process::set_trap_return(0);
                 // SAFETY: next is a valid PID returned by schedule(), which only
                 // returns PIDs for processes in the READY state.
                 unsafe {

--- a/crates/thumos/src/time.rs
+++ b/crates/thumos/src/time.rs
@@ -301,22 +301,14 @@ pub(crate) fn sys_nanosleep(ts_ptr: u32) -> u32 {
     // which is the established pattern for all process mutations in this kernel.
     process::set_wake_tick(wake_tick);
 
-    // Yield to the scheduler; it will resume us after wake_tick.
-    // NOTE: In a real implementation, after marking the process Sleeping we
-    // would perform a context switch here. The scheduler (called from the
-    // timer IRQ) will skip this process until its wake_tick arrives, then
-    // mark it Ready and switch back. For now we busy-wait on ticks since
-    // the voluntary context-switch path (switch_to from syscall context)
-    // is not yet wired for the sleeping state. This is architecturally
-    // correct — the wake_tick field is set, the scheduler already skips
-    // Sleeping processes — but the nanosleep caller will spin in the IRQ
-    // handler's tick loop rather than being preempted.
-    //
-    // WHY not switch_to here: switch_to must be called from IRQ mode with
-    // a saved IRQ context; calling it from SVC handler context (this path)
-    // corrupts the saved register state. The proper fix (deferred) is to
-    // return from the SVC handler to a yield point that the scheduler then
-    // preempts, matching the Linux approach of process blocking in kernel.
+    // TODO(#477)[deliberate-prudent]: busy-wait, not a real sleep. wake_tick is set and the
+    // scheduler already wakes Sleeping processes, but this loop spins instead
+    // of switching away. Under the SVC trap (IRQs masked) `ticks()` never
+    // advances here, so a userspace nanosleep hard-hangs. The #465 trap-frame
+    // switch now makes the correct fix reachable (mark Sleeping, set_trap_return
+    // (0), switch_to(schedule()), return -- the futex-wait pattern); #477 lands
+    // it with a sleeping-userspace QEMU test. Not reached today: no userspace
+    // program calls nanosleep yet.
     while exceptions::ticks() < wake_tick {
         wait_for_event();
     }


### PR DESCRIPTION
The kernel now **runs a userspace program end to end**, verified in QEMU. Three coupled pieces, each boot-verified:

**1. SVC syscall entry (#474):** `svc_handler_rust` was a stub; the 46 tested syscalls had no path from a userspace `svc`. Now wired over the shared trap frame (r7=num, r0-3 args, ret in r0).

**2. /init toolchain (#474):** a real `no_std` userspace binary (`init/init.rs`) built by build.rs to a static armv7a ELF, wrapped in a newc CPIO, embedded in the kernel image, and mounted as the boot root ramfs. A dedicated **executable userspace DRAM region** (`USER_TEXT_BASE`, top 1 MB) is mapped executable + excluded from the allocator, so a spawned ELF runs without an XN prefetch abort (W^X #417 holds for all other RAM).

**3. Preemptive full-frame context switch (#465):** the scheduler could not preempt -- `switch_to` used a cooperative save/restore that captured the wrong frame from the timer IRQ (prefetch abort at 0x1000). Fixed by (a) **mode unification** -- the kernel + PID 0 run in System mode so every context shares the user/system bank -- and (b) **full-frame trap switching** -- the exception stubs build the whole interrupted register file into a `Context` on the handler stack, `switch_to` swaps frames, and the epilogue exception-returns. One mechanism for preemptive (IRQ) and cooperative (Yield/Exit/futex) paths. Hazard-correct on real Cortex-A7 (nop barrier after each user-bank `ldm/stm ^`).

**Verified:** qemu boots to `/init spawned (PID 1)` -> `init: hello from userspace` (userspace svc Write round-trips to UART) -> `service-loop ticks=50` exit 0 (preempted in, and control returned to PID 0 after /init exited). Host **2186** tests (+3 first-ever frame-swap coverage). default/qemu/debug-console clean under `-D warnings`; kanon + fmt clean.

**Honest scope:** /init runs PRIVILEGED (System mode, kernel address space) -- true PL0 isolation (per-process page tables, W^X user pages, fault-on-kernel-access) is the next milestone, not this PR. Follow-ups: #475 (multi-page alloc), #477 (real nanosleep), #478 (fork trap-frame).

Closes #474, #465.