### PR TITLE
Wire the telephony AT/call stack (mock-backed under qemu), CI-verified (#398)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,12 @@ jobs:
           # display. Assert a real ~2025 epoch (not 0/1970), proving the wiring.
           grep -q 'kardia: clock src=manual' boot.log || { echo 'FAIL #402: ClockManager not wired/seeded (no manual source)'; exit 1; }
           wall=$(grep -oE 'clock src=manual wall=[0-9]+' boot.log | head -1 | grep -oE '[0-9]+$'); test "${wall:-0}" -gt 1700000000 || { echo "FAIL #402: wall clock is not a real epoch (wall=${wall:-0}) -- ClockManager not driving time"; exit 1; }
+          # #398 telephony: a seeded mock modem transport backs a LIVE Telephony
+          # stack (structurally impossible before -- zero production callers). The
+          # full 10-step AT initialize() ran and the modem reached Registered,
+          # proving the AT/call state machines are exercised in emulation without
+          # real modem hardware (the CCCI wire protocol is hardware-gated).
+          grep -q 'kardia: modem ready state=Registered' boot.log || { echo 'FAIL #398: Telephony did not initialize to Registered (AT state machine / mock wiring broken)'; exit 1; }
           # PL0 isolation + graceful user-fault kill (#487 + fault handling):
           # each probe variant attempts one PL0-illegal op. A correct kernel
           # (a) faults it -- 'hello' never prints, (b) KILLS only the faulting

--- a/crates/thumos/src/kardia.rs
+++ b/crates/thumos/src/kardia.rs
@@ -40,6 +40,7 @@ use crate::screen_search::SearchScreen;
 use crate::screen_settings::SettingsMenuScreen;
 use crate::security_mode::ModeManager;
 use crate::status_bar::{KernelStatusBar, StatusBarState};
+use crate::telephony::{BootModemTransport, Telephony};
 use crate::uart::Uart;
 use crate::ui::{Screen, ScreenId, UiManager};
 
@@ -137,6 +138,10 @@ pub(crate) struct KernelState {
     /// Last computed wall-clock epoch (seconds), fed to the home-screen display
     /// each render. Replaces the previously-hardcoded 0.
     wall_clock: u64,
+    /// The AT/call telephony stack (#398), or None when no initialized modem is
+    /// available (a device boot where the CCCI link/AT layer did not come up).
+    /// Under qemu it is a seeded mock stack; the loop drains its URCs each tick.
+    telephony: Option<Telephony<BootModemTransport>>,
     /// Render target: the hardware framebuffer (FB_BASE) on device, a synthetic
     /// heap buffer under qemu (the virt machine models no display), or None when
     /// no display path exists. Wiring the render loop through this makes the UI
@@ -157,6 +162,7 @@ impl KernelState {
         power: PowerManager,
         mode: ModeManager,
         fb: Option<&'static mut [u16]>,
+        telephony: Option<Telephony<BootModemTransport>>,
     ) -> Self {
         Self {
             boot,
@@ -172,6 +178,7 @@ impl KernelState {
                 c
             },
             wall_clock: BOOT_WALL_EPOCH,
+            telephony,
             home: HomeScreen::new(),
             messages: MessagesScreen::new(),
             search: SearchScreen::new(),
@@ -230,6 +237,12 @@ impl KernelState {
     /// only; anything slower belongs in a budgeted state machine inside its
     /// subsystem.
     pub(crate) fn poll_all(&mut self, now: u64) -> bool {
+        // #398: drain modem URCs (RING/CLIP/CREG/CSQ) each tick, non-blocking.
+        // Event handling (ring -> UI/audio, registration -> status bar) lands
+        // with those wirings; draining keeps the AT state machine current.
+        if let Some(t) = self.telephony.as_mut() {
+            while t.poll().is_some() {}
+        }
         // NOTE(foundation): the home clock (once per second) is the only
         // persisted render input; each subsystem wiring adds its step here.
         let second = now / TICKS_PER_SECOND;

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -1447,7 +1447,42 @@ pub unsafe fn run() -> ! {
     } else {
         None
     };
-    let kernel = crate::kardia::KernelState::new(state, devices, pm, mode_mgr, fb);
+    // #398: bring up the AT/call telephony stack on the modem transport. Under
+    // qemu a seeded mock runs the real 10-step init + state machines; on device
+    // the CCCI transport (init succeeds only once its wire protocol lands --
+    // hardware-gated) -- the WIRING is present either way.
+    #[cfg(feature = "qemu")]
+    let telephony = {
+        let mut t = crate::telephony::Telephony::new(
+            crate::telephony_mock::MockModemTransport::seeded_for_boot(),
+        );
+        match t.initialize() {
+            Ok(()) => {
+                let _ = write!(
+                    serial,
+                    "kardia: modem ready state={:?}\r\n",
+                    t.modem_state()
+                );
+                Some(t)
+            }
+            Err(e) => {
+                let _ = write!(serial, "kardia: modem init FAILED {e:?}\r\n");
+                None
+            }
+        }
+    };
+    #[cfg(all(not(feature = "qemu"), not(test)))]
+    let telephony = if state.modem_ok {
+        let mut t = crate::telephony::Telephony::new(crate::telephony::CcciModemTransport::new());
+        t.initialize().ok().map(|()| t)
+    } else {
+        None
+    };
+    // Host tests compile kinit::run but never execute it; CcciModemTransport is
+    // cfg(not(test)), so under test there is no modem to construct.
+    #[cfg(all(not(feature = "qemu"), test))]
+    let telephony: Option<crate::telephony::Telephony<crate::telephony::BootModemTransport>> = None;
+    let kernel = crate::kardia::KernelState::new(state, devices, pm, mode_mgr, fb, telephony);
     crate::kardia::service_loop(kernel, serial)
 }
 

--- a/crates/thumos/src/main.rs
+++ b/crates/thumos/src/main.rs
@@ -185,7 +185,10 @@ mod status_bar;
 mod syscall;
 mod t9;
 mod telephony;
-#[cfg(test)]
+// WHY (#398): the mock modem transport backs a live Telephony stack under qemu
+// (no CCCI/CLDMA model on -machine virt), so the AT/call/SIM/SMS state machines
+// are CI-exercisable without real modem hardware -- not just in unit tests.
+#[cfg(any(test, feature = "qemu"))]
 mod telephony_mock;
 mod telephony_parser;
 mod time;

--- a/crates/thumos/src/telephony.rs
+++ b/crates/thumos/src/telephony.rs
@@ -454,6 +454,16 @@ fn send_with_info<T: ModemTransport>(
 // Telephony subsystem
 // ---------------------------------------------------------------------------
 
+/// The modem transport the booted kernel wires into its Telephony stack (#398).
+/// A build-time choice so `KernelState` (a concrete struct) can hold a
+/// `Telephony<BootModemTransport>` without going generic: the seeded mock under
+/// qemu (no CCCI/CLDMA model on -machine virt), the real CCCI transport on
+/// device.
+#[cfg(any(feature = "qemu", test))]
+pub(crate) type BootModemTransport = crate::telephony_mock::MockModemTransport;
+#[cfg(not(any(feature = "qemu", test)))]
+pub(crate) type BootModemTransport = CcciModemTransport;
+
 /// Telephony subsystem: manages modem state and voice calls.
 pub struct Telephony<T: ModemTransport> {
     // kanon:ignore RUST/struct-too-many-fields -- cohesive modem state: radio + signal + registration + call + operator fields track one hardware subsystem

--- a/crates/thumos/src/telephony_mock.rs
+++ b/crates/thumos/src/telephony_mock.rs
@@ -66,6 +66,26 @@ impl MockModemTransport {
         self.queue_response(info);
         self.queue_response(b"OK");
     }
+
+    /// A mock pre-seeded with the full successful 10-step `Telephony::initialize`
+    /// AT sequence (#398): registers home on a LTE-only network with a READY
+    /// SIM. Lets a qemu kernel bring up a real, initialized Telephony stack
+    /// (the non-test analogue of the test-only `mock_for_init`).
+    #[cfg(feature = "qemu")]
+    pub(crate) fn seeded_for_boot() -> Self {
+        let mut mock = Self::new();
+        mock.queue_ok(); // 1: AT
+        mock.queue_ok(); // 2: ATE0
+        mock.queue_ok(); // 3: AT+CFUN=1
+        mock.queue_info_ok(b"+CPIN: READY"); // 4: AT+CPIN?
+        mock.queue_ok(); // 5: AT+COPS=0,,,7 (LTE only / refuse 2G)
+        mock.queue_info_ok(b"+COPS: 0,0,\"T-Mobile\""); // 6: AT+COPS?
+        mock.queue_ok(); // 7: AT+CREG=1
+        mock.queue_ok(); // 8: AT+CLIP=1
+        mock.queue_info_ok(b"+CSQ: 18,99"); // 9: AT+CSQ
+        mock.queue_info_ok(b"+CREG: 1"); // 10: AT+CREG? (registered home)
+        mock
+    }
 }
 
 impl ModemTransport for MockModemTransport {


### PR DESCRIPTION
Telephony<T>'s AT/call state machine had **zero production callers** -- voice calls + modem registration were structurally impossible. This wires a **live** Telephony stack into the kardia loop.

- The mock transport is promoted to `cfg(any(test, feature="qemu"))`, so a real initialized Telephony stack exists in a qemu kernel (no CCCI/CLDMA on -machine virt).
- `MockModemTransport::seeded_for_boot()` pre-queues the full 10-step AT init.
- A build-time `BootModemTransport` alias (mock under qemu/test, real CCCI on device) lets the concrete KernelState hold `Telephony<BootModemTransport>`.
- kinit constructs + `initialize()`s it; KernelState holds it as `Option`; `poll_all` drains URCs each tick.

**CI witness**: `kardia: modem ready state=Registered` -- the full AT init ran + the modem registered via the mock, exercising the AT/call state machines without hardware.

**Scope**: AT/call layer (core). SimManager/SmsManager + reflex RING->UI/audio remain the rest of #398. 2206 host tests; all builds clean under -D warnings; kanon+fmt clean. The highest-severity unwired subsystem, now live in emulation.