### PR TITLE
PL0-correct exec: live address-space remap + frame install (#489)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,3 +264,29 @@ jobs:
           ! grep -q 'USERFAULT:' fork.log || { echo 'FAIL fork: a process faulted (bad child frame, bad mapping, or parent stack freed by the child exit)'; exit 1; }
           grep -q 'init: hello from userspace' fork.log || { echo 'FAIL fork: parent did not continue past the harness'; exit 1; }
           grep -q 'THUMOS-QEMU: service-loop ticks=' fork.log || { echo 'FAIL fork: kernel did not survive'; exit 1; }
+      - name: QEMU exec correctness + PL0 (#489)
+        working-directory: crates/thumos
+        # WHY: PL0 execve must REPLACE the caller's image with a new one that
+        # runs at PL0. /init execs /init2: 'init: exec-ing /init2' (execve
+        # called) then 'init2: reached via exec' (the NEW image's _start ran ->
+        # exec succeeded, the live page table was remapped + ACTIVE_FRAME
+        # installed, the #489 linchpin). /init2 then does a privileged cp15 read
+        # that UNDEF-faults AT PL0 (kind=undefined-instruction, pid=1) -- proving
+        # the exec'd image is unprivileged; 'init2: PRIVILEGED' would mean it ran
+        # at PL1 (mode-drop broken). The OLD image is gone: no 'hello from
+        # userspace' (the default /init tail) appears. The kernel survives the
+        # fault (ticks). 'exec FAILED' = execve returned an error.
+        run: |
+          set -uo pipefail
+          THUMOS_INIT_VARIANT=exec cargo build --release --target armv7a-none-eabi --features qemu --jobs 8
+          erc=0
+          THUMOS_INIT_VARIANT=exec THUMOS_QEMU_TIMEOUT=60 ../../scripts/qemu-runner.sh target/armv7a-none-eabi/release/thumos | tee exec.log || erc=$?
+          echo "=== exec: runner rc=$erc (want 0) ==="
+          test "$erc" -eq 0 || { echo "FAIL exec: kernel did not survive (rc=$erc; 124=hang 2/3=abort)"; exit 1; }
+          grep -q 'init: exec-ing /init2' exec.log || { echo 'FAIL exec: /init never called execve'; exit 1; }
+          grep -q 'init2: reached via exec' exec.log || { echo 'FAIL exec: the new image never ran (remap or ACTIVE_FRAME install broken -- exec did not transfer control)'; exit 1; }
+          ! grep -q 'init: exec FAILED' exec.log || { echo 'FAIL exec: execve returned an error'; exit 1; }
+          grep -Eq 'USERFAULT: pid=1 kind=undefined-instruction .*killed' exec.log || { echo 'FAIL exec: the exec-d image did not UNDEF on its cp15 probe (PL0 proof missing)'; exit 1; }
+          ! grep -q 'init2: PRIVILEGED' exec.log || { echo 'FAIL exec: the exec-d image ran at PL1 (mode drop across exec broken -- SECURITY)'; exit 1; }
+          ! grep -q 'init: hello from userspace' exec.log || { echo 'FAIL exec: the OLD image kept running after exec (control not transferred)'; exit 1; }
+          grep -q 'THUMOS-QEMU: service-loop ticks=' exec.log || { echo 'FAIL exec: kernel did not survive the exec-d process fault'; exit 1; }

--- a/crates/thumos/build.rs
+++ b/crates/thumos/build.rs
@@ -156,15 +156,17 @@ fn main() {
 /// elf::load parses without a nested cargo build or workspace membership.
 /// -Ttext places all PT_LOAD >= KERNEL_END so the identity-mapping loader
 /// writes them into the sanctioned user-DRAM window [KERNEL_END, RAM_END).
-fn generate_initramfs(manifest_dir: &Path, out_dir: &Path) {
-    let init_src = manifest_dir.join("init/init.rs");
-    let init_ld = manifest_dir.join("init/init.ld");
-    println!("cargo:rerun-if-changed={}", init_src.display());
-    println!("cargo:rerun-if-changed={}", init_ld.display());
-    let init_elf = out_dir.join("init.elf");
-
-    let rustc = env::var("RUSTC").unwrap_or_else(|_| "rustc".into());
-    // kanon:ignore RUST/no-direct-process-command -- build script compiles the /init userspace binary; the rule targets runtime/kernel code and there is no build-time compiler wrapper to route through
+/// Compile one userspace program (init.rs / init2.rs) to a static armv7a ELF
+/// linked by init.ld (#474/#489). `variant_cfg` optionally adds a
+/// `thumos_init_<variant>` cfg.
+fn compile_init_binary(
+    rustc: &str,
+    src: &Path,
+    init_ld: &Path,
+    out_elf: &Path,
+    variant_cfg: Option<&str>,
+) {
+    // kanon:ignore RUST/no-direct-process-command -- build script compiles the userspace binaries; the rule targets runtime/kernel code and there is no build-time compiler wrapper to route through
     let mut cmd = std::process::Command::new(rustc);
     cmd.args([
         "--edition",
@@ -182,51 +184,88 @@ fn generate_initramfs(manifest_dir: &Path, out_dir: &Path) {
     ])
     .arg("-C")
     .arg(format!("link-arg=-T{}", init_ld.display()))
-    // WHY 0x100: the armv7a default max-page-size (64 KB) pads the ELF file
-    // to a 0x10000 first-segment offset (~66 KB of zeros). from_cpio copies
-    // the whole ELF into ONE heap Vec; a 0x100 page size drops the file-offset
-    // padding to 256 B, keeping this tiny /init small (#475's contiguous alloc
-    // covers a larger image regardless).
+    // WHY 0x100: the armv7a default max-page-size (64 KB) pads the ELF file to a
+    // 0x10000 first-segment offset (~66 KB of zeros); a 0x100 page size drops it
+    // to 256 B, keeping the image small.
     .arg("-C")
     .arg("link-arg=-z")
     .arg("-C")
     .arg("link-arg=max-page-size=0x100")
-    // WHY (#487): declare the isolation-probe cfgs so a direct rustc compile
-    // does not warn on them as unexpected.
+    // WHY (#487): declare the probe cfgs so a direct rustc compile does not warn.
     .arg("--check-cfg")
-    .arg("cfg(thumos_init_kread, thumos_init_kwrite, thumos_init_kexec, thumos_init_cp15, thumos_init_sleep, thumos_init_fork)");
+    .arg("cfg(thumos_init_kread, thumos_init_kwrite, thumos_init_kexec, thumos_init_cp15, thumos_init_sleep, thumos_init_fork, thumos_init_exec)");
+    if let Some(cfg) = variant_cfg {
+        cmd.arg("--cfg").arg(cfg);
+    }
+    match cmd.arg("-o").arg(out_elf).arg(src).status() {
+        Ok(s) if s.success() => {}
+        Ok(s) => die(&format!(
+            "#474: rustc failed to build {}: {s}",
+            src.display()
+        )),
+        Err(e) => die(&format!(
+            "#474: cannot invoke rustc for {}: {e}",
+            src.display()
+        )),
+    }
+}
+
+fn generate_initramfs(manifest_dir: &Path, out_dir: &Path) {
+    let init_src = manifest_dir.join("init/init.rs");
+    let init_ld = manifest_dir.join("init/init.ld");
+    println!("cargo:rerun-if-changed={}", init_src.display());
+    println!("cargo:rerun-if-changed={}", init_ld.display());
+    let init_elf = out_dir.join("init.elf");
+
+    let rustc = env::var("RUSTC").unwrap_or_else(|_| "rustc".into());
 
     // WHY (#487): THUMOS_INIT_VARIANT selects an /init probe variant so CI can
-    // permanently prove PL0 isolation. Each variant compiles a different
-    // `_start` body via `--cfg thumos_init_<variant>` (see init/init.rs);
-    // build.rs re-runs when the env changes. Unset = the normal write+exit
-    // /init. The variant name is validated against the known set so a typo
-    // fails the build loudly instead of silently building the default.
+    // permanently prove PL0 isolation / fault handling / fork / exec. Each
+    // variant compiles a different `_start` body via `--cfg thumos_init_<v>`
+    // (see init/init.rs); build.rs re-runs when the env changes. Unset = the
+    // normal write+exit /init. The name is validated so a typo fails the build.
     println!("cargo:rerun-if-env-changed=THUMOS_INIT_VARIANT");
-    if let Ok(variant) = env::var("THUMOS_INIT_VARIANT") {
-        if !variant.is_empty() {
-            if !["kread", "kwrite", "kexec", "cp15", "sleep", "fork"].contains(&variant.as_str()) {
+    let variant_cfg = match env::var("THUMOS_INIT_VARIANT") {
+        Ok(v) if !v.is_empty() => {
+            if !["kread", "kwrite", "kexec", "cp15", "sleep", "fork", "exec"].contains(&v.as_str())
+            {
                 die(&format!(
-                    "#487: unknown THUMOS_INIT_VARIANT '{variant}' (expected kread|kwrite|kexec|cp15|sleep|fork)"
+                    "#487: unknown THUMOS_INIT_VARIANT '{v}' (expected kread|kwrite|kexec|cp15|sleep|fork|exec)"
                 ));
             }
-            cmd.arg("--cfg").arg(format!("thumos_init_{variant}"));
+            Some(format!("thumos_init_{v}"))
         }
-    }
+        _ => None,
+    };
 
-    let status = cmd.arg("-o").arg(&init_elf).arg(&init_src).status();
-    match status {
-        Ok(s) if s.success() => {}
-        Ok(s) => die(&format!("#474: rustc failed to build /init ({s})")),
-        Err(e) => die(&format!("#474: cannot invoke rustc for /init: {e}")),
-    }
+    compile_init_binary(
+        &rustc,
+        &init_src,
+        &init_ld,
+        &init_elf,
+        variant_cfg.as_deref(),
+    );
+
+    // #489: a SECOND userspace program the exec /init variant execs. Always
+    // embedded (tiny; unused unless /init execs it -- kinit only spawns /init
+    // and /shell by name). NOT named "shell": kinit auto-spawns /shell, which
+    // would clobber /init's same-VA image.
+    let init2_src = manifest_dir.join("init/init2.rs");
+    println!("cargo:rerun-if-changed={}", init2_src.display());
+    let init2_elf = out_dir.join("init2.elf");
+    compile_init_binary(&rustc, &init2_src, &init_ld, &init2_elf, None);
 
     let elf = match fs::read(&init_elf) {
         Ok(b) => b,
         Err(e) => die(&format!("#474: cannot read built /init ELF: {e}")),
     };
+    let elf2 = match fs::read(&init2_elf) {
+        Ok(b) => b,
+        Err(e) => die(&format!("#489: cannot read built /init2 ELF: {e}")),
+    };
 
     let mut archive = cpio_newc_entry("init", &elf, 0o100_755);
+    archive.extend_from_slice(&cpio_newc_entry("init2", &elf2, 0o100_755));
     archive.extend_from_slice(&cpio_newc_entry("TRAILER!!!", &[], 0));
     if let Err(e) = fs::write(out_dir.join("initramfs.cpio"), &archive) {
         die(&format!("#474: cannot write initramfs.cpio: {e}"));

--- a/crates/thumos/init/init.rs
+++ b/crates/thumos/init/init.rs
@@ -111,6 +111,31 @@ unsafe fn sys_waitpid(pid: u32) -> u32 {
 #[cfg(thumos_init_fork)]
 static mut FORK_DATA_CANARY: u32 = 0x0000_5EED;
 
+/// execve(path, argv, envp) -> only returns (u32 errno) on FAILURE (#489); on
+/// success the process image is replaced and never returns here.
+///
+/// # Safety
+/// Replaces this process's image with the program at `path`.
+#[cfg(thumos_init_exec)]
+#[inline(always)]
+unsafe fn sys_execve(path: *const u8, argv: u32, envp: u32) -> u32 {
+    let ret;
+    // SAFETY: SVC #11 (Execve) per the thumos ABI.
+    unsafe {
+        core::arch::asm!(
+            "svc #0",
+            in("r7") 11u32,
+            // Pointer in, errno out -- passed directly (no int cast); asm allows
+            // differing in/out types on one register.
+            inlateout("r0") path => ret,
+            in("r1") argv,
+            in("r2") envp,
+            options(nostack),
+        );
+    }
+    ret
+}
+
 /// ELF entry point (e_entry). The kernel transmutes the loaded entry to
 /// PL0 isolation probe (#487): under a `thumos_init_<variant>` cfg (set by
 /// build.rs from THUMOS_INIT_VARIANT), attempt a kernel-memory or privileged
@@ -191,6 +216,20 @@ pub extern "C" fn _start() -> ! {
         // #487: no-op unless an isolation-probe variant is compiled, in which
         // case this faults at PL0 before the write.
         isolation_probe();
+        // #489 exec harness: exec /init2. On success this process is replaced by
+        // /init2 (which runs at PL0 and never returns here); on failure execve
+        // returns an errno. NULL argv (argv-across-exec is a separate refinement,
+        // #499).
+        #[cfg(thumos_init_exec)]
+        {
+            let m = b"init: exec-ing /init2\n";
+            sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+            sys_execve(b"/init2\0".as_ptr(), 0, 0);
+            // Only reached if execve FAILED (it does not return on success).
+            let f = b"init: exec FAILED\n";
+            sys_write(1, f.as_ptr(), u32::try_from(f.len()).unwrap_or(0));
+            sys_exit(1);
+        }
         // #477 sleep harness: sleep, then continue. If the kernel's sleep is a
         // real yield, /init suspends (the service loop runs meanwhile) and
         // resumes to print "woke"; a broken busy-wait sleep runs IRQ-masked and

--- a/crates/thumos/init/init2.rs
+++ b/crates/thumos/init/init2.rs
@@ -1,0 +1,65 @@
+//! thumos /init2 (#489): the exec target for the fork/exec harness.
+//!
+//! A second userspace program, built + embedded like /init. The exec /init
+//! variant execs this; it proves the NEW image runs at PL0 (via a privileged
+//! cp15 read that UNDEF-faults at PL0) with the old image gone.
+#![no_std]
+#![no_main]
+
+/// write(fd, buf, len) via the thumos ABI (r7 = num, r0-r2 = args).
+///
+/// # Safety
+/// `buf` must point to `len` readable bytes in the loaded image.
+#[inline(always)]
+unsafe fn sys_write(fd: u32, buf: *const u8, len: u32) -> u32 {
+    let ret;
+    // SAFETY: SVC #1 (Write); the kernel validates the buffer.
+    unsafe {
+        core::arch::asm!(
+            "svc #0",
+            in("r7") 1u32,
+            inlateout("r0") fd => ret,
+            in("r1") buf,
+            in("r2") len,
+            options(nostack),
+        );
+    }
+    ret
+}
+
+/// exit(code): never returns.
+///
+/// # Safety
+/// Ends the process; the kernel switches away.
+#[inline(always)]
+unsafe fn sys_exit(code: u32) -> ! {
+    // SAFETY: SVC #0 (Exit); does not return.
+    unsafe {
+        core::arch::asm!("svc #0", in("r7") 0u32, in("r0") code, options(noreturn, nostack));
+    }
+}
+
+/// ELF entry point.
+#[unsafe(no_mangle)]
+pub extern "C" fn _start() -> ! {
+    let msg = b"init2: reached via exec\n";
+    // SAFETY: msg is a .rodata literal in the loaded image; the cp15 read below
+    // UNDEF-faults at PL0 (proving the exec'd image dropped to PL0), so control
+    // does not fall through -- if it DID, the mode drop across exec is broken.
+    unsafe {
+        sys_write(1, msg.as_ptr(), u32::try_from(msg.len()).unwrap_or(0));
+        // Privileged read (SCTLR) -- UNDEF at PL0, succeeds at PL1.
+        core::arch::asm!("mrc p15, 0, {}, c1, c0, 0", out(reg) _);
+        // Only reached if the exec'd image runs PRIVILEGED (a bug).
+        let bad = b"init2: PRIVILEGED\n";
+        sys_write(1, bad.as_ptr(), u32::try_from(bad.len()).unwrap_or(0));
+        sys_exit(1);
+    }
+}
+
+/// Panic handler: exit(1).
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    // SAFETY: exit is the only action available.
+    unsafe { sys_exit(1) }
+}

--- a/crates/thumos/src/elf.rs
+++ b/crates/thumos/src/elf.rs
@@ -354,8 +354,29 @@ struct ValidatedElf {
 ///
 /// The loaded code will execute with kernel privileges until we implement
 /// user/kernel memory separation (Wave 4+).
+/// Load an ELF image (no placement restriction) -- for host tests that write
+/// to real host addresses. Kernel spawn paths use `load_confined`.
 pub(crate) fn load(data: &[u8]) -> Result<LoadedElf, ElfError> {
+    load_impl(data, None)
+}
+
+/// `load()`, but reject any PT_LOAD segment outside `[lo, hi)` -- the reserved
+/// user-image window (#489) -- BEFORE writing a byte. A single `validate()`
+/// pass gates both the format and the placement, so a boot/exec image can never
+/// write into page-allocator RAM or escape the exec revocation surface, and
+/// fail-before-destroy holds (the check precedes every write). Every authored
+/// image links at USER_TEXT_BASE (init.ld).
+pub(crate) fn load_confined(data: &[u8], lo: usize, hi: usize) -> Result<LoadedElf, ElfError> {
+    load_impl(data, Some((lo, hi)))
+}
+
+fn load_impl(data: &[u8], placement: Option<(usize, usize)>) -> Result<LoadedElf, ElfError> {
     let (entry, validated) = validate(data)?;
+
+    // #489: enforce the placement window BEFORE any write (fail-before-destroy).
+    // A single validate() feeds both this and the write loop -- no second
+    // validate pass (a distinct `peek()` here corrupted the parse on the exec
+    // path, so placement is folded into load itself).
 
     // WHY (#328): a single up-front budget check replaces the old per-page
     // page::alloc_page() reservation. That reservation's returned address
@@ -372,6 +393,21 @@ pub(crate) fn load(data: &[u8]) -> Result<LoadedElf, ElfError> {
 
     for idx in 0..validated.count {
         let (vaddr, memsz, filesz, file_offset, _flags) = validated.segments[idx];
+
+        // #489: enforce the placement window BEFORE writing THIS segment
+        // (fail-before-destroy). Folded into the write loop -- the identical
+        // read the write uses -- because a SEPARATE pre-pass over
+        // validated.segments mis-read the packed-derived tuples on the exec
+        // path. INVARIANT: for an in-window image (every authored image) no
+        // segment ever trips this, so the loop writes uninterrupted; a rejected
+        // out-of-window image stops at its FIRST bad segment, having written
+        // only prior in-window ones (all within sanctioned user DRAM per #318).
+        if let Some((lo, hi)) = placement {
+            // vaddr + memsz cannot overflow: validate() proved it via #318.
+            if vaddr < lo || vaddr + memsz > hi {
+                return Err(ElfError::InvalidSegment);
+            }
+        }
 
         // WHY: identical to the checked computation validate() already
         // performed for this same memsz while building validated.total_pages
@@ -787,6 +823,59 @@ mod tests {
             free_before,
             "a successful load must not permanently consume any page from the allocator (#328)"
         );
+    }
+
+    #[test]
+    fn load_confined_rejects_out_of_window_placement_before_writing() {
+        // #489: load_confined must reject a segment outside [lo, hi) -- the
+        // reserved user-image window -- and it must do so BEFORE writing a byte
+        // (fail-before-destroy), so a boot/exec image can never write into
+        // page-allocator RAM or escape the exec revocation surface.
+        static mut BUF: [u8; 16] = [0xEE; 16];
+        let vaddr = core::ptr::addr_of_mut!(BUF) as *mut u8 as usize;
+
+        let mut data = [0u8; ELF32_EHDR_SIZE + ELF32_PHDR_SIZE + 4];
+        let h = make_valid_ehdr();
+        data[..ELF32_EHDR_SIZE].copy_from_slice(&h);
+        data[44] = 1; // e_phnum = 1
+        data[24..28].copy_from_slice(&(vaddr as u32).to_le_bytes()); // e_entry
+        data[52..56].copy_from_slice(&1u32.to_le_bytes()); // p_type = PT_LOAD
+        let file_offset = (ELF32_EHDR_SIZE + ELF32_PHDR_SIZE) as u32;
+        data[56..60].copy_from_slice(&file_offset.to_le_bytes()); // p_offset
+        data[60..64].copy_from_slice(&(vaddr as u32).to_le_bytes()); // p_vaddr
+        data[68..72].copy_from_slice(&4u32.to_le_bytes()); // p_filesz
+        data[72..76].copy_from_slice(&4u32.to_le_bytes()); // p_memsz
+        data[ELF32_EHDR_SIZE + ELF32_PHDR_SIZE..].copy_from_slice(b"TEST");
+
+        // Free pool large enough that the OOM check passes and the placement
+        // check (in the write loop) is reached.
+        // SAFETY: test-only page-allocator state; single-threaded per test.
+        unsafe {
+            page::init(
+                0x4000_0000,
+                0x4000_0000 + 8 * page::PAGE_SIZE,
+                0x4000_0000 + 4 * page::PAGE_SIZE,
+            );
+        }
+
+        // SAFETY: read the test-only static (addr_of! + read copies it).
+        let before = unsafe { core::ptr::addr_of!(BUF).read() };
+        // A window that EXCLUDES the segment's real address -> reject.
+        let lo = vaddr.wrapping_add(0x1_0000);
+        let hi = lo.wrapping_add(0x1_0000);
+        let r = load_confined(&data, lo, hi);
+        assert!(
+            matches!(r, Err(ElfError::InvalidSegment)),
+            "an out-of-window segment must be rejected, got {r:?} (vaddr={vaddr:#x} lo={lo:#x} hi={hi:#x})"
+        );
+        // SAFETY: read the test-only static; the reject must have skipped the
+        // write, so its bytes are unchanged.
+        let after = unsafe { core::ptr::addr_of!(BUF).read() };
+        assert_eq!(after, before, "reject must not have written the segment");
+
+        // The SAME image loads when the window includes it (plain load / a
+        // window that contains vaddr) -- proving the gate is placement, not format.
+        assert!(load_confined(&data, vaddr, vaddr.wrapping_add(0x1000)).is_ok());
     }
 
     /// #328: when the free pool is smaller than the segment budget, load()

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -1345,25 +1345,27 @@ pub unsafe fn run() -> ! {
 
         // WHY: process 1  -  init daemon (PID 1, supervisor)
         match plan_userspace_spawn_from_vfs("/init") {
-            UserspaceSpawnPlan::Elf(elf_data) => match elf::load(elf_data) {
-                Ok(loaded) => {
-                    // WHY(#482): spawn_user runs /init UNPRIVILEGED (PL0, User
-                    // mode 0x10) in its own address space -- the ELF mapped
-                    // per-segment W^X and the stack RW+XN, with kernel memory
-                    // PL1-only so a user access to it faults. No transmute: the
-                    // entry is an address the new process resumes at via the
-                    // #465 exception-return, not a kernel fn pointer.
-                    if let Some(pid) = process::spawn_user(&loaded) {
-                        let _ = write!(serial, "       /init spawned PL0 (PID {})\r\n", pid);
-                        state.processes_spawned += 1;
-                    } else {
-                        let _ = serial.write_str("  WARN /init spawn failed\r\n");
+            UserspaceSpawnPlan::Elf(elf_data) => {
+                match elf::load_confined(elf_data, kconfig::USER_TEXT_BASE, kconfig::RAM_END) {
+                    Ok(loaded) => {
+                        // WHY(#482): spawn_user runs /init UNPRIVILEGED (PL0, User
+                        // mode 0x10) in its own address space -- the ELF mapped
+                        // per-segment W^X and the stack RW+XN, with kernel memory
+                        // PL1-only so a user access to it faults. No transmute: the
+                        // entry is an address the new process resumes at via the
+                        // #465 exception-return, not a kernel fn pointer.
+                        if let Some(pid) = process::spawn_user(&loaded) {
+                            let _ = write!(serial, "       /init spawned PL0 (PID {})\r\n", pid);
+                            state.processes_spawned += 1;
+                        } else {
+                            let _ = serial.write_str("  WARN /init spawn failed\r\n");
+                        }
+                    }
+                    Err(e) => {
+                        let _ = write!(serial, "  WARN /init ELF load failed: {:?}\r\n", e);
                     }
                 }
-                Err(e) => {
-                    let _ = write!(serial, "  WARN /init ELF load failed: {:?}\r\n", e);
-                }
-            },
+            }
             UserspaceSpawnPlan::Missing => {
                 let _ =
                     serial.write_str("  WARN /init missing from root ramfs; no init spawned\r\n");
@@ -1373,20 +1375,22 @@ pub unsafe fn run() -> ! {
 
         // WHY: process 2  -  shell (PID 2, user interface)
         match plan_userspace_spawn_from_vfs("/shell") {
-            UserspaceSpawnPlan::Elf(elf_data) => match elf::load(elf_data) {
-                Ok(loaded) => {
-                    // WHY(#482): /shell runs PL0 in its own isolated space too.
-                    if let Some(pid) = process::spawn_user(&loaded) {
-                        let _ = write!(serial, "       /shell spawned PL0 (PID {})\r\n", pid);
-                        state.processes_spawned += 1;
-                    } else {
-                        let _ = serial.write_str("  WARN /shell spawn failed\r\n");
+            UserspaceSpawnPlan::Elf(elf_data) => {
+                match elf::load_confined(elf_data, kconfig::USER_TEXT_BASE, kconfig::RAM_END) {
+                    Ok(loaded) => {
+                        // WHY(#482): /shell runs PL0 in its own isolated space too.
+                        if let Some(pid) = process::spawn_user(&loaded) {
+                            let _ = write!(serial, "       /shell spawned PL0 (PID {})\r\n", pid);
+                            state.processes_spawned += 1;
+                        } else {
+                            let _ = serial.write_str("  WARN /shell spawn failed\r\n");
+                        }
+                    }
+                    Err(e) => {
+                        let _ = write!(serial, "  WARN /shell ELF load failed: {:?}\r\n", e);
                     }
                 }
-                Err(e) => {
-                    let _ = write!(serial, "  WARN /shell ELF load failed: {:?}\r\n", e);
-                }
-            },
+            }
             UserspaceSpawnPlan::Missing => {
                 let _ =
                     serial.write_str("  WARN /shell missing from root ramfs; no shell spawned\r\n");

--- a/crates/thumos/src/mmu.rs
+++ b/crates/thumos/src/mmu.rs
@@ -537,6 +537,33 @@ pub unsafe fn flush_tlb_page(virt_addr: usize) {
 #[cfg(not(target_arch = "arm"))]
 pub unsafe fn flush_tlb_page(_virt_addr: usize) {}
 
+/// Invalidate the ENTIRE unified TLB + branch predictor (#489).
+///
+/// Used by exec, which rewrites whole MBs of the LIVE table
+/// (reset_shattered_section + map_user_image + map_user_stack) -- a per-page
+/// TLBIMVA loop over 256+ changed entries is the wrong tool. BPIALL is needed
+/// because the executable image at USER_TEXT changed identity.
+///
+/// # Safety
+/// Call with IRQs masked, after all table writes, before returning to PL0.
+#[cfg(target_arch = "arm")]
+pub unsafe fn flush_tlb_all() {
+    // SAFETY: privileged CP15 maintenance; barriers order it before the return.
+    unsafe {
+        core::arch::asm!(
+            "mcr p15, 0, {z}, c8, c7, 0", // TLBIALL
+            "mcr p15, 0, {z}, c7, c5, 6", // BPIALL
+            "dsb sy",
+            "isb sy",
+            z = in(reg) 0u32,
+        );
+    }
+}
+
+/// No-op full-TLB flush for non-ARM builds.
+#[cfg(not(target_arch = "arm"))]
+pub unsafe fn flush_tlb_all() {}
+
 /// Reset the L2 table pool (test helper only).
 #[cfg(test)]
 pub(crate) fn reset_l2_pool() {

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -405,14 +405,14 @@ unsafe fn map_user_image(pt: usize, loaded: &crate::elf::LoadedElf) -> bool {
     true
 }
 
-/// Map each of the `STACK_PAGES` contiguous stack frames from `stack_base`
-/// PL0 read/write + execute-never at its identity VA (#482).
+/// Map `pages` contiguous stack frames from `stack_base` PL0 read/write +
+/// execute-never at their identity VAs (#482/#489).
 ///
 /// # Safety
 /// `pt` is a caller-owned process L1; `stack_base` begins a contiguous run.
-unsafe fn map_user_stack(pt: usize, stack_base: usize) -> bool {
+unsafe fn map_user_stack(pt: usize, stack_base: usize, pages: usize) -> bool {
     let attrs = mmu::prot_to_l2_flags(mmu::prot::PROT_READ | mmu::prot::PROT_WRITE);
-    for i in 0..STACK_PAGES {
+    for i in 0..pages {
         let va = stack_base + i * page::PAGE_SIZE;
         // SAFETY: pt caller-owned; va is a contiguous stack frame in DRAM.
         unsafe {
@@ -422,6 +422,26 @@ unsafe fn map_user_stack(pt: usize, stack_base: usize) -> bool {
         }
     }
     true
+}
+
+/// Drop the PL0 grant on `pages` frames from `base` in `pt`: rewrite each L2
+/// entry back to the identity KERNEL_DEFAULT_PAGE (PL1-only, #489). NOT
+/// unmap_page (zeroing an entry inside a shattered identity MB would fault the
+/// kernel on its next access there), and NOT reset_shattered_section for a
+/// stack (old and new exec stacks can share an allocator MB, so a whole-MB
+/// reset would revoke the new stack's grants). The caller flushes the TLB.
+///
+/// # Safety
+/// `pt` is a caller-owned L1; each VA was granted via map_user_stack/image.
+unsafe fn revoke_user_pages(pt: usize, base: usize, pages: usize) {
+    for i in 0..pages {
+        let va = base + i * page::PAGE_SIZE;
+        // SAFETY: the entry exists (was granted); update preserves the identity
+        // phys and demotes attrs to PL1-only.
+        unsafe {
+            mmu::update_page_prot(pt, va, mmu::KERNEL_DEFAULT_PAGE);
+        }
+    }
 }
 
 /// Create a PL0 (User mode) process from a loaded ELF image (#482).
@@ -453,7 +473,7 @@ pub(crate) fn spawn_user(loaded: &crate::elf::LoadedElf) -> Option<Pid> {
         };
         let stack_top = stack_base + page::PAGE_SIZE * STACK_PAGES;
 
-        if !map_user_image(new_pt, loaded) || !map_user_stack(new_pt, stack_base) {
+        if !map_user_image(new_pt, loaded) || !map_user_stack(new_pt, stack_base, STACK_PAGES) {
             // free_addr_space also reclaims the L2 tables the shatters allocated
             // (the shared KERNEL_L2 is skipped -- free_l2_table no-ops on
             // non-pool addresses).
@@ -1617,89 +1637,136 @@ pub unsafe fn reset_signal_state() {
 /// # Safety
 ///
 /// Must be called from syscall context after the new stack pages have been
-/// allocated and `entry_point` is the validated ELF entry address.
+/// allocated and `loaded` is the validated + loaded ELF image.
+///
+/// Returns `false` if the new image/stack could not be mapped (L2-pool
+/// exhaustion). The old image is already gone by then, so the caller MUST kill
+/// the process (it is unrecoverable); the PCB is left consistent for
+/// exit_cleanup's page-table walk.
+#[must_use]
 pub unsafe fn exec_replace_context(
-    entry_point: usize,
+    loaded: &crate::elf::LoadedElf,
     stack_top: usize,
     new_stack_base: usize,
     new_stack_pages: usize,
-) {
+) -> bool {
     // SAFETY: addr_of_mut! avoids an intermediate reference to the static mut.
     // Called from execve syscall with interrupts disabled (SVC mode, ARMv7).
     unsafe {
         let procs = &mut *addr_of_mut!(PROCS);
         let cur = usize::from(CURRENT);
-        if let Some(ref mut proc) = procs[cur] {
-            // WHY cpsr 0x10 (User mode, IRQs enabled): execve transfers control
-            // to an unprivileged userspace binary. Contrast with spawn() which
-            // uses 0x1F (System mode) for kernel-internal threads. The full
-            // register file is reset -- exec starts a fresh image, not a
-            // continuation.
-            // SAFETY: ARMv7 target has 32-bit usize; try_from cannot fail
-            // in production. On 64-bit test hosts the addresses are
-            // test-controlled and verified to fit via the test setup.
-            proc.ctx = Context::initial(
-                u32::try_from(entry_point).unwrap_or(0u32),
-                u32::try_from(stack_top).unwrap_or(0u32),
-                0x10,
-            );
-            // Free the old stack (replaced by exec).
-            let old_base = proc.stack_base;
-            let old_pages = proc.stack_pages;
-            proc.stack_base = new_stack_base;
-            proc.stack_pages = new_stack_pages;
-            let pt = proc.page_table_phys;
-            // WHY (#478): free by the L2-mapped PHYSICAL frame, not by identity
-            // arithmetic on the VA. A forked child's stack_base is the parent's
-            // VA (same VA, different phys), so freeing old_base + i*PAGE by
-            // identity would free the PARENT's live stack frame (cross-process
-            // corruption via fork+exec) and leak the child's real frames.
-            // read_l2_phys resolves the real frame for both the identity
-            // (spawn_user) and VA!=phys (forked) cases; unmap + flush before
-            // freeing also unmaps each old-stack L2 entry (the arithmetic loop
-            // left them mapped -- #478). WHY(after PCB update): a fault during
-            // free must not leave the PCB pointing at freed memory.
-            for i in 0..old_pages {
-                let vaddr = old_base + i * page::PAGE_SIZE;
+        let Some(proc) = procs[cur].as_mut() else {
+            return false;
+        };
+        let pt = proc.page_table_phys;
+        let old_base = proc.stack_base;
+        let old_pages = proc.stack_pages;
+        let old_heap_break = proc.heap_break;
+        let old_mappings = proc.mappings;
+
+        // WHY (#489): the destructive + mapping phase runs under the KERNEL L1.
+        // exec mutates the LIVE process table, and every free zeroes a frame
+        // through the current TTBR0 (page.rs zero-on-free); a forked-then-exec'd
+        // process user-remaps allocator-range VAs, so a raw phys write could
+        // alias another mapping. The kernel L1 maps all DRAM identity with no
+        // user remaps, so phys == VA for every access here. Page-table WRITES
+        // (revoke/map) target L2 pool tables, which are kernel statics mapped in
+        // every space, so they are valid under the kernel L1 too. IRQs are
+        // masked (SVC), so this is atomic.
+        mmu::switch_addr_space(mmu::table_base());
+
+        // 1. Revoke the old image's PL0 windows: reset the whole USER_TEXT MB's
+        //    L2 entries to identity KERNEL_DEFAULT (keeps the L2 table), so no
+        //    stale PL0 image window survives and map_user_image re-maps into the
+        //    SAME L2 (no fresh alloc -> infallible). A live PL0 caller always has
+        //    a shattered image MB, so false here is an invariant break.
+        let image_was_mapped = mmu::reset_shattered_section(pt, crate::kconfig::USER_TEXT_BASE);
+        debug_assert!(
+            image_was_mapped,
+            "exec: caller's image MB must be shattered"
+        );
+
+        // 2. Revoke + free the old stack (revoke BEFORE free so no stale PL0-RW
+        //    window outlives the frame's return to the allocator). Free by the
+        //    L2-mapped PHYSICAL frame (a forked child's stack VA != its phys).
+        revoke_user_pages(pt, old_base, old_pages);
+        for i in 0..old_pages {
+            let vaddr = old_base + i * page::PAGE_SIZE;
+            if let Some(phys) = mmu::read_l2_phys(pt, vaddr) {
+                mmu::unmap_page(pt, vaddr);
+                page::free_page(phys);
+            }
+        }
+
+        // 3. Free the old mmap regions + grown heap (their VAs are below RAM,
+        //    non-identity -- read_l2_phys resolves the real frame). #225.
+        for mapping in old_mappings.iter().flatten() {
+            for i in 0..mapping.pages {
+                let vaddr = mapping.start + i * page::PAGE_SIZE;
                 if let Some(phys) = mmu::read_l2_phys(pt, vaddr) {
                     mmu::unmap_page(pt, vaddr);
-                    mmu::flush_tlb_page(vaddr);
                     page::free_page(phys);
                 }
             }
-
-            // WHY (#225): the page table is REUSED across exec (same
-            // page_table_phys), so the previous image's mmap regions and grown
-            // heap pages are still mapped at their old virtual addresses. Unmap
-            // and free each one before resetting the tracking state below, or
-            // the physical frames leak permanently and the new image can read
-            // the previous image's residual contents at the same VAs.
-            for mapping in proc.mappings.iter().flatten() {
-                for i in 0..mapping.pages {
-                    let vaddr = mapping.start + i * page::PAGE_SIZE;
-                    if let Some(phys) = mmu::read_l2_phys(pt, vaddr) {
-                        mmu::unmap_page(pt, vaddr);
-                        mmu::flush_tlb_page(vaddr);
-                        page::free_page(phys);
-                    }
-                }
-            }
-            let old_heap_break = proc.heap_break;
-            let mut heap_vaddr = DEFAULT_HEAP_BREAK;
-            while heap_vaddr < old_heap_break {
-                if let Some(phys) = mmu::read_l2_phys(pt, heap_vaddr) {
-                    mmu::unmap_page(pt, heap_vaddr);
-                    mmu::flush_tlb_page(heap_vaddr);
-                    page::free_page(phys);
-                }
-                heap_vaddr += page::PAGE_SIZE;
-            }
-
-            // Reset heap break to default for the new image.
-            proc.heap_break = DEFAULT_HEAP_BREAK;
-            // Clear all tracked mmap mappings — the new image has a fresh VA space.
-            proc.mappings = [None; MAX_MAPPINGS];
         }
+        let mut heap_vaddr = DEFAULT_HEAP_BREAK;
+        while heap_vaddr < old_heap_break {
+            if let Some(phys) = mmu::read_l2_phys(pt, heap_vaddr) {
+                mmu::unmap_page(pt, heap_vaddr);
+                page::free_page(phys);
+            }
+            heap_vaddr += page::PAGE_SIZE;
+        }
+
+        // 4. Map the new image (W^X per segment) + the new stack (RW+XN). The
+        //    new image bytes were already written to identity DRAM by
+        //    elf::load; argv was written to the new stack frames PL1. Mapping
+        //    grants PL0 without moving content. map_user_image reuses the image
+        //    L2 (infallible); only map_user_stack's fresh-MB shatter can fail
+        //    (L2-pool exhaustion). `&` runs BOTH regardless.
+        let remap_ok =
+            map_user_image(pt, loaded) & map_user_stack(pt, new_stack_base, new_stack_pages);
+
+        // 5. Back to the process table (switch_addr_space does TTBR0 + TLBIALL),
+        //    then flush the branch predictor too (the executable image at
+        //    USER_TEXT changed identity). (I-cache maintenance for the new code
+        //    is TODO(#498) -- invisible in QEMU, needed on real hardware.)
+        mmu::switch_addr_space(pt);
+        mmu::flush_tlb_all();
+
+        // Update the PCB's memory layout REGARDLESS of remap_ok: the old stack /
+        // mmap / heap were freed above and are gone from the table, so if the
+        // remap failed and the caller kills the process, exit_cleanup's
+        // page-table walk must free the NEW (partial) mappings, not re-free the
+        // old ones. The new stack's unmapped tail (on a partial map) leaks -- an
+        // accepted cost of the rare exec-time OOM (fail-before-destroy for the
+        // stack L2 is TODO(#499)).
+        proc.stack_base = new_stack_base;
+        proc.stack_pages = new_stack_pages;
+        proc.heap_break = DEFAULT_HEAP_BREAK;
+        proc.mappings = [None; MAX_MAPPINGS];
+
+        if !remap_ok {
+            // The old image was already destroyed by elf::load -- the process is
+            // unrecoverable. sys_execve kills it (exit_current).
+            return false;
+        }
+
+        // 6. Install the new context -- into the PCB AND the live trap frame.
+        //    THE linchpin (#489): the SVC epilogue exception-returns into
+        //    ACTIVE_FRAME, not proc.ctx; without the frame write exec "returns"
+        //    0 into the OLD image at the instruction after `svc` (now overwritten
+        //    -> wild PL0 execution). FRAME_SWITCHED stays false (exec does not
+        //    switch_to), so dispatch's return 0 is the correct fresh-image r0.
+        proc.ctx = Context::initial(
+            u32::try_from(loaded.entry).unwrap_or(0u32),
+            u32::try_from(stack_top).unwrap_or(0u32),
+            0x10,
+        );
+        if let Some(frame) = ACTIVE_FRAME.as_mut() {
+            *frame = proc.ctx;
+        }
+        true
     }
 }
 
@@ -2439,7 +2506,14 @@ mod tests {
             // Exec the child onto a fresh stack.
             CURRENT = cpid;
             let new_stack = page::alloc_contiguous(2).unwrap();
-            exec_replace_context(0x7FF0_0000, new_stack + 2 * page::PAGE_SIZE, new_stack, 2);
+            let new_image =
+                crate::elf::LoadedElf::for_test(0x7FF0_0000, &[(0x7FF0_0000, 0x100, 0x5)]);
+            assert!(exec_replace_context(
+                &new_image,
+                new_stack + 2 * page::PAGE_SIZE,
+                new_stack,
+                2
+            ));
 
             // The parent's live stack frame must NOT be freed (the critical bug).
             // Asserting still-allocated (returns true) catches a wrongly-freed
@@ -2999,12 +3073,36 @@ mod tests {
             assert!(mmu::map_page(pt, DEFAULT_HEAP_BREAK, heap_phys, l2_attrs));
             set_heap_break(DEFAULT_HEAP_BREAK + page::PAGE_SIZE);
 
+            // A real exec caller has a shattered image MB with the image mapped
+            // (exec_replace_context asserts it). map_page shatters USER_TEXT's MB;
+            // this frame stays allocated across exec (the empty new image maps
+            // nothing, reset only DEMOTES the MB), so alloc it BEFORE the baseline
+            // and it does not skew the freed-frame delta measured below.
+            let img_phys = page::alloc_page().unwrap();
+            assert!(mmu::map_page(
+                pt,
+                crate::kconfig::USER_TEXT_BASE,
+                img_phys,
+                l2_attrs
+            ));
+
             // Capture the baseline AFTER allocating the new stack so the delta
             // measures exactly the frames exec frees, not the new stack alloc.
             let new_stack_phys = page::alloc_page().unwrap();
             let free_before = page::free_count();
 
-            exec_replace_context(0x1000, new_stack_phys + page::PAGE_SIZE, new_stack_phys, 1);
+            // Empty image (no segments): this test exercises the mmap/heap
+            // FREE path (Step 3), which runs regardless of whether the remap
+            // (Step 4) succeeds. On this synthetic bare table the new stack MB is
+            // not a shatterable section, so the remap returns false -- that is
+            // fine here; the full remap is proven by the QEMU exec /init variant.
+            let new_image = crate::elf::LoadedElf::for_test(0x1000, &[]);
+            let _remapped = exec_replace_context(
+                &new_image,
+                new_stack_phys + page::PAGE_SIZE,
+                new_stack_phys,
+                1,
+            );
 
             let free_after = page::free_count();
             assert_eq!(

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -1734,23 +1734,31 @@ pub unsafe fn exec_replace_context(
         mmu::switch_addr_space(pt);
         mmu::flush_tlb_all();
 
-        // Update the PCB's memory layout REGARDLESS of remap_ok: the old stack /
-        // mmap / heap were freed above and are gone from the table, so if the
-        // remap failed and the caller kills the process, exit_cleanup's
-        // page-table walk must free the NEW (partial) mappings, not re-free the
-        // old ones. The new stack's unmapped tail (on a partial map) leaks -- an
-        // accepted cost of the rare exec-time OOM (fail-before-destroy for the
-        // stack L2 is TODO(#499)).
-        proc.stack_base = new_stack_base;
-        proc.stack_pages = new_stack_pages;
+        // The old stack / mmap / heap were freed above and are gone from the
+        // table; the heap/mmap tracking is reset for the new image.
         proc.heap_break = DEFAULT_HEAP_BREAK;
         proc.mappings = [None; MAX_MAPPINGS];
 
         if !remap_ok {
-            // The old image was already destroyed by elf::load -- the process is
-            // unrecoverable. sys_execve kills it (exit_current).
+            // The old image is already destroyed (elf::load) -- the process is
+            // unrecoverable. Free the ENTIRE new stack here: for a fresh exec
+            // stack the frame IS its identity VA, so free_page(va) reclaims each
+            // frame whether or not map_user_stack got to map it (a partial map
+            // would otherwise leak the unmapped tail -- the walk in exit_cleanup
+            // only sees MAPPED pages). unmap first so exit_cleanup's walk cannot
+            // double-free, and zero stack_pages so its stack loop skips it.
+            for i in 0..new_stack_pages {
+                let va = new_stack_base + i * page::PAGE_SIZE;
+                mmu::unmap_page(pt, va);
+                page::free_page(va);
+            }
+            proc.stack_base = 0;
+            proc.stack_pages = 0;
+            // sys_execve kills the process (exit_current).
             return false;
         }
+        proc.stack_base = new_stack_base;
+        proc.stack_pages = new_stack_pages;
 
         // 6. Install the new context -- into the PCB AND the live trap frame.
         //    THE linchpin (#489): the SVC epilogue exception-returns into
@@ -3091,24 +3099,27 @@ mod tests {
             let new_stack_phys = page::alloc_page().unwrap();
             let free_before = page::free_count();
 
-            // Empty image (no segments): this test exercises the mmap/heap
-            // FREE path (Step 3), which runs regardless of whether the remap
-            // (Step 4) succeeds. On this synthetic bare table the new stack MB is
-            // not a shatterable section, so the remap returns false -- that is
-            // fine here; the full remap is proven by the QEMU exec /init variant.
+            // Empty image (no segments): this test exercises the mmap/heap FREE
+            // path, which runs regardless of whether the remap succeeds. On this
+            // synthetic bare table the new stack MB is not a shatterable section,
+            // so map_user_stack fails, remap returns false, and the failure path
+            // ALSO frees the whole new stack (1 page) -- so exec frees the 1 mmap
+            // + 1 heap + 1 new-stack page = 3. The full success remap is proven
+            // by the QEMU exec /init variant.
             let new_image = crate::elf::LoadedElf::for_test(0x1000, &[]);
-            let _remapped = exec_replace_context(
+            let remapped = exec_replace_context(
                 &new_image,
                 new_stack_phys + page::PAGE_SIZE,
                 new_stack_phys,
                 1,
             );
+            assert!(!remapped, "bare-table remap cannot shatter the stack MB");
 
             let free_after = page::free_count();
             assert_eq!(
                 free_after,
-                free_before + 2,
-                "exec must free exactly the 1 mmap page + 1 heap page from the old image"
+                free_before + 3,
+                "exec frees the 1 mmap + 1 heap (old image) + 1 new-stack (failure path) page"
             );
 
             let procs_ro = &*core::ptr::addr_of!(PROCS);

--- a/crates/thumos/src/syscall.rs
+++ b/crates/thumos/src/syscall.rs
@@ -736,23 +736,15 @@ fn sys_execve(path_ptr: u32, argv_ptr: u32, _envp_ptr: u32) -> u32 {
         None => return ENOENT,
     };
 
-    // --- Step 3: parse and validate ELF ---
-    let loaded = match crate::elf::load(elf_data) {
-        Ok(l) => l,
-        // WHY: format/architecture failures -> ENOEXEC (matches Linux's
-        // execve(2) convention: 'not in a recognized format, wrong
-        // architecture, or some other format error'); OOM -> ENOMEM (issue
-        // #282 finding 15 -- the old blanket `Err(_) => EINVAL` never
-        // returned ENOEXEC at all).
-        Err(crate::elf::ElfError::OutOfMemory) => return ENOMEM,
-        Err(
-            crate::elf::ElfError::BadMagic
-            | crate::elf::ElfError::Not32Bit
-            | crate::elf::ElfError::NotLittleEndian
-            | crate::elf::ElfError::NotArm
-            | crate::elf::ElfError::InvalidSegment,
-        ) => return ENOEXEC,
-    };
+    // #489 fail-before-destroy: the new stack (below) and argv collection run
+    // BEFORE the destructive load(), so an OOM there returns to the STILL-INTACT
+    // old image. Image placement is enforced two ways: kinit uses load_confined
+    // for boot images, and exec's load() below is followed by a placement check
+    // on the loaded segments -- BUT the load-time write is itself confined
+    // because elf::validate rejects any segment outside sanctioned user DRAM
+    // (#318), and every authored image links at USER_TEXT_BASE (init.ld). The
+    // measured-boot chain (#480) is the primary guarantee: only signed ramfs
+    // images ever reach here.
 
     // --- Step 4: allocate new stack ---
     // WHY 4 pages (16 KB): matches spawn() stack size; sufficient for musl
@@ -834,44 +826,71 @@ fn sys_execve(path_ptr: u32, argv_ptr: u32, _envp_ptr: u32) -> u32 {
         new_stack_top - 8
     };
 
-    // Write argc onto the stack.
-    // SAFETY: sp is within [new_stack_base, new_stack_top); allocation
-    // succeeded above. Stack pages are identity-mapped (physical == virtual),
-    // so the write reaches the correct physical pages.
+    // Write the argc/argv frame onto the new stack.
+    // WHY(arm-only, #489): the frame is written to the new stack's
+    // identity-mapped DRAM. On the host new_stack_base is a page-bitmap fiction
+    // (never a valid host pointer) and the context switch is a no-op stub, so
+    // the process never resumes -- the writes are both unnecessary and unsound
+    // (a segfault, since the reorder now runs this BEFORE load's error return).
+    // Same gating as the #208 fork stack copy. sp is still computed above so
+    // exec_replace_context gets the right user sp on ARM.
+    #[cfg(target_arch = "arm")]
+    // SAFETY: sp and every cursor below lie within [new_stack_base,
+    // new_stack_top); allocation succeeded; stack pages are identity-mapped, so
+    // each write reaches the correct physical page. arg_data/arg_lens are
+    // kernel-local fixed arrays with arg_lens[i] < MAX_ARG_LEN.
     unsafe {
         (sp as *mut u32).write(argc as u32);
-    }
-
-    // Write argv[] pointers and string data.
-    let argv_array_base = sp + 4;
-    let mut string_cursor = argv_array_base + (argc + 1) * 4;
-
-    for i in 0..argc {
-        // Write the pointer to this argument string.
-        // SAFETY: argv_array_base + i*4 is within the stack frame computed above.
-        unsafe {
+        let argv_array_base = sp + 4;
+        let mut string_cursor = argv_array_base + (argc + 1) * 4;
+        for i in 0..argc {
             ((argv_array_base + i * 4) as *mut u32).write(string_cursor as u32);
-        }
-        // Copy string bytes followed by a null terminator.
-        // SAFETY: string_cursor is within the stack frame; arg_data[i] is
-        // a kernel-local fixed array; arg_lens[i] < MAX_ARG_LEN.
-        unsafe {
             core::ptr::copy_nonoverlapping(
                 arg_data[i].as_ptr(),
                 string_cursor as *mut u8,
                 arg_lens[i],
             );
             ((string_cursor + arg_lens[i]) as *mut u8).write(0);
+            string_cursor += arg_lens[i] + 1;
         }
-        string_cursor += arg_lens[i] + 1;
-    }
-    // Write null terminator for argv[argc].
-    // SAFETY: argv_array_base + argc*4 is within the stack frame.
-    unsafe {
         ((argv_array_base + argc * 4) as *mut u32).write(0);
     }
+    // arg_data/arg_lens/sp are consumed only inside the arm-only block above;
+    // touch them so the host build does not warn them unused under -D warnings.
+    let _ = (&arg_data, &arg_lens, sp);
 
-    // --- Step 5b: close-on-exec (#267) ---
+    // --- Step 6: LOAD the new image (DESTRUCTIVE) ---
+    // #489: THE point of no return -- load_confined() overwrites the caller's
+    // live image at its identity vaddrs. Everything above (stack alloc, argv
+    // collection from the still-intact old image) was fail-before-destroy;
+    // nothing below can fail-and-return-to-the-old-image. load_confined checks
+    // BOTH the OOM budget AND the placement window [USER_TEXT_BASE, RAM_END)
+    // BEFORE any write, so an out-of-window or OOM image fails cleanly without
+    // touching the old image or page-allocator RAM (#489 defects 2/3). argv
+    // strings were copied into kernel buffers + the new stack ABOVE, so
+    // overwriting the old image (where argv[] literals live) here is safe (#499).
+    let loaded = match crate::elf::load_confined(
+        elf_data,
+        crate::kconfig::USER_TEXT_BASE,
+        crate::kconfig::RAM_END,
+    ) {
+        Ok(l) => l,
+        // WHY(#489): the new stack was allocated BEFORE load (fail-before-destroy
+        // reorder), so free it on a load error -- load_confined rejected the
+        // image without writing it, and the caller keeps its intact old image.
+        Err(e) => {
+            // SAFETY: new_stack_base names the EXEC_STACK_PAGES contiguous run
+            // from alloc_contiguous above; unmapped and unused.
+            unsafe { page::free_contiguous(new_stack_base, EXEC_STACK_PAGES) };
+            return if e == crate::elf::ElfError::OutOfMemory {
+                ENOMEM
+            } else {
+                ENOEXEC
+            };
+        }
+    };
+
+    // --- Step 6b: close-on-exec (#267) ---
     // Placed after the LAST failure return so a failed execve leaves the fd
     // table untouched (POSIX: fds close only on successful exec).
     let _ = process::with_current_fds(fd::close_cloexec); // WHY: None only if no current process exists during syscall handling, which cannot happen — the sweep has nothing to report on success either way.

--- a/crates/thumos/src/syscall.rs
+++ b/crates/thumos/src/syscall.rs
@@ -753,35 +753,18 @@ fn sys_execve(path_ptr: u32, argv_ptr: u32, _envp_ptr: u32) -> u32 {
             | crate::elf::ElfError::InvalidSegment,
         ) => return ENOEXEC,
     };
-    let entry_point = loaded.entry;
 
     // --- Step 4: allocate new stack ---
     // WHY 4 pages (16 KB): matches spawn() stack size; sufficient for musl
     // libc start-up (argc/argv + environ + aux vectors + initial stack frame).
     const EXEC_STACK_PAGES: usize = 4;
-    // WHY array-tracked (#251): page::alloc_page() is a bitmap scanner with
-    // no contiguity guarantee; an OOM rollback that assumes
-    // `new_stack_base + j * PAGE_SIZE` names the j-th allocated page can free
-    // an unrelated live page. Recording each returned address makes the
-    // rollback exact regardless of fragmentation.
-    let mut exec_stack_pages: [usize; EXEC_STACK_PAGES] = [0; EXEC_STACK_PAGES];
-    for i in 0..EXEC_STACK_PAGES {
-        match page::alloc_page() {
-            Some(phys) => exec_stack_pages[i] = phys,
-            None => {
-                // OOM: free exactly the pages allocated so far, then abort.
-                for j in 0..i {
-                    // SAFETY: pages were returned by alloc_page() in this loop;
-                    // they have not been mapped or used yet.
-                    unsafe {
-                        page::free_page(exec_stack_pages[j]);
-                    }
-                }
-                return ENOMEM;
-            }
-        }
-    }
-    let new_stack_base = exec_stack_pages[0];
+    // WHY contiguous (#489): the new stack must be a single run -- new_stack_top
+    // arithmetic and exec_replace_context's map_user_stack both assume
+    // `new_stack_base + i * PAGE_SIZE` names the i-th frame (the old alloc_page
+    // loop did NOT guarantee that). One free_contiguous rolls it back.
+    let Some(new_stack_base) = page::alloc_contiguous(EXEC_STACK_PAGES) else {
+        return ENOMEM;
+    };
     let new_stack_top = new_stack_base + EXEC_STACK_PAGES * page::PAGE_SIZE;
 
     // --- Step 5: build argc/argv on the new stack ---
@@ -902,14 +885,18 @@ fn sys_execve(path_ptr: u32, argv_ptr: u32, _envp_ptr: u32) -> u32 {
         process::reset_signal_state();
     }
 
-    // --- Step 7: update PCB ---
-    // exec_replace_context frees old stack pages, resets heap_break and the
-    // mmap mapping table, and updates ctx.lr/sp/cpsr for the exception return.
-    // SAFETY: new_stack_base and EXEC_STACK_PAGES identify the freshly
-    // allocated stack verified above. entry_point is the ELF e_entry field
-    // validated by elf::load.
-    unsafe {
-        process::exec_replace_context(entry_point, sp, new_stack_base, EXEC_STACK_PAGES);
+    // --- Step 7: remap the address space + install the new context ---
+    // exec_replace_context revokes+frees the old image/stack/mmap/heap, maps the
+    // new image + stack, flushes, and installs the fresh ctx into the PCB AND
+    // the live trap frame (so the SVC epilogue returns into the new image).
+    // SAFETY: new_stack_base + EXEC_STACK_PAGES identify the freshly allocated
+    // contiguous stack; loaded is validated + written by elf::load above.
+    let remapped =
+        unsafe { process::exec_replace_context(&loaded, sp, new_stack_base, EXEC_STACK_PAGES) };
+    if !remapped {
+        // The old image is already overwritten -- the process cannot continue.
+        // Kill it (exit_current schedules away and never returns to this image).
+        process::exit_current(137);
     }
 
     0


### PR DESCRIPTION
execve now works for PL0 processes: it replaces the caller's image in place -- revoking the old image/stack/mmap/heap, mapping the NEW image (W^X per segment) + a fresh stack into the **live** page table, flushing, and installing the new context into **both the PCB and the live trap frame**.

**The linchpin (#489):** the SVC epilogue exception-returns into `ACTIVE_FRAME`, not `proc.ctx`. Writing only the PCB left the frame pointing at the OLD image's post-`svc` instruction -- now overwritten -> wild PL0 execution. `exec_replace_context` now writes `*ACTIVE_FRAME`.

- **mmu**: `flush_tlb_all` (TLBIALL + BPIALL). **process**: `map_user_stack` page-count param; `revoke_user_pages`; `exec_replace_context` rewritten -- destructive+mapping phase under the KERNEL L1 (fork-aliasing class, like exit_cleanup), old stack freed by its L2-mapped phys (forked child's VA != phys), returns false on remap-OOM so the caller kills the imageless process.
- **syscall**: contiguous new stack (`alloc_contiguous`); kill-on-remap-failure.
- **harness**: a second embedded program `/init2` (shared `compile_init_binary`; CPIO carries init+init2). The exec /init variant execs it.

**VERIFIED in QEMU** (exec /init variant): `exec-ing /init2` -> `init2: reached via exec` (new image runs = remap + frame install correct) -> USERFAULT pid=1 undefined-instruction (exec'd image is **PL0** -- the cp15 probe) -> no `PRIVILEGED`, no old-image `hello`, kernel survives. Host **2205**; default/fork/exec/sleep/kfault unregressed; all builds clean under -D warnings; kanon+fmt clean.

Follow-ups: #499 (argv-before-load; harness uses NULL argv), #498 (icache sync), #497 (brk/munmap TTBR0). Fable-designed, T0-verified. Closes #489.