### PR TITLE
Userspace sleep really yields -- no busy-wait deadlock (#477)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,3 +220,21 @@ jobs:
           grep -q 'KERNEL UNDEFINED INSTRUCTION' kfault.log || { echo 'FAIL kfault: missing kernel-fault banner'; exit 1; }
           ! grep -q 'THUMOS-QEMU: service-loop ticks=' kfault.log || { echo 'FAIL kfault: service loop ran past a KERNEL fault (fault was masked)'; exit 1; }
           ! grep -q 'USERFAULT:' kfault.log || { echo 'FAIL kfault: a PL1 fault took the USER kill branch (mode check broken)'; exit 1; }
+      - name: Userspace sleep really yields (#477, no busy-wait deadlock)
+        working-directory: crates/thumos
+        # WHY: a userspace nanosleep/Sleep must YIELD (switch away, resume after
+        # the interval), not busy-wait. The old busy-wait ran IRQ-masked in the
+        # SVC trap, so ticks() froze and the WHOLE kernel hung. The sleep /init
+        # variant sleeps 30ms between "sleeping" and "woke": a real yield lets
+        # the service loop run meanwhile and /init resume ("woke" + exit 0); a
+        # busy-wait hangs the kernel -> runner timeout (124), no "woke".
+        run: |
+          set -uo pipefail
+          THUMOS_INIT_VARIANT=sleep cargo build --release --target armv7a-none-eabi --features qemu --jobs 8
+          src=0
+          THUMOS_INIT_VARIANT=sleep THUMOS_QEMU_TIMEOUT=60 ../../scripts/qemu-runner.sh target/armv7a-none-eabi/release/thumos | tee sleep.log || src=$?
+          echo "=== sleep probe: runner rc=$src (want 0) ==="
+          test "$src" -eq 0 || { echo "FAIL sleep: kernel did not survive a userspace sleep (rc=$src; 124=hang -> busy-wait deadlock regression)"; exit 1; }
+          grep -q 'init: sleeping' sleep.log || { echo 'FAIL sleep: /init did not reach the sleep'; exit 1; }
+          grep -q 'init: woke' sleep.log || { echo 'FAIL sleep: /init never resumed from sleep (busy-wait deadlock or lost wake)'; exit 1; }
+          grep -q 'THUMOS-QEMU: service-loop ticks=' sleep.log || { echo 'FAIL sleep: service loop did not run (kernel hung during the sleep)'; exit 1; }

--- a/crates/thumos/build.rs
+++ b/crates/thumos/build.rs
@@ -194,7 +194,7 @@ fn generate_initramfs(manifest_dir: &Path, out_dir: &Path) {
     // WHY (#487): declare the isolation-probe cfgs so a direct rustc compile
     // does not warn on them as unexpected.
     .arg("--check-cfg")
-    .arg("cfg(thumos_init_kread, thumos_init_kwrite, thumos_init_kexec, thumos_init_cp15)");
+    .arg("cfg(thumos_init_kread, thumos_init_kwrite, thumos_init_kexec, thumos_init_cp15, thumos_init_sleep)");
 
     // WHY (#487): THUMOS_INIT_VARIANT selects an /init probe variant so CI can
     // permanently prove PL0 isolation. Each variant compiles a different
@@ -205,9 +205,9 @@ fn generate_initramfs(manifest_dir: &Path, out_dir: &Path) {
     println!("cargo:rerun-if-env-changed=THUMOS_INIT_VARIANT");
     if let Ok(variant) = env::var("THUMOS_INIT_VARIANT") {
         if !variant.is_empty() {
-            if !["kread", "kwrite", "kexec", "cp15"].contains(&variant.as_str()) {
+            if !["kread", "kwrite", "kexec", "cp15", "sleep"].contains(&variant.as_str()) {
                 die(&format!(
-                    "#487: unknown THUMOS_INIT_VARIANT '{variant}' (expected kread|kwrite|kexec|cp15)"
+                    "#487: unknown THUMOS_INIT_VARIANT '{variant}' (expected kread|kwrite|kexec|cp15|sleep)"
                 ));
             }
             cmd.arg("--cfg").arg(format!("thumos_init_{variant}"));

--- a/crates/thumos/init/init.rs
+++ b/crates/thumos/init/init.rs
@@ -37,6 +37,26 @@ unsafe fn sys_write(fd: u32, buf: *const u8, len: u32) -> u32 {
     ret
 }
 
+/// sleep(ms): suspend this process for at least `ms` milliseconds (#477 harness).
+///
+/// # Safety
+/// Yields to the scheduler; the kernel resumes this process after the interval.
+#[cfg(thumos_init_sleep)]
+#[inline(always)]
+unsafe fn sys_sleep(ms: u32) {
+    // SAFETY: issues SVC #7 (Sleep) per the thumos ABI; the kernel marks this
+    // process Sleeping, switches away, and resumes it after `ms` elapses.
+    unsafe {
+        core::arch::asm!(
+            "svc #0",
+            in("r7") 7u32,
+            in("r0") ms,
+            lateout("r0") _,
+            options(nostack),
+        );
+    }
+}
+
 /// exit(code): terminate this process; never returns.
 ///
 /// # Safety
@@ -135,6 +155,18 @@ pub extern "C" fn _start() -> ! {
         // #487: no-op unless an isolation-probe variant is compiled, in which
         // case this faults at PL0 before the write.
         isolation_probe();
+        // #477 sleep harness: sleep, then continue. If the kernel's sleep is a
+        // real yield, /init suspends (the service loop runs meanwhile) and
+        // resumes to print "woke"; a broken busy-wait sleep runs IRQ-masked and
+        // hard-hangs the whole kernel (runner timeout), so "woke" never prints.
+        #[cfg(thumos_init_sleep)]
+        {
+            let s = b"init: sleeping\n";
+            sys_write(1, s.as_ptr(), u32::try_from(s.len()).unwrap_or(0));
+            sys_sleep(30); // 30 ms = 3 scheduler ticks
+            let w = b"init: woke\n";
+            sys_write(1, w.as_ptr(), u32::try_from(w.len()).unwrap_or(0));
+        }
         sys_write(1, msg.as_ptr(), u32::try_from(msg.len()).unwrap_or(0));
         sys_exit(0);
     }

--- a/crates/thumos/src/syscall.rs
+++ b/crates/thumos/src/syscall.rs
@@ -337,26 +337,6 @@ impl Syscall {
     ];
 }
 
-/// Low-power wait-for-event hint, used by the tick-busy-wait sleep path.
-///
-/// On ARM this issues the `wfe` hint so the CPU parks until the next event
-/// (e.g. the timer IRQ). On the host test target there is no such instruction
-/// and no interrupt source, so it is a no-op.
-#[cfg(target_arch = "arm")]
-#[inline(always)]
-fn wait_for_event() {
-    // SAFETY: WFE is a hint instruction available in all ARM privilege levels.
-    // No memory is accessed; the CPU waits for the next event.
-    unsafe {
-        core::arch::asm!("wfe");
-    }
-}
-
-/// Host-test no-op counterpart to the ARM `wfe` hint.
-#[cfg(not(target_arch = "arm"))]
-#[inline(always)]
-fn wait_for_event() {}
-
 /// Syscall dispatch. Called FROM the SVC handler in `exceptions.rs`.
 ///
 /// # Arguments
@@ -453,11 +433,25 @@ pub(crate) fn dispatch(num: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> 
             const TICK_MS: u64 = 10;
             let ticks_needed = ms.saturating_add(TICK_MS - 1) / TICK_MS;
             let wake_tick = crate::exceptions::ticks().saturating_add(ticks_needed);
+            // Mark Sleeping and YIELD (#465/#477, mirrors sys_nanosleep): the
+            // old busy-wait hard-hung a userspace caller (SVC runs IRQ-masked,
+            // so ticks() froze and the kernel spun forever). The scheduler wakes
+            // the process at wake_tick; a later switch resumes it with r0=0.
             process::set_wake_tick(wake_tick);
-            while crate::exceptions::ticks() < wake_tick {
-                wait_for_event();
+            let next = process::schedule();
+            if next != process::current_pid() {
+                // WHY(#465): deposit the return value (0) before switching away.
+                process::set_trap_return(0);
+                // SAFETY: `next` is a valid Ready PID from schedule().
+                unsafe {
+                    process::switch_to(next);
+                }
+            } else {
+                // No other process to yield to (or a zero-length sleep the
+                // scheduler re-woke at once): the sleep is a no-op -- restore
+                // Running rather than linger mis-marked Sleeping.
+                process::clear_wake_tick();
             }
-            process::clear_wake_tick();
             0
         }
         Syscall::Send => {

--- a/crates/thumos/src/time.rs
+++ b/crates/thumos/src/time.rs
@@ -149,25 +149,6 @@ fn monotonic_secs() -> u64 {
     timer::counter() / freq
 }
 
-/// Low-power wait-for-event hint, used by the nanosleep tick-busy-wait.
-///
-/// On ARM this issues the `wfe` hint so the CPU parks until the next timer
-/// IRQ. On the host test target there is no such instruction and no interrupt
-/// source, so it is a no-op.
-#[cfg(target_arch = "arm")]
-#[inline(always)]
-fn wait_for_event() {
-    // SAFETY: WFE is a hint instruction available at EL1; no memory is accessed.
-    unsafe {
-        core::arch::asm!("wfe");
-    }
-}
-
-/// Host-test no-op counterpart to the ARM `wfe` hint.
-#[cfg(not(target_arch = "arm"))]
-#[inline(always)]
-fn wait_for_event() {}
-
 /// Convert a raw timer counter value to a (seconds, nanoseconds) pair.
 fn counter_to_timespec(count: u64, freq: u64) -> (u32, u32) {
     if freq == 0 {
@@ -296,25 +277,32 @@ pub(crate) fn sys_nanosleep(ts_ptr: u32) -> u32 {
     let now_ticks = exceptions::ticks();
     let wake_tick = now_ticks.saturating_add(ticks_needed);
 
-    // Record wake time in PCB and mark process as sleeping.
-    // SAFETY: set_wake_tick operates on the static PROCS table via addr_of_mut!,
-    // which is the established pattern for all process mutations in this kernel.
+    // Mark the process Sleeping (set_wake_tick does this) and YIELD to the
+    // scheduler -- the futex-wait pattern (#465/#477). The scheduler wakes a
+    // Sleeping process once now >= wake_tick, and a later switch resumes it in
+    // userspace at the instruction after the `svc` with r0=0 (set_trap_return
+    // below). The old busy-wait `while ticks() < wake_tick` hard-hung a
+    // userspace caller: the SVC trap runs IRQ-masked, so ticks() never advanced
+    // and the whole kernel spun forever.
+    // SAFETY: set_wake_tick mutates PROCS via addr_of_mut! (the established
+    // pattern) from syscall context (single-threaded, IRQs masked under SVC).
     process::set_wake_tick(wake_tick);
-
-    // TODO(#477)[deliberate-prudent]: busy-wait, not a real sleep. wake_tick is set and the
-    // scheduler already wakes Sleeping processes, but this loop spins instead
-    // of switching away. Under the SVC trap (IRQs masked) `ticks()` never
-    // advances here, so a userspace nanosleep hard-hangs. The #465 trap-frame
-    // switch now makes the correct fix reachable (mark Sleeping, set_trap_return
-    // (0), switch_to(schedule()), return -- the futex-wait pattern); #477 lands
-    // it with a sleeping-userspace QEMU test. Not reached today: no userspace
-    // program calls nanosleep yet.
-    while exceptions::ticks() < wake_tick {
-        wait_for_event();
+    let next = process::schedule();
+    if next != process::current_pid() {
+        // WHY(#465): deposit the wake-time return value (0) into the live trap
+        // frame before switching away, so the woken process's saved frame
+        // returns 0 from nanosleep.
+        process::set_trap_return(0);
+        // SAFETY: `next` is a valid Ready PID returned by schedule().
+        unsafe {
+            process::switch_to(next);
+        }
+    } else {
+        // No other process to yield to (degenerate: PID 0 is always Ready for a
+        // real userspace caller, so a switch normally occurs) -- restore Running
+        // rather than linger mis-marked Sleeping.
+        process::clear_wake_tick();
     }
-
-    // Clear the sleeping state now that we've woken.
-    process::clear_wake_tick();
     0
 }
 


### PR DESCRIPTION
nanosleep + the Sleep syscall busy-waited `while ticks() < wake_tick`. A userspace caller traps via `svc` (IRQ-masked), so ticks() froze and the loop spun forever -- **the first userspace sleep hard-hung the whole kernel**. Latent until now (nothing slept); #482 userspace makes it reachable.

Both paths now **yield** (the futex-wait pattern #465): mark Sleeping, set_trap_return(0), switch_to(schedule()), return. The scheduler wakes the process at wake_tick; a later switch resumes it in userspace with r0=0. A degenerate no-yield case (Sleep(0) / no other process) stays Running (clear_wake_tick). Removed the dead wait_for_event helpers.

**QEMU harness (#477):** a `sleep` /init variant sleeps 30ms between "sleeping" and "woke". A real yield lets the service loop run and /init resume; a busy-wait hangs the kernel (timeout 124, no "woke"). CI asserts exit 0 + sleeping + woke + ticks.

Verified: sleep → sleeping+woke+ticks=50 exit 0; default/kread/kfault unregressed; host **2199**; all builds clean under -D warnings; kanon + fmt clean.

Closes #477.