### PR TITLE
PL0 per-process isolation: /init runs unprivileged (#482)

### DIFF
--- a/crates/thumos/init/init.ld
+++ b/crates/thumos/init/init.ld
@@ -14,16 +14,25 @@ SECTIONS
 {
     . = 0x7FF00000;
 
+    /* WHY (#482) ALIGN(4096) at each permission-class boundary: spawn_user maps
+       the image per-segment with W^X user page permissions (.text RX,
+       .rodata RO+XN, .data/.bss RW+XN). A 4 KB page must therefore fall
+       entirely in ONE permission class -- page-aligning the section starts
+       guarantees no page carries both executable and writable content.
+       max-page-size=0x100 (build.rs) keeps the FILE offsets compact regardless,
+       so the image stays small; #475's contiguous alloc covers it either way. */
     .text : {
         *(.text.boot)
         *(.text .text.*)
     }
 
-    .rodata : ALIGN(4) {
+    . = ALIGN(4096);
+    .rodata : {
         *(.rodata .rodata.*)
     }
 
-    .data : ALIGN(4) {
+    . = ALIGN(4096);
+    .data : {
         *(.data .data.*)
     }
 

--- a/crates/thumos/src/elf.rs
+++ b/crates/thumos/src/elf.rs
@@ -26,6 +26,29 @@ const EM_ARM: u16 = 40;
 /// Program header type: loadable segment
 const PT_LOAD: u32 = 1;
 
+/// PT_LOAD segment permission flags (ELF32 program header `p_flags`).
+const PF_X: u32 = 0x1;
+const PF_W: u32 = 0x2;
+const PF_R: u32 = 0x4;
+
+/// Translate ELF `p_flags` to POSIX prot bits for `mmu::prot_to_l2_flags`
+/// (#482), so a spawned process's segments get W^X user page permissions
+/// (text RX, rodata RO, data/bss RW+XN; a W|X segment degrades to RW+XN
+/// because `prot_to_l2_flags` forces XN whenever PROT_WRITE is set).
+pub(crate) fn flags_to_prot(p_flags: u32) -> u32 {
+    let mut prot = 0;
+    if p_flags & PF_R != 0 {
+        prot |= crate::mmu::prot::PROT_READ;
+    }
+    if p_flags & PF_W != 0 {
+        prot |= crate::mmu::prot::PROT_WRITE;
+    }
+    if p_flags & PF_X != 0 {
+        prot |= crate::mmu::prot::PROT_EXEC;
+    }
+    prot
+}
+
 /// ELF32 header.
 ///
 /// Mirrors the ELF32 specification layout; splitting would break #[repr(C,
@@ -90,6 +113,35 @@ pub(crate) struct LoadedElf {
     /// Number of pages written (#328: no longer a count of
     /// `page::alloc_page()` reservations — see `load()`'s doc comment).
     pub pages_used: usize,
+    /// `(vaddr, memsz, p_flags)` per PT_LOAD segment (#482), so `spawn_user`
+    /// can map each segment PL0-accessible with W^X permissions derived from
+    /// `p_flags`. Identity-mapped, so vaddr is both the link and load address.
+    segments: [(usize, usize, u32); 16],
+    /// Number of valid entries in `segments`.
+    seg_count: usize,
+}
+
+impl LoadedElf {
+    /// The loaded PT_LOAD segments as `(vaddr, memsz, p_flags)` (#482).
+    pub(crate) fn segments(&self) -> &[(usize, usize, u32)] {
+        &self.segments[..self.seg_count]
+    }
+
+    /// Construct a `LoadedElf` from parts for tests (no ELF parsing), so
+    /// `process::spawn_user` can be host-tested against known segment layouts.
+    #[cfg(test)]
+    pub(crate) fn for_test(entry: usize, segments: &[(usize, usize, u32)]) -> Self {
+        let mut segs = [(0usize, 0usize, 0u32); 16];
+        for (i, s) in segments.iter().enumerate().take(16) {
+            segs[i] = *s;
+        }
+        Self {
+            entry,
+            pages_used: 0,
+            segments: segs,
+            seg_count: segments.len().min(16),
+        }
+    }
 }
 
 /// Error FROM ELF loading.
@@ -149,7 +201,7 @@ fn validate(data: &[u8]) -> Result<(usize, ValidatedElf), ElfError> {
     let phentsize = ehdr.e_phentsize as usize;
 
     let mut segments = ValidatedElf {
-        segments: [(0, 0, 0, 0); 16],
+        segments: [(0, 0, 0, 0, 0); 16],
         count: 0,
         total_pages: 0,
     };
@@ -201,6 +253,7 @@ fn validate(data: &[u8]) -> Result<(usize, ValidatedElf), ElfError> {
         let memsz = phdr.p_memsz as usize;
         let filesz = phdr.p_filesz as usize;
         let file_offset = phdr.p_offset as usize;
+        let seg_flags = phdr.p_flags;
 
         // WHY (#316): file_offset/filesz are attacker-controlled; checked_add
         // rejects a wrap instead of letting it bypass this guard.
@@ -250,7 +303,7 @@ fn validate(data: &[u8]) -> Result<(usize, ValidatedElf), ElfError> {
         if segments.count >= 16 {
             return Err(ElfError::InvalidSegment);
         }
-        segments.segments[segments.count] = (vaddr, memsz, filesz, file_offset);
+        segments.segments[segments.count] = (vaddr, memsz, filesz, file_offset, seg_flags);
         segments.count += 1;
     }
 
@@ -263,7 +316,7 @@ fn validate(data: &[u8]) -> Result<(usize, ValidatedElf), ElfError> {
     // not merely a crash. Require entry to fall within a segment that was
     // actually loaded before it is ever handed back to a caller.
     let entry_in_loaded_segment = (0..segments.count).any(|i| {
-        let (vaddr, memsz, _, _) = segments.segments[i];
+        let (vaddr, memsz, _, _, _) = segments.segments[i];
         entry >= vaddr && entry < vaddr.saturating_add(memsz)
     });
     if !entry_in_loaded_segment {
@@ -276,8 +329,8 @@ fn validate(data: &[u8]) -> Result<(usize, ValidatedElf), ElfError> {
 /// Validated ELF segment descriptors (output of header validation).
 #[derive(Debug)]
 struct ValidatedElf {
-    /// `(vaddr, memsz, filesz, file_offset)` for each PT_LOAD segment.
-    segments: [(usize, usize, usize, usize); 16],
+    /// `(vaddr, memsz, filesz, file_offset, p_flags)` for each PT_LOAD segment.
+    segments: [(usize, usize, usize, usize, u32); 16],
     /// Number of valid entries in `segments`.
     count: usize,
     /// Sum of each segment's page count (`ceil(memsz / PAGE_SIZE)`),
@@ -318,7 +371,7 @@ pub(crate) fn load(data: &[u8]) -> Result<LoadedElf, ElfError> {
     let mut pages_used = 0;
 
     for idx in 0..validated.count {
-        let (vaddr, memsz, filesz, file_offset) = validated.segments[idx];
+        let (vaddr, memsz, filesz, file_offset, _flags) = validated.segments[idx];
 
         // WHY: identical to the checked computation validate() already
         // performed for this same memsz while building validated.total_pages
@@ -369,7 +422,19 @@ pub(crate) fn load(data: &[u8]) -> Result<LoadedElf, ElfError> {
         }
     }
 
-    Ok(LoadedElf { entry, pages_used })
+    // Carry per-segment (vaddr, memsz, p_flags) so spawn_user can map each
+    // segment PL0-accessible with W^X permissions (#482).
+    let mut segments = [(0usize, 0usize, 0u32); 16];
+    for i in 0..validated.count {
+        let (vaddr, memsz, _, _, flags) = validated.segments[i];
+        segments[i] = (vaddr, memsz, flags);
+    }
+    Ok(LoadedElf {
+        entry,
+        pages_used,
+        segments,
+        seg_count: validated.count,
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -1347,14 +1347,14 @@ pub unsafe fn run() -> ! {
         match plan_userspace_spawn_from_vfs("/init") {
             UserspaceSpawnPlan::Elf(elf_data) => match elf::load(elf_data) {
                 Ok(loaded) => {
-                    if let Some(pid) = process::spawn(
-                        // SAFETY: loaded.entry is the ELF entry point validated
-                        // by elf::load() to be within a loaded PT_LOAD segment.
-                        // The identity-mapped physical address is a callable
-                        // no-return function per the ELF ABI contract.
-                        unsafe { core::mem::transmute::<usize, fn() -> !>(loaded.entry) },
-                    ) {
-                        let _ = write!(serial, "       /init spawned (PID {})\r\n", pid);
+                    // WHY(#482): spawn_user runs /init UNPRIVILEGED (PL0, User
+                    // mode 0x10) in its own address space -- the ELF mapped
+                    // per-segment W^X and the stack RW+XN, with kernel memory
+                    // PL1-only so a user access to it faults. No transmute: the
+                    // entry is an address the new process resumes at via the
+                    // #465 exception-return, not a kernel fn pointer.
+                    if let Some(pid) = process::spawn_user(&loaded) {
+                        let _ = write!(serial, "       /init spawned PL0 (PID {})\r\n", pid);
                         state.processes_spawned += 1;
                     } else {
                         let _ = serial.write_str("  WARN /init spawn failed\r\n");
@@ -1375,14 +1375,9 @@ pub unsafe fn run() -> ! {
         match plan_userspace_spawn_from_vfs("/shell") {
             UserspaceSpawnPlan::Elf(elf_data) => match elf::load(elf_data) {
                 Ok(loaded) => {
-                    if let Some(pid) = process::spawn(
-                        // SAFETY: loaded.entry is the ELF entry point validated
-                        // by elf::load() to be within a loaded PT_LOAD segment.
-                        // The identity-mapped physical address is a callable
-                        // no-return function per the ELF ABI contract.
-                        unsafe { core::mem::transmute::<usize, fn() -> !>(loaded.entry) },
-                    ) {
-                        let _ = write!(serial, "       /shell spawned (PID {})\r\n", pid);
+                    // WHY(#482): /shell runs PL0 in its own isolated space too.
+                    if let Some(pid) = process::spawn_user(&loaded) {
+                        let _ = write!(serial, "       /shell spawned PL0 (PID {})\r\n", pid);
                         state.processes_spawned += 1;
                     } else {
                         let _ = serial.write_str("  WARN /shell spawn failed\r\n");

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -316,6 +316,121 @@ pub(crate) fn spawn(entry_point: fn() -> !) -> Option<Pid> {
     }
 }
 
+/// Map a loaded ELF's PT_LOAD segments PL0-accessible at their identity VAs in
+/// process page table `pt`, with W^X page permissions from each segment's ELF
+/// flags (#482): text RX, rodata RO+XN, data/bss RW+XN. Fails closed on an
+/// unaligned segment vaddr (a page would carry two permission classes) or
+/// L2-pool exhaustion.
+///
+/// # Safety
+/// `pt` must be a caller-owned process L1 not currently live in TTBR0.
+unsafe fn map_user_image(pt: usize, loaded: &crate::elf::LoadedElf) -> bool {
+    for &(vaddr, memsz, flags) in loaded.segments() {
+        // INVARIANT: init.ld ALIGN(4096) page-aligns each permission class, so
+        // a segment vaddr must be page-aligned; reject a foreign image that
+        // violates it rather than granting a mixed-permission page.
+        if vaddr % page::PAGE_SIZE != 0 {
+            return false;
+        }
+        let attrs = mmu::prot_to_l2_flags(crate::elf::flags_to_prot(flags));
+        let pages = memsz.div_ceil(page::PAGE_SIZE);
+        for p in 0..pages {
+            let va = vaddr + p * page::PAGE_SIZE;
+            // SAFETY: pt is caller-owned; va is identity DRAM validated by
+            // elf::validate (#318). Shatter the MB to a fully-populated L2,
+            // then grant PL0 to this page.
+            unsafe {
+                if !mmu::shatter_section(pt, va) || !mmu::map_page(pt, va, va, attrs) {
+                    return false;
+                }
+            }
+        }
+    }
+    true
+}
+
+/// Map each of the `STACK_PAGES` contiguous stack frames from `stack_base`
+/// PL0 read/write + execute-never at its identity VA (#482).
+///
+/// # Safety
+/// `pt` is a caller-owned process L1; `stack_base` begins a contiguous run.
+unsafe fn map_user_stack(pt: usize, stack_base: usize) -> bool {
+    let attrs = mmu::prot_to_l2_flags(mmu::prot::PROT_READ | mmu::prot::PROT_WRITE);
+    for i in 0..STACK_PAGES {
+        let va = stack_base + i * page::PAGE_SIZE;
+        // SAFETY: pt caller-owned; va is a contiguous stack frame in DRAM.
+        unsafe {
+            if !mmu::shatter_section(pt, va) || !mmu::map_page(pt, va, va, attrs) {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// Create a PL0 (User mode) process from a loaded ELF image (#482).
+///
+/// Like [`spawn`], but enters at cpsr 0x10 (User/PL0) and grants the process
+/// PL0 access to EXACTLY its own image (per-segment W^X) and stack -- nothing
+/// else. Kernel .text/.data/stacks and device MMIO stay mapped PL1-only via the
+/// kernel-L1 clone (#323), so the kernel still runs when the process traps
+/// (svc/IRQ) while the process data/prefetch-aborts on any access to kernel
+/// memory. The #465 trap frame carries the per-process cpsr, so switching
+/// between PID 0 (System) and a PL0 process needs no asm change.
+pub(crate) fn spawn_user(loaded: &crate::elf::LoadedElf) -> Option<Pid> {
+    // SAFETY: PROCS/CURRENT via the established addr_of_mut! pattern; single
+    // core, no concurrent access at spawn.
+    unsafe {
+        let procs = &mut *addr_of_mut!(PROCS);
+        let slot = procs.iter().position(|p| p.is_none())?;
+        let pid = slot as Pid;
+
+        let new_pt = mmu::alloc_addr_space()?;
+        mmu::clone_addr_space(mmu::table_base(), new_pt);
+
+        // Stack: a CONTIGUOUS run (#475) so stack_top arithmetic and
+        // exit_cleanup's free loop (base + i*PAGE_SIZE) hold, and the PL0 stack
+        // has no unmapped hole SP could descend into.
+        let Some(stack_base) = page::alloc_contiguous(STACK_PAGES) else {
+            mmu::free_addr_space(new_pt);
+            return None;
+        };
+        let stack_top = stack_base + page::PAGE_SIZE * STACK_PAGES;
+
+        if !map_user_image(new_pt, loaded) || !map_user_stack(new_pt, stack_base) {
+            // free_addr_space also reclaims the L2 tables the shatters allocated
+            // (the shared KERNEL_L2 is skipped -- free_l2_table no-ops on
+            // non-pool addresses).
+            page::free_contiguous(stack_base, STACK_PAGES);
+            mmu::free_addr_space(new_pt);
+            return None;
+        }
+
+        // 0x10 = User mode (PL0), IRQs enabled; T-bit from the entry LSB.
+        let ctx = Context::initial(loaded.entry as u32, stack_top as u32, 0x10);
+
+        let proc = Process {
+            pid,
+            state: State::Ready,
+            ctx,
+            parent: Some(CURRENT),
+            exit_status: 0,
+            page_table_phys: new_pt,
+            stack_base,
+            stack_pages: STACK_PAGES,
+            heap_break: DEFAULT_HEAP_BREAK,
+            mappings: [None; MAX_MAPPINGS],
+            signal_state: SignalState::new(),
+            uid: 1,
+            wake_tick: 0,
+            capabilities: crate::capability::Capabilities::FORK_DEFAULT,
+            fds: crate::fd::FdTable::new(),
+        };
+        procs[slot] = Some(proc);
+        Some(pid)
+    }
+}
+
 /// Create a child process by cloning the current process's address space.
 /// Returns Some(child_pid) to the parent on success, or None on OOM.
 ///
@@ -1587,6 +1702,51 @@ mod tests {
             assert!(!trap_switched(), "self-switch must not flag a swap");
             assert_eq!(frame.r[0], 0x1234, "self-switch must not touch the frame");
             trap_leave();
+        }
+    }
+
+    #[test]
+    fn spawn_user_builds_pl0_context_and_isolated_space() {
+        // #482: spawn_user must build a PL0 (User mode, cpsr 0x10) process in
+        // its OWN address space, with the image mapped W^X user-accessible,
+        // the stack user-RW+XN, and kernel MMIO still PL1-only (PL0 faults).
+        // SAFETY: test-only; single-threaded (nextest process-per-test).
+        unsafe {
+            reset_all();
+            mmu::init_and_enable(); // populate the kernel L1 with SECTION descriptors
+
+            // .text RX (p_flags R|X = 0x5), .data RW (R|W = 0x6), at the
+            // page-aligned user VAs init.ld produces.
+            let loaded = crate::elf::LoadedElf::for_test(
+                0x7FF0_0000,
+                &[(0x7FF0_0000, 0x100, 0x5), (0x7FF0_1000, 0x100, 0x6)],
+            );
+            let pid = spawn_user(&loaded).expect("spawn_user must succeed");
+
+            let procs = &*core::ptr::addr_of!(PROCS);
+            let proc = procs[usize::from(pid)].as_ref().expect("pid must be live");
+            assert_eq!(proc.ctx.cpsr, 0x10, "must enter at PL0 (User mode)");
+            assert_eq!(proc.ctx.pc, 0x7FF0_0000, "entry pc");
+            let pt = proc.page_table_phys;
+            assert_ne!(pt, mmu::table_base(), "must have its own address space");
+
+            // .text page: user RX (0x46E); .data page: user RW+XN (0x47F).
+            assert_eq!(
+                mmu::read_l2_entry(pt, 0x7FF0_0000).unwrap(),
+                0x7FF0_0000u32 | 0x46E,
+                ".text must be user read-execute"
+            );
+            assert_eq!(
+                mmu::read_l2_entry(pt, 0x7FF0_1000).unwrap(),
+                0x7FF0_1000u32 | 0x47F,
+                ".data must be user read-write + execute-never"
+            );
+            // Device MMIO stays a PL1-only SECTION (never a user page table) --
+            // a PL0 access to it faults. (Extends the #323 regression.)
+            assert!(
+                mmu::read_l2_entry(pt, 0x1100_0000).is_none(),
+                "MMIO must not be a user-accessible page table"
+            );
         }
     }
 


### PR DESCRIPTION
Increment 2 of #482 (on the merged shatter_section primitive): **/init now runs at PL0 (User mode) in its own address space** instead of privileged in the kernel's.

- **elf.rs**: plumb per-segment `p_flags` → `LoadedElf.segments()` + `flags_to_prot`.
- **init.ld**: ALIGN(4096) per permission class (no page carries two classes).
- **process.rs**: `spawn_user` (cpsr=0x10) + `map_user_image` (per-segment W^X: text RX 0x46E, rodata 0x46F, data RW+XN 0x47F) + `map_user_stack` (contiguous via #475). Kernel .text/.data/stacks/MMIO stay PL1-only (#323 clone), so the kernel runs on a trap while PL0 faults on kernel memory.
- **kinit.rs**: /init + /shell via `spawn_user` (drops the fn-pointer transmute).

No #465 asm change — the trap frame already carries per-process cpsr.

**VERIFIED in QEMU (the boundary, both directions):**
- normal /init → spawned PL0 → svc Write traps to the PL1-mapped kernel → `init: hello from userspace` → exit 0.
- **isolation proof:** a PL0 /init reading the kernel load address (0x40008000) **DATA-ABORTS** (exit 2, DFAR=0x40008000), never reaching the write — PL0 cannot touch kernel memory.

Host: spawn_user builds cpsr=0x10 + own space, .text user-RX, .data user-RW+XN, MMIO PL1-only; **2194** tests (+1). All builds clean under -D warnings; kanon + fmt clean.

Refs #482 (permanent CI isolation-variant matrix + sys_execve wiring remain; the fault proof above is a one-off manual verification until the CI matrix lands).