### PR TITLE
Contiguous multi-page allocation (#475)

### DIFF
--- a/crates/thumos/src/page.rs
+++ b/crates/thumos/src/page.rs
@@ -256,6 +256,111 @@ pub unsafe fn try_free_page(addr: usize) -> bool {
     }
 }
 
+/// Allocate `n` physically-contiguous free pages, returning the base address
+/// or `None` if no run of `n` free pages exists.
+///
+/// WHY (#475): the slab's large-allocation path and per-process page-table
+/// mappings need runs larger than one page, but `alloc_page` gives no
+/// contiguity guarantee (it returns the lowest free frame). A first-fit scan of
+/// the free bitmap returns the lowest run of `n`, skipping fully-allocated
+/// words. `n == 1` delegates to `alloc_page`.
+pub(crate) fn alloc_contiguous(n: usize) -> Option<usize> {
+    if n == 0 {
+        return None;
+    }
+    if n == 1 {
+        return alloc_page();
+    }
+    // WHY (#331): serializes with every other PAGE_BITMAP/FREE_PAGES accessor.
+    let _g = PAGE_LOCK.lock();
+    // SAFETY: every bitmap index below is bounds-checked by the enclosing
+    // iteration over `bitmap`; FREE_PAGES is decremented by exactly the `n`
+    // bits set.
+    unsafe {
+        if FREE_PAGES < n {
+            return None;
+        }
+        let bitmap = &mut *addr_of_mut!(PAGE_BITMAP);
+        let mut run = 0usize;
+        let mut run_start = 0usize;
+        for word_idx in 0..bitmap.len() {
+            // A fully-allocated word breaks any in-progress run; skip its bits.
+            if bitmap[word_idx] == 0xFFFF_FFFF {
+                run = 0;
+                continue;
+            }
+            for bit in 0..32 {
+                if (bitmap[word_idx] >> bit) & 1 == 1 {
+                    run = 0;
+                    continue;
+                }
+                if run == 0 {
+                    run_start = word_idx * 32 + bit;
+                }
+                run += 1;
+                if run == n {
+                    for p in run_start..run_start + n {
+                        bitmap[p / 32] |= 1 << (p % 32);
+                    }
+                    FREE_PAGES -= n;
+                    return Some(FIRST_PAGE + run_start * PAGE_SIZE);
+                }
+            }
+        }
+        None
+    }
+}
+
+/// Free `n` physically-contiguous pages previously returned by
+/// `alloc_contiguous`. Returns `false` (no state change) if the range is
+/// misaligned, out of range, or not fully allocated (double-free guard). `n ==
+/// 1` delegates to `try_free_page`.
+///
+/// # Safety
+///
+/// `addr`/`n` must name a run previously returned by `alloc_contiguous` and not
+/// since freed.
+pub unsafe fn free_contiguous(addr: usize, n: usize) -> bool {
+    if n == 0 {
+        return false;
+    }
+    if n == 1 {
+        // SAFETY: delegated to the validated single-page path.
+        return unsafe { try_free_page(addr) };
+    }
+    let _g = PAGE_LOCK.lock();
+    // SAFETY: the run is fully validated (range + currently-allocated) before
+    // any bit is cleared, so an invalid free is an all-or-nothing no-op.
+    unsafe {
+        if addr < FIRST_PAGE {
+            return false;
+        }
+        let offset = addr - FIRST_PAGE;
+        if offset % PAGE_SIZE != 0 {
+            return false;
+        }
+        let start = offset / PAGE_SIZE;
+        let bitmap = &mut *addr_of_mut!(PAGE_BITMAP);
+        for p in start..start + n {
+            let word = p / 32;
+            if word >= bitmap.len() || bitmap[word] & (1 << (p % 32)) == 0 {
+                return false;
+            }
+        }
+        for p in start..start + n {
+            // Scrub before return to the pool (#334); device-only (see
+            // try_free_page's cfg(not(test)) rationale).
+            #[cfg(not(test))]
+            {
+                zero_page(FIRST_PAGE + p * PAGE_SIZE);
+            }
+            bitmap[p / 32] &= !(1 << (p % 32));
+        }
+        FREE_PAGES += n;
+        true
+    }
+}
+
 /// Free a physical page back to the allocator, ignoring the outcome.
 ///
 /// Fire-and-forget wrapper over [`try_free_page`] for callers that free pages
