### PR TITLE
Graceful user-fault handling: kill the faulter, kernel survives (#482)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,24 +171,44 @@ jobs:
           grep -q 'image-resident initramfs signature verified' boot.log || { echo 'FAIL: initramfs signature was not verified (measured-userspace regression)'; exit 1; }
           grep -q '/init spawned' boot.log || { echo 'FAIL: /init did not spawn from the verified initramfs'; exit 1; }
           grep -q 'init: hello from userspace' boot.log || { echo 'FAIL: userspace /init did not run + syscall (PL0->dispatch->UART)'; exit 1; }
-          # PL0 isolation proof (#487/#482): boot /init probe variants that each
-          # attempt an operation illegal at PL0. A correctly-isolated kernel
-          # faults with the exact qemu abort exit code and never prints "hello",
-          # so any regression that lets PL0 touch kernel memory / run a
-          # privileged instruction (which would instead run + print hello +
-          # exit 0) fails CI. kread: read kernel 0x40008000 -> data abort (2);
-          # kwrite: write kernel 0x40008000 -> data abort (2); kexec: execute
-          # kernel .text -> prefetch abort (3); cp15: read SCTLR (privileged) ->
-          # undefined instruction (4). cp15 is the linchpin: it SUCCEEDS at PL1,
-          # so a broken mode-drop would run + print hello + exit 0 (a red).
-          for probe in kread:2 kwrite:2 kexec:3 cp15:4; do
-            variant="${probe%%:*}"; want="${probe##*:}"
+          # PL0 isolation + graceful user-fault kill (#487 + fault handling):
+          # each probe variant attempts one PL0-illegal op. A correct kernel
+          # (a) faults it -- 'hello' never prints, (b) KILLS only the faulting
+          # process -- a USERFAULT marker names the kind, and (c) SURVIVES --
+          # the service loop still reaches its tick cap and exits 0. Fails
+          # closed on every axis: broken isolation runs the probe + prints hello
+          # (red on hello-absent AND the missing marker); a handler that still
+          # halts exits 2/3/4 != 0 (red); a kernel that dies after the kill
+          # never prints ticks= (red). cp15 stays the linchpin: it SUCCEEDS at
+          # PL1, so a broken mode-drop is a visible red, not a silent pass.
+          # kread/kwrite: kernel 0x40008000 R/W -> data-abort; kexec: exec
+          # kernel .text -> prefetch-abort; cp15: SCTLR read -> undefined-instruction.
+          for probe in kread:data-abort kwrite:data-abort kexec:prefetch-abort cp15:undefined-instruction; do
+            variant="${probe%%:*}"; kind="${probe##*:}"
             THUMOS_INIT_VARIANT="$variant" cargo build --release --target armv7a-none-eabi --features qemu --jobs 8
             prc=0
             THUMOS_INIT_VARIANT="$variant" THUMOS_QEMU_TIMEOUT=60 ../../scripts/qemu-runner.sh target/armv7a-none-eabi/release/thumos | tee "probe-$variant.log" || prc=$?
-            echo "=== isolation probe '$variant': runner rc=$prc (want $want) ==="
-            test "$prc" -eq "$want" || { echo "FAIL isolation[$variant]: PL0 op did not fault as expected (rc=$prc want=$want) -- isolation regression"; exit 1; }
+            echo "=== isolation probe '$variant': runner rc=$prc (want 0: kernel survives the kill) ==="
+            test "$prc" -eq 0 || { echo "FAIL isolation[$variant]: kernel did not survive the PL0 fault (rc=$prc; 2/3/4=halted-in-handler 5=loop-stall 1=panic 124=hang)"; exit 1; }
             grep -q '/init spawned PL0' "probe-$variant.log" || { echo "FAIL isolation[$variant]: /init did not spawn PL0 (cannot test isolation)"; exit 1; }
+            grep -Eq "USERFAULT: pid=[0-9]+ kind=$kind" "probe-$variant.log" || { echo "FAIL isolation[$variant]: no USERFAULT $kind kill marker -- PL0 op did not fault (ISOLATION BROKEN) or the kill path broke"; exit 1; }
             ! grep -q 'init: hello from userspace' "probe-$variant.log" || { echo "FAIL isolation[$variant]: /init reached the write -- the PL0 op did NOT fault (ISOLATION BROKEN)"; exit 1; }
+            grep -q 'THUMOS-QEMU: service-loop ticks=' "probe-$variant.log" || { echo "FAIL isolation[$variant]: service loop never resumed after the kill (kernel did not survive)"; exit 1; }
           done
-          echo "PL0 isolation verified: kernel read + kernel exec + privileged instruction all fault at PL0"
+          echo "PL0 isolation + graceful kill verified: every PL0-illegal op faults, the process is killed, the kernel survives"
+      - name: Kernel-fault halts (PL1 fault must NEVER be recovered)
+        working-directory: crates/thumos
+        # WHY: the other half of the safety property. A deliberate PL1 `udf`
+        # after boot-complete must take the KERNEL branch: qemu exit 4, no
+        # service-loop resume. If fault handling ever wrongly "recovers" a
+        # kernel fault, the boot continues to ticks=/exit 0 and this reds.
+        run: |
+          set -uo pipefail
+          cargo build --release --target armv7a-none-eabi --features qemu,kfault-probe --jobs 8
+          krc=0
+          THUMOS_QEMU_TIMEOUT=60 ../../scripts/qemu-runner.sh target/armv7a-none-eabi/release/thumos | tee kfault.log || krc=$?
+          echo "=== kernel-fault probe: runner rc=$krc (want 4) ==="
+          test "$krc" -eq 4 || { echo "FAIL kfault: PL1 udf did not halt with exit 4 (rc=$krc) -- a kernel fault must NEVER be gracefully recovered"; exit 1; }
+          grep -q 'KERNEL UNDEFINED INSTRUCTION' kfault.log || { echo 'FAIL kfault: missing kernel-fault banner'; exit 1; }
+          ! grep -q 'THUMOS-QEMU: service-loop ticks=' kfault.log || { echo 'FAIL kfault: service loop ran past a KERNEL fault (fault was masked)'; exit 1; }
+          ! grep -q 'USERFAULT:' kfault.log || { echo 'FAIL kfault: a PL1 fault took the USER kill branch (mode check broken)'; exit 1; }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,11 +191,19 @@ jobs:
             echo "=== isolation probe '$variant': runner rc=$prc (want 0: kernel survives the kill) ==="
             test "$prc" -eq 0 || { echo "FAIL isolation[$variant]: kernel did not survive the PL0 fault (rc=$prc; 2/3/4=halted-in-handler 5=loop-stall 1=panic 124=hang)"; exit 1; }
             grep -q '/init spawned PL0' "probe-$variant.log" || { echo "FAIL isolation[$variant]: /init did not spawn PL0 (cannot test isolation)"; exit 1; }
-            grep -Eq "USERFAULT: pid=[0-9]+ kind=$kind" "probe-$variant.log" || { echo "FAIL isolation[$variant]: no USERFAULT $kind kill marker -- PL0 op did not fault (ISOLATION BROKEN) or the kill path broke"; exit 1; }
+            grep -q "PROBE: $variant" "probe-$variant.log" || { echo "FAIL isolation[$variant]: the wrong probe variant was built (no 'PROBE: $variant' marker -- a cfg mixup)"; exit 1; }
+            grep -Eq "USERFAULT: pid=[0-9]+ kind=$kind .*killed" "probe-$variant.log" || { echo "FAIL isolation[$variant]: no USERFAULT $kind kill marker -- PL0 op did not fault (ISOLATION BROKEN) or the kill path broke"; exit 1; }
+            # Exactly ONE kill: a re-fault loop (kill path itself faulting) would
+            # print the marker repeatedly. Exactly one proves a clean single kill.
+            ufc=$(grep -c 'USERFAULT:' "probe-$variant.log")
+            test "$ufc" -eq 1 || { echo "FAIL isolation[$variant]: expected exactly 1 USERFAULT, got $ufc (a re-fault loop or double kill)"; exit 1; }
+            # The reaped half: PID 0 must reclaim the fault-killed PCB slot, else
+            # the process table leaks and exhausts at MAX_PROCS over uptime.
+            grep -q 'kardia: reaped .* fault-killed' "probe-$variant.log" || { echo "FAIL isolation[$variant]: fault-killed process was not reaped (PCB-slot leak -- table exhausts at MAX_PROCS)"; exit 1; }
             ! grep -q 'init: hello from userspace' "probe-$variant.log" || { echo "FAIL isolation[$variant]: /init reached the write -- the PL0 op did NOT fault (ISOLATION BROKEN)"; exit 1; }
             grep -q 'THUMOS-QEMU: service-loop ticks=' "probe-$variant.log" || { echo "FAIL isolation[$variant]: service loop never resumed after the kill (kernel did not survive)"; exit 1; }
           done
-          echo "PL0 isolation + graceful kill verified: every PL0-illegal op faults, the process is killed, the kernel survives"
+          echo "PL0 isolation + graceful kill + reap verified: every PL0-illegal op faults, the process is killed AND reaped, the kernel survives"
       - name: Kernel-fault halts (PL1 fault must NEVER be recovered)
         working-directory: crates/thumos
         # WHY: the other half of the safety property. A deliberate PL1 `udf`

--- a/crates/thumos/Cargo.toml
+++ b/crates/thumos/Cargo.toml
@@ -30,6 +30,11 @@ production = []
 # MT6739 build is unchanged without it. Mutually exclusive with `production`
 # (see main.rs compile_error!).
 qemu = []
+# WHY (#487 fault-handling): CI fault-injection harness -- executes a deliberate
+# PL1 `udf` after boot-complete so CI permanently pins the kernel-fault-HALTS
+# branch (qemu exit 4, no service-loop resume). Only meaningful with `qemu`;
+# mutually exclusive with `production` (main.rs compile_error!).
+kfault-probe = []
 
 [dependencies]
 aes = { version = "0.8", default-features = false }

--- a/crates/thumos/init/init.rs
+++ b/crates/thumos/init/init.rs
@@ -68,6 +68,29 @@ unsafe fn sys_exit(code: u32) -> ! {
 /// correctly-isolated kernel it faults (never returns to the caller).
 #[inline(always)]
 unsafe fn isolation_probe() {
+    // WHY (#491 review): emit a per-variant marker BEFORE the illegal op so CI
+    // can tell the probes apart -- kread and kwrite otherwise produce identical
+    // kind=data-abort output, so a cfg copy-paste swap would be invisible. A
+    // successful write here also confirms /init reached PL0 and can syscall.
+    #[cfg(any(
+        thumos_init_kread,
+        thumos_init_kwrite,
+        thumos_init_kexec,
+        thumos_init_cp15
+    ))]
+    // SAFETY: the marker literal lives in the loaded image (PL0-readable); the
+    // write is a normal syscall that returns before the illegal op below.
+    unsafe {
+        #[cfg(thumos_init_kread)]
+        let marker: &[u8] = b"PROBE: kread\n";
+        #[cfg(thumos_init_kwrite)]
+        let marker: &[u8] = b"PROBE: kwrite\n";
+        #[cfg(thumos_init_kexec)]
+        let marker: &[u8] = b"PROBE: kexec\n";
+        #[cfg(thumos_init_cp15)]
+        let marker: &[u8] = b"PROBE: cp15\n";
+        sys_write(1, marker.as_ptr(), u32::try_from(marker.len()).unwrap_or(0));
+    }
     // Kernel load address (0x4000_8000) -- PL1-only in every process page
     // table (#482), so a PL0 read data-aborts (qemu exit 2).
     #[cfg(thumos_init_kread)]

