### PR TITLE
Measured userspace: verified image-resident initramfs may spawn (#480)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,8 +155,19 @@ jobs:
           grep -q 'THUMOS v0.1.0' boot.log || { echo 'FAIL: missing banner'; exit 1; }
           grep -q 'THUMOS-QEMU: boot-complete' boot.log || { echo 'FAIL: boot did not complete'; exit 1; }
           grep -q 'THUMOS-QEMU: service-loop ticks=' boot.log || { echo 'FAIL: service loop never serviced a tick'; exit 1; }
-          # Fail-closed (#217): the qemu boot uses the dev anchor with no boot
-          # medium, so trust is never established -- assert it degraded-LOCKED
-          # (a fail-open regression would drop these lines).
+          # Fail-closed (#217): the qemu boot has NO boot medium, so medium
+          # trust is never established -- assert it degraded-LOCKED and that
+          # every MEDIUM-trust-dependent step stays refused (a fail-OPEN
+          # regression would drop these lines).
           grep -q 'Secure boot: DEGRADED' boot.log || { echo 'FAIL: untrusted boot did not report degraded (fail-closed regression)'; exit 1; }
-          grep -q 'Userspace spawn refused' boot.log || { echo 'FAIL: userspace not refused on an untrusted boot (fail-OPEN regression)'; exit 1; }
+          grep -q 'Passphrase entry refused' boot.log || { echo 'FAIL: passphrase not refused on an untrusted boot (fail-OPEN regression)'; exit 1; }
+          grep -q 'Audit log deferred' boot.log || { echo 'FAIL: audit not deferred on an untrusted boot (fail-OPEN regression)'; exit 1; }
+          # Measured userspace (#480): the image-resident initramfs is signed by
+          # the boot anchor, so userspace_image_verified is set and /init spawns
+          # + runs through the REAL gate (no bypass) even though the MEDIUM is
+          # degraded. Assert the crypto verification fired AND userspace actually
+          # executed a syscall (its svc Write reached the UART) -- if the
+          # signature check regressed, /init would be refused and these drop.
+          grep -q 'image-resident initramfs signature verified' boot.log || { echo 'FAIL: initramfs signature was not verified (measured-userspace regression)'; exit 1; }
+          grep -q '/init spawned' boot.log || { echo 'FAIL: /init did not spawn from the verified initramfs'; exit 1; }
+          grep -q 'init: hello from userspace' boot.log || { echo 'FAIL: userspace /init did not run + syscall (PL0->dispatch->UART)'; exit 1; }

--- a/crates/thumos/build.rs
+++ b/crates/thumos/build.rs
@@ -24,7 +24,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::exit;
 
-use ed25519_dalek::{SigningKey, VerifyingKey};
+use ed25519_dalek::{Signer, SigningKey, VerifyingKey};
 
 /// Ed25519 public key / seed length in bytes.
 const KEY_LEN: usize = 32;
@@ -212,6 +212,20 @@ fn generate_initramfs(manifest_dir: &Path, out_dir: &Path) {
     archive.extend_from_slice(&cpio_newc_entry("TRAILER!!!", &[], 0));
     if let Err(e) = fs::write(out_dir.join("initramfs.cpio"), &archive) {
         die(&format!("#474: cannot write initramfs.cpio: {e}"));
+    }
+
+    // WHY (#480): sign the initramfs with the dev seed so the kernel can
+    // establish `userspace_image_verified` and spawn this image-resident
+    // userspace even on a boot with no verified medium (secure_boot_ok=false,
+    // e.g. the eMMC-less QEMU boot). The signature verifies under the dev/qemu
+    // anchor (BOOT_PUBLIC_KEY = the committed dev key); under a production
+    // anchor it does NOT verify (build.rs has no production seal), so a
+    // production image correctly falls back to the eMMC secure-boot gate. The
+    // real signing infrastructure signs the production initramfs offline.
+    let seed = read_hex_key(&manifest_dir.join("keys/dev/boot-dev.seed"));
+    let signature = SigningKey::from_bytes(&seed).sign(&archive);
+    if let Err(e) = fs::write(out_dir.join("initramfs_sig.bin"), signature.to_bytes()) {
+        die(&format!("#480: cannot write initramfs_sig.bin: {e}"));
     }
 }
 

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -1311,28 +1311,34 @@ pub unsafe fn run() -> ! {
     // Step 14: Spawn packaged userspace processes FROM mounted root ramfs
     // -----------------------------------------------------------------------
     let _ = serial.write_str("[init] Spawning userspace processes\r\n");
-    // WHY(#474/#480): the /init toolchain (build → embed → mount → the #465
-    // preemptive scheduler) is complete and the image-resident initramfs is
-    // mounted as the boot root, but spawning it still respects the #217
-    // fail-closed gate below -- userspace must NOT run on a boot whose trust
-    // was not cryptographically established, and that includes image-resident
-    // userspace (an operator-security-reviewed decision). Letting a verified
-    // image-resident initramfs spawn (so the qemu bring-up boot can exercise
-    // /init end to end) is a security-policy change tracked in #480; until it
-    // lands, the qemu boot correctly refuses spawn (secure_boot_ok=false).
-    if !state.secure_boot_ok {
-        // WHY (#217, fail-closed + security review): userspace must NEVER run
-        // on a boot whose trust was not cryptographically established.
-        // Persistent-storage userspace is already gated transitively (the VFS
-        // root is LFS-backed only on a verified boot), but the operator
-        // decision names userspace explicitly, and a future baked-in
-        // initramfs would otherwise spawn from an image-resident ramfs on an
-        // unverified boot. This is the explicit gate, not an accident of an
-        // empty root.
+    // WHY (#217 + #480): userspace may run only when trust is cryptographically
+    // established -- EITHER a verified boot medium (secure_boot_ok, the
+    // persistent-storage/LFS path) OR a cryptographically-verified
+    // image-resident initramfs. The initramfs is signed by the boot anchor
+    // (build.rs, dev seed) and verified here against BOOT_PUBLIC_KEY; a valid
+    // signature means this userspace shares the kernel's own signed trust
+    // domain, which satisfies #217's requirement for the image-resident case
+    // (the prior blanket refusal existed only because no verification mechanism
+    // did). A production image's initramfs carries a dev signature that does
+    // NOT verify under the production anchor, so it correctly falls back to the
+    // eMMC secure-boot gate. secure_boot_ok stays false here (no medium), so
+    // every OTHER trust-dependent step (passphrase, audit, persistent decrypt)
+    // remains fail-closed.
+    static INITRAMFS_SIG: &[u8; 64] =
+        include_bytes!(concat!(env!("OUT_DIR"), "/initramfs_sig.bin"));
+    let userspace_image_verified =
+        crate::secure_boot::verify_userspace_image(INITRAMFS, INITRAMFS_SIG);
+    if !(state.secure_boot_ok || userspace_image_verified) {
+        // Fail-closed: no verified medium AND no verified image-resident image.
         let _ = serial.write_str(
-            "  WARN Userspace spawn refused (secure boot not established -- fail-closed)\r\n",
+            "  WARN Userspace spawn refused (no verified boot medium or image -- fail-closed)\r\n",
         );
     } else {
+        if userspace_image_verified && !state.secure_boot_ok {
+            let _ = serial.write_str(
+                "       Userspace: image-resident initramfs signature verified (boot anchor)\r\n",
+            );
+        }
         // Attempt to load and spawn two processes: /init and /shell.
         // If an entry is absent from the mounted root ramfs, report the
         // packaging gap instead of spawning a kernel-owned placeholder.

--- a/crates/thumos/src/secure_boot.rs
+++ b/crates/thumos/src/secure_boot.rs
@@ -144,6 +144,23 @@ pub(crate) fn verify_kernel_signature(
     }
 }
 
+/// Verify that an image-resident userspace payload (the boot initramfs) was
+/// signed by the embedded boot anchor (#480).
+///
+/// WHY: establishes `userspace_image_verified` so a cryptographically-verified
+/// image-resident userspace may spawn even when no boot MEDIUM was verified
+/// (`secure_boot_ok == false`, e.g. the eMMC-less QEMU boot). This FULFILLS the
+/// #217 requirement that userspace runs only when trust is cryptographically
+/// established -- for the image-resident case -- rather than weakening it: the
+/// blanket refusal existed only because no verification mechanism did. build.rs
+/// signs the initramfs with the dev seed, so this verifies under the dev/qemu
+/// anchor; under a production anchor the dev signature does NOT verify, so a
+/// production image correctly falls back to the eMMC secure-boot gate.
+#[must_use]
+pub(crate) fn verify_userspace_image(image: &[u8], signature: &[u8; SIGNATURE_LEN]) -> bool {
+    verify_kernel_signature(image, signature).is_ok()
+}
+
 /// Verify the Ed25519 signature of a kernel image using a caller-supplied
 /// public key. This allows testing with test keypairs while keeping the
 /// same verification logic.
@@ -578,6 +595,38 @@ mod tests {
     /// Test that a genuinely valid combined image (payload + Ed25519
     /// signature under the embedded boot key) verifies via
     /// [`verify_combined_image`].
+    #[test]
+    fn verify_userspace_image_accepts_boot_anchor_signature_and_rejects_tampering() {
+        use ed25519_dalek::{Signer, SigningKey};
+
+        // #480: an initramfs signed by the boot anchor verifies; any tamper to
+        // the image OR the signature is rejected (so a swapped userspace image
+        // cannot establish userspace_image_verified).
+        let seed = BOOT_KEY_DEV_SEED.expect("dev anchor required for #480 test");
+        let signing_key = SigningKey::from_bytes(&seed);
+        let image = *b"thumos initramfs bytes (stand-in)";
+        let sig = signing_key.sign(&image).to_bytes();
+
+        assert!(
+            verify_userspace_image(&image, &sig),
+            "boot-anchor-signed image must verify"
+        );
+
+        let mut tampered_image = image;
+        tampered_image[0] ^= 0xFF;
+        assert!(
+            !verify_userspace_image(&tampered_image, &sig),
+            "a tampered image must not verify under the original signature"
+        );
+
+        let mut tampered_sig = sig;
+        tampered_sig[0] ^= 0xFF;
+        assert!(
+            !verify_userspace_image(&image, &tampered_sig),
+            "a tampered signature must not verify"
+        );
+    }
+
     #[test]
     fn combined_image_valid_signature_passes() {
         use ed25519_dalek::{Signer, SigningKey};


### PR DESCRIPTION
Operator-approved (2026-07-06). #217 refused ALL userspace without a verified boot medium -- including the kernel's own image-resident initramfs -- so the eMMC-less qemu boot couldn't run /init end to end (blocking userspace-runtime + PL0-isolation verification). The blanket refusal existed only because nothing verified image-resident userspace; this adds that.

- **build.rs** signs `initramfs.cpio` with the dev seed → 64-byte Ed25519 `initramfs_sig.bin`.
- **secure_boot::verify_userspace_image** verifies it against `BOOT_PUBLIC_KEY`.
- **kinit** gates spawn on `secure_boot_ok || userspace_image_verified` -- verify-then-spawn, satisfying #217's crypto-trust requirement for the image-resident case, **not a bypass**.

**Not a weakening:** `secure_boot_ok` stays false with no medium, so passphrase/audit/persistent-decrypt remain fail-closed. **Production unchanged:** a dev-signed initramfs does NOT verify under a production anchor → falls back to eMMC secure boot (qemu ⊥ production anyway).

**CI:** medium-trust fail-closed asserts stay (DEGRADED + passphrase refused + audit deferred) AND the measured-userspace path is asserted (signature verified + /init spawned + `init: hello from userspace`). Restores the #474 end-to-end /init proof through the real gate.

Verified: signature-verified → /init spawned → hello from userspace → ticks=50 exit 0, medium fail-closed intact; 2190 host tests (+1 tamper-rejection); all builds clean under -D warnings; kanon + fmt clean.

Closes #480. Unblocks #482 (PL0 isolation runtime proof).