@@ -567,6 +672,81 @@ mod tests {
 
             try_free_page(b);
             try_free_page(c);
+        }
+    }
+
+    #[test]
+    fn contiguous_alloc_free_round_trip() {
+        // #475: alloc_contiguous(3) must return a page-aligned base whose 3
+        // pages are contiguous + marked allocated, and free_contiguous must
+        // restore them (with a double-free guard).
+        const RAM_START: usize = 0x2000_0000;
+        const RAM_END: usize = RAM_START + 16 * PAGE_SIZE;
+        // SAFETY: test-only fabricated addresses; init() only bookkeeps and the
+        // cfg(test) build skips the scrub deref, so they are never dereferenced.
+        unsafe {
+            init(RAM_START, RAM_END, RAM_START);
+            assert_eq!(core::ptr::addr_of!(FREE_PAGES).read(), 16);
+
+            let base = alloc_contiguous(3).expect("3-run in a fresh 16-page pool");
+            assert_eq!(base % PAGE_SIZE, 0, "base must be page-aligned");
+            assert!(base >= RAM_START && base + 3 * PAGE_SIZE <= RAM_END);
+            assert_eq!(
+                core::ptr::addr_of!(FREE_PAGES).read(),
+                13,
+                "3 pages consumed"
+            );
+
+            let bitmap = &*core::ptr::addr_of!(PAGE_BITMAP);
+            let start = (base - RAM_START) / PAGE_SIZE;
+            for p in start..start + 3 {
+                assert!(
+                    bitmap[p / 32] & (1 << (p % 32)) != 0,
+                    "page {p} of the run must be allocated"
+                );
+            }
+
+            assert!(free_contiguous(base, 3), "freeing the run must succeed");
+            assert_eq!(
+                core::ptr::addr_of!(FREE_PAGES).read(),
+                16,
+                "all pages returned"
+            );
+            assert!(
+                !free_contiguous(base, 3),
+                "double-free of the run must be rejected"
+            );
+            assert_eq!(core::ptr::addr_of!(FREE_PAGES).read(), 16);
+        }
+    }
+
+    #[test]
+    fn contiguous_alloc_respects_fragmentation_and_exhaustion() {
+        // #475: a run larger than the pool fails; and a pool with enough FREE
+        // pages but no contiguous run of the requested size also fails.
+        const RAM_START: usize = 0x3000_0000;
+        const RAM_END: usize = RAM_START + 8 * PAGE_SIZE;
+        // SAFETY: test-only fabricated addresses, never dereferenced.
+        unsafe {
+            init(RAM_START, RAM_END, RAM_START);
+            assert!(alloc_contiguous(9).is_none(), "no 9-run in an 8-page pool");
+            // Allocate all 8, then free only the even pages: 4 free, none
+            // adjacent.
+            for _ in 0..8 {
+                alloc_page().expect("pool has 8 pages");
+            }
+            for p in [0usize, 2, 4, 6] {
+                assert!(try_free_page(RAM_START + p * PAGE_SIZE));
+            }
+            assert_eq!(core::ptr::addr_of!(FREE_PAGES).read(), 4);
+            assert!(
+                alloc_contiguous(2).is_none(),
+                "4 free pages but no 2-run (fragmentation)"
+            );
+            assert!(
+                alloc_contiguous(1).is_some(),
+                "a single page still allocates (delegates to alloc_page)"
+            );
         }
     }
 }

