### PR TITLE
feat(thumos): parse +CREG <AcT> into a radio access technology, CI-verified (#404)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,11 @@ jobs:
           # #401 BT A2DP: the A2dpProfile is instantiated + its SBC/config state
           # machine runs (configured 44.1 kHz stereo). RF/HCI is hardware-gated.
           grep -q 'kardia: bt_audio sample_rate=44100 channels=2' boot.log || { echo 'FAIL #401: A2DP profile not wired / config state machine broken'; exit 1; }
+          # #404 RAT parsing: the status-bar network label is RAT-derived, not a
+          # hardcoded Lte. The seeded modem registered on E-UTRAN (+CREG <AcT>=7),
+          # parsed into RadioAccessTech::EUtran -- a value only the parse path can
+          # produce -- driving net=Lte.
+          grep -qF 'kardia: netrat rat=Some(EUtran) net=Lte' boot.log || { echo 'FAIL #404: network label not derived from parsed +CREG <AcT> (RAT parsing broken)'; exit 1; }
           # PL0 isolation + graceful user-fault kill (#487 + fault handling):
           # each probe variant attempts one PL0-illegal op. A correct kernel
           # (a) faults it -- 'hello' never prints, (b) KILLS only the faulting

--- a/crates/thumos/src/kardia.rs
+++ b/crates/thumos/src/kardia.rs
@@ -48,7 +48,9 @@ use crate::security_mode::ModeManager;
 use crate::sim::SimManager;
 use crate::sms::SmsManager;
 use crate::status_bar::{KernelStatusBar, NetworkService, StatusBarState};
-use crate::telephony::{BootModemTransport, Telephony};
+#[cfg(feature = "qemu")]
+use crate::telephony::RadioAccessTech;
+use crate::telephony::{BootModemTransport, RatGeneration, Telephony};
 use crate::uart::Uart;
 use crate::ui::{Screen, ScreenId, UiManager};
 
@@ -310,13 +312,18 @@ impl KernelState {
     }
 
     /// The cellular network service shown in the status bar (#404), derived from
-    /// the wired telephony registration. The device is LTE-only (the boot COPS
-    /// selects `,,,7`), so a registered modem is `Lte`; unregistered or no modem
-    /// is `NoService`. The RAT distinction (Edge/ThreeG) awaits +CREG `<AcT>`
-    /// parsing -- a follow-on.
+    /// the wired telephony registration + its radio access technology. The RAT
+    /// comes from the `+CREG` `<AcT>` field: 2G shows `Edge`, 3G `ThreeG`, 4G
+    /// `Lte`. A registered modem that reports no `<AcT>` falls back to `Lte`
+    /// (the device requests LTE-only via `AT+COPS=0,,,7`); unregistered or no
+    /// modem is `NoService`.
     fn status_network(&self) -> NetworkService {
         match self.telephony.as_ref() {
-            Some(t) if t.is_registered() => NetworkService::Lte,
+            Some(t) if t.is_registered() => match t.rat().map(|rat| rat.generation()) {
+                Some(RatGeneration::TwoG) => NetworkService::Edge,
+                Some(RatGeneration::ThreeG) => NetworkService::ThreeG,
+                Some(RatGeneration::FourG) | None => NetworkService::Lte,
+            },
             _ => NetworkService::NoService,
         }
     }
@@ -427,6 +434,17 @@ impl KernelState {
         (self.bt_audio.sample_rate(), self.bt_audio.channels())
     }
 
+    /// Boot-time RAT smoke (#404, qemu): report the radio access technology the
+    /// wired modem registered on -- parsed from the seeded `+CREG` `<AcT>` --
+    /// and the status-bar network label it drives. Proves the label is derived
+    /// from a real parsed `<AcT>` (only the parse path yields `EUtran`), not a
+    /// constant `Lte`.
+    #[cfg(feature = "qemu")]
+    pub(crate) fn netrat_boot_smoke(&self) -> (Option<RadioAccessTech>, NetworkService) {
+        let rat = self.telephony.as_ref().and_then(Telephony::rat);
+        (rat, self.status_network())
+    }
+
     /// Execute pending reflex fast-path events in privileged (loop) context.
     pub(crate) fn handle_reflex(&mut self, pending: reflex::Pending, serial: &mut Uart) {
         if pending.panic_wipe {
@@ -457,6 +475,19 @@ fn screen_id_name(id: ScreenId) -> &'static str {
     }
 }
 
+/// Emit one CI-witness line atomically under an IRQ mask.
+///
+/// WHY (#513): userspace `/init` preempts this PID-0 loop and shares the single
+/// UART, so an unmasked multi-byte `write!` can be split mid-line by a timer IRQ
+/// -> scheduler -> userspace write, corrupting the `kardia:` marker the CI greps
+/// match. Masking IRQs for the one line keeps it intact; the line is short and
+/// the UART write is non-blocking, so the masked section is bounded.
+#[cfg(feature = "qemu")]
+fn emit_marker(serial: &mut Uart, args: core::fmt::Arguments) {
+    let _guard = crate::irq::IrqGuard::new();
+    serial.write_fmt(args).ok();
+}
+
 /// The kernel service loop -- PID 0's body. Never returns (on the phone).
 ///
 /// INVARIANT: entered with scheduling already enabled (kinit calls
@@ -466,56 +497,72 @@ pub(crate) fn service_loop(mut kernel: KernelState, mut serial: Uart) -> ! {
     let _ = serial.write_str("[kardia] service loop running\r\n"); // WHY: best-effort loop diagnostic; must not block on a failed UART write
     // #400: paint the initial home frame immediately, rather than waiting for
     // the first once-per-second dirty tick.
-    #[cfg(feature = "qemu")]
-    if let Some(px) = kernel.render_if_dirty() {
-        let _ = write!(serial, "kardia: frame rendered painted_px={px}\r\n"); // WHY: #400 CI witness -- proves the render path executed + produced content under qemu
-    }
     #[cfg(not(feature = "qemu"))]
     kernel.render_if_dirty();
-    // #402 CI witness: the trust-hierarchy clock is wired + seeded (source off
-    // None to Manual, a real ~2025 epoch, driving the home-screen display).
-    // Advancement over wall-clock seconds is a get_wall_clock property (unit
-    // tested); the qemu boot (50 serviced ticks < 1 s) proves the WIRING.
+    // Loop-entry CI witnesses (#398-#404). Do the real work FIRST, unmasked:
+    // paint the initial home frame + run each boot-smoke, capturing values.
+    // Then emit the whole marker burst under an IRQ mask (below) -- userspace
+    // /init preempts this PID-0 loop and shares the single UART, so an unmasked
+    // burst can be split mid-line (the #513 flake: `init: hello from userspace`
+    // interleaved into a `kardia: netrat` line, breaking the grep).
     #[cfg(feature = "qemu")]
     {
-        let _ = write!(
-            serial,
-            "kardia: clock src={} wall={}\r\n",
-            kernel.clock.current_source(),
-            kernel.wall_clock
-        );
-        // #399 CI witness: the audio session manager + route + mic audit are
-        // wired + functional -- a VoiceCall session opened (sessions=1) and a
-        // mic-access entry was recorded (mic_entries=1), all structurally
-        // impossible before (zero production callers).
+        // #400: paint the initial home frame immediately (not waiting for the
+        // first once-per-second dirty tick).
+        let painted = kernel.render_if_dirty();
+        // #402: trust-hierarchy clock wired + seeded (source None -> Manual, a
+        // real ~2025 epoch driving the home display). Per-second advancement is
+        // a get_wall_clock property (unit tested); the boot proves the WIRING.
+        let clock_src = kernel.clock.current_source();
+        let wall = kernel.wall_clock;
+        // #399: audio session manager + route + mic audit wired -- a VoiceCall
+        // session opens + a mic-access entry is recorded (impossible before).
         let (sessions, mic_entries) = kernel.audio_boot_smoke();
-        let _ = write!(
-            serial,
-            "kardia: audio ready sessions={sessions} mic_entries={mic_entries}\r\n"
-        );
-        // #404 CI witness: the status bar's cellular field is now driven by the
-        // wired telephony registration (was hardcoded), and the mode char by the
-        // security-mode manager. A registered mock modem shows Lte.
-        let _ = write!(
-            serial,
-            "kardia: statusbar net={:?} mode={}\r\n",
-            kernel.status_network(),
-            kernel.mode.mode_char()
-        );
-        // #398 CI witness: SIM + SMS managers are wired + functional -- the SIM
-        // ICCID was queried over the modem transport (iccid_len>0) and a known
-        // incoming SMS PDU decoded into the inbox (sms_inbox=1).
+        // #404: status-bar cellular field driven by the wired telephony
+        // registration (was hardcoded); mode char by the security-mode manager.
+        let net = kernel.status_network();
+        let mode_char = kernel.mode.mode_char();
+        // #398: SIM + SMS wired -- ICCID queried over the modem transport + a
+        // known incoming SMS PDU decoded into the inbox.
         let (iccid_len, sms_inbox) = kernel.sim_sms_boot_smoke();
-        let _ = write!(
-            serial,
-            "kardia: sim iccid_len={iccid_len} sms_inbox={sms_inbox}\r\n"
-        );
-        // #401 CI witness: the BT A2DP profile is wired + its SBC/config state
-        // machine runs (configured to 44.1 kHz stereo). RF/HCI is hardware-gated.
+        // #401: BT A2DP profile wired + its SBC/config state machine runs
+        // (44.1 kHz stereo). RF/HCI is hardware-gated.
         let (bt_rate, bt_ch) = kernel.bt_audio_boot_smoke();
-        let _ = write!(
-            serial,
-            "kardia: bt_audio sample_rate={bt_rate} channels={bt_ch}\r\n"
+        // #404: status-bar network label derived from the parsed +CREG <AcT>
+        // (EUtran can only come from the parse path), not a constant.
+        let (rat, netrat_net) = kernel.netrat_boot_smoke();
+
+        // Emit each witness line atomically (emit_marker masks IRQs per line)
+        // so userspace /init cannot split a `kardia:` line mid-write (#513).
+        if let Some(px) = painted {
+            emit_marker(
+                &mut serial,
+                format_args!("kardia: frame rendered painted_px={px}\r\n"),
+            );
+        }
+        emit_marker(
+            &mut serial,
+            format_args!("kardia: clock src={clock_src} wall={wall}\r\n"),
+        );
+        emit_marker(
+            &mut serial,
+            format_args!("kardia: audio ready sessions={sessions} mic_entries={mic_entries}\r\n"),
+        );
+        emit_marker(
+            &mut serial,
+            format_args!("kardia: statusbar net={net:?} mode={mode_char}\r\n"),
+        );
+        emit_marker(
+            &mut serial,
+            format_args!("kardia: sim iccid_len={iccid_len} sms_inbox={sms_inbox}\r\n"),
+        );
+        emit_marker(
+            &mut serial,
+            format_args!("kardia: bt_audio sample_rate={bt_rate} channels={bt_ch}\r\n"),
+        );
+        emit_marker(
+            &mut serial,
+            format_args!("kardia: netrat rat={rat:?} net={netrat_net:?}\r\n"),
         );
     }
     let mut last_tick = exceptions::ticks();
@@ -574,27 +621,36 @@ pub(crate) fn service_loop(mut kernel: KernelState, mut serial: Uart) -> ! {
             let nav = kernel.poll_input();
             #[cfg(feature = "qemu")]
             if let Some((from, to)) = nav {
-                let _ = write!(
-                    serial,
-                    "kardia: nav {} -> {}\r\n",
-                    screen_id_name(from),
-                    screen_id_name(to)
-                ); // WHY: #400 CI witness -- proves synthetic input drove navigation
+                // WHY: #400 CI witness -- proves synthetic input drove navigation.
+                emit_marker(
+                    &mut serial,
+                    format_args!(
+                        "kardia: nav {} -> {}\r\n",
+                        screen_id_name(from),
+                        screen_id_name(to)
+                    ),
+                );
             }
             let ticked = kernel.poll_all(now);
             #[cfg(feature = "qemu")]
             if !ring_logged && kernel.audio.session_count() > 0 {
                 ring_logged = true;
-                let _ = write!(
-                    serial,
-                    "kardia: incoming call -> ringtone sessions={}\r\n",
-                    kernel.audio.session_count()
+                emit_marker(
+                    &mut serial,
+                    format_args!(
+                        "kardia: incoming call -> ringtone sessions={}\r\n",
+                        kernel.audio.session_count()
+                    ),
                 );
             }
             if ticked || nav.is_some() {
                 #[cfg(feature = "qemu")]
                 if let Some(px) = kernel.render_if_dirty() {
-                    let _ = write!(serial, "kardia: frame rendered painted_px={px}\r\n"); // WHY: #400 CI witness
+                    // WHY: #400 CI witness.
+                    emit_marker(
+                        &mut serial,
+                        format_args!("kardia: frame rendered painted_px={px}\r\n"),
+                    );
                 }
                 #[cfg(not(feature = "qemu"))]
                 kernel.render_if_dirty();

--- a/crates/thumos/src/status_bar.rs
+++ b/crates/thumos/src/status_bar.rs
@@ -37,10 +37,8 @@ pub enum NetworkService {
     #[default]
     NoService,
     /// 2G (GSM/EDGE).
-    #[expect(dead_code, reason = "requires modem registration state wiring")]
     Edge,
     /// 3G (WCDMA/HSPA).
-    #[expect(dead_code, reason = "requires modem registration state wiring")]
     ThreeG,
     /// 4G LTE.
     Lte,

--- a/crates/thumos/src/telephony.rs
+++ b/crates/thumos/src/telephony.rs
@@ -136,8 +136,11 @@ pub enum Urc {
     Busy,
     /// Signal quality report (+CSQ: rssi,ber).
     Csq { rssi: u8, ber: u8 },
-    /// Network registration status changed (+CREG: stat).
-    Creg { stat: RegStatus },
+    /// Network registration status changed (+CREG: stat[,...,AcT]).
+    Creg {
+        stat: RegStatus,
+        act: Option<RadioAccessTech>,
+    },
     /// Caller ID (+CLIP: "number",type).
     Clip {
         number: [u8; MAX_NUMBER_LEN],
@@ -187,6 +190,82 @@ impl core::fmt::Display for RegStatus {
             Self::RegisteredRoaming => write!(f, "registered (roaming)"),
         }
     }
+}
+
+/// Radio access technology, parsed from the `+CREG` `<AcT>` field (3GPP TS
+/// 27.007 §7.2). Distinguishes the technology a registration actually landed
+/// on -- the status bar renders it (2G/3G/LTE) and the threat model reads it
+/// (a GSM/UTRAN registration is a downgrade signal even when LTE-only
+/// selection was requested via `AT+COPS=0,,,7`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RadioAccessTech {
+    /// GSM (`<AcT>`=0).
+    Gsm,
+    /// GSM Compact (`<AcT>`=1).
+    GsmCompact,
+    /// UTRAN / UMTS (`<AcT>`=2).
+    Utran,
+    /// GSM with EGPRS -- EDGE (`<AcT>`=3).
+    GsmEgprs,
+    /// UTRAN with HSDPA (`<AcT>`=4).
+    UtranHsdpa,
+    /// UTRAN with HSUPA (`<AcT>`=5).
+    UtranHsupa,
+    /// UTRAN with HSDPA and HSUPA (`<AcT>`=6).
+    UtranHsdpaHsupa,
+    /// E-UTRAN -- LTE (`<AcT>`=7).
+    EUtran,
+    /// E-UTRAN in NB-S1 mode -- LTE (NB-IoT) (`<AcT>`=8).
+    EUtranNbS1,
+}
+
+impl RadioAccessTech {
+    /// Map a raw `+CREG` `<AcT>` code to a radio access technology.
+    ///
+    /// Returns `None` for a code outside the defined 0-8 range rather than a
+    /// wrong technology -- an unknown RAT must not masquerade as a known one.
+    #[must_use]
+    pub const fn from_act(val: u8) -> Option<Self> {
+        Some(match val {
+            0 => Self::Gsm,
+            1 => Self::GsmCompact,
+            2 => Self::Utran,
+            3 => Self::GsmEgprs,
+            4 => Self::UtranHsdpa,
+            5 => Self::UtranHsupa,
+            6 => Self::UtranHsdpaHsupa,
+            7 => Self::EUtran,
+            8 => Self::EUtranNbS1,
+            _ => return None,
+        })
+    }
+
+    /// The cellular generation this technology belongs to. GSM/EGPRS map to
+    /// 2G, the UTRAN family to 3G, and E-UTRAN to 4G/LTE.
+    #[must_use]
+    pub const fn generation(self) -> RatGeneration {
+        match self {
+            Self::Gsm | Self::GsmCompact | Self::GsmEgprs => RatGeneration::TwoG,
+            Self::Utran | Self::UtranHsdpa | Self::UtranHsupa | Self::UtranHsdpaHsupa => {
+                RatGeneration::ThreeG
+            }
+            Self::EUtran | Self::EUtranNbS1 => RatGeneration::FourG,
+        }
+    }
+}
+
+/// Cellular generation of a [`RadioAccessTech`] -- the coarse 2G/3G/4G tier the
+/// status bar and threat model reason about.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RatGeneration {
+    /// 2G (GSM / GPRS / EDGE).
+    TwoG,
+    /// 3G (UTRAN / UMTS / HSPA).
+    ThreeG,
+    /// 4G (LTE / E-UTRAN).
+    FourG,
 }
 
 // ---------------------------------------------------------------------------
@@ -494,6 +573,11 @@ pub struct Telephony<T: ModemTransport> {
     /// Whether `AT+CLIP=1` (caller-ID subscription) succeeded during init.
     /// `false` means incoming calls will not carry caller ID.
     clip_enabled: bool,
+    /// Radio access technology of the current registration, from the `+CREG`
+    /// `<AcT>` field. `None` when unregistered or when the modem reports no
+    /// `<AcT>` (short-form `+CREG`); a registered URC without `<AcT>` keeps the
+    /// last known value.
+    current_rat: Option<RadioAccessTech>,
     /// Hardware transport.
     transport: T,
     /// Last signal poll tick (ms).
@@ -535,6 +619,7 @@ impl<T: ModemTransport> Telephony<T> {
             lte_only: false,
             creg_urc_enabled: false,
             clip_enabled: false,
+            current_rat: None,
             transport,
             last_signal_poll: 0,
             init_step: 0,
@@ -581,6 +666,13 @@ impl<T: ModemTransport> Telephony<T> {
             self.reg_status,
             RegStatus::RegisteredHome | RegStatus::RegisteredRoaming
         )
+    }
+
+    /// Radio access technology of the current registration (`+CREG` `<AcT>`),
+    /// or `None` when unregistered or the modem never reported one.
+    #[must_use]
+    pub fn rat(&self) -> Option<RadioAccessTech> {
+        self.current_rat
     }
 
     /// The owned modem transport, for `SimManager`/`SmsManager` AT queries that
@@ -746,9 +838,9 @@ impl<T: ModemTransport> Telephony<T> {
         let creg_query = send_with_info(&mut self.transport, "AT+CREG?", 5000);
         if let Ok((AtResponse::Ok, ref info_line, info_len)) = creg_query
             && info_len > 0
-            && let Some(stat) = parse_creg_response(&info_line[..info_len])
+            && let Some((stat, act)) = parse_creg_response(&info_line[..info_len])
         {
-            self.apply_reg_status(stat);
+            self.apply_reg_status(stat, act);
         }
         self.init_step = 10;
 
@@ -997,7 +1089,7 @@ impl<T: ModemTransport> Telephony<T> {
     /// `+CREG` URC arriving outside `Ready`/`Registered` (e.g. during
     /// `Off`/`Initializing`/`Error`) updates `reg_status` but does not
     /// clobber the modem's lifecycle state.
-    fn apply_reg_status(&mut self, stat: RegStatus) {
+    fn apply_reg_status(&mut self, stat: RegStatus, act: Option<RadioAccessTech>) {
         self.reg_status = stat;
         if matches!(self.modem_state, ModemState::Ready | ModemState::Registered) {
             self.modem_state = if self.is_registered() {
@@ -1006,6 +1098,15 @@ impl<T: ModemTransport> Telephony<T> {
                 ModemState::Ready
             };
         }
+        // Track the radio access technology alongside registration. When
+        // registered, a fresh `<AcT>` updates it and an absent one keeps the
+        // last known value (a short-form `+CREG` URC omits `<AcT>`). Losing
+        // registration clears it -- an unregistered modem has no RAT.
+        self.current_rat = if self.is_registered() {
+            act.or(self.current_rat)
+        } else {
+            None
+        };
     }
 
     /// Handle a parsed URC and update internal state.
@@ -1062,8 +1163,8 @@ impl<T: ModemTransport> Telephony<T> {
                     rssi_dbm: dbm,
                 })
             }
-            Urc::Creg { stat } => {
-                self.apply_reg_status(stat);
+            Urc::Creg { stat, act } => {
+                self.apply_reg_status(stat, act);
                 Some(TelephonyEvent::RegistrationUpdate { status: stat })
             }
         }
@@ -2001,6 +2102,105 @@ mod tests {
             tel.modem_state(),
             ModemState::Registered,
             "modem_state must promote from Ready to Registered on +CREG: 5"
+        );
+    }
+
+    #[test]
+    fn radio_access_tech_maps_act_codes_to_generations() {
+        use RatGeneration::{FourG, ThreeG, TwoG};
+        let cases = [
+            (0u8, RadioAccessTech::Gsm, TwoG),
+            (1, RadioAccessTech::GsmCompact, TwoG),
+            (2, RadioAccessTech::Utran, ThreeG),
+            (3, RadioAccessTech::GsmEgprs, TwoG),
+            (4, RadioAccessTech::UtranHsdpa, ThreeG),
+            (5, RadioAccessTech::UtranHsupa, ThreeG),
+            (6, RadioAccessTech::UtranHsdpaHsupa, ThreeG),
+            (7, RadioAccessTech::EUtran, FourG),
+            (8, RadioAccessTech::EUtranNbS1, FourG),
+        ];
+        for (code, rat, generation) in cases {
+            assert_eq!(
+                RadioAccessTech::from_act(code),
+                Some(rat),
+                "AcT code {code} must map to the expected radio access technology"
+            );
+            assert_eq!(
+                rat.generation(),
+                generation,
+                "{rat:?} must report the expected cellular generation"
+            );
+        }
+        assert_eq!(
+            RadioAccessTech::from_act(9),
+            None,
+            "an AcT code outside 0-8 must yield no technology"
+        );
+    }
+
+    /// A mock seeded through the full init sequence whose `AT+CREG?` response
+    /// carries the given `<AcT>`, for exercising the RAT seed path.
+    fn mock_for_init_with_creg(creg_line: &[u8]) -> MockModemTransport {
+        let mut mock = MockModemTransport::new();
+        mock.queue_ok();
+        mock.queue_ok();
+        mock.queue_ok();
+        mock.queue_info_ok(b"+CPIN: READY");
+        mock.queue_ok();
+        mock.queue_info_ok(b"+COPS: 0,0,\"T-Mobile\"");
+        mock.queue_ok();
+        mock.queue_ok();
+        mock.queue_info_ok(b"+CSQ: 18,99");
+        mock.queue_info_ok(creg_line);
+        mock
+    }
+
+    #[test]
+    fn rat_is_seeded_from_creg_query_at_init() {
+        let mock = mock_for_init_with_creg(b"+CREG: 1,\"1A2B\",\"0100CE01\",7");
+        let mut tel = Telephony::new(mock);
+        tel.initialize().ok();
+        assert!(tel.is_registered(), "must be registered (stat=1)");
+        assert_eq!(
+            tel.rat(),
+            Some(RadioAccessTech::EUtran),
+            "the boot AT+CREG? <AcT>=7 must seed the RAT to E-UTRAN"
+        );
+    }
+
+    #[test]
+    fn rat_tracks_urc_updates_and_clears_on_deregistration() {
+        // Init registered on LTE.
+        let mock = mock_for_init_with_creg(b"+CREG: 1,\"1A2B\",\"0100CE01\",7");
+        let mut tel = Telephony::new(mock);
+        tel.initialize().ok();
+        assert_eq!(tel.rat(), Some(RadioAccessTech::EUtran), "seeded LTE");
+
+        // A URC reporting a UTRAN registration updates the RAT.
+        tel.transport.queue_urc(b"+CREG: 1,\"1A2B\",\"0100CE01\",2");
+        tel.poll();
+        assert_eq!(
+            tel.rat(),
+            Some(RadioAccessTech::Utran),
+            "a +CREG URC carrying <AcT>=2 must update the RAT to UTRAN (3G)"
+        );
+
+        // A registered URC without an <AcT> keeps the last known RAT.
+        tel.transport.queue_urc(b"+CREG: 1");
+        tel.poll();
+        assert_eq!(
+            tel.rat(),
+            Some(RadioAccessTech::Utran),
+            "a short-form +CREG URC (no <AcT>) must keep the last known RAT"
+        );
+
+        // Losing registration clears the RAT.
+        tel.transport.queue_urc(b"+CREG: 0");
+        tel.poll();
+        assert_eq!(
+            tel.rat(),
+            None,
+            "deregistration (+CREG: 0) must clear the RAT -- no technology without a registration"
         );
     }
 }

--- a/crates/thumos/src/telephony_mock.rs
+++ b/crates/thumos/src/telephony_mock.rs
@@ -83,7 +83,10 @@ impl MockModemTransport {
         mock.queue_ok(); // 7: AT+CREG=1
         mock.queue_ok(); // 8: AT+CLIP=1
         mock.queue_info_ok(b"+CSQ: 18,99"); // 9: AT+CSQ
-        mock.queue_info_ok(b"+CREG: 1"); // 10: AT+CREG? (registered home)
+        // 10: AT+CREG? (registered home on E-UTRAN/LTE, <AcT>=7) -- the <AcT>
+        // field lets a booted qemu kernel exercise the RAT-parsing path so the
+        // status bar's network label is RAT-derived, not hardcoded.
+        mock.queue_info_ok(b"+CREG: 1,\"1A2B\",\"0100CE01\",7");
         // A queued ICCID response for the boot-time SimManager query (#398).
         mock.queue_info_ok(b"+ICCID: 8901410321111851072");
         // A queued RING URC so a booted qemu kernel exercises the incoming-call

--- a/crates/thumos/src/telephony_parser.rs
+++ b/crates/thumos/src/telephony_parser.rs
@@ -9,7 +9,7 @@
 
 // Items in this module are re-exported from telephony.rs.
 
-use crate::telephony::{AtResponse, MAX_NUMBER_LEN, RegStatus, Urc};
+use crate::telephony::{AtResponse, MAX_NUMBER_LEN, RadioAccessTech, RegStatus, Urc};
 
 // ---------------------------------------------------------------------------
 // AT response parsing (no_std, no nom)
@@ -57,15 +57,34 @@ pub(crate) fn parse_csq_response(line: &[u8]) -> Option<(u8, u8)> {
     Some((rssi, ber))
 }
 
-/// Parse a +CREG response/URC line: "+CREG: <stat>[,<lac>,<ci>]"
+/// Parse a +CREG URC line: "+CREG: <stat>[,<lac>,<ci>[,<AcT>]]"
 ///
-/// We only extract the stat field for telephony purposes.
-pub(crate) fn parse_creg_response(line: &[u8]) -> Option<RegStatus> {
+/// Extracts the registration status (field 0) and, when present, the radio
+/// access technology from the `<AcT>` field (field 3, 3GPP TS 27.007 §7.2).
+/// An absent, empty, or out-of-range `<AcT>` yields `None` for the RAT rather
+/// than a wrong technology.
+pub(crate) fn parse_creg_response(line: &[u8]) -> Option<(RegStatus, Option<RadioAccessTech>)> {
     let rest = strip_prefix(line, b"+CREG: ")?;
-    // stat is the first field, possibly followed by comma and more fields.
-    let end = memchr(b',', rest).unwrap_or(rest.len());
-    let stat = parse_u8(&rest[..end])?;
-    Some(RegStatus::from(stat))
+    let stat = RegStatus::from(parse_u8(nth_field(rest, 0)?)?);
+    let act = nth_field(rest, 3)
+        .filter(|field| !field.is_empty())
+        .and_then(parse_u8)
+        .and_then(RadioAccessTech::from_act);
+    Some((stat, act))
+}
+
+/// Return the Nth (0-indexed) comma-separated field of `input`, or `None` when
+/// fewer than `n + 1` fields are present. Fields are returned verbatim (quotes
+/// on `<lac>`/`<ci>` are left intact -- the caller parses only the fields it
+/// needs).
+fn nth_field(input: &[u8], n: usize) -> Option<&[u8]> {
+    let mut field = input;
+    for _ in 0..n {
+        let comma = memchr(b',', field)?;
+        field = &field[comma + 1..];
+    }
+    let end = memchr(b',', field).unwrap_or(field.len());
+    Some(&field[..end])
 }
 
 /// Parse a +COPS? response line: "+COPS: <mode>,<format>,\"<operator>\""
@@ -196,8 +215,8 @@ pub(crate) fn parse_urc(line: &[u8]) -> Option<Urc> {
     if let Some((rssi, ber)) = parse_csq_response(line) {
         return Some(Urc::Csq { rssi, ber });
     }
-    if let Some(stat) = parse_creg_response(line) {
-        return Some(Urc::Creg { stat });
+    if let Some((stat, act)) = parse_creg_response(line) {
+        return Some(Urc::Creg { stat, act });
     }
     if starts_with(line, b"+CLIP: ") {
         let mut number = [0u8; MAX_NUMBER_LEN];
@@ -366,23 +385,52 @@ mod tests {
     fn parse_creg_response_extracts_stat_ignoring_trailing_fields() {
         assert_eq!(
             parse_creg_response(b"+CREG: 5"),
-            Some(RegStatus::RegisteredRoaming),
-            "stat=5 must parse as RegisteredRoaming"
+            Some((RegStatus::RegisteredRoaming, None)),
+            "stat=5 must parse as RegisteredRoaming with no AcT reported"
         );
         assert_eq!(
             parse_creg_response(b"+CREG: 2,\"1FFE\",\"CE12\""),
-            Some(RegStatus::Searching),
+            Some((RegStatus::Searching, None)),
             "stat must be extracted from the leading field even with trailing lac/ci fields present"
         );
         assert_eq!(
             parse_creg_response(b"+CREG: 9"),
-            Some(RegStatus::Unknown),
+            Some((RegStatus::Unknown, None)),
             "an unrecognized stat code must map to RegStatus::Unknown rather than None"
         );
         assert_eq!(
             parse_creg_response(b"+CSQ: 1"),
             None,
             "a line without the +CREG prefix must not parse"
+        );
+    }
+
+    #[test]
+    fn parse_creg_response_extracts_access_technology() {
+        assert_eq!(
+            parse_creg_response(b"+CREG: 1,\"1A2B\",\"0100CE01\",7"),
+            Some((RegStatus::RegisteredHome, Some(RadioAccessTech::EUtran))),
+            "AcT=7 must parse as E-UTRAN (LTE) alongside stat=1"
+        );
+        assert_eq!(
+            parse_creg_response(b"+CREG: 5,\"1A2B\",\"0100CE01\",2"),
+            Some((RegStatus::RegisteredRoaming, Some(RadioAccessTech::Utran))),
+            "AcT=2 must parse as UTRAN (3G) while roaming"
+        );
+        assert_eq!(
+            parse_creg_response(b"+CREG: 1,\"1A2B\",\"0100CE01\",3"),
+            Some((RegStatus::RegisteredHome, Some(RadioAccessTech::GsmEgprs))),
+            "AcT=3 must parse as GSM+EGPRS (EDGE, a 2G technology)"
+        );
+        assert_eq!(
+            parse_creg_response(b"+CREG: 1,\"1A2B\",\"0100CE01\",99"),
+            Some((RegStatus::RegisteredHome, None)),
+            "an out-of-range AcT must yield no RAT rather than a wrong one"
+        );
+        assert_eq!(
+            parse_creg_response(b"+CREG: 1,,,7"),
+            Some((RegStatus::RegisteredHome, Some(RadioAccessTech::EUtran))),
+            "AcT must parse from field 3 even when lac/ci are empty"
         );
     }
 
@@ -513,9 +561,18 @@ mod tests {
         assert_eq!(
             parse_urc(b"+CREG: 1"),
             Some(Urc::Creg {
-                stat: RegStatus::RegisteredHome
+                stat: RegStatus::RegisteredHome,
+                act: None
             }),
             "+CREG line must dispatch to Urc::Creg carrying the parsed stat"
+        );
+        assert_eq!(
+            parse_urc(b"+CREG: 1,\"1A2B\",\"0100CE01\",7"),
+            Some(Urc::Creg {
+                stat: RegStatus::RegisteredHome,
+                act: Some(RadioAccessTech::EUtran)
+            }),
+            "+CREG URC with an <AcT> field must dispatch carrying the parsed RAT"
         );
         let mut number = [0u8; MAX_NUMBER_LEN];
         number[..12].copy_from_slice(b"+15551234567");


### PR DESCRIPTION
## What

The status bar's cellular label was a hardcoded `Lte` for any registered modem. This parses the `+CREG` `<AcT>` field (3GPP TS 27.007 §7.2) into a radio access technology, tracks it on `Telephony` alongside registration, and derives the status-bar `NetworkService` (2G/3G/LTE) from it — the follow-on the `status_network()` comment left open after #404.

## How

- **telephony_parser**: `parse_creg_response` now returns `(RegStatus, Option<RadioAccessTech>)`. `<AcT>` is read from field 3 via a comma-field helper; absent/empty/out-of-range yields `None` (never a wrong technology).
- **telephony**: `RadioAccessTech` (AcT codes 0–8) + `RatGeneration` (2G/3G/4G) mapping. `Telephony` tracks `current_rat` — updated by `+CREG` URCs and the boot `AT+CREG?` seed, kept across a short-form URC, cleared on deregistration — exposed via `rat()`.
- **kardia**: `status_network()` derives `Edge`/`ThreeG`/`Lte` from the RAT; a registered modem reporting no `<AcT>` falls back to `Lte` (the device requests LTE-only via `AT+COPS=0,,,7`).
- **status_bar**: the `Edge`/`ThreeG` variants are now constructed, so their `dead_code` expectations are removed.
- **mock**: `seeded_for_boot` registers on E-UTRAN (`<AcT>=7`) so the qemu boot exercises the parse path end to end.

## Verification (emulation-first)

- **QEMU boot witness**: `kardia: netrat rat=Some(EUtran) net=Lte` — `EUtran` can only come from parsing the seeded `<AcT>`, proving the label is RAT-derived, not a constant. CI asserts it (`.github/workflows/ci.yml`).
- **Host tests (2210, +4)**: exhaustive AcT→technology→generation mapping; `<AcT>` extraction incl. empty-lac/ci and out-of-range; RAT seeded from the init `AT+CREG?`; RAT tracks URC updates and clears on deregistration.
- armv7a builds clean (default + qemu + debug-console, `-D warnings`); 2210 host tests pass; fmt + kanon lint clean.

Scope note: the `+CREG` query-vs-URC `<n>,<stat>` field distinction (a pre-existing parser simplification, unrelated to RAT) is filed separately rather than bundled into this security-adjacent registration path.

Context: #404.