### PR TITLE
feat(thumos): wire the SIM-management API over the modem transport, CI-verified (#398)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,10 +212,13 @@ jobs:
           # ringtone audio session -- the "phone rings" path across the wired
           # telephony (#398) + audio (#399) stacks.
           grep -qE 'kardia: incoming call -> ringtone sessions=[1-9]' boot.log || { echo 'FAIL #398: incoming call did not open a ringtone session (telephony->audio integration broken)'; exit 1; }
-          # #398 SIM/SMS: the SIM ICCID was queried over the modem transport
-          # (iccid_len>0) and a known incoming SMS PDU decoded into the inbox
-          # (sms_inbox>0) -- both managers functional against the wired transport.
-          grep -qE 'kardia: sim iccid_len=[1-9][0-9]* sms_inbox=[1-9]' boot.log || { echo 'FAIL #398: SIM/SMS not wired (ICCID not queried or SMS not decoded)'; exit 1; }
+          # #398 SIM/SMS: the SIM-management API is exercised over the modem
+          # transport -- ICCID queried (iccid_len>0), PIN status READ
+          # (sim_ready=true), signal strength decoded (signal_bars>0), operator
+          # name queried (operator_len>0) -- and a known incoming SMS PDU decoded
+          # into the inbox (sms_inbox>0). Both managers functional against the
+          # wired transport.
+          grep -qE 'kardia: sim iccid_len=[1-9][0-9]* sms_inbox=[1-9] sim_ready=true signal_bars=[1-9] operator_len=[1-9]' boot.log || { echo 'FAIL #398: SIM management not fully wired (ICCID/PIN/signal/operator/SMS)'; exit 1; }
           # #401 BT A2DP: the A2dpProfile is instantiated + its SBC/config state
           # machine runs (configured 44.1 kHz stereo). RF/HCI is hardware-gated.
           grep -q 'kardia: bt_audio sample_rate=44100 channels=2' boot.log || { echo 'FAIL #401: A2DP profile not wired / config state machine broken'; exit 1; }

--- a/crates/thumos/src/kardia.rs
+++ b/crates/thumos/src/kardia.rs
@@ -399,19 +399,37 @@ impl KernelState {
         (sessions, mic_entries)
     }
 
-    /// Boot-time SIM/SMS smoke (#398, qemu): query the SIM ICCID over the modem
-    /// transport (mock-seeded response), then decode + file a known incoming SMS
-    /// PDU. Returns (ICCID byte length, inbox message count) for the CI witness,
-    /// exercising both managers against the wired modem transport.
+    /// Boot-time SIM/SMS smoke (#398, qemu): exercise the SIM-management API over
+    /// the modem transport (mock-seeded) -- ICCID query, PIN status, signal
+    /// strength, operator name -- then decode + file a known incoming SMS PDU.
+    /// Returns (ICCID len, inbox count, SIM ready, signal bars, operator name
+    /// len) for the CI witness, exercising both managers against the wired
+    /// transport. All SIM queries are `ModemTransport`-abstracted, so the mock
+    /// exercises them fully under qemu; only the returned values are hardware.
     #[cfg(feature = "qemu")]
-    pub(crate) fn sim_sms_boot_smoke(&mut self) -> (usize, usize) {
-        // SIM: query the ICCID over Telephony's owned transport.
-        let iccid_len = if let Some(t) = self.telephony.as_mut() {
-            self.sim.query_iccid(t.transport_mut()).ok();
-            self.sim.sim_info().iccid_len as usize
-        } else {
-            0
-        };
+    pub(crate) fn sim_sms_boot_smoke(&mut self) -> (usize, usize, bool, u8, usize) {
+        // SIM: query ICCID + PIN status + signal + operator over Telephony's
+        // owned transport, in the order the mock queues the responses.
+        let (iccid_len, sim_ready, signal_bars, operator_len) =
+            if let Some(t) = self.telephony.as_mut() {
+                self.sim.query_iccid(t.transport_mut()).ok();
+                // PIN status (AT+CPIN?): READY => no PIN required => ready.
+                let ready = self.sim.check_pin(t.transport_mut()).unwrap_or(false);
+                // Signal (AT+CSQ): first poll fires immediately (last tick is None).
+                self.sim.poll_signal(t.transport_mut(), 0);
+                // Operator name (AT+COPS?).
+                let mut op_name = [0u8; 32];
+                let op_len = SimManager::query_operator(t.transport_mut(), &mut op_name)
+                    .unwrap_or(0) as usize;
+                (
+                    self.sim.sim_info().iccid_len as usize,
+                    ready,
+                    self.sim.signal_info().bars,
+                    op_len,
+                )
+            } else {
+                (0, false, 0, 0)
+            };
         // SMS: decode a known SMS-DELIVER PDU ("Hello" from +1234567890) + file it.
         const PDU: &[u8] = &[
             0x00, 0x00, 0x0A, 0x91, 0x21, 0x43, 0x65, 0x87, 0x09, 0x00, 0x00, 0x32, 0x10, 0x51,
@@ -420,7 +438,13 @@ impl KernelState {
         if let Ok(msg) = SmsManager::handle_incoming(PDU) {
             self.sms.receive(msg).ok();
         }
-        (iccid_len, self.sms.inbox().len())
+        (
+            iccid_len,
+            self.sms.inbox().len(),
+            sim_ready,
+            signal_bars,
+            operator_len,
+        )
     }
 
     /// Boot-time BT A2DP smoke (#401, qemu): configure the A2DP profile (SBC
@@ -522,9 +546,11 @@ pub(crate) fn service_loop(mut kernel: KernelState, mut serial: Uart) -> ! {
         // registration (was hardcoded); mode char by the security-mode manager.
         let net = kernel.status_network();
         let mode_char = kernel.mode.mode_char();
-        // #398: SIM + SMS wired -- ICCID queried over the modem transport + a
-        // known incoming SMS PDU decoded into the inbox.
-        let (iccid_len, sms_inbox) = kernel.sim_sms_boot_smoke();
+        // #398: SIM + SMS wired -- ICCID / PIN status / signal / operator queried
+        // over the modem transport + a known incoming SMS PDU decoded into the
+        // inbox.
+        let (iccid_len, sms_inbox, sim_ready, signal_bars, operator_len) =
+            kernel.sim_sms_boot_smoke();
         // #401: BT A2DP profile wired + its SBC/config state machine runs
         // (44.1 kHz stereo). RF/HCI is hardware-gated.
         let (bt_rate, bt_ch) = kernel.bt_audio_boot_smoke();
@@ -554,7 +580,9 @@ pub(crate) fn service_loop(mut kernel: KernelState, mut serial: Uart) -> ! {
         );
         emit_marker(
             &mut serial,
-            format_args!("kardia: sim iccid_len={iccid_len} sms_inbox={sms_inbox}\r\n"),
+            format_args!(
+                "kardia: sim iccid_len={iccid_len} sms_inbox={sms_inbox} sim_ready={sim_ready} signal_bars={signal_bars} operator_len={operator_len}\r\n"
+            ),
         );
         emit_marker(
             &mut serial,

--- a/crates/thumos/src/sim.rs
+++ b/crates/thumos/src/sim.rs
@@ -19,11 +19,9 @@
 //!
 //! ## Integration
 //!
-//! Used by the telephony subsystem during modem initialization and
-//! periodic signal polling. Boot integration deferred to Phase 07 kinit wiring.
-
-// WHY: SIM management API not yet wired to upper layers (kinit integration pending).
-#![expect(dead_code, reason = "SIM management API not yet wired to kinit")]
+//! Wired into the kernel at boot: `kardia::KernelState` holds a `SimManager`
+//! and the qemu boot smoke exercises ICCID / PIN status / signal / operator
+//! queries over the modem transport (#398).
 
 extern crate alloc;
 

--- a/crates/thumos/src/telephony_mock.rs
+++ b/crates/thumos/src/telephony_mock.rs
@@ -89,6 +89,13 @@ impl MockModemTransport {
         mock.queue_info_ok(b"+CREG: 1,\"1A2B\",\"0100CE01\",7");
         // A queued ICCID response for the boot-time SimManager query (#398).
         mock.queue_info_ok(b"+ICCID: 8901410321111851072");
+        // Post-init responses for the boot-time SIM-management smoke (#398), in
+        // the order sim_sms_boot_smoke queries them over the same transport:
+        // check_pin (AT+CPIN?), poll_signal->query_signal (AT+CSQ), and
+        // query_operator (AT+COPS?).
+        mock.queue_info_ok(b"+CPIN: READY");
+        mock.queue_info_ok(b"+CSQ: 18,99");
+        mock.queue_info_ok(b"+COPS: 0,0,\"T-Mobile\"");
         // A queued RING URC so a booted qemu kernel exercises the incoming-call
         // -> ringtone-audio integration path (#398): poll() surfaces it as an
         // IncomingCall event after init.


### PR DESCRIPTION
## What

Wires the remaining SIM-management API (PIN status, signal strength, operator name) into the boot path and removes `sim.rs`'s module-level `dead_code` suppression — the last of #398's three (`telephony.rs`/`sms.rs` were removed in #507/#511). Only the ICCID query was previously wired.

## How

- **kardia**: `sim_sms_boot_smoke` now exercises the full SIM-management read API over `Telephony`'s owned transport — `check_pin` (AT+CPIN?), `poll_signal → query_signal` (AT+CSQ), `query_operator` (AT+COPS?) — alongside the existing ICCID query + SMS decode. Every method is `ModemTransport`-abstracted, so the mock exercises them fully under qemu (only the returned *values* are hardware).
- **telephony_mock**: `seeded_for_boot` queues the post-init `+CPIN`/`+CSQ`/`+COPS` responses.
- **sim.rs**: module-level `dead_code` suppression removed.

## Verification

- **QEMU boot witness**: `kardia: sim iccid_len=19 sms_inbox=1 sim_ready=true signal_bars=3 operator_len=8` (RSSI 18 → −77 dBm → 3 bars; operator "T-Mobile" = 8 chars). CI asserts all five fields.
- 2210 host tests pass; armv7a builds clean (default + qemu + debug-console, `-D warnings`); fmt + kanon lint clean.

## Scope

An actual SIM **PIN/PUK unlock** (`AT+CPIN=<pin>`) is net-new code — it does not exist anywhere in the tree — and is not part of this wiring change. This PR completes the *SIM-management-read* surface #398 named; the unlock flow (and SMS *send*) are follow-ons.

Context: #398.