--- a/crates/thumos/src/slab.rs
+++ b/crates/thumos/src/slab.rs
@@ -262,17 +262,20 @@ impl SlabAllocator {
                 unsafe { self.classes[idx].alloc_obj(page_fn) }
             }
             None => {
-                // Large allocation: fall back to the page allocator directly.
-                // Allocate enough whole pages to cover the request.
+                // Large allocation: back it with whole pages from the page
+                // allocator.
                 let pages = (size + page::PAGE_SIZE - 1) / page::PAGE_SIZE;
-                if pages > 1 {
-                    // Multi-page large allocs are not supported without a
-                    // contiguous page allocator. Return null.
-                    return ptr::null_mut();
-                }
-                // SAFETY: large_alloc_fn returns a page from an initialized
-                // page allocator.
-                let addr = unsafe { large_alloc_fn() };
+                let addr = if pages == 1 {
+                    // SAFETY: large_alloc_fn returns a page from an initialized
+                    // page allocator (injected so the single-page path stays
+                    // host-fakeable).
+                    unsafe { large_alloc_fn() }
+                } else {
+                    // WHY (#475): multi-page requests need a contiguous run;
+                    // the injected single-page fn cannot express that, so go
+                    // direct to the page allocator's contiguous path.
+                    page::alloc_contiguous(pages)
+                };
                 match addr {
                     Some(a) => {
                         self.large_alloc_count += 1;
@@ -308,10 +311,19 @@ impl SlabAllocator {
                 unsafe { self.classes[idx].dealloc_obj(ptr) };
             }
             None => {
-                // SAFETY: ptr was returned by alloc_inner for a large
-                // allocation, so it is a page-aligned address previously
-                // returned by the page allocator.
-                unsafe { large_free_fn(ptr as usize) };
+                // ptr was returned by alloc_inner's large path, so it is a
+                // page-aligned base of `pages` whole pages.
+                let pages = (size + page::PAGE_SIZE - 1) / page::PAGE_SIZE;
+                if pages == 1 {
+                    // SAFETY: single-page large alloc came from large_alloc_fn.
+                    unsafe { large_free_fn(ptr as usize) };
+                } else {
+                    // WHY (#475): free the contiguous run alloc_contiguous
+                    // handed out. The bool return is a validated no-op on a bad
+                    // address (not an error to propagate).
+                    // SAFETY: ptr/pages name the run from alloc_contiguous.
+                    unsafe { page::free_contiguous(ptr as usize, pages) };
+                }
                 self.large_free_count += 1;
             }
         }
@@ -788,5 +800,42 @@ mod tests {
             crate::irq::mock_enabled(),
             "outer drop restores IRQ delivery"
         );
+    }
+
+    #[test]
+    fn large_multi_page_alloc_writes_reads_and_round_trips() {
+        // #475: a >4 KB (2-page) allocation must succeed via the contiguous
+        // page path, be writable/readable across its whole span, and
+        // round-trip. Back the page allocator with a REAL host-aligned buffer
+        // so the returned addresses are dereferenceable (fabricated addresses
+        // would SIGSEGV). The multi-page path goes direct to
+        // page::alloc_contiguous, so the injected fakes are unused here.
+        #[repr(align(4096))]
+        struct Pool([u8; 64 * 4096]);
+        static mut POOL: Pool = Pool([0; 64 * 4096]);
+        // SAFETY: single-threaded test (nextest runs it in its own process);
+        // POOL is a real, page-aligned, host-backed buffer.
+        unsafe {
+            let base = core::ptr::addr_of_mut!(POOL) as usize;
+            page::init(base, base + 64 * page::PAGE_SIZE, base);
+            let mut sa = make_allocator();
+
+            let layout = Layout::from_size_align(6000, 8).unwrap(); // 2 pages
+            let ptr = sa.alloc_inner(layout, fake_alloc_page, fake_alloc_page);
+            assert!(!ptr.is_null(), "multi-page large alloc must succeed");
+            assert_eq!(ptr as usize % page::PAGE_SIZE, 0, "must be page-aligned");
+
+            // Writable + readable across the full 2-page span (proves the run
+            // is real contiguous backing, not a single page).
+            core::ptr::write_bytes(ptr, 0xAB, 6000);
+            assert_eq!(*ptr, 0xAB, "first byte");
+            assert_eq!(*ptr.add(5999), 0xAB, "last byte of the 2-page span");
+
+            sa.dealloc_inner(ptr, layout, fake_free_page);
+            // The run is returned to the pool: a second identical alloc works.
+            let ptr2 = sa.alloc_inner(layout, fake_alloc_page, fake_alloc_page);
+            assert!(!ptr2.is_null(), "pages must be reusable after free");
+            sa.dealloc_inner(ptr2, layout, fake_free_page);
+        }
     }
 }


### PR DESCRIPTION
The slab large-alloc path refused >1 page, capping every single allocation at 4 KB. Surfaced building /init (ramfs::from_cpio copies each file into one Vec → 4 KB file-size ceiling; any >4 KB kernel Vec panicked).

- **page.rs**: `alloc_contiguous(n)` (first-fit free-bitmap scan, word-skip optimized) + `free_contiguous(addr, n)` (validated, double-free-guarded, scrub-on-free).
- **slab.rs**: large path routes `pages > 1` to the contiguous allocator; single-page path keeps the injected fn (zero churn to existing faked tests).

**Verified (host):** run round-trip + double-free reject; fragmentation (4 free, no 2-run) + exhaustion fail correctly; a >4 KB 2-page slab alloc over a real host buffer is writable/readable across its full span + reusable after free. 2189 tests (+3); default/qemu/debug-console clean under -D warnings; kanon + fmt clean.

Closes #475.