### PR TITLE
fix(thumos): per-process image mapping — fork+exec composes (#502)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,30 +1,19 @@
 # cargo-audit configuration.
 #
-# WHY: cargo-audit does not read deny.toml. This file mirrors the advisory
-# ignore list in deny.toml so both tools stay in sync. When adding or
-# removing an ignore here, update deny.toml's [[advisories.ignore]]
-# entries to match (and vice versa). See standards/SUPPLY-CHAIN.md.
+# WHY: This file is DERIVED from deny.toml [[advisories.ignore]].
+# Do not edit the ignore list here; edit deny.toml and run
+# `kanon audit derive-ignores --apply`. See standards/SUPPLY-CHAIN.md.
 
 [advisories]
 ignore = [
-    # bincode 1.x unmaintained — used directly by kanon storage codec (index +
-    # treesitter cache) and transitively via syntect. No safe upgrade: bincode
-    # 2.x is a breaking-change rewrite and syntect has not migrated.
+    # bincode 1.x unmaintained — used directly by kanon storage codec (index + treesitter cache) and transitively via syntect. No safe upgrade: bincode 2.x is a breaking-change rewrite and syntect has not migrated.
     "RUSTSEC-2025-0141",
-    # paste unmaintained — transitive via tokenizers (logismos → mnemosyne);
-    # no safe upgrade available upstream.
+    # paste unmaintained, transitive via tokenizers (logismos → mnemosyne); no safe upgrade available upstream.
     "RUSTSEC-2024-0436",
-    # False positive: name+version collision. The "cache 0.0.0" matched here
-    # is logismos's internal KV-cache crate (publish = false, path dep), not
-    # the abandoned crates.io "cache" crate that the 2020 advisory covers.
+    # False positive: name+version collision. The flagged `cache 0.0.0` is logismos's internal KV-cache crate (publish = false, path dep), not the abandoned crates.io `cache` crate the 2020 advisory covers.
     "RUSTSEC-2020-0128",
-    # False positive: same collision as RUSTSEC-2020-0128. The flagged
-    # "cache 0.0.0" is logismos's internal KV-cache crate, unrelated to the
-    # 2021 advisory's raw-pointer footgun in the abandoned crates.io crate.
+    # False positive: same collision as RUSTSEC-2020-0128. The flagged `cache 0.0.0` is logismos's internal KV-cache crate, unrelated to the 2021 advisory's raw-pointer footgun in the abandoned crates.io crate.
     "RUSTSEC-2021-0006",
-    # atomic-polyfill unmaintained — transitive via heapless 0.7.17 →
-    # postcard 1.1.3 → sema/krypta. heapless 0.8+ drops atomic-polyfill in
-    # favor of portable-atomic, but postcard 1.x has not yet bumped its
-    # heapless pin past 0.7. Track postcard upstream for the heapless bump.
+    # atomic-polyfill unmaintained — transitive via heapless 0.7.17 → postcard 1.1.3 → sema/krypta. heapless 0.8+ drops atomic-polyfill in favor of portable-atomic, but postcard 1.x has not yet bumped its heapless pin past 0.7. Track postcard upstream for the heapless bump.
     "RUSTSEC-2023-0089",
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,3 +359,36 @@ jobs:
           ! grep -q 'init2: PRIVILEGED' exec.log || { echo 'FAIL exec: the exec-d image ran at PL1 (mode drop across exec broken -- SECURITY)'; exit 1; }
           ! grep -q 'init: hello from userspace' exec.log || { echo 'FAIL exec: the OLD image kept running after exec (control not transferred)'; exit 1; }
           grep -q 'THUMOS-QEMU: service-loop ticks=' exec.log || { echo 'FAIL exec: kernel did not survive the exec-d process fault'; exit 1; }
+      - name: QEMU fork+exec composes -- per-process images (#502)
+        working-directory: crates/thumos
+        # WHY: the #502 keystone. Pre-#502 every userspace image loaded + mapped
+        # at the SAME identity USER_TEXT frame, so a forked child that exec'd a
+        # new program re-ran the PARENT's image instead (a fork bomb) and two
+        # spawned programs could not coexist. Now each process loads into its OWN
+        # per-process frame. /init forks; the CHILD execs /init2; the PARENT
+        # waitpids it and re-checks its own .data canary.
+        #   - 'init2: reached via exec' proves the child ran /init2's OWN image,
+        #     NOT a re-run of /init -- the fork bomb is dead.
+        #   - the exec marker appearing EXACTLY ONCE is the belt-and-suspenders
+        #     fork-bomb check (a re-run would fork+exec again, repeating it).
+        #   - 'forkexec: parent integrity ok' proves the child's exec (alloc of a
+        #     fresh image frame + teardown of the child's old one) never touched
+        #     the PARENT's separate image frame -- per-process isolation holds.
+        run: |
+          set -uo pipefail
+          THUMOS_INIT_VARIANT=forkexec cargo build --release --target armv7a-none-eabi --features qemu --jobs 8
+          ferc=0
+          THUMOS_INIT_VARIANT=forkexec THUMOS_QEMU_TIMEOUT=60 ../../scripts/qemu-runner.sh target/armv7a-none-eabi/release/thumos | tee forkexec.log || ferc=$?
+          echo "=== forkexec: runner rc=$ferc (want 0) ==="
+          test "$ferc" -eq 0 || { echo "FAIL forkexec: kernel did not survive (rc=$ferc; 124=hang 2/3=abort)"; exit 1; }
+          grep -q 'forkexec: start' forkexec.log || { echo 'FAIL forkexec: harness never started'; exit 1; }
+          grep -q 'forkexec: parent waiting' forkexec.log || { echo 'FAIL forkexec: no parent branch (fork did not return the child pid)'; exit 1; }
+          ! grep -q 'forkexec: fork FAILED' forkexec.log || { echo 'FAIL forkexec: fork returned an error'; exit 1; }
+          ! grep -q 'forkexec: child exec FAILED' forkexec.log || { echo 'FAIL forkexec: the child execve returned an error (per-process image load broken)'; exit 1; }
+          grep -q 'init2: reached via exec' forkexec.log || { echo 'FAIL forkexec: the child never ran /init2 -- exec did not load the new per-process image'; exit 1; }
+          xc=$(grep -c 'forkexec: child exec-ing /init2' forkexec.log)
+          test "$xc" -eq 1 || { echo "FAIL forkexec: the exec marker appeared $xc times (want 1) -- a FORK BOMB re-ran /init instead of /init2 (#502 regressed)"; exit 1; }
+          grep -q 'forkexec: parent integrity ok' forkexec.log || { echo 'FAIL forkexec: parent .data was corrupted by the child exec (per-process image isolation broken)'; exit 1; }
+          ! grep -q 'forkexec: parent integrity BROKEN' forkexec.log || { echo 'FAIL forkexec: explicit parent-integrity break'; exit 1; }
+          ! grep -q 'init2: PRIVILEGED' forkexec.log || { echo 'FAIL forkexec: the exec-d child ran at PL1 (mode drop across exec broken -- SECURITY)'; exit 1; }
+          grep -q 'THUMOS-QEMU: service-loop ticks=' forkexec.log || { echo 'FAIL forkexec: kernel did not survive'; exit 1; }

--- a/crates/thumos/build.rs
+++ b/crates/thumos/build.rs
@@ -251,8 +251,12 @@ fn generate_initramfs(manifest_dir: &Path, out_dir: &Path) {
 
     // #489: a SECOND userspace program the exec /init variant execs. Always
     // embedded (tiny; unused unless /init execs it -- kinit only spawns /init
-    // and /shell by name). NOT named "shell": kinit auto-spawns /shell, which
-    // would clobber /init's same-VA image.
+    // and /shell by name). NOT named "shell": kinit auto-spawns /shell, and this
+    // program deliberately UNDEF-faults on a cp15 probe (its PL0 proof), so
+    // auto-spawning it would fault at boot. NOTE (#502): the old reason -- that a
+    // /shell would "clobber /init's same-VA image" -- no longer holds now that
+    // every process loads into its OWN per-process image frame; a real /shell
+    // that coexists with /init is unblocked (tracked as a follow-up).
     let init2_src = manifest_dir.join("init/init2.rs");
     println!("cargo:rerun-if-changed={}", init2_src.display());
     let init2_elf = out_dir.join("init2.elf");

--- a/crates/thumos/build.rs
+++ b/crates/thumos/build.rs
@@ -193,7 +193,7 @@ fn compile_init_binary(
     .arg("link-arg=max-page-size=0x100")
     // WHY (#487): declare the probe cfgs so a direct rustc compile does not warn.
     .arg("--check-cfg")
-    .arg("cfg(thumos_init_kread, thumos_init_kwrite, thumos_init_kexec, thumos_init_cp15, thumos_init_sleep, thumos_init_fork, thumos_init_exec)");
+    .arg("cfg(thumos_init_kread, thumos_init_kwrite, thumos_init_kexec, thumos_init_cp15, thumos_init_sleep, thumos_init_fork, thumos_init_exec, thumos_init_forkexec)");
     if let Some(cfg) = variant_cfg {
         cmd.arg("--cfg").arg(cfg);
     }
@@ -227,10 +227,13 @@ fn generate_initramfs(manifest_dir: &Path, out_dir: &Path) {
     println!("cargo:rerun-if-env-changed=THUMOS_INIT_VARIANT");
     let variant_cfg = match env::var("THUMOS_INIT_VARIANT") {
         Ok(v) if !v.is_empty() => {
-            if !["kread", "kwrite", "kexec", "cp15", "sleep", "fork", "exec"].contains(&v.as_str())
+            if ![
+                "kread", "kwrite", "kexec", "cp15", "sleep", "fork", "exec", "forkexec",
+            ]
+            .contains(&v.as_str())
             {
                 die(&format!(
-                    "#487: unknown THUMOS_INIT_VARIANT '{v}' (expected kread|kwrite|kexec|cp15|sleep|fork|exec)"
+                    "#487: unknown THUMOS_INIT_VARIANT '{v}' (expected kread|kwrite|kexec|cp15|sleep|fork|exec|forkexec)"
                 ));
             }
             Some(format!("thumos_init_{v}"))

--- a/crates/thumos/init/init.rs
+++ b/crates/thumos/init/init.rs
@@ -41,7 +41,7 @@ unsafe fn sys_write(fd: u32, buf: *const u8, len: u32) -> u32 {
 ///
 /// # Safety
 /// Yields to the scheduler; the kernel resumes this process after the interval.
-#[cfg(any(thumos_init_sleep, thumos_init_fork))]
+#[cfg(any(thumos_init_sleep, thumos_init_fork, thumos_init_forkexec))]
 #[inline(always)]
 unsafe fn sys_sleep(ms: u32) {
     // SAFETY: issues SVC #7 (Sleep) per the thumos ABI; the kernel marks this
@@ -79,7 +79,7 @@ unsafe fn sys_exit(code: u32) -> ! {
 ///
 /// # Safety
 /// Creates a child process; both branches return here (the #478 ctx seed).
-#[cfg(thumos_init_fork)]
+#[cfg(any(thumos_init_fork, thumos_init_forkexec))]
 #[inline(always)]
 unsafe fn sys_fork() -> u32 {
     let ret;
@@ -95,7 +95,7 @@ unsafe fn sys_fork() -> u32 {
 ///
 /// # Safety
 /// Reads a child's exit status; reaps its slot when Dead.
-#[cfg(thumos_init_fork)]
+#[cfg(any(thumos_init_fork, thumos_init_forkexec))]
 #[inline(always)]
 unsafe fn sys_waitpid(pid: u32) -> u32 {
     let ret;
@@ -111,12 +111,19 @@ unsafe fn sys_waitpid(pid: u32) -> u32 {
 #[cfg(thumos_init_fork)]
 static mut FORK_DATA_CANARY: u32 = 0x0000_5EED;
 
+/// #502 parent-integrity canary: a .data value the forkexec parent re-checks
+/// after the child's exec + exit. A wrong-owner free during the child's exec
+/// (per-process image mapping done wrong) would zero the parent's OWN image
+/// frame -- this catches that where a fork/exit count alone would not.
+#[cfg(thumos_init_forkexec)]
+static mut PARENT_CANARY: u32 = 0x600D_600D;
+
 /// execve(path, argv, envp) -> only returns (u32 errno) on FAILURE (#489); on
 /// success the process image is replaced and never returns here.
 ///
 /// # Safety
 /// Replaces this process's image with the program at `path`.
-#[cfg(thumos_init_exec)]
+#[cfg(any(thumos_init_exec, thumos_init_forkexec))]
 #[inline(always)]
 unsafe fn sys_execve(path: *const u8, argv: u32, envp: u32) -> u32 {
     let ret;
@@ -281,6 +288,49 @@ pub extern "C" fn _start() -> ! {
                 b"init: fork isolation intact\n"
             } else {
                 b"init: fork isolation BROKEN\n"
+            };
+            sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+        }
+        // #502 forkexec harness: /init forks; the CHILD execs /init2 (which must
+        // run /init2's OWN image + print "init2: reached via exec", NOT re-run
+        // this /init image -- the identity-USER_TEXT fork bomb); the PARENT
+        // waitpids the child, then verifies its own .data survived the child's
+        // exec (a wrong-owner free during exec would zero the parent's frame).
+        #[cfg(thumos_init_forkexec)]
+        {
+            let s = b"forkexec: start\n";
+            sys_write(1, s.as_ptr(), u32::try_from(s.len()).unwrap_or(0));
+            core::ptr::write_volatile(core::ptr::addr_of_mut!(PARENT_CANARY), 0x600D_600D);
+            let pid = sys_fork();
+            if pid == 0 {
+                // CHILD: exec /init2. On success this image is replaced (never
+                // returns here); a #502 fork bomb would re-run THIS /init instead.
+                let m = b"forkexec: child exec-ing /init2\n";
+                sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+                sys_execve(b"/init2\0".as_ptr(), 0, 0);
+                let f = b"forkexec: child exec FAILED\n";
+                sys_write(1, f.as_ptr(), u32::try_from(f.len()).unwrap_or(0));
+                sys_exit(1);
+            }
+            if pid == u32::MAX {
+                let m = b"forkexec: fork FAILED\n";
+                sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+                sys_exit(1);
+            }
+            let m = b"forkexec: parent waiting\n";
+            sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+            // Reap the child (non-blocking waitpid; sleep yields to the child).
+            loop {
+                if sys_waitpid(pid) != u32::MAX {
+                    break;
+                }
+                sys_sleep(10);
+            }
+            let ok = core::ptr::read_volatile(core::ptr::addr_of!(PARENT_CANARY)) == 0x600D_600D;
+            let m: &[u8] = if ok {
+                b"forkexec: parent integrity ok\n"
+            } else {
+                b"forkexec: parent integrity BROKEN\n"
             };
             sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
         }

--- a/crates/thumos/src/elf.rs
+++ b/crates/thumos/src/elf.rs
@@ -403,6 +403,56 @@ pub(crate) unsafe fn load_confined(
     load_impl(data, Some((lo, hi)))
 }
 
+/// #502 CONFINED-load pre-pass: validate every segment lands in `[lo, hi)`,
+/// prove the segments tile a gapless span (`span == total_pages`), and allocate
+/// the contiguous per-process image frame. Returns `(image_phys, image_lo)`.
+///
+/// WHY its own `#[inline(never)]` function: see the call site in `load_impl` --
+/// keeping this out of load_impl's frame is what prevents the armv7 exec-path
+/// codegen from corrupting the returned `ValidatedElf`.
+#[inline(never)]
+fn plan_confined_image(
+    validated: &ValidatedElf,
+    lo: usize,
+    hi: usize,
+) -> Result<(usize, usize), ElfError> {
+    let mut lo_img = usize::MAX;
+    let mut max_end = 0usize;
+    for idx in 0..validated.count {
+        let (vaddr, memsz, _, _, _) = validated.segments[idx];
+        // Fully inside [lo, hi). Rejecting here (before alloc/write) keeps
+        // fail-before-destroy AND makes the (vaddr - lo_img) offset in load_impl
+        // non-negative (vaddr >= lo_img). vaddr + memsz cannot overflow:
+        // validate() proved it via #318. Per-segment PAGE alignment is enforced
+        // by map_user_image (process.rs) -- a non-aligned image fails there
+        // cleanly (the image frame is freed on the spawn/exec map-failure path),
+        // so it is not re-checked here (which would also reject the host test's
+        // arbitrary-aligned static-buffer vaddr).
+        if vaddr < lo || vaddr + memsz > hi {
+            return Err(ElfError::InvalidSegment);
+        }
+        lo_img = lo_img.min(vaddr);
+        max_end = max_end.max(vaddr + memsz);
+    }
+    // INVARIANT (#502): span == Σ ceil(memsz/PAGE) (= total_pages) means, by
+    // pigeonhole, the segments tile the span with NO gaps and NO overlaps -- so
+    // the contiguous image frame maps exactly, every allocated page is mapped,
+    // and the L2 walk is a complete ownership record. validate() rejects a
+    // segmentless confined image (its entry must fall inside a loaded segment),
+    // so count >= 1 here.
+    let span_pages = (max_end - lo_img).div_ceil(page::PAGE_SIZE);
+    if span_pages != validated.total_pages {
+        return Err(ElfError::InvalidSegment);
+    }
+    // Allocate the contiguous per-process image frame (arm only; host
+    // load_confined writes to real host addresses at identity vaddr).
+    #[cfg(target_arch = "arm")]
+    let phys = page::alloc_contiguous(validated.total_pages).ok_or(ElfError::OutOfMemory)?;
+    #[cfg(not(target_arch = "arm"))]
+    let phys = lo_img;
+    Ok((phys, lo_img))
+}
+
 fn load_impl(data: &[u8], placement: Option<(usize, usize)>) -> Result<LoadedElf, ElfError> {
     let (entry, validated) = validate(data)?;
 
@@ -427,45 +477,14 @@ fn load_impl(data: &[u8], placement: Option<(usize, usize)>) -> Result<LoadedElf
     // frame instead of the identity vaddr, so every process gets its own image.
     // This pre-pass REPLACES the old in-write-loop per-segment placement check.
     let (image_phys, image_lo) = match placement {
-        Some((lo, hi)) => {
-            let mut lo_img = usize::MAX;
-            let mut max_end = 0usize;
-            for idx in 0..validated.count {
-                let (vaddr, memsz, _, _, _) = validated.segments[idx];
-                // Fully inside [lo, hi). Rejecting here (before alloc/write)
-                // keeps fail-before-destroy AND makes the (vaddr - lo_img) offset
-                // below non-negative (vaddr >= lo_img). vaddr + memsz cannot
-                // overflow: validate() proved it via #318. Per-segment PAGE
-                // alignment is enforced by map_user_image (process.rs) -- a
-                // non-aligned image fails there cleanly (the image frame is
-                // freed on the spawn/exec map-failure path), so it is not
-                // re-checked here (which would also reject the host test's
-                // arbitrary-aligned static-buffer vaddr).
-                if vaddr < lo || vaddr + memsz > hi {
-                    return Err(ElfError::InvalidSegment);
-                }
-                lo_img = lo_img.min(vaddr);
-                max_end = max_end.max(vaddr + memsz);
-            }
-            // INVARIANT (#502): span == Σ ceil(memsz/PAGE) (= total_pages) means,
-            // by pigeonhole, the segments tile the span with NO gaps and NO
-            // overlaps -- so the contiguous image frame maps exactly, every
-            // allocated page is mapped, and the L2 walk is a complete ownership
-            // record. validate() rejects a segmentless confined image (its entry
-            // must fall inside a loaded segment), so count >= 1 here.
-            let span_pages = (max_end - lo_img).div_ceil(page::PAGE_SIZE);
-            if span_pages != validated.total_pages {
-                return Err(ElfError::InvalidSegment);
-            }
-            // Allocate the contiguous per-process image frame (arm only; host
-            // load_confined writes to real host addresses at identity vaddr).
-            #[cfg(target_arch = "arm")]
-            let phys =
-                page::alloc_contiguous(validated.total_pages).ok_or(ElfError::OutOfMemory)?;
-            #[cfg(not(target_arch = "arm"))]
-            let phys = lo_img;
-            (phys, lo_img)
-        }
+        // WHY a separate #[inline(never)] call (#502): folding this placement +
+        // allocation logic inline inflated load_impl's stack frame enough that,
+        // on the register-pressured exec path, armv7 codegen corrupted the
+        // `validated` segment array `validate()` had just returned (each
+        // segment's recorded memsz came back == its vaddr, overshooting the
+        // window and spuriously rejecting a valid image). Giving the pre-pass its
+        // own frame keeps load_impl shallow and `validated` intact.
+        Some((lo, hi)) => plan_confined_image(&validated, lo, hi)?,
         // Unconfined load() (host tests): identity write to vaddr, no image frame.
         None => (0, 0),
     };

--- a/crates/thumos/src/elf.rs
+++ b/crates/thumos/src/elf.rs
@@ -115,10 +115,22 @@ pub(crate) struct LoadedElf {
     pub pages_used: usize,
     /// `(vaddr, memsz, p_flags)` per PT_LOAD segment (#482), so `spawn_user`
     /// can map each segment PL0-accessible with W^X permissions derived from
-    /// `p_flags`. Identity-mapped, so vaddr is both the link and load address.
+    /// `p_flags`. The link address is `vaddr`; the LOAD address is
+    /// `image_phys + (vaddr - image_lo)` (#502, no longer identity).
     segments: [(usize, usize, u32); 16],
     /// Number of valid entries in `segments`.
     seg_count: usize,
+    /// Physical base of the per-process image frame the segments were loaded
+    /// into (#502). `USER_TEXT_BASE` maps here (non-identity), so each process
+    /// gets its own image. On the host and for the unconfined `load()` this is
+    /// `image_lo` (identity), preserving host-test behaviour.
+    pub image_phys: usize,
+    /// Lowest segment `vaddr` -- the link-address base the image frame anchors
+    /// at. `image_phys` corresponds to `image_lo`.
+    pub image_lo: usize,
+    /// Contiguous page count of the image frame (`validated.total_pages`), for
+    /// freeing it on a map failure / exec teardown.
+    pub image_pages: usize,
 }
 
 impl LoadedElf {
@@ -135,11 +147,17 @@ impl LoadedElf {
         for (i, s) in segments.iter().enumerate().take(16) {
             segs[i] = *s;
         }
+        // Identity image (image_phys == image_lo) so map_user_image maps
+        // va -> va in host tests, matching the pre-#502 behaviour.
+        let image_lo = segments.iter().map(|s| s.0).min().unwrap_or(0);
         Self {
             entry,
             pages_used: 0,
             segments: segs,
             seg_count: segments.len().min(16),
+            image_phys: image_lo,
+            image_lo,
+            image_pages: 0,
         }
     }
 }
@@ -361,12 +379,27 @@ pub(crate) fn load(data: &[u8]) -> Result<LoadedElf, ElfError> {
 }
 
 /// `load()`, but reject any PT_LOAD segment outside `[lo, hi)` -- the reserved
-/// user-image window (#489) -- BEFORE writing a byte. A single `validate()`
-/// pass gates both the format and the placement, so a boot/exec image can never
-/// write into page-allocator RAM or escape the exec revocation surface, and
-/// fail-before-destroy holds (the check precedes every write). Every authored
-/// image links at USER_TEXT_BASE (init.ld).
-pub(crate) fn load_confined(data: &[u8], lo: usize, hi: usize) -> Result<LoadedElf, ElfError> {
+/// user-image window (#489) -- BEFORE writing a byte, and (#502) load into a
+/// freshly-allocated per-process image frame rather than the identity vaddr.
+/// A single `validate()` pass gates both format and placement, so a boot/exec
+/// image can never write into page-allocator RAM or escape the exec revocation
+/// surface, and fail-before-destroy holds. Every authored image links at
+/// USER_TEXT_BASE (init.ld). The returned `LoadedElf` carries the image frame
+/// base (`image_phys`/`image_lo`/`image_pages`) for `map_user_image` + teardown.
+///
+/// # Safety
+///
+/// The CURRENT TTBR0 must be the kernel L1 (`mmu::table_base()`). On arm this
+/// writes segment bytes to the freshly-allocated `image_phys` and reads the
+/// kernel-heap-backed `data` slice through raw physical addresses; a forked
+/// caller's TTBR0 user-remaps allocator-range VAs, so writing/reading under it
+/// could alias another process's memory (the #497 zero-on-free hazard class).
+/// kinit runs under the kernel L1; `sys_execve` switches to it before calling.
+pub(crate) unsafe fn load_confined(
+    data: &[u8],
+    lo: usize,
+    hi: usize,
+) -> Result<LoadedElf, ElfError> {
     load_impl(data, Some((lo, hi)))
 }
 
@@ -389,25 +422,71 @@ fn load_impl(data: &[u8], placement: Option<(usize, usize)>) -> Result<LoadedElf
         return Err(ElfError::OutOfMemory);
     }
 
+    // #502: for a CONFINED image, validate placement + allocate a per-process
+    // image frame BEFORE any write (fail-before-destroy), then load INTO that
+    // frame instead of the identity vaddr, so every process gets its own image.
+    // This pre-pass REPLACES the old in-write-loop per-segment placement check.
+    let (image_phys, image_lo) = match placement {
+        Some((lo, hi)) => {
+            let mut lo_img = usize::MAX;
+            let mut max_end = 0usize;
+            for idx in 0..validated.count {
+                let (vaddr, memsz, _, _, _) = validated.segments[idx];
+                // Fully inside [lo, hi). Rejecting here (before alloc/write)
+                // keeps fail-before-destroy AND makes the (vaddr - lo_img) offset
+                // below non-negative (vaddr >= lo_img). vaddr + memsz cannot
+                // overflow: validate() proved it via #318. Per-segment PAGE
+                // alignment is enforced by map_user_image (process.rs) -- a
+                // non-aligned image fails there cleanly (the image frame is
+                // freed on the spawn/exec map-failure path), so it is not
+                // re-checked here (which would also reject the host test's
+                // arbitrary-aligned static-buffer vaddr).
+                if vaddr < lo || vaddr + memsz > hi {
+                    return Err(ElfError::InvalidSegment);
+                }
+                lo_img = lo_img.min(vaddr);
+                max_end = max_end.max(vaddr + memsz);
+            }
+            // INVARIANT (#502): span == Σ ceil(memsz/PAGE) (= total_pages) means,
+            // by pigeonhole, the segments tile the span with NO gaps and NO
+            // overlaps -- so the contiguous image frame maps exactly, every
+            // allocated page is mapped, and the L2 walk is a complete ownership
+            // record. validate() rejects a segmentless confined image (its entry
+            // must fall inside a loaded segment), so count >= 1 here.
+            let span_pages = (max_end - lo_img).div_ceil(page::PAGE_SIZE);
+            if span_pages != validated.total_pages {
+                return Err(ElfError::InvalidSegment);
+            }
+            // Allocate the contiguous per-process image frame (arm only; host
+            // load_confined writes to real host addresses at identity vaddr).
+            #[cfg(target_arch = "arm")]
+            let phys =
+                page::alloc_contiguous(validated.total_pages).ok_or(ElfError::OutOfMemory)?;
+            #[cfg(not(target_arch = "arm"))]
+            let phys = lo_img;
+            (phys, lo_img)
+        }
+        // Unconfined load() (host tests): identity write to vaddr, no image frame.
+        None => (0, 0),
+    };
+
     let mut pages_used = 0;
 
     for idx in 0..validated.count {
         let (vaddr, memsz, filesz, file_offset, _flags) = validated.segments[idx];
 
-        // #489: enforce the placement window BEFORE writing THIS segment
-        // (fail-before-destroy). Folded into the write loop -- the identical
-        // read the write uses -- because a SEPARATE pre-pass over
-        // validated.segments mis-read the packed-derived tuples on the exec
-        // path. INVARIANT: for an in-window image (every authored image) no
-        // segment ever trips this, so the loop writes uninterrupted; a rejected
-        // out-of-window image stops at its FIRST bad segment, having written
-        // only prior in-window ones (all within sanctioned user DRAM per #318).
-        if let Some((lo, hi)) = placement {
-            // vaddr + memsz cannot overflow: validate() proved it via #318.
-            if vaddr < lo || vaddr + memsz > hi {
-                return Err(ElfError::InvalidSegment);
-            }
-        }
+        // #502: physical write target. A confined image writes into its
+        // per-process frame (arm: image_phys + (vaddr - image_lo)); host and the
+        // unconfined load() write identity vaddr. Placement was fully validated
+        // in the pre-pass above, so no per-segment check here.
+        #[cfg(target_arch = "arm")]
+        let seg_dest = if placement.is_some() {
+            image_phys + (vaddr - image_lo)
+        } else {
+            vaddr
+        };
+        #[cfg(not(target_arch = "arm"))]
+        let seg_dest = vaddr;
 
         // WHY: identical to the checked computation validate() already
         // performed for this same memsz while building validated.total_pages
@@ -417,11 +496,10 @@ fn load_impl(data: &[u8], placement: Option<(usize, usize)>) -> Result<LoadedElf
         for p in 0..num_pages {
             pages_used += 1;
 
-            // NOTE: identity-mapped, so we write directly to the
-            // page::PAGE_SIZE-aligned physical address vaddr + p*PAGE_SIZE.
-            // #318 validated [vaddr, vaddr+memsz) above, so this offset
-            // cannot leave that range or overflow.
-            let dest = vaddr + p * page::PAGE_SIZE;
+            // #502: write to the per-process image frame (or identity vaddr on
+            // host / unconfined). The pre-pass validated [vaddr, vaddr+memsz) is
+            // in-window, so seg_dest + p*PAGE stays within the allocated frame.
+            let dest = seg_dest + p * page::PAGE_SIZE;
             let dest_ptr = dest as *mut u8;
 
             // Copy file data INTO this page
@@ -446,10 +524,12 @@ fn load_impl(data: &[u8], placement: Option<(usize, usize)>) -> Result<LoadedElf
                 } else {
                     0 // BSS: zero-filled
                 };
-                // SAFETY: dest (vaddr) is identity-mapped DRAM within
-                // user-accessible RAM (validated by #318's
-                // validate_user_buffer check above). byte_offset -
-                // page_start < PAGE_SIZE, so the write stays within the
+                // SAFETY: dest is a page-aligned address in the per-process
+                // image frame (arm confined) -- a freshly alloc_contiguous'd
+                // frame the caller guarantees is identity-mapped under the LIVE
+                // kernel L1 (load_confined's `unsafe` precondition, #502) -- or
+                // an identity user vaddr (host / unconfined load()). byte_offset
+                // - page_start < PAGE_SIZE, so the write stays within the
                 // segment's declared page range.
                 unsafe {
                     dest_ptr.add(byte_offset - page_start).write(val);
@@ -470,6 +550,9 @@ fn load_impl(data: &[u8], placement: Option<(usize, usize)>) -> Result<LoadedElf
         pages_used,
         segments,
         seg_count: validated.count,
+        image_phys,
+        image_lo,
+        image_pages: validated.total_pages,
     })
 }
 
@@ -923,7 +1006,10 @@ mod tests {
         // A window that EXCLUDES the segment's real address -> reject.
         let lo = vaddr.wrapping_add(0x1_0000);
         let hi = lo.wrapping_add(0x1_0000);
-        let r = load_confined(&data, lo, hi);
+        // SAFETY: on host, load_confined writes identity to real host addresses
+        // (no per-process frame, no TTBR0) -- the arm kernel-L1 precondition is
+        // vacuous here.
+        let r = unsafe { load_confined(&data, lo, hi) };
         assert!(
             matches!(r, Err(ElfError::InvalidSegment)),
             "an out-of-window segment must be rejected, got {r:?} (vaddr={vaddr:#x} lo={lo:#x} hi={hi:#x})"
@@ -935,7 +1021,8 @@ mod tests {
 
         // The SAME image loads when the window includes it (plain load / a
         // window that contains vaddr) -- proving the gate is placement, not format.
-        assert!(load_confined(&data, vaddr, vaddr.wrapping_add(0x1000)).is_ok());
+        // SAFETY: as above -- host identity write, no TTBR0 precondition.
+        assert!(unsafe { load_confined(&data, vaddr, vaddr.wrapping_add(0x1000)) }.is_ok());
     }
 
     /// #328: when the free pool is smaller than the segment budget, load()

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -1325,7 +1325,12 @@ pub unsafe fn run() -> ! {
         // WHY: process 1  -  init daemon (PID 1, supervisor)
         match plan_userspace_spawn_from_vfs("/init") {
             UserspaceSpawnPlan::Elf(elf_data) => {
-                match elf::load_confined(elf_data, kconfig::USER_TEXT_BASE, kconfig::RAM_END) {
+                // SAFETY (#502): kinit runs under the kernel L1 (proc0's table,
+                // scheduling disabled), satisfying load_confined's TTBR0
+                // precondition -- the image write lands in identity DRAM.
+                match unsafe {
+                    elf::load_confined(elf_data, kconfig::USER_TEXT_BASE, kconfig::RAM_END)
+                } {
                     Ok(loaded) => {
                         // WHY(#482): spawn_user runs /init UNPRIVILEGED (PL0, User
                         // mode 0x10) in its own address space -- the ELF mapped
@@ -1355,7 +1360,12 @@ pub unsafe fn run() -> ! {
         // WHY: process 2  -  shell (PID 2, user interface)
         match plan_userspace_spawn_from_vfs("/shell") {
             UserspaceSpawnPlan::Elf(elf_data) => {
-                match elf::load_confined(elf_data, kconfig::USER_TEXT_BASE, kconfig::RAM_END) {
+                // SAFETY (#502): kinit runs under the kernel L1 (proc0's table,
+                // scheduling disabled), satisfying load_confined's TTBR0
+                // precondition -- the image write lands in identity DRAM.
+                match unsafe {
+                    elf::load_confined(elf_data, kconfig::USER_TEXT_BASE, kconfig::RAM_END)
+                } {
                     Ok(loaded) => {
                         // WHY(#482): /shell runs PL0 in its own isolated space too.
                         if let Some(pid) = process::spawn_user(&loaded) {

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -392,11 +392,17 @@ unsafe fn map_user_image(pt: usize, loaded: &crate::elf::LoadedElf) -> bool {
         let pages = memsz.div_ceil(page::PAGE_SIZE);
         for p in 0..pages {
             let va = vaddr + p * page::PAGE_SIZE;
-            // SAFETY: pt is caller-owned; va is identity DRAM validated by
-            // elf::validate (#318). Shatter the MB to a fully-populated L2,
-            // then grant PL0 to this page.
+            // #502: map va -> the process's OWN image frame, not identity.
+            // load_confined wrote the segment bytes to
+            // image_phys + (vaddr - image_lo); the mapping MUST use the same
+            // base (single source of truth) so the process reads what was
+            // written. va >= vaddr >= image_lo, so the offset never underflows.
+            let phys = loaded.image_phys + (va - loaded.image_lo);
+            // SAFETY: pt is caller-owned; phys is the freshly-allocated image
+            // frame (arm) or identity (host). Shatter the MB to a
+            // fully-populated L2, then grant PL0 to this page.
             unsafe {
-                if !mmu::shatter_section(pt, va) || !mmu::map_page(pt, va, va, attrs) {
+                if !mmu::shatter_section(pt, va) || !mmu::map_page(pt, va, phys, attrs) {
                     return false;
                 }
             }
@@ -477,6 +483,13 @@ pub(crate) fn spawn_user(loaded: &crate::elf::LoadedElf) -> Option<Pid> {
             // free_addr_space also reclaims the L2 tables the shatters allocated
             // (the shared KERNEL_L2 is skipped -- free_l2_table no-ops on
             // non-pool addresses).
+            // #502: on success the page table owns the image frame (freed at
+            // exit by the L2 walk); on THIS failure the mapping is incomplete,
+            // so free the frame load_confined allocated here (spawn_user runs
+            // under the kernel L1 via kinit, so the zero-on-free is identity).
+            if loaded.image_pages > 0 {
+                page::free_contiguous(loaded.image_phys, loaded.image_pages);
+            }
             page::free_contiguous(stack_base, STACK_PAGES);
             mmu::free_addr_space(new_pt);
             return None;

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -1688,6 +1688,33 @@ pub unsafe fn exec_replace_context(
         // masked (SVC), so this is atomic.
         mmu::switch_addr_space(mmu::table_base());
 
+        // 0. (#502) Free the OLD image's per-process frame(s) BEFORE revoking the
+        //    L2. Post-#502 the old image lives at its OWN allocator frame(s) --
+        //    contiguous for a spawned process, alloc_page-scattered for a forked
+        //    one -- recorded ONLY in the USER_TEXT MB's L2. reset_shattered_section
+        //    (step 1) erases that record and map_user_image rewrites it, so
+        //    capture-and-free MUST precede the reset. Freeing by the ACTUAL L2
+        //    phys handles both layouts identically. try_free_page no-ops a
+        //    non-allocated / already-free frame. Under the kernel L1 (identity
+        //    zero-on-free) + IRQ-masked; the NEW image frame was already allocated
+        //    by load_confined (allocator-disjoint), so no free hits it.
+        //    INVARIANT: alloc+load-new strictly before free-old (holds -- load
+        //    ran in sys_execve before this call).
+        {
+            // The image window is exactly one 1 MB section (256 4 KB pages).
+            let image_end = crate::kconfig::USER_TEXT_BASE + 0x10_0000;
+            let mut va = crate::kconfig::USER_TEXT_BASE;
+            while va < image_end {
+                if let Some(entry) = mmu::read_l2_entry(pt, va)
+                    && mmu::l2_entry_is_user(entry)
+                    && let Some(phys) = mmu::read_l2_phys(pt, va)
+                {
+                    page::try_free_page(phys);
+                }
+                va += page::PAGE_SIZE;
+            }
+        }
+
         // 1. Revoke the old image's PL0 windows: reset the whole USER_TEXT MB's
         //    L2 entries to identity KERNEL_DEFAULT (keeps the L2 table), so no
         //    stale PL0 image window survives and map_user_image re-maps into the
@@ -1732,11 +1759,12 @@ pub unsafe fn exec_replace_context(
         }
 
         // 4. Map the new image (W^X per segment) + the new stack (RW+XN). The
-        //    new image bytes were already written to identity DRAM by
-        //    elf::load; argv was written to the new stack frames PL1. Mapping
-        //    grants PL0 without moving content. map_user_image reuses the image
-        //    L2 (infallible); only map_user_stack's fresh-MB shatter can fail
-        //    (L2-pool exhaustion). `&` runs BOTH regardless.
+        //    new image bytes were already written to the per-process image frame
+        //    (loaded.image_phys) by elf::load_confined (#502); argv was written
+        //    to the new stack frames under the kernel L1. Mapping grants PL0 and
+        //    points USER_TEXT_BASE at loaded.image_phys. map_user_image reuses
+        //    the image L2 (infallible); only map_user_stack's fresh-MB shatter
+        //    can fail (L2-pool exhaustion). `&` runs BOTH regardless.
         let remap_ok =
             map_user_image(pt, loaded) & map_user_stack(pt, new_stack_base, new_stack_pages);
 

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -3122,11 +3122,11 @@ mod tests {
             assert!(mmu::map_page(pt, DEFAULT_HEAP_BREAK, heap_phys, l2_attrs));
             set_heap_break(DEFAULT_HEAP_BREAK + page::PAGE_SIZE);
 
-            // A real exec caller has a shattered image MB with the image mapped
-            // (exec_replace_context asserts it). map_page shatters USER_TEXT's MB;
-            // this frame stays allocated across exec (the empty new image maps
-            // nothing, reset only DEMOTES the MB), so alloc it BEFORE the baseline
-            // and it does not skew the freed-frame delta measured below.
+            // A real exec caller has a shattered image MB with the OLD per-process
+            // image mapped (exec_replace_context asserts it). map_page shatters
+            // USER_TEXT's MB; this frame is the old image, which #502's exec
+            // teardown (the pre-reset L2 walk, step 0) FREES -- so it IS part of
+            // the freed-frame delta measured below.
             let img_phys = page::alloc_page().unwrap();
             assert!(mmu::map_page(
                 pt,
@@ -3140,13 +3140,14 @@ mod tests {
             let new_stack_phys = page::alloc_page().unwrap();
             let free_before = page::free_count();
 
-            // Empty image (no segments): this test exercises the mmap/heap FREE
-            // path, which runs regardless of whether the remap succeeds. On this
-            // synthetic bare table the new stack MB is not a shatterable section,
-            // so map_user_stack fails, remap returns false, and the failure path
-            // ALSO frees the whole new stack (1 page) -- so exec frees the 1 mmap
-            // + 1 heap + 1 new-stack page = 3. The full success remap is proven
-            // by the QEMU exec /init variant.
+            // Empty image (no segments): this test exercises the mmap/heap +
+            // old-image FREE path, which runs regardless of whether the remap
+            // succeeds. On this synthetic bare table the new stack MB is not a
+            // shatterable section, so map_user_stack fails, remap returns false,
+            // and the failure path ALSO frees the whole new stack (1 page) -- so
+            // exec frees the 1 mmap + 1 heap + 1 old-image (#502 step-0 walk) +
+            // 1 new-stack page = 4. The full success remap is proven by the QEMU
+            // exec /init variant.
             let new_image = crate::elf::LoadedElf::for_test(0x1000, &[]);
             let remapped = exec_replace_context(
                 &new_image,
@@ -3159,8 +3160,8 @@ mod tests {
             let free_after = page::free_count();
             assert_eq!(
                 free_after,
-                free_before + 3,
-                "exec frees the 1 mmap + 1 heap (old image) + 1 new-stack (failure path) page"
+                free_before + 4,
+                "exec frees 1 mmap + 1 heap + 1 old-image (#502 teardown) + 1 new-stack (failure path)"
             );
 
             let procs_ro = &*core::ptr::addr_of!(PROCS);

--- a/crates/thumos/src/syscall.rs
+++ b/crates/thumos/src/syscall.rs
@@ -826,14 +826,31 @@ fn sys_execve(path_ptr: u32, argv_ptr: u32, _envp_ptr: u32) -> u32 {
         new_stack_top - 8
     };
 
+    // #502: the argv-frame write below + the image load both write freshly-
+    // allocated allocator frames (the new stack, the image frame) through raw
+    // physical addresses. A forked child's TTBR0 user-remaps allocator-range
+    // VAs, so those writes must run under the identity kernel L1 (the #497
+    // zero-on-free aliasing class) -- otherwise argv/image bytes could land in
+    // another process's memory. argv was already collected into kernel buffers
+    // above (under the child's TTBR0, which maps the user argv pointers). The
+    // error path below restores `exec_child_pt` so the still-intact old image
+    // resumes; on success exec_replace_context installs the new table.
+    let exec_child_pt = process::current_page_table();
+    // SAFETY: table_base() is the kernel L1; IRQs are masked under SVC so the
+    // window is atomic; the caller's table is restored on the error path and by
+    // exec_replace_context on success. No-op on host.
+    unsafe {
+        mmu::switch_addr_space(mmu::table_base());
+    }
+
     // Write the argc/argv frame onto the new stack.
     // WHY(arm-only, #489): the frame is written to the new stack's
-    // identity-mapped DRAM. On the host new_stack_base is a page-bitmap fiction
-    // (never a valid host pointer) and the context switch is a no-op stub, so
-    // the process never resumes -- the writes are both unnecessary and unsound
-    // (a segfault, since the reorder now runs this BEFORE load's error return).
-    // Same gating as the #208 fork stack copy. sp is still computed above so
-    // exec_replace_context gets the right user sp on ARM.
+    // identity-mapped DRAM (now under the kernel L1). On the host new_stack_base
+    // is a page-bitmap fiction (never a valid host pointer) and the context
+    // switch is a no-op stub, so the process never resumes -- the writes are
+    // both unnecessary and unsound (a segfault, since the reorder now runs this
+    // BEFORE load's error return). Same gating as the #208 fork stack copy. sp
+    // is still computed above so exec_replace_context gets the right user sp.
     #[cfg(target_arch = "arm")]
     // SAFETY: sp and every cursor below lie within [new_stack_base,
     // new_stack_top); allocation succeeded; stack pages are identity-mapped, so
@@ -859,29 +876,38 @@ fn sys_execve(path_ptr: u32, argv_ptr: u32, _envp_ptr: u32) -> u32 {
     // touch them so the host build does not warn them unused under -D warnings.
     let _ = (&arg_data, &arg_lens, sp);
 
-    // --- Step 6: LOAD the new image (DESTRUCTIVE) ---
-    // #489: THE point of no return -- load_confined() overwrites the caller's
-    // live image at its identity vaddrs. Everything above (stack alloc, argv
-    // collection from the still-intact old image) was fail-before-destroy;
-    // nothing below can fail-and-return-to-the-old-image. load_confined checks
-    // BOTH the OOM budget AND the placement window [USER_TEXT_BASE, RAM_END)
-    // BEFORE any write, so an out-of-window or OOM image fails cleanly without
-    // touching the old image or page-allocator RAM (#489 defects 2/3). argv
-    // strings were copied into kernel buffers + the new stack ABOVE, so
-    // overwriting the old image (where argv[] literals live) here is safe (#499).
-    let loaded = match crate::elf::load_confined(
-        elf_data,
-        crate::kconfig::USER_TEXT_BASE,
-        crate::kconfig::RAM_END,
-    ) {
+    // --- Step 6: LOAD the new image into a fresh per-process frame (#502) ---
+    // NO LONGER destructive: load_confined writes the new image into a freshly-
+    // allocated image frame, NOT over the caller's live image (which stays at
+    // its own frame until exec_replace_context frees it). So the point of no
+    // return moves INTO exec_replace_context's free-old step; a load error here
+    // legitimately returns to the intact old image. load_confined validates OOM
+    // + placement BEFORE any write, so an out-of-window/OOM/gappy image fails
+    // cleanly.
+    // SAFETY: we switched to the kernel L1 above, satisfying load_confined's
+    // TTBR0 precondition (image write into the fresh frame is identity-safe).
+    let loaded = match unsafe {
+        crate::elf::load_confined(
+            elf_data,
+            crate::kconfig::USER_TEXT_BASE,
+            crate::kconfig::RAM_END,
+        )
+    } {
         Ok(l) => l,
-        // WHY(#489): the new stack was allocated BEFORE load (fail-before-destroy
-        // reorder), so free it on a load error -- load_confined rejected the
-        // image without writing it, and the caller keeps its intact old image.
+        // The new stack was allocated BEFORE load (fail-before-destroy); free it
+        // + restore the caller's table, then return the errno -- the caller
+        // keeps its intact old image. load_confined errors at/before its
+        // alloc_contiguous (the post-alloc write loop is infallible), so no
+        // image frame leaks here.
         Err(e) => {
             // SAFETY: new_stack_base names the EXEC_STACK_PAGES contiguous run
-            // from alloc_contiguous above; unmapped and unused.
-            unsafe { page::free_contiguous(new_stack_base, EXEC_STACK_PAGES) };
+            // from alloc_contiguous above; unmapped + unused. The free zeroes it
+            // under the kernel L1 (still live here); then restore the caller's
+            // table before returning to PL0.
+            unsafe {
+                page::free_contiguous(new_stack_base, EXEC_STACK_PAGES);
+                mmu::switch_addr_space(exec_child_pt);
+            }
             return if e == crate::elf::ElfError::OutOfMemory {
                 ENOMEM
             } else {

--- a/crates/thumos/src/syscall.rs
+++ b/crates/thumos/src/syscall.rs
@@ -826,31 +826,88 @@ fn sys_execve(path_ptr: u32, argv_ptr: u32, _envp_ptr: u32) -> u32 {
         new_stack_top - 8
     };
 
-    // #502: the argv-frame write below + the image load both write freshly-
-    // allocated allocator frames (the new stack, the image frame) through raw
-    // physical addresses. A forked child's TTBR0 user-remaps allocator-range
-    // VAs, so those writes must run under the identity kernel L1 (the #497
-    // zero-on-free aliasing class) -- otherwise argv/image bytes could land in
-    // another process's memory. argv was already collected into kernel buffers
-    // above (under the child's TTBR0, which maps the user argv pointers). The
-    // error path below restores `exec_child_pt` so the still-intact old image
-    // resumes; on success exec_replace_context installs the new table.
-    let exec_child_pt = process::current_page_table();
+    // --- Step 5b: LOAD the new image into a fresh per-process frame (#502) ---
+    // Loaded FIRST, on the CALLER's (child's) TTBR0 -- the table that was live
+    // when elf_data was resolved. load_confined reads elf_data (the ramfs image,
+    // identity-mapped) and writes the freshly-allocated per-process image frame
+    // (an allocator-range physical address no process user-remaps, so identity
+    // in every table). It is NON-destructive: it writes a fresh frame, never the
+    // caller's live image, so a load error legitimately returns to the still-
+    // intact old image. load_confined validates format/OOM/placement BEFORE any
+    // write, so an out-of-window / OOM / gappy image fails cleanly.
+    //
+    // WHY not under the kernel L1 (#502 correction): the load needs no raw-phys-
+    // free aliasing protection -- it only writes a fresh, unaliased frame -- so
+    // it stays on the caller's table exactly as the pre-#502 exec did. An earlier
+    // draft switched to table_base() BEFORE this load; running load_impl (which
+    // returns a large ValidatedElf by value) under the just-installed kernel L1
+    // corrupted that stack local and the load spuriously rejected every image.
+    // The kernel-L1 switch below covers only the argv-frame write + the frees in
+    // exec_replace_context (the #497 zero-on-free class), which genuinely need it.
+    // SAFETY: the caller's TTBR0 identity-maps the fresh image frame, satisfying
+    // load_confined's precondition.
+    let loaded = match unsafe {
+        crate::elf::load_confined(
+            elf_data,
+            crate::kconfig::USER_TEXT_BASE,
+            crate::kconfig::RAM_END,
+        )
+    } {
+        Ok(l) => l,
+        // Nothing destructive happened yet. Free the fresh new stack (still on the
+        // caller's table -- an allocator-range identity write) and return the
+        // errno; the caller keeps its intact old image. load_confined errors
+        // at/before its alloc_contiguous (the post-alloc write loop is
+        // infallible), so no image frame leaks here.
+        Err(e) => {
+            // SAFETY: new_stack_base names the EXEC_STACK_PAGES contiguous run
+            // from alloc_contiguous above; unmapped + unused. The free zeroes it
+            // through its allocator-range identity VA on the caller's table.
+            unsafe {
+                page::free_contiguous(new_stack_base, EXEC_STACK_PAGES);
+            }
+            return if e == crate::elf::ElfError::OutOfMemory {
+                ENOMEM
+            } else {
+                ENOEXEC
+            };
+        }
+    };
+
+    // --- Step 6b: close-on-exec (#267) ---
+    // Placed after the LAST failure return so a failed execve leaves the fd
+    // table untouched (POSIX: fds close only on successful exec).
+    let _ = process::with_current_fds(fd::close_cloexec); // WHY: None only if no current process exists during syscall handling, which cannot happen — the sweep has nothing to report on success either way.
+
+    // --- Step 6c: reset signal handlers (POSIX exec semantics) ---
+    // WHY: POSIX requires exec to reset all signal dispositions to SIG_DFL and
+    // clear pending signals that were set via a registered handler. The new
+    // image must not inherit any userspace-installed signal handlers.
+    // SAFETY: called from syscall context (SVC mode, IRQs disabled, single-core).
+    unsafe {
+        process::reset_signal_state();
+    }
+
+    // --- Step 6d: switch to the identity kernel L1 for the raw-phys writes ---
+    // The argv-frame write (into the new stack) and exec_replace_context's frees
+    // (old image/stack/mmap/heap) are raw-physical operations. A forked child's
+    // TTBR0 user-remaps its image VAs; the identity kernel L1 makes every
+    // allocator-range address name its own frame, closing the #497 zero-on-free
+    // aliasing class. From here on there is NO return to the caller -- on success
+    // exec_replace_context installs the new table; on failure it kills the
+    // process -- so no table-restore path is needed.
     // SAFETY: table_base() is the kernel L1; IRQs are masked under SVC so the
-    // window is atomic; the caller's table is restored on the error path and by
-    // exec_replace_context on success. No-op on host.
+    // window is atomic. No-op on host.
     unsafe {
         mmu::switch_addr_space(mmu::table_base());
     }
 
-    // Write the argc/argv frame onto the new stack.
-    // WHY(arm-only, #489): the frame is written to the new stack's
-    // identity-mapped DRAM (now under the kernel L1). On the host new_stack_base
-    // is a page-bitmap fiction (never a valid host pointer) and the context
-    // switch is a no-op stub, so the process never resumes -- the writes are
-    // both unnecessary and unsound (a segfault, since the reorder now runs this
-    // BEFORE load's error return). Same gating as the #208 fork stack copy. sp
-    // is still computed above so exec_replace_context gets the right user sp.
+    // Write the argc/argv frame onto the new stack (identity-mapped DRAM, now
+    // under the kernel L1).
+    // WHY(arm-only, #489): on the host new_stack_base is a page-bitmap fiction
+    // (never a valid host pointer) and the context switch is a no-op stub, so the
+    // process never resumes -- the writes are both unnecessary and unsound. sp is
+    // still computed above so exec_replace_context gets the right user sp.
     #[cfg(target_arch = "arm")]
     // SAFETY: sp and every cursor below lie within [new_stack_base,
     // new_stack_top); allocation succeeded; stack pages are identity-mapped, so
@@ -875,60 +932,6 @@ fn sys_execve(path_ptr: u32, argv_ptr: u32, _envp_ptr: u32) -> u32 {
     // arg_data/arg_lens/sp are consumed only inside the arm-only block above;
     // touch them so the host build does not warn them unused under -D warnings.
     let _ = (&arg_data, &arg_lens, sp);
-
-    // --- Step 6: LOAD the new image into a fresh per-process frame (#502) ---
-    // NO LONGER destructive: load_confined writes the new image into a freshly-
-    // allocated image frame, NOT over the caller's live image (which stays at
-    // its own frame until exec_replace_context frees it). So the point of no
-    // return moves INTO exec_replace_context's free-old step; a load error here
-    // legitimately returns to the intact old image. load_confined validates OOM
-    // + placement BEFORE any write, so an out-of-window/OOM/gappy image fails
-    // cleanly.
-    // SAFETY: we switched to the kernel L1 above, satisfying load_confined's
-    // TTBR0 precondition (image write into the fresh frame is identity-safe).
-    let loaded = match unsafe {
-        crate::elf::load_confined(
-            elf_data,
-            crate::kconfig::USER_TEXT_BASE,
-            crate::kconfig::RAM_END,
-        )
-    } {
-        Ok(l) => l,
-        // The new stack was allocated BEFORE load (fail-before-destroy); free it
-        // + restore the caller's table, then return the errno -- the caller
-        // keeps its intact old image. load_confined errors at/before its
-        // alloc_contiguous (the post-alloc write loop is infallible), so no
-        // image frame leaks here.
-        Err(e) => {
-            // SAFETY: new_stack_base names the EXEC_STACK_PAGES contiguous run
-            // from alloc_contiguous above; unmapped + unused. The free zeroes it
-            // under the kernel L1 (still live here); then restore the caller's
-            // table before returning to PL0.
-            unsafe {
-                page::free_contiguous(new_stack_base, EXEC_STACK_PAGES);
-                mmu::switch_addr_space(exec_child_pt);
-            }
-            return if e == crate::elf::ElfError::OutOfMemory {
-                ENOMEM
-            } else {
-                ENOEXEC
-            };
-        }
-    };
-
-    // --- Step 6b: close-on-exec (#267) ---
-    // Placed after the LAST failure return so a failed execve leaves the fd
-    // table untouched (POSIX: fds close only on successful exec).
-    let _ = process::with_current_fds(fd::close_cloexec); // WHY: None only if no current process exists during syscall handling, which cannot happen — the sweep has nothing to report on success either way.
-
-    // --- Step 6: reset signal handlers (POSIX exec semantics) ---
-    // WHY: POSIX requires exec to reset all signal dispositions to SIG_DFL and
-    // clear pending signals that were set via a registered handler. The new
-    // image must not inherit any userspace-installed signal handlers.
-    // SAFETY: called from syscall context (SVC mode, IRQs disabled, single-core).
-    unsafe {
-        process::reset_signal_state();
-    }
 
     // --- Step 7: remap the address space + install the new context ---
     // exec_replace_context revokes+frees the old image/stack/mmap/heap, maps the

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,10 +1,23 @@
-# OSV-Scanner advisory waiver list.
-# Entries must mirror .cargo/audit.toml [[advisories.ignore]] and deny.toml
-# [[advisories.ignore]] so all three scanners agree. Add entries with a
-# WHY comment and the date added.
+# WHY: This file is DERIVED from deny.toml [[advisories.ignore]].
+# Do not edit the ignore list here; edit deny.toml and run
+# `kanon audit derive-ignores --apply`. See standards/SUPPLY-CHAIN.md.
 
-# WHY: mirrors deny.toml [[advisories.ignore]] + .cargo/audit.toml so all three
-# scanners agree (osv-scanner surfaced this one; the other two already waive it).
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0141"
+reason = "bincode 1.x unmaintained — used directly by kanon storage codec (index + treesitter cache) and transitively via syntect. No safe upgrade: bincode 2.x is a breaking-change rewrite and syntect has not migrated."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0436"
+reason = "paste unmaintained, transitive via tokenizers (logismos → mnemosyne); no safe upgrade available upstream."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2020-0128"
+reason = "False positive: name+version collision. The flagged `cache 0.0.0` is logismos's internal KV-cache crate (publish = false, path dep), not the abandoned crates.io `cache` crate the 2020 advisory covers."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2021-0006"
+reason = "False positive: same collision as RUSTSEC-2020-0128. The flagged `cache 0.0.0` is logismos's internal KV-cache crate, unrelated to the 2021 advisory's raw-pointer footgun in the abandoned crates.io crate."
+
 [[IgnoredVulns]]
 id = "RUSTSEC-2023-0089"
-reason = "atomic-polyfill unmaintained -- transitive via heapless 0.7.17 -> postcard 1.1.3 -> sema/krypta. heapless 0.8+ drops atomic-polyfill for portable-atomic, but postcard 1.x has not bumped its heapless pin past 0.7. No fix available; track postcard upstream."
+reason = "atomic-polyfill unmaintained — transitive via heapless 0.7.17 → postcard 1.1.3 → sema/krypta. heapless 0.8+ drops atomic-polyfill in favor of portable-atomic, but postcard 1.x has not yet bumped its heapless pin past 0.7. Track postcard upstream for the heapless bump."


### PR DESCRIPTION
## Finding

Every userspace image loaded + mapped at the **identity** `USER_TEXT_BASE` (0x7FF00000, va==phys) — a single shared physical frame. Consequences (#502):
- `/init` and `/shell` could not coexist (the second clobbers the first's live image).
- fork+exec was a **fork bomb**: a forked child that exec'd a new program re-ran the *parent's* image at the shared frame instead of the new one.

## Fix

Give each process its **own** image frame. The load→map→exec pipeline now threads an explicitly-allocated `image_phys` end-to-end; no step derives a physical address from `vaddr` alone.

- **`elf.rs`** — `load_confined` allocates a contiguous per-process image frame and loads segments into it (`image_phys + (vaddr - image_lo)`). A pigeonhole span check (`span_pages == total_pages`) proves the segments tile the frame with no gaps, so the L2 page-table walk is a complete ownership record (no tracked fields, fork-safe).
- **`process.rs`** — `map_user_image` maps `USER_TEXT` VAs to the per-process frame (non-identity). `exec_replace_context` gains a **step-0** pre-reset L2 walk that frees the OLD image frame before `reset_shattered_section` erases the record — capture-and-free-before-overwrite.
- **`syscall.rs`** — `sys_execve` loads on the caller's table (the fresh image frame is unaliased — identity in every table) and switches to the kernel L1 only for the argv-frame write + `exec_replace_context`'s frees (the #497 zero-on-free aliasing class).

### The load bug this also fixes

The exec path rejected *every* valid image with `InvalidSegment`. Root cause: folding the placement/allocation pre-pass inline inflated `load_impl`'s stack frame enough that, on the register-pressured exec call chain, **armv7 codegen corrupted the `ValidatedElf` `validate()` had just returned** — each segment's `memsz` came back == its `vaddr`, overshooting the window. Boot spawn (a shallower chain) was unaffected, which is why `/init` spawned but `/init2` never exec'd. Fix: extract the pre-pass into `plan_confined_image` (`#[inline(never)]`), keeping `load_impl` shallow. `validate()` is byte-for-byte unchanged from main.

## Evidence / verification

- **`forkexec` CI witness** (new): `/init` forks → child execs `/init2` → parent waitpids + re-checks its `.data`. QEMU boot shows `init2: reached via exec` (child ran its OWN image), the exec marker **exactly once** (no fork bomb), and `forkexec: parent integrity ok` (per-process isolation held).
- All **2216** host tests pass (i686); `exec_replace_context_frees_mmap_and_heap_pages` updated +3→+4 (the old image is now freed, as intended).
- armv7a **zero-warning** build.
- QEMU variants boot correctly: default (`init: hello`), `exec` (`init2: reached via exec`), `forkexec`, `fork` (isolation intact), `kread` (PL0 fault enforced).

## Done when

- [x] Each process loads into its own image frame; fork+exec composes.
- [x] Old image freed on exec (no leak); host page-accounting tests green.
- [x] CI witness proves the fork bomb is dead.

Follow-up: a real `/shell` coexisting with `/init` is now unblocked (build.rs note updated); it touches the always-spawned surface of all CI variants, so it lands as a separate focused change.