--- a/crates/thumos/init/init.rs
+++ b/crates/thumos/init/init.rs
@@ -1,14 +1,13 @@
 //! thumos /init (#474): minimal userspace bring-up program.
 //!
-//! Built by build.rs to a static armv7a ELF linked at 0x40100000
-//! (kconfig::KERNEL_END), wrapped in a newc CPIO, and embedded into the
+//! Built by build.rs to a static armv7a ELF linked at 0x7FF00000
+//! (kconfig::USER_TEXT_BASE), wrapped in a newc CPIO, and embedded into the
 //! kernel image. kinit spawns it from the boot root ramfs.
 //!
-//! WHY privileged: spawn currently runs this at PL1 (System mode) in the
-//! kernel address space -- true PL0 usermode isolation (own page table, W^X
-//! user pages, exception-return) is deferred (elf.rs Wave 4+). This proves the
-//! spawn -> schedule -> SVC -> dispatch path end to end, not a security
-//! boundary.
+//! Runs UNPRIVILEGED: spawn_user runs this at PL0 (User mode) in its own
+//! address space with the image mapped W^X (#482), so a kernel-memory access
+//! faults. Proves the spawn -> schedule -> SVC -> dispatch path AND the
+//! isolation boundary (see the #487 probe variants below).
 #![no_std]
 #![no_main]
 

