### PR TITLE
feat(thumos): ship /shell — /init+/shell coexistence witness (#526)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,16 @@ jobs:
           grep -q 'image-resident initramfs signature verified' boot.log || { echo 'FAIL: initramfs signature was not verified (measured-userspace regression)'; exit 1; }
           grep -q '/init spawned' boot.log || { echo 'FAIL: /init did not spawn from the verified initramfs'; exit 1; }
           grep -q 'init: hello from userspace' boot.log || { echo 'FAIL: userspace /init did not run + syscall (PL0->dispatch->UART)'; exit 1; }
+          # #526/#502: /init AND /shell coexist -- two userspace images running
+          # from their OWN per-process frames in one boot. Pre-#502 the second
+          # load clobbered the first's shared identity USER_TEXT frame, so one
+          # hello marker would print twice and the other never; the two -c==1
+          # counts below are that anti-clobber witness.
+          grep -q '/shell spawned PL0' boot.log || { echo 'FAIL #526: /shell did not spawn (absent from ramfs or spawn regressed)'; exit 1; }
+          grep -q 'shell: hello from userspace' boot.log || { echo 'FAIL #526: /shell did not run + syscall from its own frame'; exit 1; }
+          grep -q '2 userspace ELF processes running' boot.log || { echo 'FAIL #526: kinit did not report both userspace processes running'; exit 1; }
+          ic=$(grep -c 'init: hello from userspace' boot.log); test "$ic" -eq 1 || { echo "FAIL #526: 'init: hello' x$ic (want 1) -- per-process image-frame clobber regressed (#502)"; exit 1; }
+          sc=$(grep -c 'shell: hello from userspace' boot.log); test "$sc" -eq 1 || { echo "FAIL #526: 'shell: hello' x$sc (want 1) -- per-process image-frame clobber regressed (#502)"; exit 1; }
           # #400 render foundation: the kardia service loop paints the home
           # frame through the real screen-dispatch path (not a boot-time one-shot),
           # into a synthetic framebuffer under qemu (virt models no display). The
@@ -271,6 +281,9 @@ jobs:
             grep -q 'kardia: reaped .* fault-killed' "probe-$variant.log" || { echo "FAIL isolation[$variant]: fault-killed process was not reaped (PCB-slot leak -- table exhausts at MAX_PROCS)"; exit 1; }
             ! grep -q 'init: hello from userspace' "probe-$variant.log" || { echo "FAIL isolation[$variant]: /init reached the write -- the PL0 op did NOT fault (ISOLATION BROKEN)"; exit 1; }
             grep -q 'THUMOS-QEMU: service-loop ticks=' "probe-$variant.log" || { echo "FAIL isolation[$variant]: service loop never resumed after the kill (kernel did not survive)"; exit 1; }
+            # #526: /init's fault-kill must be SURGICAL -- the coexisting /shell
+            # (PID 2, its own image frame) runs to completion regardless.
+            grep -q 'shell: hello from userspace' "probe-$variant.log" || { echo "FAIL isolation[$variant]: /shell (PID 2) did not run -- killing /init took down its sibling (#526)"; exit 1; }
           done
           echo "PL0 isolation + graceful kill + reap verified: every PL0-illegal op faults, the process is killed AND reaped, the kernel survives"
       - name: Kernel-fault halts (PL1 fault must NEVER be recovered)
@@ -307,6 +320,7 @@ jobs:
           grep -q 'init: sleeping' sleep.log || { echo 'FAIL sleep: /init did not reach the sleep'; exit 1; }
           grep -q 'init: woke' sleep.log || { echo 'FAIL sleep: /init never resumed from sleep (busy-wait deadlock or lost wake)'; exit 1; }
           grep -q 'THUMOS-QEMU: service-loop ticks=' sleep.log || { echo 'FAIL sleep: service loop did not run (kernel hung during the sleep)'; exit 1; }
+          grep -q 'shell: hello from userspace' sleep.log || { echo 'FAIL sleep: /shell (PID 2) did not run alongside the sleeping /init (#526 coexistence)'; exit 1; }
       - name: QEMU fork correctness + isolation (#478)
         working-directory: crates/thumos
         # WHY: a PL0 fork must give the child its OWN deep-copied memory. /init
@@ -333,6 +347,7 @@ jobs:
           ! grep -q 'USERFAULT:' fork.log || { echo 'FAIL fork: a process faulted (bad child frame, bad mapping, or parent stack freed by the child exit)'; exit 1; }
           grep -q 'init: hello from userspace' fork.log || { echo 'FAIL fork: parent did not continue past the harness'; exit 1; }
           grep -q 'THUMOS-QEMU: service-loop ticks=' fork.log || { echo 'FAIL fork: kernel did not survive'; exit 1; }
+          grep -q 'shell: hello from userspace' fork.log || { echo 'FAIL fork: /shell (PID 2) did not run alongside the forking /init (#526 coexistence)'; exit 1; }
       - name: QEMU exec correctness + PL0 (#489)
         working-directory: crates/thumos
         # WHY: PL0 execve must REPLACE the caller's image with a new one that
@@ -359,6 +374,7 @@ jobs:
           ! grep -q 'init2: PRIVILEGED' exec.log || { echo 'FAIL exec: the exec-d image ran at PL1 (mode drop across exec broken -- SECURITY)'; exit 1; }
           ! grep -q 'init: hello from userspace' exec.log || { echo 'FAIL exec: the OLD image kept running after exec (control not transferred)'; exit 1; }
           grep -q 'THUMOS-QEMU: service-loop ticks=' exec.log || { echo 'FAIL exec: kernel did not survive the exec-d process fault'; exit 1; }
+          grep -q 'shell: hello from userspace' exec.log || { echo 'FAIL exec: /shell (PID 2) did not run alongside the exec-ing /init (#526 coexistence)'; exit 1; }
       - name: QEMU fork+exec composes -- per-process images (#502)
         working-directory: crates/thumos
         # WHY: the #502 keystone. Pre-#502 every userspace image loaded + mapped
@@ -392,3 +408,4 @@ jobs:
           ! grep -q 'forkexec: parent integrity BROKEN' forkexec.log || { echo 'FAIL forkexec: explicit parent-integrity break'; exit 1; }
           ! grep -q 'init2: PRIVILEGED' forkexec.log || { echo 'FAIL forkexec: the exec-d child ran at PL1 (mode drop across exec broken -- SECURITY)'; exit 1; }
           grep -q 'THUMOS-QEMU: service-loop ticks=' forkexec.log || { echo 'FAIL forkexec: kernel did not survive'; exit 1; }
+          grep -q 'shell: hello from userspace' forkexec.log || { echo 'FAIL forkexec: /shell (PID 2) did not run alongside the fork+exec /init (#526 coexistence)'; exit 1; }

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ thumos is pre-hardware. What is proven is the boot path under emulation and the 
 - **Hardware validation** on a physical AGM M7 - the frontier. QEMU exercises the boot path, not the MT6739's binary-only modem/WiFi/BT/GPS blobs.
 - **Boot-wiring**: implemented capabilities are not all reachable from the boot/service loop or from userspace yet; the wiring lands incrementally. See the [kernel wiring audit](docs/KERNEL-WIRING-AUDIT.md).
 - **Real radio I/O**: WiFi packet TX/RX, scan, and association over WMT/STP are hardware work; boot degrades to a fail-closed loopback path when the data path is absent.
-- **Userspace image packaging**: boot reports missing `/init` and `/shell` instead of spawning them.
 - **Aletheia live runtime** ([docs/ALETHEIA-BRIDGE.md](docs/ALETHEIA-BRIDGE.md), `metaxu`): live transport, grant verification, and UI wiring are future work.
 
 ## Related

--- a/crates/thumos/build.rs
+++ b/crates/thumos/build.rs
@@ -256,11 +256,22 @@ fn generate_initramfs(manifest_dir: &Path, out_dir: &Path) {
     // auto-spawning it would fault at boot. NOTE (#502): the old reason -- that a
     // /shell would "clobber /init's same-VA image" -- no longer holds now that
     // every process loads into its OWN per-process image frame; a real /shell
-    // that coexists with /init is unblocked (tracked as a follow-up).
+    // that coexists with /init now ships (#526), packed as a third CPIO entry
+    // below and spawned by kinit as PID 2 (see init/shell.rs).
     let init2_src = manifest_dir.join("init/init2.rs");
     println!("cargo:rerun-if-changed={}", init2_src.display());
     let init2_elf = out_dir.join("init2.elf");
     compile_init_binary(&rustc, &init2_src, &init_ld, &init2_elf, None);
+
+    // #526: /shell -- a THIRD boot-resident program kinit spawns by name
+    // alongside /init to WITNESS per-process image frames (#502): two userspace
+    // images run from their own frames in one boot. Distinct from init2 (an
+    // exec-only target that UNDEF-faults); /shell prints a marker and exits
+    // cleanly. Compiled variant-agnostic (None), like init2.
+    let shell_src = manifest_dir.join("init/shell.rs");
+    println!("cargo:rerun-if-changed={}", shell_src.display());
+    let shell_elf = out_dir.join("shell.elf");
+    compile_init_binary(&rustc, &shell_src, &init_ld, &shell_elf, None);
 
     let elf = match fs::read(&init_elf) {
         Ok(b) => b,
@@ -270,9 +281,14 @@ fn generate_initramfs(manifest_dir: &Path, out_dir: &Path) {
         Ok(b) => b,
         Err(e) => die(&format!("#489: cannot read built /init2 ELF: {e}")),
     };
+    let elf_shell = match fs::read(&shell_elf) {
+        Ok(b) => b,
+        Err(e) => die(&format!("#526: cannot read built /shell ELF: {e}")),
+    };
 
     let mut archive = cpio_newc_entry("init", &elf, 0o100_755);
     archive.extend_from_slice(&cpio_newc_entry("init2", &elf2, 0o100_755));
+    archive.extend_from_slice(&cpio_newc_entry("shell", &elf_shell, 0o100_755));
     archive.extend_from_slice(&cpio_newc_entry("TRAILER!!!", &[], 0));
     if let Err(e) = fs::write(out_dir.join("initramfs.cpio"), &archive) {
         die(&format!("#474: cannot write initramfs.cpio: {e}"));

--- a/crates/thumos/init/shell.rs
+++ b/crates/thumos/init/shell.rs
@@ -1,0 +1,66 @@
+//! thumos /shell (#526): a SECOND boot-resident userspace program.
+//!
+//! kinit spawns BOTH /init (PID 1) and /shell (PID 2) from the boot ramfs.
+//! Pre-#502 this was impossible: every image mapped at the identity
+//! USER_TEXT_BASE, so /shell would clobber /init's live image. #502 gave each
+//! process its OWN per-process image frame, so the two coexist -- this program
+//! is the witness: it prints a marker and exits cleanly, proving a second image
+//! ran from its own frame while /init's frame stayed intact.
+//!
+//! Deliberately does NO privileged probe (unlike init2.rs, which UNDEF-faults
+//! as its PL0 proof): /shell is auto-spawned on EVERY boot, so a fault here
+//! would break every init variant. A richer interactive shell is future work.
+#![no_std]
+#![no_main]
+
+/// write(fd, buf, len) via the thumos ABI (r7 = num, r0-r2 = args).
+///
+/// # Safety
+/// `buf` must point to `len` readable bytes in the loaded image.
+#[inline(always)]
+unsafe fn sys_write(fd: u32, buf: *const u8, len: u32) -> u32 {
+    let ret;
+    // SAFETY: SVC #1 (Write); the kernel validates the buffer.
+    unsafe {
+        core::arch::asm!(
+            "svc #0",
+            in("r7") 1u32,
+            inlateout("r0") fd => ret,
+            in("r1") buf,
+            in("r2") len,
+            options(nostack),
+        );
+    }
+    ret
+}
+
+/// exit(code): never returns.
+///
+/// # Safety
+/// Ends the process; the kernel switches away.
+#[inline(always)]
+unsafe fn sys_exit(code: u32) -> ! {
+    // SAFETY: SVC #0 (Exit); does not return.
+    unsafe {
+        core::arch::asm!("svc #0", in("r7") 0u32, in("r0") code, options(noreturn, nostack));
+    }
+}
+
+/// ELF entry point.
+#[unsafe(no_mangle)]
+pub extern "C" fn _start() -> ! {
+    let msg = b"shell: hello from userspace\n";
+    // SAFETY: msg is a .rodata literal in the loaded image; sys_exit terminates
+    // the process so control never falls through.
+    unsafe {
+        sys_write(1, msg.as_ptr(), u32::try_from(msg.len()).unwrap_or(0));
+        sys_exit(0);
+    }
+}
+
+/// Panic handler: exit(1). no_std has no unwinding.
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    // SAFETY: exit is the only action available; nothing reads its result.
+    unsafe { sys_exit(1) }
+}


### PR DESCRIPTION
## Finding

The second half of #502. kinit already spawns `/shell` by name (it WARNed `/shell missing from root ramfs`), but no `/shell` was packed into the boot ramfs. Pre-#502 that was deliberate — every userspace image mapped at the identity `USER_TEXT_BASE`, so a second spawned program would clobber /init's live image. #502 gave each process its own per-process image frame; this ships the `/shell` that proves the two coexist.

## Fix

- **`init/shell.rs`** (new): minimal program — prints `shell: hello from userspace`, exits 0. NO privileged probe (unlike init2, which UNDEF-faults as its PL0 proof): /shell is auto-spawned on *every* boot, so a fault here would break every variant.
- **`build.rs`**: compile + pack `/shell` as a third CPIO entry (variant-agnostic, like init2). The initramfs Ed25519 signature covers it automatically.
- **`.github/workflows/ci.yml`**: default boot asserts both hello markers with `-c`==1 **counts** — the anti-clobber witness: a per-process-frame regression prints one marker twice and the other never — plus `/shell spawned PL0` and `2 userspace ELF processes running`. Every init variant (kread/kwrite/kexec/cp15/sleep/fork/exec/forkexec) gains a `shell: hello` assert.
- **`README.md`**: drops the now-obsolete "userspace image packaging: boot reports missing /init and /shell" known-gap bullet.

## The surface-risk verdict (why unconditional coexistence is clean)

`/shell` lives in the CPIO for every build, so kinit spawns it (PID 2) alongside /init in all 8 init variants. Verified it perturbs **none** of the existing witnesses:
- **Probes** (`ufc == 1`): /shell exits cleanly (no USERFAULT) → the count stays 1. Its presence is now a *stronger* property — `shell: hello` proves /init's fault-kill is **surgical** (the sibling runs to completion). `! init: hello` holds (/shell prints `shell: hello`).
- **forkexec** (`xc == 1`, parent integrity): /shell never prints the exec marker; the parent's `.data` canary is untouched (separate per-process frame).
- **exec** (`USERFAULT: pid=1`): /init2 keeps /init's PID 1 across exec; /shell (PID 2) never faults.

## Evidence

QEMU boots verified locally: **default** (both hello markers, `2 userspace ELF processes running`), **cp15** (exactly 1 USERFAULT, `! init: hello`, `shell: hello` — surgical kill), **forkexec** (exec-marker x1, parent integrity ok, /shell coexists). 2216 host tests pass; armv7a zero-warning; full `kanon gate` green.

## Done when

- [x] `/init` + `/shell` both run + print from their own frames on a default boot, CI-asserted.
- [x] Every existing variant witness still green, with `/shell` proven to coexist.

**Note:** a host packaging test was intentionally *not* added — `mod kinit` is `#[cfg(not(test))]`, so kinit's `#[cfg(test)] mod tests` never compiles (the pre-existing kinit tests are dead too; filed separately). The executing QEMU witnesses are the real coverage.