### PR TITLE
Live UI render loop: kardia paints the home frame, CI-verified (#400)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,13 @@ jobs:
           grep -q 'image-resident initramfs signature verified' boot.log || { echo 'FAIL: initramfs signature was not verified (measured-userspace regression)'; exit 1; }
           grep -q '/init spawned' boot.log || { echo 'FAIL: /init did not spawn from the verified initramfs'; exit 1; }
           grep -q 'init: hello from userspace' boot.log || { echo 'FAIL: userspace /init did not run + syscall (PL0->dispatch->UART)'; exit 1; }
+          # #400 render foundation: the kardia service loop paints the home
+          # frame through the real screen-dispatch path (not a boot-time one-shot),
+          # into a synthetic framebuffer under qemu (virt models no display). The
+          # painted-pixel count proves the render EXECUTED and produced content --
+          # the UI render path was entirely dead under qemu before this.
+          grep -q 'kardia: frame rendered painted_px=' boot.log || { echo 'FAIL #400: service loop never rendered a frame (render path dead)'; exit 1; }
+          px=$(grep -oE 'painted_px=[0-9]+' boot.log | head -1 | grep -oE '[0-9]+'); test "${px:-0}" -gt 0 || { echo "FAIL #400: rendered frame is BLANK (painted_px=${px:-0}) -- screen draw produced nothing"; exit 1; }
           # PL0 isolation + graceful user-fault kill (#487 + fault handling):
           # each probe variant attempts one PL0-illegal op. A correct kernel
           # (a) faults it -- 'hello' never prints, (b) KILLS only the faulting

--- a/crates/thumos/src/kardia.rs
+++ b/crates/thumos/src/kardia.rs
@@ -32,8 +32,11 @@ use crate::exceptions;
 use crate::kinit::BootState;
 use crate::power::PowerManager;
 use crate::reflex;
+use crate::screen_home::{HomeScreen, HomeScreenState, OperatingMode};
 use crate::security_mode::ModeManager;
+use crate::status_bar::{KernelStatusBar, StatusBarState};
 use crate::uart::Uart;
+use crate::ui::UiManager;
 
 /// Timer ticks per wall-clock second (exceptions.rs TICK_MS = 10).
 const TICKS_PER_SECOND: u64 = 100;
@@ -92,28 +95,40 @@ pub(crate) struct KernelState {
         reason = "radio-policy service steps land with the security-mode wiring (#404)"
     )]
     pub(crate) power: PowerManager,
-    #[expect(
-        dead_code,
-        reason = "duress/panic mode transitions land with the security-mode wiring (#404)"
-    )]
     pub(crate) mode: ModeManager,