--- a/crates/thumos/src/exceptions.rs
+++ b/crates/thumos/src/exceptions.rs
@@ -1,8 +1,9 @@
 //! ARM exception vector table and interrupt handler.
 //!
-//! The ARM Cortex-A53 has 7 exception vectors at fixed offsets.
-//! We place the vector table at a known address and install handlers
-//! for IRQ (FROM GIC) and data/prefetch abort (for debugging).
+//! The ARMv7-A (Cortex-A7) has 7 exception vectors at fixed offsets. We place
+//! the vector table at a known address and install handlers for IRQ (FROM GIC),
+//! SVC (syscalls), and the abort/undef traps. Abort/undef traps from PL0 kill
+//! the faulting process; from PL1 they halt the kernel (see handle_fault).
 //!
 //! Vector table layout (ARM ARM B1.8):
 //! Offset 0x00: Reset
@@ -138,22 +139,87 @@ core::arch::global_asm!(
     "    ldmia   sp, {{r0-r12}}",
     "    add     sp, sp, #68",
     "    movs    pc, lr", // exception return: CPSR := SPSR
-    // Abort handlers: print info and hang
+    // Abort/undef wrappers (graceful user-fault kill): same full-frame contract
+    // as IRQ/SVC (#465). Build a process::Context on the banked ABT/UND stack,
+    // pass it to the Rust handler, which either KILLS a PL0 faulter (frame
+    // swapped to the successor via process::switch_to; this epilogue
+    // exception-returns into it) or HALTS on a PL1 fault (the handler diverges;
+    // this epilogue is never reached). Saved pc = the FAULTING instruction (ARM
+    // ARM B1.8.3 Table B1-7 link offsets: data abort lr-8, prefetch abort lr-4,
+    // undef lr-4 ARM / lr-2 Thumb); pc is diagnostic-only on both paths -- a
+    // fault frame is never resumed.
+    // INVARIANT: this epilogue's `ldm {r13,r14}^` user-bank restore is correct
+    // ONLY because it is reached solely on the kill path, where the frame holds
+    // a scheduled process's context (mode 0x10 or 0x1F -- both use the user
+    // bank). A PL1 fault (including one from SVC/IRQ/ABT/UND mode, whose banked
+    // sp/lr this frame does NOT capture) halts in Rust and never returns here.
     "data_abort_handler_asm:",
-    "    push    {{r0-r12, lr}}",
+    "    sub     lr, lr, #8", // pc = faulting instruction (DA: lr = pc+8)
+    "    sub     sp, sp, #68",
+    "    stmia   sp, {{r0-r12}}",
+    "    str     lr, [sp, #60]", // pc
+    "    mrs     r0, spsr",
+    "    str     r0, [sp, #64]", // cpsr (= SPSR: the faulter's mode)
+    "    add     r0, sp, #52",
+    "    stmia   r0, {{r13, r14}}^", // banked user sp @52, lr @56
+    "    nop",                       // ldm/stm(user) hazard barrier
+    "    mov     r0, sp",            // frame ptr -> handler
     "    bl      data_abort_handler_rust",
-    "    pop     {{r0-r12, lr}}",
-    "    b       .",
+    "    add     r0, sp, #52", // kill path only: frame = successor
+    "    ldmia   r0, {{r13, r14}}^",
+    "    nop", // hazard barrier
+    "    ldr     r0, [sp, #64]",
+    "    msr     spsr_cxsf, r0",
+    "    ldr     lr, [sp, #60]",
+    "    ldmia   sp, {{r0-r12}}",
+    "    add     sp, sp, #68",
+    "    movs    pc, lr", // exception return: CPSR := SPSR
     "prefetch_abort_handler_asm:",
-    "    push    {{r0-r12, lr}}",
+    "    sub     lr, lr, #4", // pc = faulting instruction (PA: lr = pc+4)
+    "    sub     sp, sp, #68",
+    "    stmia   sp, {{r0-r12}}",
+    "    str     lr, [sp, #60]",
+    "    mrs     r0, spsr",
+    "    str     r0, [sp, #64]",
+    "    add     r0, sp, #52",
+    "    stmia   r0, {{r13, r14}}^",
+    "    nop",
+    "    mov     r0, sp",
     "    bl      prefetch_abort_handler_rust",
-    "    pop     {{r0-r12, lr}}",
-    "    b       .",
+    "    add     r0, sp, #52",
+    "    ldmia   r0, {{r13, r14}}^",
+    "    nop",
+    "    ldr     r0, [sp, #64]",
+    "    msr     spsr_cxsf, r0",
+    "    ldr     lr, [sp, #60]",
+    "    ldmia   sp, {{r0-r12}}",
+    "    add     sp, sp, #68",
+    "    movs    pc, lr",
     "undefined_handler_asm:",
-    "    push    {{r0-r12, lr}}",
+    // UNDEF's link offset is STATE-dependent (ARM pc+4, Thumb pc+2), so adjust
+    // pc using SPSR.T after saving the registers (r0 is already captured).
+    "    sub     sp, sp, #68",
+    "    stmia   sp, {{r0-r12}}",
+    "    mrs     r0, spsr",
+    "    str     r0, [sp, #64]", // cpsr
+    "    tst     r0, #0x20",     // SPSR.T (Thumb)?
+    "    subeq   lr, lr, #4",    // ARM:   pc = lr - 4
+    "    subne   lr, lr, #2",    // Thumb: pc = lr - 2
+    "    str     lr, [sp, #60]", // pc = faulting instruction
+    "    add     r0, sp, #52",
+    "    stmia   r0, {{r13, r14}}^",
+    "    nop",
+    "    mov     r0, sp",
     "    bl      undefined_handler_rust",
-    "    pop     {{r0-r12, lr}}",
-    "    b       .",
+    "    add     r0, sp, #52",
+    "    ldmia   r0, {{r13, r14}}^",
+    "    nop",
+    "    ldr     r0, [sp, #64]",
+    "    msr     spsr_cxsf, r0",
+    "    ldr     lr, [sp, #60]",
+    "    ldmia   sp, {{r0-r12}}",
+    "    add     sp, sp, #68",
+    "    movs    pc, lr",
     // SVC (syscall) wrapper (#465/#474): identical full-frame handling to IRQ,
     // EXCEPT no `sub lr, #4` -- SVC lr already points at the instruction after
     // `svc`. The frame lets a syscall that switches away (Yield/Exit/futex)
@@ -299,59 +365,152 @@ fn irq_handler_body() {
     }
 }
 
