### PR TITLE
Permanent CI proof of PL0 isolation via /init probe matrix (#487)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,3 +171,24 @@ jobs:
           grep -q 'image-resident initramfs signature verified' boot.log || { echo 'FAIL: initramfs signature was not verified (measured-userspace regression)'; exit 1; }
           grep -q '/init spawned' boot.log || { echo 'FAIL: /init did not spawn from the verified initramfs'; exit 1; }
           grep -q 'init: hello from userspace' boot.log || { echo 'FAIL: userspace /init did not run + syscall (PL0->dispatch->UART)'; exit 1; }
+          # PL0 isolation proof (#487/#482): boot /init probe variants that each
+          # attempt an operation illegal at PL0. A correctly-isolated kernel
+          # faults with the exact qemu abort exit code and never prints "hello",
+          # so any regression that lets PL0 touch kernel memory / run a
+          # privileged instruction (which would instead run + print hello +
+          # exit 0) fails CI. kread: read kernel 0x40008000 -> data abort (2);
+          # kwrite: write kernel 0x40008000 -> data abort (2); kexec: execute
+          # kernel .text -> prefetch abort (3); cp15: read SCTLR (privileged) ->
+          # undefined instruction (4). cp15 is the linchpin: it SUCCEEDS at PL1,
+          # so a broken mode-drop would run + print hello + exit 0 (a red).
+          for probe in kread:2 kwrite:2 kexec:3 cp15:4; do
+            variant="${probe%%:*}"; want="${probe##*:}"
+            THUMOS_INIT_VARIANT="$variant" cargo build --release --target armv7a-none-eabi --features qemu --jobs 8
+            prc=0
+            THUMOS_INIT_VARIANT="$variant" THUMOS_QEMU_TIMEOUT=60 ../../scripts/qemu-runner.sh target/armv7a-none-eabi/release/thumos | tee "probe-$variant.log" || prc=$?
+            echo "=== isolation probe '$variant': runner rc=$prc (want $want) ==="
+            test "$prc" -eq "$want" || { echo "FAIL isolation[$variant]: PL0 op did not fault as expected (rc=$prc want=$want) -- isolation regression"; exit 1; }
+            grep -q '/init spawned PL0' "probe-$variant.log" || { echo "FAIL isolation[$variant]: /init did not spawn PL0 (cannot test isolation)"; exit 1; }
+            ! grep -q 'init: hello from userspace' "probe-$variant.log" || { echo "FAIL isolation[$variant]: /init reached the write -- the PL0 op did NOT fault (ISOLATION BROKEN)"; exit 1; }
+          done
+          echo "PL0 isolation verified: kernel read + kernel exec + privileged instruction all fault at PL0"

--- a/crates/thumos/build.rs
+++ b/crates/thumos/build.rs
@@ -165,38 +165,56 @@ fn generate_initramfs(manifest_dir: &Path, out_dir: &Path) {
 
     let rustc = env::var("RUSTC").unwrap_or_else(|_| "rustc".into());
     // kanon:ignore RUST/no-direct-process-command -- build script compiles the /init userspace binary; the rule targets runtime/kernel code and there is no build-time compiler wrapper to route through
-    let status = std::process::Command::new(rustc)
-        .args([
-            "--edition",
-            "2024",
-            "--target",
-            "armv7a-none-eabi",
-            "--crate-type",
-            "bin",
-            "-C",
-            "panic=abort",
-            "-C",
-            "opt-level=s",
-            "-C",
-            "relocation-model=static",
-        ])
-        .arg("-C")
-        .arg(format!("link-arg=-T{}", init_ld.display()))
-        // WHY 0x100: the armv7a default max-page-size (64 KB) pads the ELF file
-        // to a 0x10000 first-segment offset (~66 KB of zeros). from_cpio copies
-        // the whole ELF into ONE heap Vec, and the slab's large-alloc path
-        // (slab.rs) refuses multi-page (>4 KB) requests, so the image must stay
-        // under a single 4 KB page. A 0x100 page size drops the file-offset
-        // padding to 256 B, keeping this tiny /init well under one page. (A
-        // larger userspace needs multi-page/contiguous alloc support -- #475.)
-        .arg("-C")
-        .arg("link-arg=-z")
-        .arg("-C")
-        .arg("link-arg=max-page-size=0x100")
-        .arg("-o")
-        .arg(&init_elf)
-        .arg(&init_src)
-        .status();
+    let mut cmd = std::process::Command::new(rustc);
+    cmd.args([
+        "--edition",
+        "2024",
+        "--target",
+        "armv7a-none-eabi",
+        "--crate-type",
+        "bin",
+        "-C",
+        "panic=abort",
+        "-C",
+        "opt-level=s",
+        "-C",
+        "relocation-model=static",
+    ])
+    .arg("-C")
+    .arg(format!("link-arg=-T{}", init_ld.display()))
+    // WHY 0x100: the armv7a default max-page-size (64 KB) pads the ELF file
+    // to a 0x10000 first-segment offset (~66 KB of zeros). from_cpio copies
+    // the whole ELF into ONE heap Vec; a 0x100 page size drops the file-offset
+    // padding to 256 B, keeping this tiny /init small (#475's contiguous alloc
+    // covers a larger image regardless).
+    .arg("-C")
+    .arg("link-arg=-z")
+    .arg("-C")
+    .arg("link-arg=max-page-size=0x100")
+    // WHY (#487): declare the isolation-probe cfgs so a direct rustc compile
+    // does not warn on them as unexpected.
+    .arg("--check-cfg")
+    .arg("cfg(thumos_init_kread, thumos_init_kwrite, thumos_init_kexec, thumos_init_cp15)");
+
+    // WHY (#487): THUMOS_INIT_VARIANT selects an /init probe variant so CI can
+    // permanently prove PL0 isolation. Each variant compiles a different
+    // `_start` body via `--cfg thumos_init_<variant>` (see init/init.rs);
+    // build.rs re-runs when the env changes. Unset = the normal write+exit
+    // /init. The variant name is validated against the known set so a typo
+    // fails the build loudly instead of silently building the default.
+    println!("cargo:rerun-if-env-changed=THUMOS_INIT_VARIANT");
+    if let Ok(variant) = env::var("THUMOS_INIT_VARIANT") {
+        if !variant.is_empty() {
+            if !["kread", "kwrite", "kexec", "cp15"].contains(&variant.as_str()) {
+                die(&format!(
+                    "#487: unknown THUMOS_INIT_VARIANT '{variant}' (expected kread|kwrite|kexec|cp15)"
+                ));
+            }
+            cmd.arg("--cfg").arg(format!("thumos_init_{variant}"));
+        }
+    }
+
+    let status = cmd.arg("-o").arg(&init_elf).arg(&init_src).status();
     match status {
         Ok(s) if s.success() => {}
         Ok(s) => die(&format!("#474: rustc failed to build /init ({s})")),

--- a/crates/thumos/init/init.rs
+++ b/crates/thumos/init/init.rs
@@ -57,6 +57,52 @@ unsafe fn sys_exit(code: u32) -> ! {
 }
 
 /// ELF entry point (e_entry). The kernel transmutes the loaded entry to
+/// PL0 isolation probe (#487): under a `thumos_init_<variant>` cfg (set by
+/// build.rs from THUMOS_INIT_VARIANT), attempt a kernel-memory or privileged
+/// operation that MUST fault at PL0 -- BEFORE the normal write, so a working
+/// isolation boundary faults and "hello from userspace" never prints. CI
+/// asserts the exact qemu abort exit code per variant. The default build (no
+/// cfg) is a no-op, so /init behaves normally.
+///
+/// # Safety
+/// Each probe deliberately performs an operation that is illegal at PL0; on a
+/// correctly-isolated kernel it faults (never returns to the caller).
+#[inline(always)]
+unsafe fn isolation_probe() {
+    // Kernel load address (0x4000_8000) -- PL1-only in every process page
+    // table (#482), so a PL0 read data-aborts (qemu exit 2).
+    #[cfg(thumos_init_kread)]
+    // SAFETY: the read is expected to fault at PL0; it never completes.
+    unsafe {
+        core::ptr::read_volatile(0x4000_8000 as *const u32);
+    }
+    // A PL0 WRITE to kernel memory (the more dangerous capability) must also
+    // data-abort (exit 2). With the ARM AP model a page is all-or-nothing for
+    // PL0, so this shares the read's fault, but it exercises the write fault
+    // path specifically -- the capability an isolation break would most want.
+    #[cfg(thumos_init_kwrite)]
+    // SAFETY: the write is expected to fault at PL0; it never completes.
+    unsafe {
+        core::ptr::write_volatile(0x4000_8000 as *mut u32, 0);
+    }
+    // Kernel .text (PL1-RX) -- a PL0 instruction fetch prefetch-aborts (exit 3).
+    #[cfg(thumos_init_kexec)]
+    // SAFETY: transmuting a kernel address to a fn and calling it is expected
+    // to prefetch-abort at PL0; it never returns.
+    unsafe {
+        let f: extern "C" fn() = core::mem::transmute(0x4000_8000usize);
+        f();
+    }
+    // CP15 read (SCTLR) is privileged -- undefined instruction at PL0 (exit 4).
+    // Proves the mode drop directly: at PL1 this succeeds, so a broken drop
+    // would fall through to exit 0 (a visible red).
+    #[cfg(thumos_init_cp15)]
+    // SAFETY: mrc p15 at PL0 traps as UNDEF; it never completes.
+    unsafe {
+        core::arch::asm!("mrc p15, 0, {}, c1, c0, 0", out(reg) _);
+    }
+}
+
 /// `fn() -> !` and calls it on the kernel-allocated process stack.
 #[unsafe(no_mangle)]
 pub extern "C" fn _start() -> ! {
@@ -64,6 +110,9 @@ pub extern "C" fn _start() -> ! {
     // SAFETY: `msg` is a .rodata literal in the loaded image (VA >= 0x40100000);
     // sys_exit terminates the process so control never falls through.
     unsafe {
+        // #487: no-op unless an isolation-probe variant is compiled, in which
+        // case this faults at PL0 before the write.
+        isolation_probe();
         sys_write(1, msg.as_ptr(), u32::try_from(msg.len()).unwrap_or(0));
         sys_exit(0);
     }


### PR DESCRIPTION
PL0 isolation (#482) was boot-proven ONCE by hand. The default CI boot only proves /init RUNS at PL0 -- not that PL0 CANNOT touch kernel memory. This makes fault-on-kernel-access a **permanent** CI assertion, so a regression (wrong AP bit / broken mode-drop) fails CI instead of slipping through green.

- **init.rs**: `isolation_probe()` gated on `thumos_init_<variant>` -- each variant does a PL0-illegal op before the write: `kread`/`kwrite` (kernel 0x40008000 R/W → data abort, exit 2), `kexec` (exec kernel .text → prefetch abort, exit 3), `cp15` (mrc p15 SCTLR → undef, exit 4). Default = no-op (exit 0).
- **build.rs**: `THUMOS_INIT_VARIANT` selects it (validated; re-signs the per-variant initramfs so it spawns through the #480 gate).
- **ci.yml**: a loop builds+boots each probe and asserts exact exit code + /init spawned PL0 + hello ABSENT.

**Fails closed both ways:** broken isolation → probe runs → hello + exit 0 ≠ want → red; plumbing break → exit 0 ≠ want → red. `cp15` is the linchpin (succeeds at PL1, proving the mode drop); `kwrite` covers the write capability distinctly.

Verified locally: default→0+hello; kread/kwrite→2; kexec→3; cp15→4; each spawns PL0, no hello. 2194 tests; all builds clean under -D warnings; kanon + fmt clean. Adversarially self-reviewed as T0.

Closes #487.