### PR TITLE
Retire MemoryType::UserText -- kernel view is fully W^X (#482)

### DIFF
--- a/crates/thumos/src/kconfig.rs
+++ b/crates/thumos/src/kconfig.rs
@@ -51,13 +51,14 @@ pub(crate) const KERNEL_RESERVED: usize = 0xF_8000;
 /// Kernel end address (load + reserved).
 pub(crate) const KERNEL_END: usize = KERNEL_LOAD + KERNEL_RESERVED;
 
-/// Userspace text region base (#474): the top 1 MB of DRAM
-/// (0x7FF0_0000..0x8000_0000). Mapped EXECUTABLE (all other DRAM is
-/// execute-never per W^X #417) and EXCLUDED from the page allocator (kinit
-/// passes this as the allocator's upper bound), so spawned userspace ELFs run
-/// here without colliding with kernel page allocations. A single shared region
-/// suffices while userspace runs privileged in the kernel address space;
-/// per-process user address spaces + PL0 isolation are Wave 4+.
+/// Userspace text region base (#474/#482): the top 1 MB of DRAM
+/// (0x7FF0_0000..0x8000_0000), the fixed identity load address for the
+/// image-resident /init. EXCLUDED from the page allocator (kinit passes this as
+/// the allocator's upper bound) so an allocation never collides with the loaded
+/// image. In the KERNEL address space it is plain RAM + execute-never (W^X
+/// #417 -- the kernel never executes user code from its own space); a spawned
+/// process runs it user-RX from its OWN page table via `mmu` per-process
+/// mappings (PL0 isolation, #482).
 pub(crate) const USER_TEXT_BASE: usize = 0x7FF0_0000;
 
 /// UART0 base address (MT6739 ttyMT0, MTK 8250-style register map).

--- a/crates/thumos/src/mmu.rs
+++ b/crates/thumos/src/mmu.rs
@@ -494,10 +494,6 @@ pub enum MemoryType {
     Ram,
     /// Device/MMIO registers (non-cacheable, strongly ordered).
     Device,
-    /// Executable userspace text region (#474): normal RAM WITHOUT
-    /// execute-never so spawned userspace ELFs can run. All other RAM is XN
-    /// (W^X, #417).
-    UserText,
 }
 
 /// The W^X access-permission + execute bits for a kernel page at virtual
@@ -570,12 +566,6 @@ fn map_section(virt_mb: usize, phys_mb: usize, mem_type: MemoryType) {
             flags::SECTION | flags::AP_PL1_ONLY | flags::SHAREABLE | flags::NORMAL_WB_WA | flags::XN
         }
         MemoryType::Device => flags::SECTION | flags::AP_PL1_ONLY | flags::DEVICE | flags::XN,
-        // WHY (#474): identical to Ram but WITHOUT XN -- the one executable RAM
-        // section, holding spawned userspace code. PL1-only (privileged /init;
-        // PL0 isolation is Wave 4+).
-        MemoryType::UserText => {
-            flags::SECTION | flags::AP_PL1_ONLY | flags::SHAREABLE | flags::NORMAL_WB_WA
-        }
     };
     unsafe {
         let table = &mut *core::ptr::addr_of_mut!(L1);
@@ -643,16 +633,18 @@ pub unsafe fn init_and_enable() {
     #[cfg(test)]
     map_section(0x400, 0x400, MemoryType::Ram);
 
-    // DRAM beyond the kernel image, below the userspace text region:
-    // 0x4010_0000 - 0x7FEF_FFFF, RAM + XN (kernel heap + page allocator, #417).
-    for mb in 0x401..0x7FF {
+    // DRAM beyond the kernel image: 0x4010_0000 - 0x7FFF_FFFF, RAM + XN.
+    // WHY (#482): this INCLUDES the userspace text region (0x7FF0_0000, still
+    // excluded from the page allocator as the fixed /init load address). The
+    // kernel never executes user code from its own address space anymore --
+    // spawned processes run from their OWN page tables, where `map_user_image`
+    // maps the image user-RX. So the kernel view has NO executable RAM outside
+    // kernel .text, completing #417's W^X: a kernel control-flow hijack into
+    // the attacker-influenced /init image region now prefetch-aborts (XN)
+    // instead of executing. (Retires MemoryType::UserText.)
+    for mb in 0x401..0x800 {
         map_section(mb, mb, MemoryType::Ram);
     }
-    // Userspace text region (#474): the top 1 MB (0x7FF0_0000) is executable
-    // RAM so spawned userspace ELFs run. Excluded from the page allocator
-    // (kinit passes USER_TEXT_BASE as its upper bound) so it never holds kernel
-    // data. WHY 0x7FF: USER_TEXT_BASE (0x7FF0_0000) >> 20.
-    map_section(0x7FF, 0x7FF, MemoryType::UserText);
 
     // Program CP15 and enable address translation.
     // WHY(host-test): the L1 table is populated above on every target, but the


### PR DESCRIPTION
`MemoryType::UserText` mapped 0x7FF0_0000 as **executable RAM in the kernel address space** -- a leftover from before PL0 isolation. A spawned process now runs from its OWN page table (map_user_image maps it user-RX, #482); the kernel never executes user code from its own space.

So the top 1 MB is now plain **RAM + execute-never** like all other DRAM (still allocator-excluded as the /init load address). This completes #417's W^X in the kernel view: **no executable RAM outside kernel .text**. A kernel control-flow hijack into the attacker-influenced /init image region now prefetch-aborts (XN) instead of executing -- defense-in-depth.

Retires the variant + its map_section arm; init maps 0x401..0x800 uniformly as Ram. The 0x7FF section test passes unchanged (PL1-only, now +XN).

Verified: /init still spawns PL0 + runs + exit 0 (the qemu tripwire); isolation matrix intact (kread → exit 2, no hello); 2194 tests; all builds clean under -D warnings; kanon + fmt clean.

Refs #482.