-/// Data abort handler  -  print fault info and hang.
+/// Data abort trap: a PL0 fault kills the process, a PL1 fault halts. See
+/// [`handle_fault`].
 #[unsafe(no_mangle)]
-pub extern "C" fn data_abort_handler_rust() {
-    let mut serial = Uart::new();
+pub(crate) extern "C" fn data_abort_handler_rust(frame: *mut process::Context) {
     let dfar: u32;
     let dfsr: u32;
-    // SAFETY: CP15 system register access is a privileged operation. DFAR (c6, c0, 0)
-    // holds the faulting address and DFSR (c5, c0, 0) holds the fault status. Both
-    // are read-only in this context and are valid after a data abort exception.
+    // SAFETY: CP15 access is privileged. DFAR (c6, c0, 0) holds the faulting
+    // address, DFSR (c5, c0, 0) the fault status; both valid after a data abort.
     unsafe {
         core::arch::asm!("mrc p15, 0, {}, c6, c0, 0", out(reg) dfar); // DFAR
         core::arch::asm!("mrc p15, 0, {}, c5, c0, 0", out(reg) dfsr); // DFSR
     }
-    let _ = write!(serial, "\r\n!!! DATA ABORT !!!\r\n"); // WHY: best-effort serial write in exception handler; cannot recover from UART failure
-    let _ = write!(serial, "DFAR: {dfar:#010x} (fault address)\r\n"); // WHY: best-effort serial write in exception handler; cannot recover from UART failure
-    let _ = write!(serial, "DFSR: {dfsr:#010x} (fault status)\r\n"); // WHY: best-effort serial write in exception handler; cannot recover from UART failure
-    // WHY(qemu): distinct exit code lets CI tell a data abort from a panic
-    // or a hang; the asm wrapper otherwise parks in `b .` until timeout.
-    #[cfg(feature = "qemu")]
-    crate::qemu::request_exit(2);
+    handle_fault(
+        frame,
+        process::FaultKind::DataAbort {
+            fault_addr: dfar,
+            fault_status: dfsr,
+        },
+        2,
+    );
 }
 
-/// Prefetch abort handler.
+/// Prefetch abort trap: a PL0 fault kills the process, a PL1 fault halts.
 #[unsafe(no_mangle)]
-pub extern "C" fn prefetch_abort_handler_rust() {
-    let mut serial = Uart::new();
+pub(crate) extern "C" fn prefetch_abort_handler_rust(frame: *mut process::Context) {
     let ifar: u32;
     let ifsr: u32;
-    // SAFETY: CP15 system register access is a privileged operation. IFAR (c6, c0, 2)
-    // holds the faulting instruction address and IFSR (c5, c0, 1) holds the fault
-    // status. Both are read-only in this context and are valid after a prefetch abort.
+    // SAFETY: CP15 access is privileged. IFAR (c6, c0, 2) holds the faulting
+    // fetch address, IFSR (c5, c0, 1) the status; both valid after a prefetch abort.
     unsafe {
         core::arch::asm!("mrc p15, 0, {}, c6, c0, 2", out(reg) ifar); // IFAR
         core::arch::asm!("mrc p15, 0, {}, c5, c0, 1", out(reg) ifsr); // IFSR
     }
-    let _ = write!(serial, "\r\n!!! PREFETCH ABORT !!!\r\n"); // WHY: best-effort serial write in exception handler; cannot recover from UART failure
-    let _ = write!(serial, "IFAR: {ifar:#010x}\r\n"); // WHY: best-effort serial write in exception handler; cannot recover from UART failure
-    let _ = write!(serial, "IFSR: {ifsr:#010x}\r\n"); // WHY: best-effort serial write in exception handler; cannot recover from UART failure
-    // WHY(qemu): distinct exit code for CI (3 = prefetch abort).
-    #[cfg(feature = "qemu")]
-    crate::qemu::request_exit(3);
+    handle_fault(
+        frame,
+        process::FaultKind::PrefetchAbort {
+            fault_addr: ifar,
+            fault_status: ifsr,
+        },
+        3,
+    );
 }
 
-/// Undefined instruction handler.
+/// Undefined-instruction trap: a PL0 fault kills the process, a PL1 fault halts.
 #[unsafe(no_mangle)]
-pub extern "C" fn undefined_handler_rust() {
+pub(crate) extern "C" fn undefined_handler_rust(frame: *mut process::Context) {
+    handle_fault(frame, process::FaultKind::UndefinedInstruction, 4);
+}
+
+/// Shared fault-trap body for the abort/undef handlers.
+///
+/// Disposition comes from the SAVED CPSR mode in the trap frame
+/// (`process::fault_disposition`, host-tested):
+/// - PL0 (User): print the `USERFAULT` kill marker, kill via
+///   `process::fault_exit_current` (Dead + PID-0 IPC + teardown + frame swap to
+///   the successor) and RETURN -- the stub epilogue exception-returns into the
+///   successor. The kernel and every other process continue.
+/// - PL1 (everything else): a kernel bug. Print the fault state and halt: qemu
+///   exits with the per-kind CI code; hardware parks with IRQs masked so the
+///   un-petted watchdog resets. NEVER returns -- continuing past a kernel fault
+///   would mask corruption of unknown extent.
+fn handle_fault(frame: *mut process::Context, kind: process::FaultKind, qemu_exit_code: u32) {
+    // SAFETY: `frame` is the Context the stub built on the ABT/UND stack --
+    // valid and unaliased for this call (traps never nest: entry masks I, and no
+    // handler re-enables it).
+    unsafe { process::trap_enter(frame) };
+    // SAFETY: same frame liveness; copy the saved state for reporting.
+    let saved = unsafe { *frame };
     let mut serial = Uart::new();
-    serial
-        .write_str("\r\n!!! UNDEFINED INSTRUCTION !!!\r\n")
-        .ok();
-    // WHY(qemu): distinct exit code for CI (4 = undefined instruction).
-    #[cfg(feature = "qemu")]
-    crate::qemu::request_exit(4);
+    match process::fault_disposition(saved.cpsr) {
+        process::FaultDisposition::KillUser => {
+            let pid = process::current_pid();
+            // WHY: machine-parseable kill marker -- the CI isolation matrix
+            // asserts `USERFAULT: pid=N kind=<kind>` per probe. Best-effort
+            // serial write; cannot recover from UART failure.
+            let _ = match kind {
+                process::FaultKind::DataAbort {
+                    fault_addr,
+                    fault_status,
+                } => write!(
+                    serial,
+                    "USERFAULT: pid={pid} kind=data-abort addr={fault_addr:#010x} status={fault_status:#010x} killed\r\n"
+                ),
+                process::FaultKind::PrefetchAbort {
+                    fault_addr,
+                    fault_status,
+                } => write!(
+                    serial,
+                    "USERFAULT: pid={pid} kind=prefetch-abort addr={fault_addr:#010x} status={fault_status:#010x} killed\r\n"
+                ),
+                process::FaultKind::UndefinedInstruction => write!(
+                    serial,
+                    "USERFAULT: pid={pid} kind=undefined-instruction pc={:#010x} killed\r\n",
+                    saved.pc
+                ),
+            };
+            process::fault_exit_current(kind);
+            process::trap_leave();
+            // Returning re-enters the stub epilogue, which exception-returns
+            // into the successor's frame.
+        }
+        process::FaultDisposition::KernelHalt => {
+            let name = match kind {
+                process::FaultKind::DataAbort { .. } => "DATA ABORT",
+                process::FaultKind::PrefetchAbort { .. } => "PREFETCH ABORT",
+                process::FaultKind::UndefinedInstruction => "UNDEFINED INSTRUCTION",
+            };
+            let _ = write!(serial, "\r\n!!! KERNEL {name} !!!\r\n"); // WHY: best-effort serial write in exception handler
+            let _ = write!(
+                serial,
+                "PC:   {:#010x} (faulting instruction)\r\n",
+                saved.pc
+            ); // WHY: best-effort serial write
+            let _ = write!(serial, "CPSR: {:#010x} (faulting mode)\r\n", saved.cpsr); // WHY: best-effort serial write
+            match kind {
+                process::FaultKind::DataAbort {
+                    fault_addr,
+                    fault_status,
+                } => {
+                    let _ = write!(serial, "DFAR: {fault_addr:#010x} (fault address)\r\n"); // WHY: best-effort serial write
+                    let _ = write!(serial, "DFSR: {fault_status:#010x} (fault status)\r\n"); // WHY: best-effort serial write
+                }
+                process::FaultKind::PrefetchAbort {
+                    fault_addr,
+                    fault_status,
+                } => {
+                    let _ = write!(serial, "IFAR: {fault_addr:#010x}\r\n"); // WHY: best-effort serial write
+                    let _ = write!(serial, "IFSR: {fault_status:#010x}\r\n"); // WHY: best-effort serial write
+                }
+                process::FaultKind::UndefinedInstruction => {}
+            }
+            // WHY(qemu): distinct exit codes let CI tell a KERNEL data abort (2)
+            // / prefetch abort (3) / undef (4) from a panic (1) or hang.
+            #[cfg(feature = "qemu")]
+            crate::qemu::request_exit(qemu_exit_code);
+            #[cfg(not(feature = "qemu"))]
+            let _ = qemu_exit_code;
+            // INVARIANT: never continue past a PL1 fault. Park with IRQs masked
+            // (exception entry set CPSR.I); the timer IRQ can no longer pet the
+            // watchdog, so hardware resets -- the same end-state as the previous
+            // `b .` stubs.
+            loop {
+                core::hint::spin_loop();
+            }
+        }
+    }
 }
 
 /// SVC (supervisor call) handler -- the userspace -> kernel syscall entry

--- a/crates/thumos/src/exceptions.rs
+++ b/crates/thumos/src/exceptions.rs
@@ -427,9 +427,15 @@ pub(crate) extern "C" fn undefined_handler_rust(frame: *mut process::Context) {
 ///   un-petted watchdog resets. NEVER returns -- continuing past a kernel fault
 ///   would mask corruption of unknown extent.
 fn handle_fault(frame: *mut process::Context, kind: process::FaultKind, qemu_exit_code: u32) {
-    // SAFETY: `frame` is the Context the stub built on the ABT/UND stack --
-    // valid and unaliased for this call (traps never nest: entry masks I, and no
-    // handler re-enables it).
+    // SAFETY: `frame` is the Context the stub built on the ABT/UND stack, valid
+    // and unaliased for this call. ACTIVE_FRAME holds one frame at a time: an
+    // IRQ cannot preempt this handler (entry masks CPSR.I). A SYNCHRONOUS
+    // re-fault from within this handler's own code IS architecturally possible
+    // (aborts/undef are not I-gated) -- but it is made safe, not by
+    // non-nesting, but because such a re-fault's saved mode is a privileged
+    // mode (ABT/UND/SVC/...), never User 0x10, so fault_disposition routes it to
+    // KernelHalt, which parks without resuming or recursing further -- bounding
+    // the depth at one level.
     unsafe { process::trap_enter(frame) };
     // SAFETY: same frame liveness; copy the saved state for reporting.
     let saved = unsafe { *frame };

--- a/crates/thumos/src/kardia.rs
+++ b/crates/thumos/src/kardia.rs
@@ -9,15 +9,12 @@
 //! scheduler round-robins away from PID 0 and back; the loop itself never
 //! calls `process::schedule()`.
 //!
-//! WARNING (coexistence is UNVERIFIED): the "timer IRQ preempts PID 0 and
-//! round-robins back" model is correct by construction, but has zero runtime
-//! coverage -- `process::switch_to`'s taken branch is `cfg(target_arch=arm)`
-//! asm (a no-op on host tests) and no userspace ELF has ever run (`/init`
-//! and `/shell` are missing from the ramfs). The qemu tick-cap below
-//! exercises only the solo-PID-0 path. TODO(#420)[deliberate-prudent]: once a userspace ELF
-//! exists in the qemu ramfs, add a two-process qemu soak that forces
-//! `schedule() -> switch_to() -> round-robin back to PID 0` before phone
-//! bring-up depends on preemption.
+//! Coexistence is VERIFIED (#482/#487 + fault handling): the qemu isolation
+//! matrix boots a real PL0 `/init`, so the timer IRQ preempts PID 0 into
+//! userspace, `process::switch_to`'s taken branch runs, the process faults, the
+//! kernel kills + reaps it, and control round-robins back to this loop (which
+//! then services ticks to the cap). That is the two-process preempt-and-return
+//! soak TODO(#420) asked for, now permanent in CI.
 //!
 //! WHY WFI (not WFE) for the phone idle (#461): WFE has no configured event
 //! source (no SEV/SEVONPEND) and parks forever under qemu-virt; WFI wakes on
@@ -209,6 +206,18 @@ pub(crate) fn service_loop(mut kernel: KernelState, mut serial: Uart) -> ! {
             // with the latest `now` -- poll(now) interfaces are time-based, so
             // catch-up replay is unnecessary.
             last_tick = now;
+            // WHY (#491 review): PID 0 is the parent of every spawned process,
+            // so it reaps fault-killed (and exited) children each tick --
+            // otherwise a fault-killed PCB slot leaks and the process table
+            // exhausts at MAX_PROCS after repeated user faults. The marker is
+            // the reaped-half witness the CI isolation matrix asserts.
+            let reaped = crate::process::reap_dead_children();
+            if reaped > 0 {
+                let _ = write!(
+                    serial,
+                    "kardia: reaped {reaped} fault-killed process(es)\r\n"
+                ); // WHY: best-effort diagnostic + CI marker
+            }
             // TODO(#400)[deliberate-prudent]: poll_input() -> key events -> active-screen dispatch.
             if kernel.poll_all(now) {
                 kernel.render_if_dirty();

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -1424,6 +1424,17 @@ pub unsafe fn run() -> ! {
     #[cfg(feature = "qemu")]
     let _ = serial.write_str("THUMOS-QEMU: boot-complete\r\n");
 
+    // Deliberate PL1 fault probe (#487 fault-handling): CI asserts the KERNEL
+    // branch halts (qemu exit 4) and the service loop never runs past it.
+    // Structurally excluded from production (main.rs compile_error!).
+    #[cfg(all(feature = "kfault-probe", target_arch = "arm"))]
+    {
+        let _ = serial.write_str("THUMOS-QEMU: kernel-fault probe (udf at PL1)\r\n");
+        // SAFETY: `udf #0` is a permanently-undefined encoding; the undef
+        // handler takes the KERNEL halt branch (System mode) and never returns.
+        unsafe { core::arch::asm!("udf #0") };
+    }
+
     // -----------------------------------------------------------------------
     // Debug console or idle
     // -----------------------------------------------------------------------

--- a/crates/thumos/src/main.rs
+++ b/crates/thumos/src/main.rs
@@ -61,6 +61,13 @@ compile_error!(
     "qemu and production are mutually exclusive: the QEMU bring-up harness remaps MT6739 peripheral addresses and must never ship."
 );
 
+// WHY (#487 fault-handling): the kfault-probe injects a deliberate kernel fault
+// for CI; a production image must never contain one.
+#[cfg(all(feature = "kfault-probe", feature = "production"))]
+compile_error!(
+    "kfault-probe is a CI fault-injection harness; a production image must not contain a deliberate kernel fault."
+);
+
 // WHY (issue #372): also gated `not(test)` — the console's command methods
 // (cmd_mem/cmd_ps/…) read kernel state via `crate::heap`/`page`/`process`,
 // several of which are themselves `#[cfg(not(test))]`, so the module cannot

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -54,6 +54,62 @@ pub enum FaultKind {
     UndefinedInstruction,
 }
 
+/// Disposition of a CPU fault, decided from the trap frame's saved CPSR.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FaultDisposition {
+    /// Fault came from User mode (PL0): kill the process; the kernel and every
+    /// other process continue.
+    KillUser,
+    /// Fault came from any PL1 mode: a kernel bug -- halt, never recover.
+    KernelHalt,
+}
+
+/// CPSR mode field mask (ARM ARM B1.3.1, M[4:0]).
+const CPSR_MODE_MASK: u32 = 0x1F;
+/// User mode (PL0) CPSR mode value.
+const CPSR_MODE_USER: u32 = 0x10;
+
+/// Kill-vs-halt decision for a fault, from the SAVED CPSR in the trap frame.
+///
+/// ONLY User mode (0x10) is killable: scheduled processes run at User
+/// (spawn_user/exec) or System (PID 0 + spawn kernel threads), and System-mode
+/// code is kernel code in the kernel address space, so its faults are kernel
+/// bugs. A saved exception mode (SVC/IRQ/ABT/UND/FIQ) means a HANDLER faulted
+/// -- also a kernel bug; ABT/UND halting here is what bounds recursion if the
+/// kill path itself faults. Fail-closed: anything unrecognized halts.
+pub(crate) fn fault_disposition(saved_cpsr: u32) -> FaultDisposition {
+    if saved_cpsr & CPSR_MODE_MASK == CPSR_MODE_USER {
+        FaultDisposition::KillUser
+    } else {
+        FaultDisposition::KernelHalt
+    }
+}
+
+/// Exit status for a fault-killed process: 128 + POSIX signal number
+/// (SIGSEGV=11 for aborts -> 139, SIGILL=4 for undef -> 132), so a wait-based
+/// supervisor can distinguish fault kills from voluntary exits.
+pub(crate) fn fault_exit_status(kind: FaultKind) -> i32 {
+    match kind {
+        FaultKind::DataAbort { .. } | FaultKind::PrefetchAbort { .. } => 139,
+        FaultKind::UndefinedInstruction => 132,
+    }
+}
+
+/// Kill the CURRENT process for `kind`, from abort/undef trap context: notify
+/// PID 0 (Dead + fd drain + IPC, via notify_fault), then run the exit path
+/// (exit_current: resource teardown + trap-frame swap to the successor). On
+/// return the trap frame holds the successor's context and the stub epilogue
+/// exception-returns into it -- the same unwind contract as the Exit syscall.
+///
+/// INVARIANT: exit_current frees the victim's L1 while TTBR0 still points at
+/// it; safe because free_addr_space only clears a pool bit (tables are zeroed
+/// at ALLOC, not free) and nothing allocates before switch_to's TTBR0 +
+/// TLBIALL -- the exact pattern the Exit-syscall path already relies on.
+pub(crate) fn fault_exit_current(kind: FaultKind) {
+    notify_fault(current_pid(), kind);
+    let _ = exit_current(fault_exit_status(kind)); // WHY: exit_current returns the SVC-return-value convention (u32, not a Result); the abort path has no syscall caller to return it to
+}
+
 /// Full trap-frame CPU context, captured at exception entry (#465).
 ///
 /// WARNING: THIS LAYOUT IS ABI. The exception stubs in `exceptions.rs` build
@@ -1747,6 +1803,112 @@ mod tests {
                 mmu::read_l2_entry(pt, 0x1100_0000).is_none(),
                 "MMIO must not be a user-accessible page table"
             );
+        }
+    }
+
+    #[test]
+    fn fault_disposition_kills_only_user_mode() {
+        // The killable set is EXACTLY User (0x10). System (0x1F) is PID 0 +
+        // spawn() kernel threads; SVC/IRQ/ABT/UND/FIQ mean a handler faulted.
+        // ABT/UND halting is the recursion breaker: if the kill path itself
+        // faults, the nested trap's saved mode is ABT/UND.
+        assert_eq!(fault_disposition(0x10), FaultDisposition::KillUser);
+        // The decision masks to M[4:0] -- flag/IT/E/T bits are ignored.
+        assert_eq!(fault_disposition(0x6000_0010), FaultDisposition::KillUser);
+        assert_eq!(fault_disposition(0x0000_0030), FaultDisposition::KillUser); // User + Thumb
+        for cpsr in [0x1Fu32, 0x13, 0x12, 0x17, 0x1B, 0x11, 0x16, 0x1A, 0x00] {
+            assert_eq!(
+                fault_disposition(cpsr),
+                FaultDisposition::KernelHalt,
+                "saved mode {cpsr:#x} is not User -- must halt, never recover a kernel fault"
+            );
+        }
+    }
+
+    #[test]
+    fn fault_exit_status_uses_posix_signal_convention() {
+        assert_eq!(
+            fault_exit_status(FaultKind::DataAbort {
+                fault_addr: 0,
+                fault_status: 0
+            }),
+            139
+        );
+        assert_eq!(
+            fault_exit_status(FaultKind::PrefetchAbort {
+                fault_addr: 0,
+                fault_status: 0
+            }),
+            139
+        );
+        assert_eq!(fault_exit_status(FaultKind::UndefinedInstruction), 132);
+    }
+
+    #[test]
+    fn fault_exit_current_kills_notifies_and_swaps_to_successor() {
+        fn fault_test_entry() -> ! {
+            loop {}
+        }
+        // The composed abort-path kill the ARM stubs rely on, end to end: Dead +
+        // fault status + resource teardown + PID-0 IPC + frame swap.
+        // SAFETY: test-only; reset_all reinitialises global state; nextest runs
+        // each test in its own process.
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            procs[0] = Some(test_process(mmu::alloc_addr_space().unwrap()));
+            let pid0_ctx = Context {
+                r: [3; 13],
+                sp: 0x4300_0000,
+                lr: 0x1,
+                pc: 0x4000_9000,
+                cpsr: 0x1F,
+            };
+            procs[0].as_mut().unwrap().ctx = pid0_ctx;
+            let pid = spawn(fault_test_entry).expect("spawn victim");
+            let free_before_kill = page::free_count();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            procs[usize::from(pid)].as_mut().unwrap().state = State::Running;
+            procs[0].as_mut().unwrap().state = State::Ready;
+            CURRENT = pid;
+
+            let mut frame = Context {
+                cpsr: 0x10,
+                ..Context::zero()
+            };
+            trap_enter(&mut frame as *mut Context);
+            fault_exit_current(FaultKind::DataAbort {
+                fault_addr: 0xDEAD_0000,
+                fault_status: 0x80D,
+            });
+
+            let procs = &*core::ptr::addr_of!(PROCS);
+            let victim = procs[usize::from(pid)].as_ref().unwrap();
+            assert_eq!(victim.state, State::Dead, "faulter must die");
+            assert_eq!(
+                victim.exit_status, 139,
+                "fault kill must carry the SIGSEGV-style status"
+            );
+            assert_eq!(victim.page_table_phys, 0, "address space must be reclaimed");
+            assert_eq!(
+                page::free_count(),
+                free_before_kill + STACK_PAGES,
+                "victim stack pages must return to the pool"
+            );
+            assert_eq!(
+                frame, pid0_ctx,
+                "trap frame must hold the successor (PID 0)"
+            );
+            let current = CURRENT;
+            assert_eq!(current, 0, "PID 0 must be the successor");
+            assert!(
+                trap_switched(),
+                "the stub epilogue must see a swapped frame"
+            );
+            let msg = ipc::recv().expect("PID 0 must receive the fault notification");
+            assert_eq!(msg.tag, 1, "DataAbort IPC tag");
+            assert_eq!(msg.payload()[0], pid, "payload names the faulting PID");
+            trap_leave();
         }
     }
 

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -718,6 +718,34 @@ pub(crate) fn waitpid(child_pid: Pid) -> Option<i32> {
     }
 }
 
+/// Reap every Dead child of the CURRENT process, returning each PCB slot to the
+/// free pool; returns the count reaped.
+///
+/// WHY (#491 review): a fault-killed process is marked Dead by the abort
+/// handler (fault_exit_current), but its PCB slot is only reclaimed by waitpid,
+/// which is otherwise reachable only via the SVC Waitpid syscall. The kardia
+/// service loop (PID 0, the parent of every spawned process) calls this each
+/// tick so a fault-killed slot does not leak -- without it the process table
+/// monotonically exhausts at MAX_PROCS after repeated user faults, and every
+/// subsequent spawn/fork silently fails while the kernel still appears alive.
+/// Scan-based (not fault-inbox-driven) so it reaps every Dead child even if the
+/// fault notification was dropped on a full inbox, and without consuming any
+/// non-fault IPC a userspace process may have sent PID 0.
+pub(crate) fn reap_dead_children() -> usize {
+    let mut reaped = 0;
+    for pid in 0..MAX_PROCS {
+        // waitpid reaps only a Dead child of CURRENT; live/non-child PIDs (and
+        // PID 0 itself, whose parent is None) return None and are skipped.
+        // MAX_PROCS (16) fits Pid (u8), so the cast is total.
+        if let Ok(p) = Pid::try_from(pid) {
+            if waitpid(p).is_some() {
+                reaped += 1;
+            }
+        }
+    }
+    reaped
+}
+
 /// Notify kinit (PID 0) that process `faulting_pid` has faulted.
 /// Marks the faulting process Dead and delivers a fault message to PID 0's inbox.
 ///
@@ -1909,6 +1937,68 @@ mod tests {
             assert_eq!(msg.tag, 1, "DataAbort IPC tag");
             assert_eq!(msg.payload()[0], pid, "payload names the faulting PID");
             trap_leave();
+        }
+    }
+
+    #[test]
+    fn reap_dead_children_frees_only_dead_children_of_current() {
+        // #491 review: the fix for the PCB-slot leak. reap_dead_children (run by
+        // PID 0's service loop) must free a Dead child's slot, leave a Running
+        // child alone, and never touch PID 0 itself.
+        // SAFETY: test-only; reset_all reinitialises global state; single-threaded.
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            procs[0] = Some(test_process(mmu::alloc_addr_space().unwrap()));
+            CURRENT = 0;
+            // A Dead child (fault-killed) + a Running child, both of PID 0.
+            let dead = Process {
+                pid: 1,
+                parent: Some(0),
+                state: State::Dead,
+                exit_status: 139,
+                ..test_process(mmu::alloc_addr_space().unwrap())
+            };
+            let running = Process {
+                pid: 2,
+                parent: Some(0),
+                state: State::Running,
+                ..test_process(mmu::alloc_addr_space().unwrap())
+            };
+            procs[1] = Some(dead);
+            procs[2] = Some(running);
+
+            let reaped = reap_dead_children();
+
+            let procs = &*core::ptr::addr_of!(PROCS);
+            assert_eq!(reaped, 1, "exactly the one Dead child is reaped");
+            assert!(procs[1].is_none(), "the Dead child's slot must be freed");
+            assert!(procs[2].is_some(), "the Running child must be left alone");
+            assert!(procs[0].is_some(), "PID 0 must never be reaped");
+        }
+    }
+
+    #[test]
+    fn reap_dead_children_ignores_a_dead_non_child() {
+        // A Dead process that is NOT a child of CURRENT must not be reaped by
+        // CURRENT (only the direct parent reaps).
+        // SAFETY: test-only; single-threaded.
+        unsafe {
+            reset_all();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            procs[0] = Some(test_process(mmu::alloc_addr_space().unwrap()));
+            CURRENT = 0;
+            let orphan = Process {
+                pid: 3,
+                parent: Some(2), // not a child of CURRENT (0)
+                state: State::Dead,
+                ..test_process(mmu::alloc_addr_space().unwrap())
+            };
+            procs[3] = Some(orphan);
+
+            assert_eq!(reap_dead_children(), 0, "a non-child Dead is not reaped");
+            let procs = &*core::ptr::addr_of!(PROCS);
+            assert!(procs[3].is_some(), "the non-child Dead slot is untouched");
         }
     }
 


### PR DESCRIPTION
A PL0 fault (data/prefetch abort, undef) **halted the whole kernel** -- unacceptable for a phone OS (any user bug takes down the device). Now a **user** fault kills only the faulting process and the kernel continues; a **kernel** fault still halts (a kernel bug must never be masked).

- **exceptions.rs**: the 3 abort/undef stubs build a full `Context` frame (extends #465 to the abort vectors; correct per-exception LR adjust). `handle_fault` reads the saved CPSR mode: User (0x10) → USERFAULT marker + kill via `fault_exit_current` (reuses exit_current's proven unwind → successor); anything else → **halt** (never mask a kernel bug; ABT/UND halting also bounds recursion).
- **process.rs**: `fault_disposition` (host-tested kill/halt rule), `fault_exit_status` (SIGSEGV/SIGILL), `fault_exit_current`.
- **kfault-probe** feature + kinit udf: CI permanently pins the kernel-fault-HALTS branch (excluded from production).
- **ci.yml**: the #487 matrix is now STRONGER -- each probe asserts killed (USERFAULT) + hello absent + **service loop resumes to exit 0** (kernel survived); a new stanza asserts the kfault build halts (exit 4). Fails closed on every axis.

**VERIFIED in QEMU (both halves):** kread/kwrite/kexec/cp15 → /init killed + kernel survives + ticks=50 exit 0, no hello; kfault → `KERNEL UNDEFINED INSTRUCTION` (CPSR mode 0x1F) → exit 4, no resume. Host **2197** (+3); all builds clean under -D warnings; kanon + fmt clean.

Fable-designed, T0-verified (design's claims checked against code; caught a bug in the prompt's undef LR offset). Refs #482.