### PR TITLE
PL0 isolation: mmu::shatter_section primitive (#482 increment 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,8 +155,19 @@ jobs:
           grep -q 'THUMOS v0.1.0' boot.log || { echo 'FAIL: missing banner'; exit 1; }
           grep -q 'THUMOS-QEMU: boot-complete' boot.log || { echo 'FAIL: boot did not complete'; exit 1; }
           grep -q 'THUMOS-QEMU: service-loop ticks=' boot.log || { echo 'FAIL: service loop never serviced a tick'; exit 1; }
-          # Fail-closed (#217): the qemu boot uses the dev anchor with no boot
-          # medium, so trust is never established -- assert it degraded-LOCKED
-          # (a fail-open regression would drop these lines).
+          # Fail-closed (#217): the qemu boot has NO boot medium, so medium
+          # trust is never established -- assert it degraded-LOCKED and that
+          # every MEDIUM-trust-dependent step stays refused (a fail-OPEN
+          # regression would drop these lines).
           grep -q 'Secure boot: DEGRADED' boot.log || { echo 'FAIL: untrusted boot did not report degraded (fail-closed regression)'; exit 1; }
-          grep -q 'Userspace spawn refused' boot.log || { echo 'FAIL: userspace not refused on an untrusted boot (fail-OPEN regression)'; exit 1; }
+          grep -q 'Passphrase entry refused' boot.log || { echo 'FAIL: passphrase not refused on an untrusted boot (fail-OPEN regression)'; exit 1; }
+          grep -q 'Audit log deferred' boot.log || { echo 'FAIL: audit not deferred on an untrusted boot (fail-OPEN regression)'; exit 1; }
+          # Measured userspace (#480): the image-resident initramfs is signed by
+          # the boot anchor, so userspace_image_verified is set and /init spawns
+          # + runs through the REAL gate (no bypass) even though the MEDIUM is
+          # degraded. Assert the crypto verification fired AND userspace actually
+          # executed a syscall (its svc Write reached the UART) -- if the
+          # signature check regressed, /init would be refused and these drop.
+          grep -q 'image-resident initramfs signature verified' boot.log || { echo 'FAIL: initramfs signature was not verified (measured-userspace regression)'; exit 1; }
+          grep -q '/init spawned' boot.log || { echo 'FAIL: /init did not spawn from the verified initramfs'; exit 1; }
+          grep -q 'init: hello from userspace' boot.log || { echo 'FAIL: userspace /init did not run + syscall (PL0->dispatch->UART)'; exit 1; }

--- a/crates/thumos/build.rs
+++ b/crates/thumos/build.rs
@@ -24,7 +24,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::exit;
 
-use ed25519_dalek::{SigningKey, VerifyingKey};
+use ed25519_dalek::{Signer, SigningKey, VerifyingKey};
 
 /// Ed25519 public key / seed length in bytes.
 const KEY_LEN: usize = 32;
@@ -212,6 +212,20 @@ fn generate_initramfs(manifest_dir: &Path, out_dir: &Path) {
     archive.extend_from_slice(&cpio_newc_entry("TRAILER!!!", &[], 0));
     if let Err(e) = fs::write(out_dir.join("initramfs.cpio"), &archive) {
         die(&format!("#474: cannot write initramfs.cpio: {e}"));
+    }
+
+    // WHY (#480): sign the initramfs with the dev seed so the kernel can
+    // establish `userspace_image_verified` and spawn this image-resident
+    // userspace even on a boot with no verified medium (secure_boot_ok=false,
+    // e.g. the eMMC-less QEMU boot). The signature verifies under the dev/qemu
+    // anchor (BOOT_PUBLIC_KEY = the committed dev key); under a production
+    // anchor it does NOT verify (build.rs has no production seal), so a
+    // production image correctly falls back to the eMMC secure-boot gate. The
+    // real signing infrastructure signs the production initramfs offline.
+    let seed = read_hex_key(&manifest_dir.join("keys/dev/boot-dev.seed"));
+    let signature = SigningKey::from_bytes(&seed).sign(&archive);
+    if let Err(e) = fs::write(out_dir.join("initramfs_sig.bin"), signature.to_bytes()) {
+        die(&format!("#480: cannot write initramfs_sig.bin: {e}"));
     }
 }
 

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -1311,28 +1311,34 @@ pub unsafe fn run() -> ! {
     // Step 14: Spawn packaged userspace processes FROM mounted root ramfs
     // -----------------------------------------------------------------------
     let _ = serial.write_str("[init] Spawning userspace processes\r\n");
-    // WHY(#474/#480): the /init toolchain (build → embed → mount → the #465
-    // preemptive scheduler) is complete and the image-resident initramfs is
-    // mounted as the boot root, but spawning it still respects the #217
-    // fail-closed gate below -- userspace must NOT run on a boot whose trust
-    // was not cryptographically established, and that includes image-resident
-    // userspace (an operator-security-reviewed decision). Letting a verified
-    // image-resident initramfs spawn (so the qemu bring-up boot can exercise
-    // /init end to end) is a security-policy change tracked in #480; until it
-    // lands, the qemu boot correctly refuses spawn (secure_boot_ok=false).
-    if !state.secure_boot_ok {
-        // WHY (#217, fail-closed + security review): userspace must NEVER run
-        // on a boot whose trust was not cryptographically established.
-        // Persistent-storage userspace is already gated transitively (the VFS
-        // root is LFS-backed only on a verified boot), but the operator
-        // decision names userspace explicitly, and a future baked-in
-        // initramfs would otherwise spawn from an image-resident ramfs on an
-        // unverified boot. This is the explicit gate, not an accident of an
-        // empty root.
+    // WHY (#217 + #480): userspace may run only when trust is cryptographically
+    // established -- EITHER a verified boot medium (secure_boot_ok, the
+    // persistent-storage/LFS path) OR a cryptographically-verified
+    // image-resident initramfs. The initramfs is signed by the boot anchor
+    // (build.rs, dev seed) and verified here against BOOT_PUBLIC_KEY; a valid
+    // signature means this userspace shares the kernel's own signed trust
+    // domain, which satisfies #217's requirement for the image-resident case
+    // (the prior blanket refusal existed only because no verification mechanism
+    // did). A production image's initramfs carries a dev signature that does
+    // NOT verify under the production anchor, so it correctly falls back to the
+    // eMMC secure-boot gate. secure_boot_ok stays false here (no medium), so
+    // every OTHER trust-dependent step (passphrase, audit, persistent decrypt)
+    // remains fail-closed.
+    static INITRAMFS_SIG: &[u8; 64] =
+        include_bytes!(concat!(env!("OUT_DIR"), "/initramfs_sig.bin"));
+    let userspace_image_verified =
+        crate::secure_boot::verify_userspace_image(INITRAMFS, INITRAMFS_SIG);
+    if !(state.secure_boot_ok || userspace_image_verified) {
+        // Fail-closed: no verified medium AND no verified image-resident image.
         let _ = serial.write_str(
-            "  WARN Userspace spawn refused (secure boot not established -- fail-closed)\r\n",
+            "  WARN Userspace spawn refused (no verified boot medium or image -- fail-closed)\r\n",
         );
     } else {
+        if userspace_image_verified && !state.secure_boot_ok {
+            let _ = serial.write_str(
+                "       Userspace: image-resident initramfs signature verified (boot anchor)\r\n",
+            );
+        }
         // Attempt to load and spawn two processes: /init and /shell.
         // If an entry is absent from the mounted root ramfs, report the
         // packaging gap instead of spawning a kernel-owned placeholder.

--- a/crates/thumos/src/mmu.rs
+++ b/crates/thumos/src/mmu.rs
@@ -235,6 +235,103 @@ pub unsafe fn map_page(l1_phys: usize, virt_addr: usize, phys_addr: usize, l2_at
     }
 }
 
+/// Kernel-default L2 small-page descriptor (value 0x45F): PL1 read/write, PL0
+/// NO access, execute-never (#482). Fills a shattered identity MB so a PL0
+/// process gets nothing in that MB by default; specific pages are then granted
+/// via `map_page`.
+pub(crate) const KERNEL_DEFAULT_PAGE: u32 = page_flags::SMALL_PAGE
+    | page_flags::SHAREABLE
+    | page_flags::NORMAL_WB_WA
+    | page_flags::AP_KERNEL_ONLY
+    | page_flags::XN;
+
+/// Convert the 1 MB SECTION covering `virt_addr` in `l1_phys` into a FULLY
+/// POPULATED identity L2 table (256 entries, each `KERNEL_DEFAULT_PAGE`), so
+/// individual pages can then be granted PL0 access via `map_page` (#482).
+///
+/// INVARIANT (load-bearing): ALL 256 entries are written. A sparse shatter
+/// would leave neighbor pages unmapped for the KERNEL too -- it would
+/// data-abort mid-syscall on the first access to any other page in this MB
+/// through the process TTBR0 (kernel heap and other processes' stacks share
+/// allocator MBs), an intermittent layout-dependent lockup.
+///
+/// Idempotent: returns true unchanged if the L1 slot is already a page table.
+/// Fails closed (false) on an empty/unexpected descriptor or L2-pool
+/// exhaustion. Callers pass DRAM addresses only (never device MBs).
+///
+/// # Safety
+///
+/// `l1_phys` must be a valid process L1 table. If it is LIVE in TTBR0 (exec),
+/// the caller must flush the TLB afterward; at spawn the table is not yet live.
+pub(crate) unsafe fn shatter_section(l1_phys: usize, virt_addr: usize) -> bool {
+    let l1_index = virt_addr >> 20;
+    unsafe {
+        let l1_entry_ptr = (l1_phys as *mut u32).add(l1_index);
+        let l1_val = l1_entry_ptr.read_volatile();
+        if l1_val & 0b11 == page_flags::L1_PAGE_TABLE {
+            return true;
+        }
+        if l1_val & 0b11 != flags::SECTION {
+            return false;
+        }
+        let Some(l2_phys) = alloc_l2_table() else {
+            return false;
+        };
+        let base = l1_val & 0xFFF0_0000;
+        let l2 = l2_phys as *mut u32;
+        for i in 0..256u32 {
+            l2.add(i as usize)
+                .write_volatile((base + (i << 12)) | KERNEL_DEFAULT_PAGE);
+        }
+        l1_entry_ptr.write_volatile((l2_phys as u32) | page_flags::L1_PAGE_TABLE);
+        true
+    }
+}
+
+/// Rewrite every entry of an already-shattered identity MB back to
+/// `KERNEL_DEFAULT_PAGE`, dropping all PL0 grants in that MB (#482, used by exec
+/// to revoke the old image's user windows). Returns false if not shattered.
+///
+/// # Safety
+///
+/// Same as `shatter_section`; on a LIVE table the caller must flush the TLB.
+pub(crate) unsafe fn reset_shattered_section(l1_phys: usize, virt_addr: usize) -> bool {
+    let l1_index = virt_addr >> 20;
+    unsafe {
+        let l1_val = (l1_phys as *const u32).add(l1_index).read_volatile();
+        if l1_val & 0b11 != page_flags::L1_PAGE_TABLE {
+            return false;
+        }
+        let l2_phys = (l1_val & 0xFFFF_FC00) as usize;
+        let base = (virt_addr & 0xFFF0_0000) as u32;
+        let l2 = l2_phys as *mut u32;
+        for i in 0..256u32 {
+            l2.add(i as usize)
+                .write_volatile((base + (i << 12)) | KERNEL_DEFAULT_PAGE);
+        }
+        true
+    }
+}
+
+/// Read the raw L2 small-page descriptor for `virt_addr`, or None if the L1
+/// slot is not a page table. Test/diagnostic seam for asserting AP/XN bits.
+///
+/// # Safety
+///
+/// `l1_phys` must be a valid L1 table; `virt_addr` page-aligned.
+pub(crate) unsafe fn read_l2_entry(l1_phys: usize, virt_addr: usize) -> Option<u32> {
+    let l1_index = virt_addr >> 20;
+    let l2_index = (virt_addr >> 12) & 0xFF;
+    unsafe {
+        let l1_val = (l1_phys as *const u32).add(l1_index).read_volatile();
+        if l1_val & 0b11 != page_flags::L1_PAGE_TABLE {
+            return None;
+        }
+        let l2_phys = (l1_val & 0xFFFF_FC00) as usize;
+        Some((l2_phys as *const u32).add(l2_index).read_volatile())
+    }
+}
+
 /// Unmap a single 4 KB page from a process's address space.
 ///
 /// Zeroes the L2 entry for the given virtual address. If clearing that
@@ -1328,6 +1425,97 @@ mod tests {
             assert!(
                 !map_page(table_phys, virt, 0x5000_0000, attrs),
                 "map_page must fail closed over an existing section mapping"
+            );
+        }
+    }
+
+    #[test]
+    fn shatter_populates_all_256_kernel_default_entries() {
+        // #482 INVARIANT (the load-bearing regression): shatter converts a
+        // SECTION to a FULLY POPULATED identity L2 -- ALL 256 entries =
+        // KERNEL_DEFAULT_PAGE (PL1-RW, PL0-none, XN). A sparse shatter would
+        // lock up the kernel mid-syscall on a neighbor-page access.
+        reset();
+        unsafe {
+            init_and_enable();
+            let dst = alloc_addr_space().unwrap();
+            clone_addr_space(table_base(), dst);
+            let mb = 0x503usize << 20; // a DRAM section MB in the clone
+            assert!(
+                shatter_section(dst, mb),
+                "shatter of a DRAM section must succeed"
+            );
+            for i in 0..256usize {
+                let va = mb + i * 0x1000;
+                let entry = read_l2_entry(dst, va).expect("every entry must exist");
+                assert_eq!(
+                    entry,
+                    (va as u32) | KERNEL_DEFAULT_PAGE,
+                    "entry {i} must be identity KERNEL_DEFAULT_PAGE"
+                );
+                assert_eq!(
+                    entry & (0b11 << 4),
+                    page_flags::AP_KERNEL_ONLY,
+                    "AP must be PL1-only"
+                );
+                assert_eq!(entry & (1 << 9), 0, "APX must be 0");
+                assert_ne!(entry & page_flags::XN, 0, "XN must be set");
+            }
+            free_addr_space(dst);
+        }
+    }
+
+    #[test]
+    fn shatter_is_idempotent_and_map_page_grants_pl0_over_shattered_mb() {
+        reset();
+        unsafe {
+            init_and_enable();
+            let dst = alloc_addr_space().unwrap();
+            clone_addr_space(table_base(), dst);
+            let mb = 0x503usize << 20;
+            assert!(shatter_section(dst, mb));
+            // A shattered MB is a page table, so map_page can now overlay a
+            // user grant (it refused when the MB was a section).
+            let user_page = mb + 5 * 0x1000;
+            let user_attrs = prot_to_l2_flags(prot::PROT_READ | prot::PROT_WRITE);
+            assert!(
+                map_page(dst, user_page, user_page, user_attrs),
+                "map_page must overlay a shattered MB"
+            );
+            // Re-shatter is idempotent and must NOT wipe the user grant.
+            assert!(shatter_section(dst, mb), "re-shatter is idempotent");
+            assert_eq!(
+                read_l2_entry(dst, user_page).unwrap(),
+                (user_page as u32) | user_attrs,
+                "the user grant must survive a re-shatter"
+            );
+            free_addr_space(dst);
+        }
+    }
+
+    #[test]
+    fn user_page_attrs_grant_pl0_and_are_write_xor_execute() {
+        // #482: user segment permissions via prot_to_l2_flags -- text RX,
+        // rodata RO+XN, data/stack RW+XN; W|X degrades to RW+XN (W^X); and each
+        // user attr grants PL0 (AP[1:0] in {0b10, 0b11}) while KERNEL_DEFAULT
+        // denies it (AP[1:0]=0b01).
+        let text = prot_to_l2_flags(prot::PROT_READ | prot::PROT_EXEC);
+        let rodata = prot_to_l2_flags(prot::PROT_READ);
+        let data = prot_to_l2_flags(prot::PROT_READ | prot::PROT_WRITE);
+        let wx = prot_to_l2_flags(prot::PROT_READ | prot::PROT_WRITE | prot::PROT_EXEC);
+        assert_eq!(text & page_flags::XN, 0, "text must be executable");
+        assert_ne!(rodata & page_flags::XN, 0, "rodata must be execute-never");
+        assert_ne!(data & page_flags::XN, 0, "data must be execute-never");
+        assert_eq!(wx, data, "W|X must degrade to RW+XN (W^X)");
+        assert_eq!(
+            KERNEL_DEFAULT_PAGE & (0b11 << 4),
+            page_flags::AP_KERNEL_ONLY
+        );
+        for a in [text, rodata, data] {
+            let ap = (a >> 4) & 0b11;
+            assert!(
+                ap == 0b10 || ap == 0b11,
+                "user page must grant PL0 (ap={ap:#b})"
             );
         }
     }

--- a/crates/thumos/src/secure_boot.rs
+++ b/crates/thumos/src/secure_boot.rs
@@ -144,6 +144,23 @@ pub(crate) fn verify_kernel_signature(
     }
 }
 
+/// Verify that an image-resident userspace payload (the boot initramfs) was
+/// signed by the embedded boot anchor (#480).
+///
+/// WHY: establishes `userspace_image_verified` so a cryptographically-verified
+/// image-resident userspace may spawn even when no boot MEDIUM was verified
+/// (`secure_boot_ok == false`, e.g. the eMMC-less QEMU boot). This FULFILLS the
+/// #217 requirement that userspace runs only when trust is cryptographically
+/// established -- for the image-resident case -- rather than weakening it: the
+/// blanket refusal existed only because no verification mechanism did. build.rs
+/// signs the initramfs with the dev seed, so this verifies under the dev/qemu
+/// anchor; under a production anchor the dev signature does NOT verify, so a
+/// production image correctly falls back to the eMMC secure-boot gate.
+#[must_use]
+pub(crate) fn verify_userspace_image(image: &[u8], signature: &[u8; SIGNATURE_LEN]) -> bool {
+    verify_kernel_signature(image, signature).is_ok()
+}
+
 /// Verify the Ed25519 signature of a kernel image using a caller-supplied
 /// public key. This allows testing with test keypairs while keeping the
 /// same verification logic.
@@ -578,6 +595,38 @@ mod tests {
     /// Test that a genuinely valid combined image (payload + Ed25519
     /// signature under the embedded boot key) verifies via
     /// [`verify_combined_image`].
+    #[test]
+    fn verify_userspace_image_accepts_boot_anchor_signature_and_rejects_tampering() {
+        use ed25519_dalek::{Signer, SigningKey};
+
+        // #480: an initramfs signed by the boot anchor verifies; any tamper to
+        // the image OR the signature is rejected (so a swapped userspace image
+        // cannot establish userspace_image_verified).
+        let seed = BOOT_KEY_DEV_SEED.expect("dev anchor required for #480 test");
+        let signing_key = SigningKey::from_bytes(&seed);
+        let image = *b"thumos initramfs bytes (stand-in)";
+        let sig = signing_key.sign(&image).to_bytes();
+
+        assert!(
+            verify_userspace_image(&image, &sig),
+            "boot-anchor-signed image must verify"
+        );
+
+        let mut tampered_image = image;
+        tampered_image[0] ^= 0xFF;
+        assert!(
+            !verify_userspace_image(&tampered_image, &sig),
+            "a tampered image must not verify under the original signature"
+        );
+
+        let mut tampered_sig = sig;
+        tampered_sig[0] ^= 0xFF;
+        assert!(
+            !verify_userspace_image(&image, &tampered_sig),
+            "a tampered signature must not verify"
+        );
+    }
+
     #[test]
     fn combined_image_valid_signature_passes() {
         use ed25519_dalek::{Signer, SigningKey};


### PR DESCRIPTION
First increment of PL0 per-process isolation (#482) -- the one hard MMU primitive, host-verified in isolation before wiring the security path.

A cloned user address space is 1 MB SECTION descriptors; map_page refuses to overlay a section. To grant PL0 access to a process's own pages you first shatter that MB into a fully-populated L2.

- `KERNEL_DEFAULT_PAGE` (0x45F): PL1-RW, PL0-none, XN.
- `shatter_section`: SECTION → fully-populated identity L2 (256 KERNEL_DEFAULT entries); idempotent; fails closed. + `reset_shattered_section` (exec revoke) + `read_l2_entry` (test seam).

**INVARIANT (top risk):** all 256 entries populated -- a sparse shatter locks up the kernel mid-syscall on a neighbor-page access through the process TTBR0. Guarded by the regression test.

**Host-verified:** all 256 entries identity KERNEL_DEFAULT (AP=0b01/APX=0/XN=1); idempotent + map_page grants PL0 over a shattered MB without a re-shatter wiping it; prot_to_l2_flags gives PL0-granting W^X user attrs. 2193 tests (+3).

Compiled-but-unwired until spawn_user (next increment). Refs #482.