### PR TITLE
Incoming call -> ringtone audio session, CI-verified (#398)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,11 @@ jobs:
           # telephony registration (was hardcoded) + the mode char by the
           # security-mode manager. A registered mock modem shows Lte.
           grep -q 'kardia: statusbar net=Lte' boot.log || { echo 'FAIL #404: status bar network not driven by telephony registration (modem-state bridge broken)'; exit 1; }
+          # #398 ring->audio integration: a seeded RING URC, surfaced by
+          # telephony poll() as an IncomingCall, drives the loop to open a
+          # ringtone audio session -- the "phone rings" path across the wired
+          # telephony (#398) + audio (#399) stacks.
+          grep -qE 'kardia: incoming call -> ringtone sessions=[1-9]' boot.log || { echo 'FAIL #398: incoming call did not open a ringtone session (telephony->audio integration broken)'; exit 1; }
           # PL0 isolation + graceful user-fault kill (#487 + fault handling):
           # each probe variant attempts one PL0-illegal op. A correct kernel
           # (a) faults it -- 'hello' never prints, (b) KILLS only the faulting

--- a/crates/thumos/src/kardia.rs
+++ b/crates/thumos/src/kardia.rs
@@ -254,10 +254,26 @@ impl KernelState {
     /// subsystem.
     pub(crate) fn poll_all(&mut self, now: u64) -> bool {
         // #398: drain modem URCs (RING/CLIP/CREG/CSQ) each tick, non-blocking.
-        // Event handling (ring -> UI/audio, registration -> status bar) lands
-        // with those wirings; draining keeps the AT state machine current.
+        // An incoming call opens a ringtone audio session -- the phone-rings
+        // integration across the wired telephony (#398) + audio (#399) stacks.
+        let mut incoming_call = false;
         if let Some(t) = self.telephony.as_mut() {
-            while t.poll().is_some() {}
+            while let Some(ev) = t.poll() {
+                if matches!(ev, crate::telephony::TelephonyEvent::IncomingCall { .. }) {
+                    incoming_call = true;
+                }
+            }
+        }
+        if incoming_call {
+            // telephony borrow released above; open the ringtone on the audio
+            // manager (Idempotent-ish: a second RING while ringing is a no-op
+            // preempt at the same priority).
+            let route = self
+                .route
+                .default_route_for(crate::audio_route::SessionKind::Ringtone);
+            self.audio
+                .open_session(crate::audio_route::SessionKind::Ringtone, route)
+                .ok();
         }
         // NOTE(foundation): the home clock (once per second) is the only
         // persisted render input; each subsystem wiring adds its step here.
@@ -439,6 +455,10 @@ pub(crate) fn service_loop(mut kernel: KernelState, mut serial: Uart) -> ! {
     let mut serviced: u32 = 0;
     #[cfg(feature = "qemu")]
     let mut wakes: u32 = 0;
+    // #398: emit the ring->audio CI witness once, when the seeded RING URC has
+    // driven the loop to open a ringtone session.
+    #[cfg(feature = "qemu")]
+    let mut ring_logged = false;
     loop {
         #[cfg(feature = "qemu")]
         {
@@ -494,6 +514,15 @@ pub(crate) fn service_loop(mut kernel: KernelState, mut serial: Uart) -> ! {
                 ); // WHY: #400 CI witness -- proves synthetic input drove navigation
             }
             let ticked = kernel.poll_all(now);
+            #[cfg(feature = "qemu")]
+            if !ring_logged && kernel.audio.session_count() > 0 {
+                ring_logged = true;
+                let _ = write!(
+                    serial,
+                    "kardia: incoming call -> ringtone sessions={}\r\n",
+                    kernel.audio.session_count()
+                );
+            }
             if ticked || nav.is_some() {
                 #[cfg(feature = "qemu")]
                 if let Some(px) = kernel.render_if_dirty() {

--- a/crates/thumos/src/telephony_mock.rs
+++ b/crates/thumos/src/telephony_mock.rs
@@ -84,6 +84,10 @@ impl MockModemTransport {
         mock.queue_ok(); // 8: AT+CLIP=1
         mock.queue_info_ok(b"+CSQ: 18,99"); // 9: AT+CSQ
         mock.queue_info_ok(b"+CREG: 1"); // 10: AT+CREG? (registered home)
+        // A queued RING URC so a booted qemu kernel exercises the incoming-call
+        // -> ringtone-audio integration path (#398): poll() surfaces it as an
+        // IncomingCall event after init.
+        mock.queue_urc(b"RING");
         mock
     }
 }


### PR DESCRIPTION
The first cross-subsystem **integration** over the newly-wired stacks: a modem RING now opens a ringtone audio session -- the "phone rings" path across telephony (#398) + audio (#399), previously two independent islands.

- `poll_all` detects a `Telephony::poll()` `IncomingCall` event and opens a Ringtone session on the AudioManager (routed via RouteManager).
- The boot mock queues a RING URC, so a qemu boot surfaces the IncomingCall after init and drives the integration deterministically.

**CI witness**: `kardia: incoming call -> ringtone sessions=1` -- the seeded RING opened a ringtone session, exercising telephony -> audio end-to-end without hardware.

The real CCCI RING IRQ -> reflex path (hardware) is separate; both feed the same ring->audio logic. 2206 host tests; all builds clean under -D warnings; kanon+fmt clean. Eighth PR of the wiring thrust -- the first subsystem-to-subsystem integration.