### PR TITLE
PL0-correct fork: deep-copy the child's address space (#478)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,3 +238,29 @@ jobs:
           grep -q 'init: sleeping' sleep.log || { echo 'FAIL sleep: /init did not reach the sleep'; exit 1; }
           grep -q 'init: woke' sleep.log || { echo 'FAIL sleep: /init never resumed from sleep (busy-wait deadlock or lost wake)'; exit 1; }
           grep -q 'THUMOS-QEMU: service-loop ticks=' sleep.log || { echo 'FAIL sleep: service loop did not run (kernel hung during the sleep)'; exit 1; }
+      - name: QEMU fork correctness + isolation (#478)
+        working-directory: crates/thumos
+        # WHY: a PL0 fork must give the child its OWN deep-copied memory. /init
+        # forks; the parent and child write DISTINCT markers (proving the r0
+        # split -- child gets 0, parent gets the child pid -- and that the child
+        # resumed at the fork return via the seeded trap frame); the child
+        # mutates a stack canary + a .data canary and the parent then checks its
+        # OWN copies are untouched (a shared-page fork leaks the mutation ->
+        # 'isolation BROKEN' + likely parent corruption/USERFAULT); the child
+        # exits(7) and the parent waitpids it (proving exit_cleanup freed the
+        # CHILD's frames, not the parent's -- else the parent's stack faults).
+        run: |
+          set -uo pipefail
+          THUMOS_INIT_VARIANT=fork cargo build --release --target armv7a-none-eabi --features qemu --jobs 8
+          frc=0
+          THUMOS_INIT_VARIANT=fork THUMOS_QEMU_TIMEOUT=60 ../../scripts/qemu-runner.sh target/armv7a-none-eabi/release/thumos | tee fork.log || frc=$?
+          echo "=== fork: runner rc=$frc (want 0) ==="
+          test "$frc" -eq 0 || { echo "FAIL fork: kernel did not survive (rc=$frc; 124=hang 2/3/4=abort)"; exit 1; }
+          grep -q 'init: fork parent' fork.log || { echo 'FAIL fork: no parent branch (fork did not return the child pid)'; exit 1; }
+          grep -q 'init: fork child' fork.log || { echo 'FAIL fork: no child branch (child did not resume at the fork return with r0=0 -- the #478 ctx seed)'; exit 1; }
+          grep -q 'init: fork isolation intact' fork.log || { echo 'FAIL fork: child writes reached the parent (SHARED PAGES -- deep copy broken)'; exit 1; }
+          ! grep -q 'init: fork isolation BROKEN' fork.log || { echo 'FAIL fork: explicit isolation break'; exit 1; }
+          ! grep -q 'init: fork FAILED' fork.log || { echo 'FAIL fork: fork returned an error'; exit 1; }
+          ! grep -q 'USERFAULT:' fork.log || { echo 'FAIL fork: a process faulted (bad child frame, bad mapping, or parent stack freed by the child exit)'; exit 1; }
+          grep -q 'init: hello from userspace' fork.log || { echo 'FAIL fork: parent did not continue past the harness'; exit 1; }
+          grep -q 'THUMOS-QEMU: service-loop ticks=' fork.log || { echo 'FAIL fork: kernel did not survive'; exit 1; }

--- a/crates/thumos/build.rs
+++ b/crates/thumos/build.rs
@@ -194,7 +194,7 @@ fn generate_initramfs(manifest_dir: &Path, out_dir: &Path) {
     // WHY (#487): declare the isolation-probe cfgs so a direct rustc compile
     // does not warn on them as unexpected.
     .arg("--check-cfg")
-    .arg("cfg(thumos_init_kread, thumos_init_kwrite, thumos_init_kexec, thumos_init_cp15, thumos_init_sleep)");
+    .arg("cfg(thumos_init_kread, thumos_init_kwrite, thumos_init_kexec, thumos_init_cp15, thumos_init_sleep, thumos_init_fork)");
 
     // WHY (#487): THUMOS_INIT_VARIANT selects an /init probe variant so CI can
     // permanently prove PL0 isolation. Each variant compiles a different
@@ -205,9 +205,9 @@ fn generate_initramfs(manifest_dir: &Path, out_dir: &Path) {
     println!("cargo:rerun-if-env-changed=THUMOS_INIT_VARIANT");
     if let Ok(variant) = env::var("THUMOS_INIT_VARIANT") {
         if !variant.is_empty() {
-            if !["kread", "kwrite", "kexec", "cp15", "sleep"].contains(&variant.as_str()) {
+            if !["kread", "kwrite", "kexec", "cp15", "sleep", "fork"].contains(&variant.as_str()) {
                 die(&format!(
-                    "#487: unknown THUMOS_INIT_VARIANT '{variant}' (expected kread|kwrite|kexec|cp15|sleep)"
+                    "#487: unknown THUMOS_INIT_VARIANT '{variant}' (expected kread|kwrite|kexec|cp15|sleep|fork)"
                 ));
             }
             cmd.arg("--cfg").arg(format!("thumos_init_{variant}"));

--- a/crates/thumos/init/init.rs
+++ b/crates/thumos/init/init.rs
@@ -41,7 +41,7 @@ unsafe fn sys_write(fd: u32, buf: *const u8, len: u32) -> u32 {
 ///
 /// # Safety
 /// Yields to the scheduler; the kernel resumes this process after the interval.
-#[cfg(thumos_init_sleep)]
+#[cfg(any(thumos_init_sleep, thumos_init_fork))]
 #[inline(always)]
 unsafe fn sys_sleep(ms: u32) {
     // SAFETY: issues SVC #7 (Sleep) per the thumos ABI; the kernel marks this
@@ -74,6 +74,42 @@ unsafe fn sys_exit(code: u32) -> ! {
         );
     }
 }
+
+/// fork() -> child pid in the parent, 0 in the child, u32::MAX on failure.
+///
+/// # Safety
+/// Creates a child process; both branches return here (the #478 ctx seed).
+#[cfg(thumos_init_fork)]
+#[inline(always)]
+unsafe fn sys_fork() -> u32 {
+    let ret;
+    // SAFETY: SVC #10 (Fork) per the thumos ABI.
+    unsafe {
+        core::arch::asm!("svc #0", in("r7") 10u32, lateout("r0") ret, options(nostack));
+    }
+    ret
+}
+
+/// waitpid(pid) -> exit status, or u32::MAX while the child is not yet Dead
+/// (non-blocking).
+///
+/// # Safety
+/// Reads a child's exit status; reaps its slot when Dead.
+#[cfg(thumos_init_fork)]
+#[inline(always)]
+unsafe fn sys_waitpid(pid: u32) -> u32 {
+    let ret;
+    // SAFETY: SVC #12 (Waitpid) per the thumos ABI.
+    unsafe {
+        core::arch::asm!("svc #0", in("r7") 12u32, inlateout("r0") pid => ret, options(nostack));
+    }
+    ret
+}
+
+/// .data isolation canary (#478): a user-RW image page. The child mutates its
+/// OWN copy; a shared-page fork would leak the mutation into the parent.
+#[cfg(thumos_init_fork)]
+static mut FORK_DATA_CANARY: u32 = 0x0000_5EED;
 
 /// ELF entry point (e_entry). The kernel transmutes the loaded entry to
 /// PL0 isolation probe (#487): under a `thumos_init_<variant>` cfg (set by
@@ -166,6 +202,48 @@ pub extern "C" fn _start() -> ! {
             sys_sleep(30); // 30 ms = 3 scheduler ticks
             let w = b"init: woke\n";
             sys_write(1, w.as_ptr(), u32::try_from(w.len()).unwrap_or(0));
+        }
+        // #478 fork harness: fork, both branches write a DISTINCT marker (proving
+        // the r0 split + the child resuming at the fork return), the child
+        // mutates two canaries the parent then checks (a shared-page fork leaks
+        // them = isolation BROKEN), the child exits and the parent waitpids it.
+        #[cfg(thumos_init_fork)]
+        {
+            let mut stack_canary: u32 = 0xA5A5_5A5A;
+            core::ptr::write_volatile(&mut stack_canary, 0xA5A5_5A5A);
+            let pid = sys_fork();
+            if pid == 0 {
+                // CHILD: resumes HERE (the fork return) iff the ctx seed is
+                // right; mutates its OWN canary copies.
+                core::ptr::write_volatile(&mut stack_canary, 0xDEAD_DEAD);
+                core::ptr::write_volatile(core::ptr::addr_of_mut!(FORK_DATA_CANARY), 0xDEAD_DEAD);
+                let m = b"init: fork child\n";
+                sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+                sys_exit(7);
+            }
+            if pid == u32::MAX {
+                let m = b"init: fork FAILED\n";
+                sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+                sys_exit(1);
+            }
+            let m = b"init: fork parent\n";
+            sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+            // Reap: waitpid is non-blocking (u32::MAX until Dead); sleep yields
+            // so the Ready child runs.
+            loop {
+                if sys_waitpid(pid) != u32::MAX {
+                    break;
+                }
+                sys_sleep(10);
+            }
+            let ok = core::ptr::read_volatile(&stack_canary) == 0xA5A5_5A5A
+                && core::ptr::read_volatile(core::ptr::addr_of!(FORK_DATA_CANARY)) == 0x0000_5EED;
+            let m: &[u8] = if ok {
+                b"init: fork isolation intact\n"
+            } else {
+                b"init: fork isolation BROKEN\n"
+            };
+            sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
         }
         sys_write(1, msg.as_ptr(), u32::try_from(msg.len()).unwrap_or(0));
         sys_exit(0);

--- a/crates/thumos/src/mmu.rs
+++ b/crates/thumos/src/mmu.rs
@@ -875,9 +875,14 @@ pub fn alloc_addr_space() -> Option<usize> {
 /// space's L1 entries -- page-mapped mmap/heap/stack regions the process
 /// never individually unmapped before exit -- so a process that exits
 /// without tearing down its own mappings cannot permanently strand pool
-/// slots (#330). Cloned kernel identity-map entries are section descriptors
-/// (`flags::SECTION`, bits [1:0] = 0b10), never `page_flags::L1_PAGE_TABLE`
-/// (0b01), so this walk never touches or frees the kernel's own mappings.
+/// slots (#330). Cloned kernel identity-map entries are section descriptors,
+/// so the walk skips them. The ONE cloned kernel entry that IS an
+/// `L1_PAGE_TABLE` -- the shared `KERNEL_L2` at L1[0x400] (#417 W^X) -- is
+/// visited by this walk, but `free_l2_table` rejects it: it only frees an
+/// address that matches an `L2_TABLES` pool slot, and `KERNEL_L2` is a separate
+/// static, never a pool member. So the kernel's own mappings are never freed --
+/// safety here rests on that pool-membership check, not on the descriptor type
+/// alone.
 ///
 /// Returns `true` if `phys_addr` matched an allocated pool slot and was
 /// freed, `false` if it matched no slot -- WHY (finding 8): the caller can

--- a/crates/thumos/src/mmu.rs
+++ b/crates/thumos/src/mmu.rs
@@ -332,6 +332,64 @@ pub(crate) unsafe fn read_l2_entry(l1_phys: usize, virt_addr: usize) -> Option<u
     }
 }
 
+/// True if a small-page L2 descriptor grants ANY PL0 access (#478).
+///
+/// A small-page descriptor is bits[1:0] = 0b1X, where bit 1 marks the small
+/// page and bit 0 is the XN flag -- so an executable page is 0b10 and an
+/// execute-never (data/stack) page is 0b11. Checking `bit 1 set` (not `== 0b10`)
+/// therefore catches BOTH; a large-page (0b01) or fault (0b00) entry is
+/// rejected. ARM AP[1:0] at bits [5:4]: PL0 has access iff AP[1:0] >= 0b10
+/// (0b10 user-RO, 0b11 user-RW); 0b01 is PL1-only in both APX variants
+/// (`AP_KERNEL_ONLY`, `AP_KERNEL_RO`). So this selects exactly the pages a PL0
+/// process can touch -- image, stack, heap/mmap -- and rejects sections and
+/// every kernel-only entry (the shared `KERNEL_L2` at L1[0x400] carries no user
+/// AP, so it is skipped).
+pub(crate) fn l2_entry_is_user(entry: u32) -> bool {
+    entry & 0b10 != 0 && (entry >> 4) & 0b11 >= 0b10
+}
+
+/// Visit every PL0-accessible small page in `l1_phys`, calling `f(va, phys,
+/// attrs)` per page where `attrs` is the full low-12 descriptor bits
+/// (type+XN, C/B, AP, TEX, APX, S). Early-aborts (returns false) when `f`
+/// returns false; returns true after a full walk (#478).
+///
+/// A PL0 process's ENTIRE user-visible memory is, by construction, exactly the
+/// set of user-AP L2 entries in its own L1 -- so enumerating the page table is
+/// complete (fork needs no ELF), and passing `attrs` straight to `map_page`
+/// reconstructs each descriptor bit-for-bit (same W^X, XN, AP, memory type).
+///
+/// # Safety
+/// `l1_phys` must be a valid L1 table; its L2 tables live in kernel statics
+/// mapped in every address space.
+pub(crate) unsafe fn for_each_user_page(
+    l1_phys: usize,
+    mut f: impl FnMut(usize, usize, u32) -> bool,
+) -> bool {
+    // SAFETY: caller guarantees l1_phys is a valid L1; every read below is
+    // bounds-checked by the fixed 4096/256 loop extents.
+    unsafe {
+        let l1 = l1_phys as *const u32;
+        for l1_idx in 0..4096usize {
+            let l1_val = l1.add(l1_idx).read_volatile();
+            if l1_val & 0b11 != page_flags::L1_PAGE_TABLE {
+                continue;
+            }
+            let l2 = (l1_val & 0xFFFF_FC00) as *const u32;
+            for l2_idx in 0..256usize {
+                let entry = l2.add(l2_idx).read_volatile();
+                if !l2_entry_is_user(entry) {
+                    continue;
+                }
+                let va = (l1_idx << 20) | (l2_idx << 12);
+                if !f(va, (entry & 0xFFFF_F000) as usize, entry & 0xFFF) {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+}
+
 /// Unmap a single 4 KB page from a process's address space.
 ///
 /// Zeroes the L2 entry for the given virtual address. If clearing that
@@ -1664,6 +1722,70 @@ mod tests {
                     "executable page must be read-only"
                 );
             }
+        }
+    }
+
+    #[test]
+    fn l2_entry_is_user_covers_xn_data_and_rejects_kernel_only() {
+        // #478 regression: a small-page descriptor is bits[1:0]=0b1X (bit 0 =
+        // XN), so an execute-never DATA/stack page is 0b11 -- NOT 0b10. The
+        // enumerator must catch it, or a fork would silently skip every user
+        // data/stack page (the bug this test pins).
+        // User RX (.text): SMALL_PAGE | AP_READ_ONLY, XN clear -> bits 0b10.
+        assert!(l2_entry_is_user(
+            page_flags::SMALL_PAGE | page_flags::AP_READ_ONLY
+        ));
+        // User RW+XN (.data/stack): SMALL_PAGE | XN | AP_FULL -> bits 0b11.
+        assert!(l2_entry_is_user(
+            page_flags::SMALL_PAGE | page_flags::XN | page_flags::AP_FULL
+        ));
+        // Real attrs from prot_to_l2_flags must all count as user.
+        for prot in [
+            prot::PROT_READ | prot::PROT_EXEC,
+            prot::PROT_READ,
+            prot::PROT_READ | prot::PROT_WRITE,
+        ] {
+            assert!(l2_entry_is_user(prot_to_l2_flags(prot)), "prot {prot:#x}");
+        }
+        // Kernel-only (PL1 RW, PL0 none) and the shatter default: NOT user.
+        assert!(!l2_entry_is_user(
+            page_flags::SMALL_PAGE | page_flags::XN | page_flags::AP_KERNEL_ONLY
+        ));
+        assert!(!l2_entry_is_user(KERNEL_DEFAULT_PAGE));
+        // Large page (0b01) and fault (0b00): not small pages -> NOT user.
+        assert!(!l2_entry_is_user(0b01 | page_flags::AP_FULL));
+        assert!(!l2_entry_is_user(0));
+    }
+
+    #[test]
+    fn for_each_user_page_visits_user_pages_and_skips_kernel_only() {
+        // #478: enumerate exactly the PL0-accessible pages of a table.
+        reset();
+        unsafe {
+            init_and_enable();
+            let pt = alloc_addr_space().unwrap();
+            clone_addr_space(table_base(), pt);
+            let mb = 0x503usize << 20;
+            assert!(shatter_section(pt, mb)); // fills 256 KERNEL_DEFAULT (PL1-only)
+            let user_va = mb + 7 * 0x1000;
+            assert!(map_page(
+                pt,
+                user_va,
+                user_va,
+                prot_to_l2_flags(prot::PROT_READ | prot::PROT_WRITE)
+            ));
+
+            let mut visited = alloc::vec::Vec::new();
+            for_each_user_page(pt, |va, phys, _attrs| {
+                visited.push((va, phys));
+                true
+            });
+            assert_eq!(
+                visited,
+                alloc::vec![(user_va, user_va)],
+                "only the one granted user page is visited; the 255 KERNEL_DEFAULT entries are skipped"
+            );
+            free_addr_space(pt);
         }
     }
 }

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -1186,19 +1186,6 @@ pub(crate) fn trap_switched() -> bool {
     unsafe { FRAME_SWITCHED }
 }
 
-/// True if the in-flight trap frame is a User-mode (PL0) trap. False outside
-/// trap context (host tests, where no frame is installed) or on a PL1 trap.
-/// Used to gate PL0-unsupported operations (e.g. fork, #478).
-pub(crate) fn trap_from_user() -> bool {
-    // SAFETY: ACTIVE_FRAME is null or the valid in-flight frame; a by-value
-    // read of its cpsr does not alias.
-    unsafe {
-        ACTIVE_FRAME
-            .as_ref()
-            .is_some_and(|f| f.cpsr & CPSR_MODE_MASK == CPSR_MODE_USER)
-    }
-}
-
 /// The in-flight trap frame's register file, or `fallback` outside trap context
 /// (#478). On ARM, fork is only reachable through the SVC trap, where
 /// `trap_enter` published the frame; the fallback serves host tests that call
@@ -1661,10 +1648,24 @@ pub unsafe fn exec_replace_context(
             let old_pages = proc.stack_pages;
             proc.stack_base = new_stack_base;
             proc.stack_pages = new_stack_pages;
-            // WHY: free old pages AFTER updating PCB so that any fault during
-            // free does not leave the PCB pointing at freed memory.
+            let pt = proc.page_table_phys;
+            // WHY (#478): free by the L2-mapped PHYSICAL frame, not by identity
+            // arithmetic on the VA. A forked child's stack_base is the parent's
+            // VA (same VA, different phys), so freeing old_base + i*PAGE by
+            // identity would free the PARENT's live stack frame (cross-process
+            // corruption via fork+exec) and leak the child's real frames.
+            // read_l2_phys resolves the real frame for both the identity
+            // (spawn_user) and VA!=phys (forked) cases; unmap + flush before
+            // freeing also unmaps each old-stack L2 entry (the arithmetic loop
+            // left them mapped -- #478). WHY(after PCB update): a fault during
+            // free must not leave the PCB pointing at freed memory.
             for i in 0..old_pages {
-                page::free_page(old_base + i * page::PAGE_SIZE);
+                let vaddr = old_base + i * page::PAGE_SIZE;
+                if let Some(phys) = mmu::read_l2_phys(pt, vaddr) {
+                    mmu::unmap_page(pt, vaddr);
+                    mmu::flush_tlb_page(vaddr);
+                    page::free_page(phys);
+                }
             }
 
             // WHY (#225): the page table is REUSED across exec (same
@@ -1673,7 +1674,6 @@ pub unsafe fn exec_replace_context(
             // and free each one before resetting the tracking state below, or
             // the physical frames leak permanently and the new image can read
             // the previous image's residual contents at the same VAs.
-            let pt = proc.page_table_phys;
             for mapping in proc.mappings.iter().flatten() {
                 for i in 0..mapping.pages {
                     let vaddr = mapping.start + i * page::PAGE_SIZE;
@@ -2329,6 +2329,130 @@ mod tests {
                 page::free_count(),
                 free_before,
                 "a rolled-back fork must leak no frames"
+            );
+        }
+    }
+
+    #[test]
+    fn fork_pl0_child_exit_frees_own_frames_not_parents() {
+        // #478 (review): a forked child's exit must free the child's OWN
+        // deep-copied frames (via exit_cleanup's page-table WALK), never the
+        // parent's -- the child's stack_base is the parent's VA, so an
+        // identity free would free the parent's live stack.
+        // SAFETY: test-only; single-threaded.
+        unsafe {
+            reset_all();
+            mmu::init_and_enable();
+            let loaded = crate::elf::LoadedElf::for_test(
+                0x7FF0_0000,
+                &[(0x7FF0_0000, 0x100, 0x5), (0x7FF0_1000, 0x100, 0x6)],
+            );
+            let ppid = spawn_user(&loaded).expect("spawn PL0 parent");
+            CURRENT = ppid;
+            let (parent_pt, parent_stack_base) = {
+                let procs = &*core::ptr::addr_of!(PROCS);
+                let p = procs[usize::from(ppid)].as_ref().unwrap();
+                (p.page_table_phys, p.stack_base)
+            };
+            // The parent's real stack frame (identity == its L2 mapping).
+            let parent_stack_frame = mmu::read_l2_phys(parent_pt, parent_stack_base).unwrap();
+
+            let mut frame = Context {
+                cpsr: 0x10,
+                ..Context::zero()
+            };
+            trap_enter(&mut frame as *mut Context);
+            let cpid = fork().expect("PL0 fork");
+            trap_leave();
+
+            let free_before_exit = page::free_count();
+            // Count the child's deep-copied frames (image + stack pages).
+            let child_pt = {
+                let procs = &*core::ptr::addr_of!(PROCS);
+                procs[usize::from(cpid)].as_ref().unwrap().page_table_phys
+            };
+            let mut child_frames = 0usize;
+            mmu::for_each_user_page(child_pt, |_v, _p, _a| {
+                child_frames += 1;
+                true
+            });
+            assert!(child_frames > 0);
+
+            CURRENT = cpid;
+            exit_cleanup(0);
+
+            // The child's frames are returned; the parent's stack frame is NOT.
+            assert_eq!(
+                page::free_count(),
+                free_before_exit + child_frames,
+                "child exit frees exactly its own deep-copied frames"
+            );
+            // try_free_page returns true iff the frame was still ALLOCATED (and
+            // frees it); asserting true confirms the child exit did NOT free the
+            // parent's frame -- a wrongly-freed frame would already be free
+            // (returns false) and fail here.
+            assert!(
+                page::try_free_page(parent_stack_frame),
+                "parent's live stack frame must NOT have been freed by the child exit"
+            );
+        }
+    }
+
+    #[test]
+    fn exec_replace_frees_forked_childs_real_stack_not_parents() {
+        // #478 CRITICAL (review): exec on a forked child must free the child's
+        // REAL stack frames (resolved via the page table), not the parent's
+        // live frame at the shared stack VA.
+        // SAFETY: test-only; single-threaded.
+        unsafe {
+            reset_all();
+            mmu::init_and_enable();
+            let loaded = crate::elf::LoadedElf::for_test(
+                0x7FF0_0000,
+                &[(0x7FF0_0000, 0x100, 0x5), (0x7FF0_1000, 0x100, 0x6)],
+            );
+            let ppid = spawn_user(&loaded).expect("spawn PL0 parent");
+            CURRENT = ppid;
+            let (parent_pt, parent_stack_base) = {
+                let procs = &*core::ptr::addr_of!(PROCS);
+                let p = procs[usize::from(ppid)].as_ref().unwrap();
+                (p.page_table_phys, p.stack_base)
+            };
+            let parent_stack_frame = mmu::read_l2_phys(parent_pt, parent_stack_base).unwrap();
+
+            let mut frame = Context {
+                cpsr: 0x10,
+                ..Context::zero()
+            };
+            trap_enter(&mut frame as *mut Context);
+            let cpid = fork().expect("PL0 fork");
+            trap_leave();
+
+            // The child's real stack frame (a fresh deep-copied page).
+            let child_pt = {
+                let procs = &*core::ptr::addr_of!(PROCS);
+                procs[usize::from(cpid)].as_ref().unwrap().page_table_phys
+            };
+            let child_stack_frame = mmu::read_l2_phys(child_pt, parent_stack_base).unwrap();
+            assert_ne!(child_stack_frame, parent_stack_frame, "distinct frames");
+
+            // Exec the child onto a fresh stack.
+            CURRENT = cpid;
+            let new_stack = page::alloc_contiguous(2).unwrap();
+            exec_replace_context(0x7FF0_0000, new_stack + 2 * page::PAGE_SIZE, new_stack, 2);
+
+            // The parent's live stack frame must NOT be freed (the critical bug).
+            // Asserting still-allocated (returns true) catches a wrongly-freed
+            // parent frame (which would already be free -> false).
+            assert!(
+                page::try_free_page(parent_stack_frame),
+                "the parent's live stack frame must NOT be freed by the child's exec"
+            );
+            // The child's OLD stack frame WAS freed by exec, so it is now free --
+            // try_free_page returns false (already free), not true (was allocated).
+            assert!(
+                !page::try_free_page(child_stack_frame),
+                "the child's old stack frame must be freed by exec (no leak)"
             );
         }
     }

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -487,11 +487,161 @@ pub(crate) fn spawn_user(loaded: &crate::elf::LoadedElf) -> Option<Pid> {
     }
 }
 
-/// Create a child process by cloning the current process's address space.
-/// Returns Some(child_pid) to the parent on success, or None on OOM.
+/// Free every PL0-mapped frame of `pt` back to the allocator (#478).
+///
+/// `try_free_page`'s own validation makes this exact: a spawn_user image at
+/// USER_TEXT_BASE lies OUTSIDE the allocator range (kinit passes USER_TEXT_BASE
+/// as the upper bound) and is rejected as a no-op, while fork-copied image
+/// pages, stack backing, and heap/mmap frames are allocator pages freed exactly
+/// once. Ownership derives from the page table, not a separate record.
+///
+/// # Safety
+/// `pt` is a valid L1; the current TTBR0 must be the KERNEL table (try_free_page
+/// zeroes the frame through the live TTBR0, so a user-remapped VA would alias).
+unsafe fn free_user_pages(pt: usize) {
+    // SAFETY: caller guarantees pt valid + kernel TTBR0; try_free_page validates
+    // each frame (out-of-range / not-allocated = no-op false).
+    unsafe {
+        mmu::for_each_user_page(pt, |_va, phys, _attrs| {
+            let _ = page::try_free_page(phys); // WHY: bool no-op on a non-allocator/already-free frame; fire-and-forget by design
+            true
+        });
+    }
+}
+
+/// Deep-copy every PL0 page of `parent_pt` into `child_pt`: a fresh frame, the
+/// parent's content copied, mapped at the SAME VA with the SAME attributes
+/// (#478). Returns false (with exact rollback) on OOM, a non-DRAM user page, or
+/// L2-pool exhaustion.
+///
+/// Runs under the KERNEL address space: fork executes with the parent's TTBR0
+/// live, where an allocator page's physical address can alias a VA the parent
+/// (a forked ancestor) user-remapped -- a raw phys write through such a VA would
+/// corrupt live memory. The kernel L1 maps all DRAM identity with no user
+/// remaps, so phys == VA holds for every access here, including the zero-on-free
+/// inside the rollback. IRQs are masked for the whole SVC, so the window is
+/// atomic.
+///
+/// # Safety
+/// Trap context (IRQs masked); `parent_pt` valid + live; `child_pt` a fresh
+/// kernel-clone not yet live in TTBR0.
+unsafe fn fork_copy_phase(parent_pt: usize, child_pt: usize) -> bool {
+    // SAFETY: see the doc invariants; all page-table/frame ops are validated.
+    unsafe {
+        mmu::switch_addr_space(mmu::table_base());
+        let ok = mmu::for_each_user_page(parent_pt, |va, parent_phys, attrs| {
+            // Fail closed: only DRAM-backed user pages are copyable. A
+            // device-mapped user page has no copy semantics -- refuse the whole
+            // fork rather than share or skip it.
+            if !(crate::kconfig::RAM_START..crate::kconfig::RAM_END).contains(&parent_phys) {
+                return false;
+            }
+            let Some(child_page) = page::alloc_page() else {
+                return false;
+            };
+            // WHY(arm-only): host "phys" values are bitmap fictions, never valid
+            // host pointers (same gating as the #208 stack copy). On ARM both
+            // sides are identity DRAM under the kernel L1.
+            #[cfg(target_arch = "arm")]
+            core::ptr::copy_nonoverlapping(
+                parent_phys as *const u8,
+                child_page as *mut u8,
+                page::PAGE_SIZE,
+            );
+            if !mmu::shatter_section(child_pt, va)
+                || !mmu::map_page(child_pt, va, child_page, attrs)
+            {
+                // Not yet recorded in child_pt's L2 -- free inline; the walk
+                // rollback below covers the pages already mapped.
+                page::free_page(child_page);
+                return false;
+            }
+            true
+        });
+        if !ok {
+            // Exact rollback needs no tracking array: every allocated page was
+            // mapped into child_pt immediately, so the child's own L2 entries
+            // ARE the allocation record. Still under the kernel map.
+            free_user_pages(child_pt);
+        }
+        mmu::switch_addr_space(parent_pt);
+        ok
+    }
+}
+
+/// The PL0 (userspace) fork path (#478): a fresh isolated address space with the
+/// parent's user pages DEEP-COPIED (fresh frames, content copied, same VA + same
+/// W^X attrs). Never shares the parent's L2 tables.
+///
+/// # Safety
+/// Trap context; `procs`/`slot`/`parent_pid` valid; `parent_pt` is the parent's
+/// live L1; `child_ctx` seeded from the trap frame with r0 = 0.
+unsafe fn fork_pl0(
+    procs: &mut [Option<Process>; MAX_PROCS],
+    slot: usize,
+    child_pid: Pid,
+    parent_pid: Pid,
+    parent_pt: usize,
+    child_ctx: Context,
+) -> Option<Pid> {
+    // SAFETY: delegated to fork_copy_phase / mmu; procs indexing is bounded.
+    unsafe {
+        // A PL0 process must own its L1 (spawn_user gives it one); a User-mode
+        // frame without a per-process table is an invariant break.
+        if parent_pt == 0 || parent_pt == mmu::table_base() {
+            return None;
+        }
+        let child_pt = mmu::alloc_addr_space()?;
+        // KERNEL entries only, like spawn_user -- NOT the parent's user L2
+        // pointers (which the shallow clone would alias).
+        mmu::clone_addr_space(mmu::table_base(), child_pt);
+        if !fork_copy_phase(parent_pt, child_pt) {
+            mmu::free_addr_space(child_pt); // reclaims the child's shatter L2s
+            return None;
+        }
+        let parent_ref = procs[usize::from(parent_pid)].as_ref();
+        // stack_base/stack_pages are the STACK VA RANGE (== the parent's -- same
+        // VA, different phys); the backing frames live only in the child's L2
+        // entries and are freed by exit_cleanup's table walk, never by identity.
+        let child = Process {
+            pid: child_pid,
+            state: State::Ready,
+            ctx: child_ctx,
+            parent: Some(parent_pid),
+            exit_status: 0,
+            page_table_phys: child_pt,
+            stack_base: parent_ref.map_or(0, |p| p.stack_base),
+            stack_pages: parent_ref.map_or(0, |p| p.stack_pages),
+            heap_break: parent_ref.map_or(DEFAULT_HEAP_BREAK, |p| p.heap_break),
+            mappings: parent_ref.map_or([None; MAX_MAPPINGS], |p| p.mappings),
+            signal_state: parent_ref.map_or(SignalState::new(), |p| {
+                let mut s = p.signal_state;
+                s.pending = 0; // POSIX: child starts with a clean pending mask
+                s
+            }),
+            uid: parent_ref.map_or(1, |p| p.uid),
+            wake_tick: 0,
+            capabilities: parent_ref.map_or(crate::capability::Capabilities::FORK_DEFAULT, |p| {
+                p.capabilities
+            }) & crate::capability::Capabilities::FORK_DEFAULT,
+            fds: parent_ref.map_or_else(crate::fd::FdTable::new, |p| crate::fd::fork_table(&p.fds)),
+        };
+        procs[slot] = Some(child);
+        Some(child_pid)
+    }
+}
+
+/// Create a child process (POSIX fork).
+///
+/// A PL0 (userspace) parent gets a fresh ISOLATED address space with its user
+/// pages deep-copied (#478, fork_pl0). A PL1 parent (PID 0 / spawn kernel
+/// threads / host tests) takes the legacy path: shallow L1 clone + fresh
+/// translated stack (correct because kernel threads share the kernel identity
+/// map and their stacks are sections, not L2 mappings).
 ///
 /// NOTE: unlike POSIX fork(), both parent and child continue FROM the next
-/// scheduler tick. The child inherits the parent's saved context exactly.
+/// scheduler tick; the child resumes at the fork return (its ctx is seeded from
+/// the live trap frame) with r0 = 0, the parent with r0 = child_pid.
 pub(crate) fn fork() -> Option<Pid> {
     // SAFETY: current process PCB pointer is valid; set by the scheduler on
     // context switch. addr_of_mut! avoids intermediate references to static mut.
@@ -499,32 +649,32 @@ pub(crate) fn fork() -> Option<Pid> {
     unsafe {
         let procs = &mut *addr_of_mut!(PROCS);
 
-        // WHY(#478): fork is not yet supported for PL0 (userspace) processes.
-        // A correct PL0 fork needs a fresh isolated address space with the
-        // parent's user pages DEEP-COPIED. The current clone_addr_space is a
-        // SHALLOW L1 copy, so the child would share the parent's shattered L2
-        // tables (aliasing its physical pages), and at child exit
-        // free_addr_space would free the PARENT's L2-pool slots while the
-        // identity stack-free would free the parent's live stack -- corrupting
-        // the parent. Fail CLOSED (dispatch surfaces the error) rather than
-        // corrupt, until the deep-copy fork lands (full design on #478). PL1
-        // forks (PID 0 / spawn kernel threads / host tests) share the kernel
-        // identity map and are unaffected -- their stacks are sections, not L2
-        // mappings, so the shallow clone is correct for them.
-        if trap_from_user() {
-            return None;
-        }
-
         // Find a free process slot
         let slot = procs.iter().position(|p| p.is_none())?;
         let child_pid = slot as Pid;
         let parent_pid = CURRENT;
 
-        // Get parent's page table
-        let parent_pt = procs[usize::from(parent_pid)]
-            .as_ref()
-            .map(|p| p.page_table_phys)
-            .unwrap_or(0);
+        let parent_ref0 = procs[usize::from(parent_pid)].as_ref();
+        let parent_pt = parent_ref0.map_or(0, |p| p.page_table_phys);
+        let parent_pcb_ctx = parent_ref0.map(|p| p.ctx).unwrap_or_else(Context::zero);
+
+        // #478: seed the child from the LIVE trap frame (the in-flight fork
+        // SVC), not the PCB's stale switch-OUT snapshot; the child resumes at
+        // the fork return with r0 = 0. The parent's r0 (= child_pid) is written
+        // by svc_handler_rust after dispatch returns -- fork never switch_to's,
+        // so FRAME_SWITCHED stays false. The saved cpsr mode is the path
+        // selector: User (0x10) => PL0 deep-copy, else legacy PL1.
+        let mut child_ctx = active_frame_ctx_or(parent_pcb_ctx);
+        child_ctx.r[0] = 0;
+
+        if child_ctx.cpsr & CPSR_MODE_MASK == CPSR_MODE_USER {
+            return fork_pl0(procs, slot, child_pid, parent_pid, parent_pt, child_ctx);
+        }
+
+        // === PL1 legacy path (PID 0 / spawn kernel threads / host tests) ===
+        // Kernel threads share the kernel identity map; their stacks are 1 MB
+        // sections, invisible to the user-page walk, so a shallow clone + fresh
+        // translated stack is correct for them.
 
         // Allocate child address space
         let child_pt = mmu::alloc_addr_space()?;
@@ -562,9 +712,10 @@ pub(crate) fn fork() -> Option<Pid> {
         }
         let stack_base = child_stack_pages_alloc[0];
 
-        // Inherit parent context and memory layout (child resumes FROM same saved state)
+        // Inherit parent memory layout (child_ctx is already seeded from the
+        // trap frame above -- for a real PL1 fork, i.e. host tests, no frame is
+        // installed, so child_ctx == the parent's PCB ctx).
         let parent_ref = procs[usize::from(parent_pid)].as_ref();
-        let parent_ctx = parent_ref.map(|p| p.ctx).unwrap_or_else(Context::zero);
         let parent_break = parent_ref.map_or(DEFAULT_HEAP_BREAK, |p| p.heap_break);
 
         // WHY(#208): the child MUST run on its OWN freshly-allocated stack, not
@@ -581,9 +732,8 @@ pub(crate) fn fork() -> Option<Pid> {
         // physical pages, matching how spawn() sets up kernel-thread stacks.
         let parent_stack_base = parent_ref.map_or(0, |p| p.stack_base);
         let parent_stack_pages = parent_ref.map_or(0, |p| p.stack_pages);
-        let mut child_ctx = parent_ctx;
         child_ctx.sp = translate_stack_pointer(
-            parent_ctx.sp,
+            child_ctx.sp,
             parent_stack_base,
             parent_stack_pages,
             stack_base,
@@ -837,6 +987,15 @@ pub(crate) fn exit_cleanup(status: i32) {
     // context switch. Page table and stack pages are reclaimed only after
     // marking the process Dead; mmu::free_addr_space validates its input.
     unsafe {
+        // WHY (#478): every free below may zero the frame through the CURRENT
+        // TTBR0 (page.rs zero-on-free); a forked child's table user-remaps
+        // allocator-range VAs, so a raw phys write could alias another
+        // process's memory. The kernel L1 maps all DRAM identity with no user
+        // remaps, so we tear down under it; switch_to installs the successor's
+        // table afterward, and only kernel memory is touched in between. (This
+        // supersedes fault_exit_current's freed-L1-while-live note -- we no
+        // longer run teardown on the dying process's own table.)
+        mmu::switch_addr_space(mmu::table_base());
         let cur = usize::from(CURRENT);
         let procs = &mut *addr_of_mut!(PROCS);
         if let Some(ref mut proc) = procs[cur] {
@@ -847,19 +1006,34 @@ pub(crate) fn exit_cleanup(status: i32) {
             // releasing shared OFDs (and pipe/socket ends) at refcount zero.
             crate::fd::close_all(&mut proc.fds);
 
-            // Reclaim page table (but never free the kernel's global L1)
             let pt = proc.page_table_phys;
-            if pt != 0 && pt != mmu::table_base() {
+            let own_table = pt != 0 && pt != mmu::table_base();
+            // WHY (#478): a PL0 process's memory is exactly what its table maps
+            // PL0 -- image copies, stack backing, heap/mmap frames. The table
+            // is the ownership record; walk it to free those frames (also
+            // retires the old exit leak of heap/mmap frames, which
+            // free_addr_space reclaimed the L2 TABLES of but not their backing).
+            // A stack that is L2-backed (a PL0 process, incl. a forked child
+            // whose stack VA's identity phys belongs to an ANCESTOR) must NOT
+            // be freed by the identity loop below -- the walk already freed its
+            // real frames.
+            let stack_l2_backed = own_table
+                && mmu::read_l2_entry(pt, proc.stack_base).is_some_and(mmu::l2_entry_is_user);
+            if own_table {
+                free_user_pages(pt);
                 mmu::free_addr_space(pt);
             }
             proc.page_table_phys = 0;
 
-            // Free stack pages
+            // Free stack pages -- identity-stack (PL1) processes only. A PL0
+            // stack's frames were freed by the walk above.
             let base = proc.stack_base;
             let pages = proc.stack_pages;
             proc.stack_pages = 0;
-            for i in 0..pages {
-                page::free_page(base + i * page::PAGE_SIZE);
+            if !stack_l2_backed {
+                for i in 0..pages {
+                    page::free_page(base + i * page::PAGE_SIZE);
+                }
             }
         }
         // WHY: a self-exiting process cannot itself be blocked in
@@ -1023,6 +1197,16 @@ pub(crate) fn trap_from_user() -> bool {
             .as_ref()
             .is_some_and(|f| f.cpsr & CPSR_MODE_MASK == CPSR_MODE_USER)
     }
+}
+
+/// The in-flight trap frame's register file, or `fallback` outside trap context
+/// (#478). On ARM, fork is only reachable through the SVC trap, where
+/// `trap_enter` published the frame; the fallback serves host tests that call
+/// `fork()` without installing a mock frame.
+fn active_frame_ctx_or(fallback: Context) -> Context {
+    // SAFETY: ACTIVE_FRAME is null or the valid, unaliased in-flight frame; the
+    // by-value copy does not alias.
+    unsafe { ACTIVE_FRAME.as_ref().map_or(fallback, |f| *f) }
 }
 
 /// Deposit a syscall return value into the CURRENT process's live frame BEFORE
@@ -2053,36 +2237,98 @@ mod tests {
     }
 
     #[test]
-    fn fork_fails_closed_for_a_pl0_caller() {
-        // #478: a PL0 (User-mode) fork must be REFUSED (deny, not corrupt) until
-        // deep-copy fork lands -- a shallow clone would share the parent's L2
-        // tables and corrupt it on child exit. A PL1 fork (no frame / non-User
-        // saved mode) still succeeds (the other fork tests).
+    fn fork_pl0_deep_copies_user_pages_fresh_frames_same_attrs() {
+        // #478: a PL0 fork gives the child its OWN address space with the
+        // parent's user pages DEEP-COPIED -- fresh frames (distinct phys), the
+        // SAME VAs, the SAME W^X attrs -- never sharing the parent's L2 tables.
+        // The child's ctx is seeded from the trap frame with r0 = 0.
         // SAFETY: test-only; single-threaded; reset_all reinitialises state.
         unsafe {
             reset_all();
-            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
-            procs[0] = Some(test_process(mmu::alloc_addr_space().unwrap()));
-            CURRENT = 0;
+            mmu::init_and_enable();
+            // A PL0 parent like spawn_user builds: .text RX + .data RW + stack.
+            let loaded = crate::elf::LoadedElf::for_test(
+                0x7FF0_0000,
+                &[(0x7FF0_0000, 0x100, 0x5), (0x7FF0_1000, 0x100, 0x6)],
+            );
+            let ppid = spawn_user(&loaded).expect("spawn PL0 parent");
+            CURRENT = ppid;
+            let parent_pt = {
+                let procs = &*core::ptr::addr_of!(PROCS);
+                procs[usize::from(ppid)].as_ref().unwrap().page_table_phys
+            };
+
+            // Install a User-mode trap frame with distinctive registers.
+            let mut frame = Context {
+                r: [9; 13],
+                sp: 0x7F00_0000,
+                lr: 0xC0DE,
+                pc: 0x7FF0_0010,
+                cpsr: 0x10,
+            };
+            trap_enter(&mut frame as *mut Context);
+            let child_pid = fork().expect("PL0 fork must deep-copy");
+            trap_leave();
+
+            let procs = &*core::ptr::addr_of!(PROCS);
+            let child = procs[usize::from(child_pid)].as_ref().unwrap();
+            // Child resumes at the fork return (frame) with r0 = 0.
+            assert_eq!(child.ctx.pc, 0x7FF0_0010, "child resumes at the fork site");
+            assert_eq!(child.ctx.r[0], 0, "child returns 0 from fork");
+            let child_pt = child.page_table_phys;
+            assert_ne!(child_pt, parent_pt, "child has its OWN address space");
+
+            for va in [0x7FF0_0000usize, 0x7FF0_1000] {
+                let pe = mmu::read_l2_entry(parent_pt, va).unwrap();
+                let ce = mmu::read_l2_entry(child_pt, va).unwrap();
+                assert_eq!(pe & 0xFFF, ce & 0xFFF, "same attrs at {va:#x}");
+                assert_ne!(
+                    pe & 0xFFFF_F000,
+                    ce & 0xFFFF_F000,
+                    "child page {va:#x} must be a DIFFERENT frame (deep copy)"
+                );
+            }
+            // MMIO stays PL1-only in the child (never a user page table).
+            assert!(mmu::read_l2_entry(child_pt, 0x1100_0000).is_none());
+        }
+    }
+
+    #[test]
+    fn fork_pl0_oom_rolls_back_exactly() {
+        // #478: a PL0 fork that OOMs mid-copy must leave the allocator + address
+        // space pools exactly as before -- no leaked child frames or L2s.
+        // SAFETY: test-only; single-threaded.
+        unsafe {
+            reset_all();
+            mmu::init_and_enable();
+            let loaded = crate::elf::LoadedElf::for_test(
+                0x7FF0_0000,
+                &[(0x7FF0_0000, 0x100, 0x5), (0x7FF0_1000, 0x100, 0x6)],
+            );
+            let ppid = spawn_user(&loaded).expect("spawn PL0 parent");
+            CURRENT = ppid;
             let free_before = page::free_count();
 
-            // Install a User-mode (PL0) trap frame, as the SVC stub would for a
-            // userspace fork syscall.
+            // Drain the page pool so the copy phase OOMs after 0..n pages.
+            let mut hog = alloc::vec::Vec::new();
+            while let Some(p) = page::alloc_page() {
+                hog.push(p);
+            }
             let mut frame = Context {
                 cpsr: 0x10,
                 ..Context::zero()
             };
             trap_enter(&mut frame as *mut Context);
-            assert!(fork().is_none(), "a PL0 fork must fail closed");
+            assert!(fork().is_none(), "fork must fail closed on OOM");
             trap_leave();
 
-            // No process slot consumed, no pages/address spaces leaked.
-            let procs = &*core::ptr::addr_of!(PROCS);
-            assert!(procs[1].is_none(), "no child slot allocated on refusal");
+            for p in hog {
+                page::free_page(p);
+            }
             assert_eq!(
                 page::free_count(),
                 free_before,
-                "a refused fork must allocate nothing"
+                "a rolled-back fork must leak no frames"
             );
         }
     }

--- a/crates/thumos/src/syscall.rs
+++ b/crates/thumos/src/syscall.rs
@@ -1071,6 +1071,19 @@ fn sys_mmap(arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> u32 {
         return MAP_FAILED;
     }
 
+    // WHY (#478): reject a mapping with NO PL0 access (no PROT_READ and no
+    // PROT_WRITE -- i.e. PROT_NONE or exec-only, both AP[1:0]=0b01, which is
+    // PL0-inaccessible and indistinguishable from a shattered MB's
+    // KERNEL_DEFAULT fill). Such a page cannot be told apart from kernel-owned
+    // scaffolding, so fork's page-table enumeration (mmu::l2_entry_is_user)
+    // would silently omit it from the deep copy AND from teardown. Denying it
+    // keeps the invariant "every user page has AP >= 0b10", so enumeration is
+    // complete. PROT_NONE guard-page support needs membership-based
+    // enumeration -- TODO(#496).
+    if prot_flags & (mmu::prot::PROT_READ | mmu::prot::PROT_WRITE) == 0 {
+        return MAP_FAILED;
+    }
+
     // Round length up to page boundary
     let page_count = (length + page::PAGE_SIZE - 1) / page::PAGE_SIZE;
 
@@ -1246,6 +1259,15 @@ fn sys_mprotect(arg0: u32, arg1: u32, arg2: u32) -> u32 {
         return EINVAL;
     }
 
+    // WHY (#478): reject a new protection with NO PL0 access (PROT_NONE /
+    // exec-only). Same reason as sys_mmap -- an AP[1:0]=0b01 user page is
+    // indistinguishable from kernel scaffolding, so fork's enumeration would
+    // drop it. Keeping every user page at AP >= 0b10 makes the deep copy
+    // complete.
+    if new_prot & (mmu::prot::PROT_READ | mmu::prot::PROT_WRITE) == 0 {
+        return EINVAL;
+    }
+
     // Find the mapping
     let Some(mapping) = process::find_mapping(addr) else {
         return EINVAL;
@@ -1260,7 +1282,13 @@ fn sys_mprotect(arg0: u32, arg1: u32, arg2: u32) -> u32 {
         // page-aligned within the mapping returned by find_mapping().
         // flush_tlb_page invalidates the TLB entry after the protection bits change.
         unsafe {
-            mmu::update_page_prot(pt, vaddr, l2_attrs);
+            // WHY (#478): propagate update_page_prot's failure instead of
+            // swallowing it -- a page in the mapping's VA range with no L2 entry
+            // means the mapping/table are inconsistent; return EFAULT rather
+            // than silently reporting success on a partial protection change.
+            if !mmu::update_page_prot(pt, vaddr, l2_attrs) {
+                return EFAULT;
+            }
             mmu::flush_tlb_page(vaddr);
         }
     }


### PR DESCRIPTION
Replaces the #478 fail-close guard with a working fork. A PL0 parent gets a child with its OWN isolated address space -- the parent's user pages **deep-copied** (fresh frames, content copied, same VA + same W^X attrs), never sharing the parent's L2 tables. The child resumes at the fork return (ctx seeded from the live trap frame #465, not the stale PCB) with r0=0; parent gets the child pid.

- **mmu**: `l2_entry_is_user` (catches XN data/stack pages, not just executable) + `for_each_user_page` (the page table IS the user-memory record -- fork needs no ELF).
- **process**: `fork_pl0` + `fork_copy_phase` (fresh L1 from the KERNEL table, per-page copy+map under the kernel L1 to avoid the forked-ancestor aliasing class, exact rollback via the child's own L2s). PL1 path unchanged.
- **exit_cleanup reworked**: tear down under the kernel L1 + free frames by WALKING the page table, not identity stack address (else a forked child's exit frees the PARENT's stack).

**VERIFIED in QEMU** (fork /init variant): parent+child both run (r0 split + seeded frame); child mutates stack + .data canaries, parent's copies intact (`isolation intact` -- real deep copy); child exits(7), parent waitpids, kernel survives ticks=50 exit 0 (exit_cleanup freed the CHILD's frames). Host **2203** (+4); default/kread/kfault/sleep unregressed; all builds clean under -D warnings; kanon + fmt clean.

Found + fixed the XN-bit enumeration bug (data/stack pages were 0b11, not 0b10) via the host test. Fable-designed, T0-verified. Closes #478.