+    /// UI manager: owns the active-screen selection + navigation stack (#400).
+    ui: UiManager,
+    /// The home screen, re-stated + drawn each dirty tick.
+    home: HomeScreen,
+    /// Render target: the hardware framebuffer (FB_BASE) on device, a synthetic
+    /// heap buffer under qemu (the virt machine models no display), or None when
+    /// no display path exists. Wiring the render loop through this makes the UI
+    /// surface CI-verifiable in emulation for the first time (#400).
+    fb: Option<&'static mut [u16]>,
     /// Last whole second observed, for once-per-second dirty marking.
     last_second: u64,
 }
 
 impl KernelState {
-    /// Take ownership of the boot-built subsystem state.
+    /// Take ownership of the boot-built subsystem state. `fb` is the render
+    /// target the caller resolved (hardware framebuffer, qemu synthetic buffer,
+    /// or None); the UI manager + home screen are constructed here (both are
+    /// dependency-free).
     pub(crate) fn new(
         boot: BootState,
         devices: DeviceRegistry,
         power: PowerManager,
         mode: ModeManager,
+        fb: Option<&'static mut [u16]>,
     ) -> Self {
         Self {
             boot,
             devices,
             power,
             mode,
+            ui: UiManager::new(),
+            home: HomeScreen::new(),
+            fb,
             last_second: 0,
         }
     }
@@ -135,16 +150,37 @@ impl KernelState {
         false
     }
 
-    /// Render the active screen when marked dirty.
+    /// Render the active screen to the framebuffer (#400). Called when the frame
+    /// is dirty (and once at loop entry for the initial frame). No-op when there
+    /// is no render target.
     ///
-    /// TODO(#400)[deliberate-prudent]: screen-registry dispatch + framebuffer render; until then
-    /// this is the seam where the frame is produced. Rendering is skipped when
-    /// no display was brought up.
-    pub(crate) fn render_if_dirty(&mut self) {
-        if !self.boot.display_ok {
-            return;
-        }
-        // TODO(#400)[deliberate-prudent]: dispatch to the active screen's draw().
+    /// The status badge + operating mode are read LIVE from the security-mode
+    /// manager (#404) rather than hardcoded. The wall-clock epoch is still 0
+    /// until ClockManager is wired (#402).
+    pub(crate) fn render_if_dirty(&mut self) -> Option<usize> {
+        let fb = self.fb.as_deref_mut()?;
+        let status = StatusBarState {
+            battery_pct: 0,
+            mode_badge: Some(self.mode.status_badge()),
+            mode_badge_color: Some(self.mode.status_badge_color()),
+            threat_high: !self.boot.modem_ok,
+            ..StatusBarState::default()
+        };
+        self.home.update_state(HomeScreenState {
+            epoch_secs: 0,
+            carrier: "",
+            mode: OperatingMode::from(self.mode.mode()),
+            unread_count: 0,
+        });
+        // Disjoint field borrows: fb (self.fb), self.ui, self.home.
+        self.ui
+            .render(&self.home, |s| KernelStatusBar::draw(s, &status), fb);
+        // Returns the painted (non-blank) pixel count so the caller (which owns
+        // serial) can emit the #400 CI witness. The render path was DEAD under
+        // qemu until now (display_ok is always false on -machine virt); a
+        // non-zero count proves the frame rendered CONTENT, not just that the
+        // loop ticked. On device the count is unused (the caller drops it).
+        Some(fb.iter().filter(|&&px| px != 0).count())
     }
 
     /// Execute pending reflex fast-path events in privileged (loop) context.
@@ -171,6 +207,14 @@ impl KernelState {
 /// at any instruction outside an `IrqSpinlock` critical section.
 pub(crate) fn service_loop(mut kernel: KernelState, mut serial: Uart) -> ! {
     let _ = serial.write_str("[kardia] service loop running\r\n"); // WHY: best-effort loop diagnostic; must not block on a failed UART write
+    // #400: paint the initial home frame immediately, rather than waiting for
+    // the first once-per-second dirty tick.
+    #[cfg(feature = "qemu")]
+    if let Some(px) = kernel.render_if_dirty() {
+        let _ = write!(serial, "kardia: frame rendered painted_px={px}\r\n"); // WHY: #400 CI witness -- proves the render path executed + produced content under qemu
+    }
+    #[cfg(not(feature = "qemu"))]
+    kernel.render_if_dirty();
     let mut last_tick = exceptions::ticks();
     #[cfg(feature = "qemu")]
     let mut serviced: u32 = 0;
@@ -220,6 +264,11 @@ pub(crate) fn service_loop(mut kernel: KernelState, mut serial: Uart) -> ! {
             }
             // TODO(#400)[deliberate-prudent]: poll_input() -> key events -> active-screen dispatch.
             if kernel.poll_all(now) {
+                #[cfg(feature = "qemu")]
+                if let Some(px) = kernel.render_if_dirty() {
+                    let _ = write!(serial, "kardia: frame rendered painted_px={px}\r\n"); // WHY: #400 CI witness
+                }
+                #[cfg(not(feature = "qemu"))]
                 kernel.render_if_dirty();
             }
             #[cfg(feature = "qemu")]

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -12,7 +12,6 @@
 extern crate alloc;
 
 use core::fmt::Write;
-use core::slice;
 use core::sync::atomic::AtomicBool;
 #[cfg(not(feature = "qemu"))]
 use core::sync::atomic::Ordering;
@@ -49,10 +48,8 @@ use crate::power::PowerManager;
 use crate::process;
 #[cfg(test)]
 use crate::ramfs::RamFs;
-use crate::screen_home::{HomeScreen, HomeScreenState, OperatingMode};
-use crate::status_bar::{KernelStatusBar, StatusBarState};
 use crate::uart::Uart;
-use crate::ui::{self, UiManager};
+use crate::ui;
 #[cfg(not(feature = "qemu"))]
 use crate::usb::UsbController;
 use crate::watchdog;
@@ -372,29 +369,6 @@ fn halt_boot(serial: &mut Uart, display_ok: bool) -> ! {
 // ---------------------------------------------------------------------------
 
 /// Render the first user-visible home frame after boot-time hardware init.
-fn render_initial_home_frame(fb: &mut [u16], state: &BootState) {
-    let mut home = HomeScreen::new();
-    home.update_state(HomeScreenState {
-        epoch_secs: 0,
-        carrier: "",
-        mode: OperatingMode::Daily,
-        unread_count: 0,
-    });
-
-    let status = StatusBarState {
-        battery_pct: 0,
-        mode_badge: Some("DAILY"),
-        mode_badge_color: Some(ui::color::WHITE),
-        threat_high: !state.modem_ok,
-        ..StatusBarState::default()
-    };
-
-    UiManager::new().render(
-        &home,
-        |status_fb| KernelStatusBar::draw(status_fb, &status),
-        fb,
-    );
-}
 
 // ---------------------------------------------------------------------------
 // Init helpers  -  each returns Ok/Err for fault isolation
@@ -1293,19 +1267,10 @@ pub unsafe fn run() -> ! {
     }
     let _ = serial.write_str("\r\n");
 
-    // -----------------------------------------------------------------------
-    // Step 13d: Initial UI home frame
-    // -----------------------------------------------------------------------
-    if state.display_ok {
-        let _ = serial.write_str("[init] Rendering home UI\r\n");
-        // SAFETY: state.display_ok is only set after display.init(FB_BASE)
-        // succeeds. That maps FB_BASE as a writable RGB565 framebuffer of
-        // SCREEN_WIDTH * SCREEN_HEIGHT pixels for the GC9306 panel.
-        let fb =
-            unsafe { slice::from_raw_parts_mut(kconfig::FB_BASE as *mut u16, FRAMEBUFFER_PIXELS) };
-        render_initial_home_frame(fb, &state);
-        let _ = serial.write_str("       Home/status frame rendered\r\n");
-    }
+    // WHY (#400): the home frame is no longer rendered once here at boot -- the
+    // kardia service loop owns rendering now (render_if_dirty paints the initial
+    // frame at loop entry, then on every dirty tick), through the same
+    // screen-dispatch path the running UI uses.
 
     // -----------------------------------------------------------------------
     // Step 14: Spawn packaged userspace processes FROM mounted root ramfs
@@ -1465,7 +1430,24 @@ pub unsafe fn run() -> ! {
     // as before -- the loop never calls process::schedule() itself;
     // userspace runs by the timer IRQ preempting PID 0 and round-robining
     // back.
-    let kernel = crate::kardia::KernelState::new(state, devices, pm, mode_mgr);
+    // #400: resolve the render target the service loop paints each frame into.
+    // On device this is the hardware framebuffer FB_BASE (only when the display
+    // came up). Under qemu, where -machine virt models no display, a synthetic
+    // heap buffer -- so render_if_dirty actually runs and the UI surface is
+    // CI-verifiable in emulation (the render path was dead under qemu before).
+    #[cfg(feature = "qemu")]
+    let fb: Option<&'static mut [u16]> = Some(alloc::vec![0u16; FRAMEBUFFER_PIXELS].leak());
+    #[cfg(not(feature = "qemu"))]
+    let fb: Option<&'static mut [u16]> = if state.display_ok {
+        // SAFETY: display_ok is set only after display.init(FB_BASE) mapped
+        // FB_BASE as a writable RGB565 framebuffer of FRAMEBUFFER_PIXELS pixels.
+        Some(unsafe {
+            core::slice::from_raw_parts_mut(kconfig::FB_BASE as *mut u16, FRAMEBUFFER_PIXELS)
+        })
+    } else {
+        None
+    };
+    let kernel = crate::kardia::KernelState::new(state, devices, pm, mode_mgr, fb);
     crate::kardia::service_loop(kernel, serial)
 }
 

--- a/crates/thumos/src/screen_home.rs
+++ b/crates/thumos/src/screen_home.rs
@@ -53,11 +53,21 @@ pub enum OperatingMode {
     #[default]
     Daily,
     /// Heightened awareness mode.
-    #[expect(dead_code, reason = "requires security mode manager state wiring")]
     Sentinel,
     /// Emergency mode.
-    #[expect(dead_code, reason = "requires security mode manager state wiring")]
     Panic,
+}
+
+impl From<crate::security_mode::SecurityMode> for OperatingMode {
+    /// Bridge the runtime security-mode manager into the home-screen display
+    /// mode (#404): the badge/color follow the live ModeManager, not a hardcode.
+    fn from(m: crate::security_mode::SecurityMode) -> Self {
+        match m {
+            crate::security_mode::SecurityMode::Daily => Self::Daily,
+            crate::security_mode::SecurityMode::Sentinel => Self::Sentinel,
+            crate::security_mode::SecurityMode::Panic => Self::Panic,
+        }
+    }
 }
 
 impl OperatingMode {


### PR DESCRIPTION
The UI render path was **dead under qemu** (`render_if_dirty` a TODO stub + the boot one-shot both gated on `display_ok`, always false on -machine virt). This wires the render foundation through the kardia service loop.

- **KernelState** gains `ui`/`home`/`fb`; `fb` is the hardware framebuffer on device, a **synthetic heap buffer under qemu** so the render path executes + is CI-verifiable. `render_if_dirty` renders the active screen through the real UiManager 3-zone dispatch, returning the painted-pixel count.
- The service loop paints the initial frame + every dirty tick through the same dispatch path (removing the boot-time `render_initial_home_frame` special case).
- Status badge + mode read **live from the security-mode manager** (#404 security-half; `OperatingMode: From<SecurityMode>`, no more hardcoded DAILY).

**CI witness** (default qemu boot): `kardia: frame rendered painted_px=2342` (> 0) proves the render executed + produced content -- the UI surface is CI-verifiable in emulation for the first time.

Removed suppressions: OperatingMode Sentinel/Panic, KernelState.mode. Foundation for #400-input (navigation), #402 (clock), #404 (modem-half). 2206 host tests; all builds clean under -D warnings; kanon + fmt clean. Part of the dead-subsystem wiring thrust.