### PR TITLE
chore(deps): bump yanked spin 0.9.8 -> 0.9.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "aither"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "getrandom 0.4.2",
  "hmac",
@@ -59,7 +59,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "asphaleia"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "log",
  "rustix",
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "eidolon"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "embedded-graphics",
  "embedded-graphics-core",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "haphe"
-version = "0.1.6"
+version = "0.1.7"
 
 [[package]]
 name = "hash32"
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "kelyphos"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "log",
  "snafu",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "klesis"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "log",
  "nom",
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "krypta"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "aes-gcm",
  "ed25519-dalek",
@@ -690,7 +690,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "leipsanon"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "getrandom 0.4.2",
  "log",
@@ -740,7 +740,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metaxu"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "compact_str",
  "jiff",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "pteron"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "jiff",
  "log",
@@ -1042,7 +1042,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sema"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "jiff",
  "log",
@@ -1173,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
@@ -1204,7 +1204,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stegnos"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "topos"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "jiff",
  "log",


### PR DESCRIPTION
## What

`cargo audit --deny yanked` (the **Security** CI job) fails on **spin 0.9.8**, which was yanked from crates.io — this blocks the Security check on *every* open PR (the advisory DB flagged it after #521 merged). spin is a transitive dependency of the userspace workspace crates.

## How

- `cargo update -p spin` → **0.9.9** (the yank-fix patch release).
- The lock also syncs the pre-existing stale workspace-version drift (`0.1.6 → 0.1.7`): the member manifests are already at 0.1.7, so every build regenerated this locally but it was never committed. Bringing `Cargo.lock` in line with the manifests.

## Verification

- `cargo audit --deny unmaintained --deny unsound --deny yanked` → clean (exit 0, no yanked warning).
- `cargo clippy --workspace --all-targets` clean; all **661** workspace tests pass on spin 0.9.9.

Repo-wide CI unblock.