### PR TITLE
Wire the trust-hierarchy clock into the loop + home display (#402)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,11 @@ jobs:
           # follows the active screen (a distinct painted_px for Search).
           grep -q 'kardia: nav Home -> Search' boot.log || { echo 'FAIL #400: synthetic input did not navigate Home->Search (input dispatch / on_key broken)'; exit 1; }
           grep -q 'kardia: nav Search -> Home' boot.log || { echo 'FAIL #400: back-navigation did not return to Home (screen stack broken)'; exit 1; }
+          # #402 clock: the trust-hierarchy ClockManager is wired into the loop
+          # (was zero production callers) + seeded Manual + drives the home-screen
+          # display. Assert a real ~2025 epoch (not 0/1970), proving the wiring.
+          grep -q 'kardia: clock src=manual' boot.log || { echo 'FAIL #402: ClockManager not wired/seeded (no manual source)'; exit 1; }
+          wall=$(grep -oE 'clock src=manual wall=[0-9]+' boot.log | head -1 | grep -oE '[0-9]+$'); test "${wall:-0}" -gt 1700000000 || { echo "FAIL #402: wall clock is not a real epoch (wall=${wall:-0}) -- ClockManager not driving time"; exit 1; }
           # PL0 isolation + graceful user-fault kill (#487 + fault handling):
           # each probe variant attempts one PL0-illegal op. A correct kernel
           # (a) faults it -- 'hello' never prints, (b) KILLS only the faulting

--- a/crates/thumos/src/kardia.rs
+++ b/crates/thumos/src/kardia.rs
@@ -27,6 +27,7 @@
 
 use core::fmt::Write;
 
+use crate::clock::ClockManager;
 use crate::device::DeviceRegistry;
 use crate::exceptions;
 use crate::kinit::BootState;
@@ -44,6 +45,17 @@ use crate::ui::{Screen, ScreenId, UiManager};
 
 /// Timer ticks per wall-clock second (exceptions.rs TICK_MS = 10).
 const TICKS_PER_SECOND: u64 = 100;
+
+/// Milliseconds per timer tick (exceptions.rs TICK_MS). `ticks * TICK_MS` is the
+/// monotonic ms the ClockManager needs -- via the IRQ tick counter, which
+/// advances under qemu-virt (unlike CNTPCT, #461).
+const TICK_MS: u64 = 10;
+
+/// Boot wall-clock epoch (2025-01-01 UTC) -- matches time::REALTIME_OFFSET_SECS.
+/// Seeds ClockManager as a Manual (lowest-trust) source until a trusted source
+/// (GPS #129 / NTP / modem RTC #398) lands; on device the modem RTC replaces
+/// this at boot.
+const BOOT_WALL_EPOCH: u64 = 1_735_603_200;
 
 /// QEMU CI cap: serviced ticks before a clean semihosting-exit 0. Proves the
 /// service loop RUNS -- ticks advance and the loop body executes repeatedly
@@ -119,6 +131,12 @@ pub(crate) struct KernelState {
     /// -> navigation path the real keypad will drive.
     #[cfg(feature = "qemu")]
     input_cursor: usize,
+    /// Wall clock (#402): the trust-hierarchy time source (GPS > NTP > modem
+    /// RTC > Manual). Seeded Manual at boot; the loop evaluates it each second.
+    clock: ClockManager,
+    /// Last computed wall-clock epoch (seconds), fed to the home-screen display
+    /// each render. Replaces the previously-hardcoded 0.
+    wall_clock: u64,
     /// Render target: the hardware framebuffer (FB_BASE) on device, a synthetic
     /// heap buffer under qemu (the virt machine models no display), or None when
     /// no display path exists. Wiring the render loop through this makes the UI
@@ -146,6 +164,14 @@ impl KernelState {
             power,
             mode,
             ui: UiManager::new(),
+            clock: {
+                // Seed Manual at boot (tick_ms 0) so QEMU + a fresh device have
+                // a wall clock before any trusted source is available.
+                let mut c = ClockManager::new();
+                c.set_manual(BOOT_WALL_EPOCH, 0);
+                c
+            },
+            wall_clock: BOOT_WALL_EPOCH,
             home: HomeScreen::new(),
             messages: MessagesScreen::new(),
             search: SearchScreen::new(),
@@ -209,6 +235,12 @@ impl KernelState {
         let second = now / TICKS_PER_SECOND;
         if second != self.last_second {
             self.last_second = second;
+            // #402: advance the trust-hierarchy clock and cache the wall time
+            // for the render. now_ms via the IRQ tick counter (advances under
+            // qemu, #461). evaluate() re-checks source validity/staleness.
+            let now_ms = now * TICK_MS;
+            self.clock.evaluate(now_ms);
+            self.wall_clock = self.clock.get_wall_clock(now_ms);
             return true;
         }
         false
@@ -219,8 +251,8 @@ impl KernelState {
     /// is no render target.
     ///
     /// The status badge + operating mode are read LIVE from the security-mode
-    /// manager (#404) rather than hardcoded. The wall-clock epoch is still 0
-    /// until ClockManager is wired (#402).
+    /// manager (#404), and the wall-clock epoch from the ClockManager trust
+    /// hierarchy (#402) -- both formerly hardcoded.
     pub(crate) fn render_if_dirty(&mut self) -> Option<usize> {
         let fb = self.fb.as_deref_mut()?;
         let status = StatusBarState {
@@ -231,7 +263,7 @@ impl KernelState {
             ..StatusBarState::default()
         };
         self.home.update_state(HomeScreenState {
-            epoch_secs: 0,
+            epoch_secs: self.wall_clock,
             carrier: "",
             mode: OperatingMode::from(self.mode.mode()),
             unread_count: 0,
@@ -302,6 +334,19 @@ pub(crate) fn service_loop(mut kernel: KernelState, mut serial: Uart) -> ! {
     }
     #[cfg(not(feature = "qemu"))]
     kernel.render_if_dirty();
+    // #402 CI witness: the trust-hierarchy clock is wired + seeded (source off
+    // None to Manual, a real ~2025 epoch, driving the home-screen display).
+    // Advancement over wall-clock seconds is a get_wall_clock property (unit
+    // tested); the qemu boot (50 serviced ticks < 1 s) proves the WIRING.
+    #[cfg(feature = "qemu")]
+    {
+        let _ = write!(
+            serial,
+            "kardia: clock src={} wall={}\r\n",
+            kernel.clock.current_source(),
+            kernel.wall_clock
+        );
+    }
     let mut last_tick = exceptions::ticks();
     #[cfg(feature = "qemu")]
     let mut serviced: u32 = 0;
@@ -361,7 +406,8 @@ pub(crate) fn service_loop(mut kernel: KernelState, mut serial: Uart) -> ! {
                     screen_id_name(to)
                 ); // WHY: #400 CI witness -- proves synthetic input drove navigation
             }
-            if kernel.poll_all(now) || nav.is_some() {
+            let ticked = kernel.poll_all(now);
+            if ticked || nav.is_some() {
                 #[cfg(feature = "qemu")]
                 if let Some(px) = kernel.render_if_dirty() {
                     let _ = write!(serial, "kardia: frame rendered painted_px={px}\r\n"); // WHY: #400 CI witness


### PR DESCRIPTION
ClockManager (GPS > NTP > modem RTC > Manual) had **zero production callers** and the home-screen epoch was hardcoded 0 (1970). This wires it into the kardia loop as the display-clock authority.

- KernelState holds `clock: ClockManager`, seeded Manual at boot with a real ~2025 epoch (until a trusted source lands; modem RTC replaces it on device).
- `poll_all` advances it each second (`evaluate` + `get_wall_clock` via the IRQ tick counter, which advances under qemu unlike CNTPCT #461).
- `render_if_dirty` feeds it into the home-screen epoch -- the displayed time is now ClockManager-driven, not 0.

**CI witness**: `kardia: clock src=manual wall=1735603200` (asserted > 1.7e9, a real 2025 epoch, not 0/1970).

**Deferred**: feeding `get_wall_clock` into `time::set_realtime_offset` to unify the USERSPACE clock -- time.rs uses monotonic_secs (CNTPCT, frozen under qemu) vs the loop's tick counter, so it needs #461 first. Tracked as a follow-on. 2206 host tests; all builds clean under -D warnings; kanon+fmt clean. Third increment of the dead-subsystem wiring thrust.