### PR TITLE
feat(thumos): PROT_NONE user pages via a USER_OWNED page tag (#496)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,3 +409,41 @@ jobs:
           ! grep -q 'init2: PRIVILEGED' forkexec.log || { echo 'FAIL forkexec: the exec-d child ran at PL1 (mode drop across exec broken -- SECURITY)'; exit 1; }
           grep -q 'THUMOS-QEMU: service-loop ticks=' forkexec.log || { echo 'FAIL forkexec: kernel did not survive'; exit 1; }
           grep -q 'shell: hello from userspace' forkexec.log || { echo 'FAIL forkexec: /shell (PID 2) did not run alongside the fork+exec /init (#526 coexistence)'; exit 1; }
+      - name: QEMU PROT_NONE guard pages survive fork (#496)
+        working-directory: crates/thumos
+        # WHY: #496. A PROT_NONE page maps to AP[1:0]=0b01 -- byte-identical to a
+        # shattered MB's KERNEL_DEFAULT fill -- so the old AP-based enumeration
+        # (mmu::l2_entry_is_user) could not tell it from kernel scaffolding and
+        # would DROP it from fork's deep-copy and from teardown. mmap/mprotect
+        # therefore rejected PROT_NONE outright. Now every user page carries the
+        # nG (USER_OWNED) software tag and enumeration keys on that instead.
+        #
+        # /init mmaps a PROT_NONE guard, forks, and the CHILD reads it. The
+        # load-bearing assertion is the DFSR status:
+        #   status=0x0000000f -> PERMISSION fault: the child HAS its own copy of
+        #                        the guard, i.e. fork enumerated + deep-copied a
+        #                        PL0-inaccessible page. This is the fix.
+        #   status=0x00000007 -> TRANSLATION fault: the page was DROPPED from the
+        #                        deep-copy -- the exact #496 bug, regressed.
+        # The parent then reaps the child (SIGSEGV=139) and mprotects the guard
+        # NONE->READ and reads it, proving the frame survived and a live
+        # PROT_NONE->READ transition works.
+        run: |
+          set -uo pipefail
+          THUMOS_INIT_VARIANT=guard cargo build --release --target armv7a-none-eabi --features qemu --jobs 8
+          grc=0
+          THUMOS_INIT_VARIANT=guard THUMOS_QEMU_TIMEOUT=60 ../../scripts/qemu-runner.sh target/armv7a-none-eabi/release/thumos | tee guard.log || grc=$?
+          echo "=== guard: runner rc=$grc (want 0) ==="
+          test "$grc" -eq 0 || { echo "FAIL guard: kernel did not survive (rc=$grc; 124=hang 2/3=abort)"; exit 1; }
+          grep -q 'init: guard mapped' guard.log || { echo 'FAIL #496: mmap(PROT_NONE) was rejected -- the guard-page gate regressed (or mmap cannot shatter its section)'; exit 1; }
+          ! grep -q 'init: guard mmap FAILED' guard.log || { echo 'FAIL #496: mmap(PROT_NONE) returned MAP_FAILED'; exit 1; }
+          ! grep -q 'init: guard fork FAILED' guard.log || { echo 'FAIL #496: fork failed in the guard harness'; exit 1; }
+          ! grep -q 'init: guard NOT enforced' guard.log || { echo 'FAIL #496: the child READ the PROT_NONE guard without faulting -- PL0 access was not denied (SECURITY)'; exit 1; }
+          grep -Eq 'USERFAULT: pid=[0-9]+ kind=data-abort addr=0x20000000 status=0x0000000f killed' guard.log || { echo 'FAIL #496: no PERMISSION data-abort at the guard VA -- the forked child did not get its own PROT_NONE page'; exit 1; }
+          ! grep -q 'USERFAULT.*addr=0x20000000 status=0x00000007' guard.log || { echo 'FAIL #496: TRANSLATION fault at the guard VA -- fork DROPPED the PROT_NONE page from the deep-copy (the #496 bug regressed)'; exit 1; }
+          gufc=$(grep -c 'USERFAULT:' guard.log)
+          test "$gufc" -eq 1 || { echo "FAIL #496: expected exactly 1 USERFAULT, got $gufc"; exit 1; }
+          grep -q 'init: guard child killed status=139' guard.log || { echo 'FAIL #496: the guard-faulting child did not exit SIGSEGV(139) / was not reaped by the parent'; exit 1; }
+          grep -q 'init: guard readable after mprotect' guard.log || { echo 'FAIL #496: mprotect(PROT_NONE -> PROT_READ) failed, or the guard frame did not survive'; exit 1; }
+          grep -q 'shell: hello from userspace' guard.log || { echo 'FAIL #496: /shell did not coexist (#526)'; exit 1; }
+          grep -q 'THUMOS-QEMU: service-loop ticks=' guard.log || { echo 'FAIL #496: kernel did not survive the guard fault'; exit 1; }

--- a/crates/thumos/build.rs
+++ b/crates/thumos/build.rs
@@ -193,7 +193,7 @@ fn compile_init_binary(
     .arg("link-arg=max-page-size=0x100")
     // WHY (#487): declare the probe cfgs so a direct rustc compile does not warn.
     .arg("--check-cfg")
-    .arg("cfg(thumos_init_kread, thumos_init_kwrite, thumos_init_kexec, thumos_init_cp15, thumos_init_sleep, thumos_init_fork, thumos_init_exec, thumos_init_forkexec)");
+    .arg("cfg(thumos_init_kread, thumos_init_kwrite, thumos_init_kexec, thumos_init_cp15, thumos_init_sleep, thumos_init_fork, thumos_init_exec, thumos_init_forkexec, thumos_init_guard)");
     if let Some(cfg) = variant_cfg {
         cmd.arg("--cfg").arg(cfg);
     }
@@ -228,12 +228,12 @@ fn generate_initramfs(manifest_dir: &Path, out_dir: &Path) {
     let variant_cfg = match env::var("THUMOS_INIT_VARIANT") {
         Ok(v) if !v.is_empty() => {
             if ![
-                "kread", "kwrite", "kexec", "cp15", "sleep", "fork", "exec", "forkexec",
+                "kread", "kwrite", "kexec", "cp15", "sleep", "fork", "exec", "forkexec", "guard",
             ]
             .contains(&v.as_str())
             {
                 die(&format!(
-                    "#487: unknown THUMOS_INIT_VARIANT '{v}' (expected kread|kwrite|kexec|cp15|sleep|fork|exec|forkexec)"
+                    "#487: unknown THUMOS_INIT_VARIANT '{v}' (expected kread|kwrite|kexec|cp15|sleep|fork|exec|forkexec|guard)"
                 ));
             }
             Some(format!("thumos_init_{v}"))

--- a/crates/thumos/init/init.rs
+++ b/crates/thumos/init/init.rs
@@ -41,7 +41,7 @@ unsafe fn sys_write(fd: u32, buf: *const u8, len: u32) -> u32 {
 ///
 /// # Safety
 /// Yields to the scheduler; the kernel resumes this process after the interval.
-#[cfg(any(thumos_init_sleep, thumos_init_fork, thumos_init_forkexec))]
+#[cfg(any(thumos_init_sleep, thumos_init_fork, thumos_init_forkexec, thumos_init_guard))]
 #[inline(always)]
 unsafe fn sys_sleep(ms: u32) {
     // SAFETY: issues SVC #7 (Sleep) per the thumos ABI; the kernel marks this
@@ -79,7 +79,7 @@ unsafe fn sys_exit(code: u32) -> ! {
 ///
 /// # Safety
 /// Creates a child process; both branches return here (the #478 ctx seed).
-#[cfg(any(thumos_init_fork, thumos_init_forkexec))]
+#[cfg(any(thumos_init_fork, thumos_init_forkexec, thumos_init_guard))]
 #[inline(always)]
 unsafe fn sys_fork() -> u32 {
     let ret;
@@ -95,7 +95,7 @@ unsafe fn sys_fork() -> u32 {
 ///
 /// # Safety
 /// Reads a child's exit status; reaps its slot when Dead.
-#[cfg(any(thumos_init_fork, thumos_init_forkexec))]
+#[cfg(any(thumos_init_fork, thumos_init_forkexec, thumos_init_guard))]
 #[inline(always)]
 unsafe fn sys_waitpid(pid: u32) -> u32 {
     let ret;
@@ -137,6 +137,51 @@ unsafe fn sys_execve(path: *const u8, argv: u32, envp: u32) -> u32 {
             inlateout("r0") path => ret,
             in("r1") argv,
             in("r2") envp,
+            options(nostack),
+        );
+    }
+    ret
+}
+
+/// mmap(addr_hint, len, prot, flags) -> mapped address, or u32::MAX (MAP_FAILED).
+///
+/// # Safety
+/// Requests a new user mapping; the returned VA is valid only if != u32::MAX.
+#[cfg(thumos_init_guard)]
+#[inline(always)]
+unsafe fn sys_mmap(addr: u32, len: u32, prot: u32, flags: u32) -> u32 {
+    let ret;
+    // SAFETY: SVC #20 (Mmap) per the thumos ABI.
+    unsafe {
+        core::arch::asm!(
+            "svc #0",
+            in("r7") 20u32,
+            inlateout("r0") addr => ret,
+            in("r1") len,
+            in("r2") prot,
+            in("r3") flags,
+            options(nostack),
+        );
+    }
+    ret
+}
+
+/// mprotect(addr, len, prot) -> 0 on success, else an errno.
+///
+/// # Safety
+/// Changes the protection of an existing user mapping.
+#[cfg(thumos_init_guard)]
+#[inline(always)]
+unsafe fn sys_mprotect(addr: u32, len: u32, prot: u32) -> u32 {
+    let ret;
+    // SAFETY: SVC #23 (Mprotect) per the thumos ABI.
+    unsafe {
+        core::arch::asm!(
+            "svc #0",
+            in("r7") 23u32,
+            inlateout("r0") addr => ret,
+            in("r1") len,
+            in("r2") prot,
             options(nostack),
         );
     }
@@ -332,6 +377,65 @@ pub extern "C" fn _start() -> ! {
             } else {
                 b"forkexec: parent integrity BROKEN\n"
             };
+            sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+        }
+        // #496 guard harness: mmap a PROT_NONE guard page, fork, and prove the
+        // child got its OWN copy of the guard page -- a read faults with a
+        // PERMISSION status (the page EXISTS as PROT_NONE, so fork enumerated the
+        // PL0-inaccessible page), not a TRANSLATION status (which would mean fork
+        // dropped it). Then the parent lifts the guard to PROT_READ and reads it.
+        #[cfg(thumos_init_guard)]
+        {
+            // prot = PROT_NONE (0); flags = MAP_ANONYMOUS (0x20) | fd(-1) in the
+            // high 16 bits (0xFFFF). In a fresh /init the first mmap lands
+            // deterministically at MMAP_BASE.
+            let guard = sys_mmap(0, 4096, 0, 0xFFFF_0020);
+            if guard == u32::MAX {
+                let m = b"init: guard mmap FAILED\n";
+                sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+                sys_exit(1);
+            }
+            let m = b"init: guard mapped\n";
+            sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+            let pid = sys_fork();
+            if pid == 0 {
+                // CHILD: touch the guard -> data-abort. A permission fault
+                // (DFSR status ...0f) proves fork COPIED the PROT_NONE page; a
+                // translation fault (...07) would mean it was dropped.
+                core::ptr::read_volatile(guard as usize as *const u32);
+                // Only reached if the read did NOT fault -- guard not enforced.
+                let m = b"init: guard NOT enforced\n";
+                sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+                sys_exit(2);
+            }
+            if pid == u32::MAX {
+                let m = b"init: guard fork FAILED\n";
+                sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+                sys_exit(1);
+            }
+            // PARENT: reap the guard-killed child (SIGSEGV -> status 139).
+            let status = loop {
+                let s = sys_waitpid(pid);
+                if s != u32::MAX {
+                    break s;
+                }
+                sys_sleep(10);
+            };
+            let m: &[u8] = if status == 139 {
+                b"init: guard child killed status=139\n"
+            } else {
+                b"init: guard child WRONG status\n"
+            };
+            sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+            // PARENT: lift the guard to PROT_READ (=1) and read it -- the frame
+            // survived, and NONE->READ is a live mprotect on a PROT_NONE page.
+            if sys_mprotect(guard, 4096, 1) != 0 {
+                let m = b"init: guard mprotect FAILED\n";
+                sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+                sys_exit(1);
+            }
+            core::ptr::read_volatile(guard as usize as *const u32);
+            let m = b"init: guard readable after mprotect\n";
             sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
         }
         sys_write(1, msg.as_ptr(), u32::try_from(msg.len()).unwrap_or(0));

--- a/crates/thumos/init/init.rs
+++ b/crates/thumos/init/init.rs
@@ -397,12 +397,14 @@ pub extern "C" fn _start() -> ! {
             }
             let m = b"init: guard mapped\n";
             sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+            // The guard VA as a pointer, converted once (mmap returned != MAX).
+            let guard_addr = usize::try_from(guard).unwrap_or(0) as *const u32;
             let pid = sys_fork();
             if pid == 0 {
                 // CHILD: touch the guard -> data-abort. A permission fault
                 // (DFSR status ...0f) proves fork COPIED the PROT_NONE page; a
                 // translation fault (...07) would mean it was dropped.
-                core::ptr::read_volatile(guard as usize as *const u32);
+                core::ptr::read_volatile(guard_addr);
                 // Only reached if the read did NOT fault -- guard not enforced.
                 let m = b"init: guard NOT enforced\n";
                 sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
@@ -434,7 +436,7 @@ pub extern "C" fn _start() -> ! {
                 sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
                 sys_exit(1);
             }
-            core::ptr::read_volatile(guard as usize as *const u32);
+            core::ptr::read_volatile(guard_addr);
             let m = b"init: guard readable after mprotect\n";
             sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
         }

--- a/crates/thumos/src/mmu.rs
+++ b/crates/thumos/src/mmu.rs
@@ -74,6 +74,16 @@ pub(crate) mod page_flags {
     pub(crate) const SHAREABLE: u32 = 1 << 10;
     /// Normal memory for small pages: TEX[2:0]=0b001 (bits [8:6]), C=1 (bit 3), B=1 (bit 2).
     pub(crate) const NORMAL_WB_WA: u32 = (0b001 << 6) | (1 << 3) | (1 << 2);
+    /// Not-global (nG, bit 11), repurposed as a software USER_OWNED tag (#496).
+    /// Every user page (minted through `prot_to_l2_flags`) carries it; the kernel
+    /// fills (`KERNEL_DEFAULT_PAGE`, `wx_page_attrs`) never do. This lets
+    /// `l2_entry_is_user` recognise a PROT_NONE user page -- whose AP (0b01) is
+    /// byte-identical to a kernel fill -- so fork/exit/exec enumeration copies +
+    /// frees it. HW effect: nG makes the TLB entry ASID-tagged; harmless here
+    /// because CONTEXTIDR is pinned 0 (see `program_translation`) and every
+    /// address-space switch does TLBIALL, so `TLBIMVA(VA, ASID=0)` still hits
+    /// user entries.
+    pub(crate) const NG: u32 = 1 << 11;
 }
 
 /// L2 page table: 256 entries x 4 bytes = 1 KB, must be 1 KB aligned.
@@ -165,7 +175,14 @@ pub(crate) mod prot {
 /// WHY: userspace passes POSIX prot flags (PROT_READ|PROT_WRITE|PROT_EXEC),
 /// but the ARM MMU uses AP bits and XN to control access and execution.
 pub(crate) fn prot_to_l2_flags(prot_flags: u32) -> u32 {
-    let mut attrs = page_flags::SMALL_PAGE | page_flags::SHAREABLE | page_flags::NORMAL_WB_WA;
+    // #496: this function is the SOLE funnel for user L2 descriptors (image,
+    // stack, heap/brk, mmap, mprotect all route through it), so tagging nG
+    // (USER_OWNED) here -- unconditionally, every page it mints is a user page --
+    // marks exactly the user pages and nothing else. Enumeration keys on this tag,
+    // not AP, so a PROT_NONE page (AP 0b01) is no longer confused with a kernel
+    // fill.
+    let mut attrs =
+        page_flags::SMALL_PAGE | page_flags::SHAREABLE | page_flags::NORMAL_WB_WA | page_flags::NG;
 
     // Access permissions
     if prot_flags & prot::PROT_WRITE != 0 {
@@ -288,6 +305,32 @@ pub(crate) unsafe fn shatter_section(l1_phys: usize, virt_addr: usize) -> bool {
     }
 }
 
+/// Ensure the MB covering `virt_addr` in `l1_phys` can accept a `map_page` (#496).
+///
+/// `map_page` REFUSES to overlay a 1 MB SECTION descriptor, and the identity map
+/// covers the user windows (the mmap region, the heap) with sections -- so a
+/// syscall that maps a page there must shatter the section first, exactly as
+/// `map_user_image` / `map_user_stack` do at spawn.
+///
+/// Unlike `shatter_section`, an ABSENT L1 entry is not an error here: `map_page`
+/// allocates the L2 itself in that case. So this returns true for absent and for
+/// already-shattered entries, and only shatters an actual section.
+///
+/// # Safety
+///
+/// Same as `shatter_section`; on a LIVE table the caller must flush the TLB for
+/// the affected VA (the stale section entry would otherwise still resolve).
+pub(crate) unsafe fn ensure_page_mappable(l1_phys: usize, virt_addr: usize) -> bool {
+    let l1_index = virt_addr >> 20;
+    // SAFETY: the caller guarantees `l1_phys` is a valid L1 table.
+    let l1_val = unsafe { (l1_phys as *const u32).add(l1_index).read_volatile() };
+    if l1_val & 0b11 != flags::SECTION {
+        return true; // absent (map_page allocates) or already a page table
+    }
+    // SAFETY: the entry is a section; shatter it into a KERNEL_DEFAULT L2.
+    unsafe { shatter_section(l1_phys, virt_addr) }
+}
+
 /// Rewrite every entry of an already-shattered identity MB back to
 /// `KERNEL_DEFAULT_PAGE`, dropping all PL0 grants in that MB (#482, used by exec
 /// to revoke the old image's user windows). Returns false if not shattered.
@@ -332,20 +375,22 @@ pub(crate) unsafe fn read_l2_entry(l1_phys: usize, virt_addr: usize) -> Option<u
     }
 }
 
-/// True if a small-page L2 descriptor grants ANY PL0 access (#478).
+/// True if a small-page L2 descriptor is a USER-OWNED page (#478, #496).
 ///
-/// A small-page descriptor is bits[1:0] = 0b1X, where bit 1 marks the small
-/// page and bit 0 is the XN flag -- so an executable page is 0b10 and an
-/// execute-never (data/stack) page is 0b11. Checking `bit 1 set` (not `== 0b10`)
-/// therefore catches BOTH; a large-page (0b01) or fault (0b00) entry is
-/// rejected. ARM AP[1:0] at bits [5:4]: PL0 has access iff AP[1:0] >= 0b10
-/// (0b10 user-RO, 0b11 user-RW); 0b01 is PL1-only in both APX variants
-/// (`AP_KERNEL_ONLY`, `AP_KERNEL_RO`). So this selects exactly the pages a PL0
-/// process can touch -- image, stack, heap/mmap -- and rejects sections and
-/// every kernel-only entry (the shared `KERNEL_L2` at L1[0x400] carries no user
-/// AP, so it is skipped).
+/// A small-page descriptor is bits[1:0] = 0b1X (bit 1 marks the small page, bit
+/// 0 is XN), so `bit 1 set` catches an executable (0b10) or execute-never (0b11)
+/// page and rejects a large-page (0b01) or fault (0b00) entry. Ownership is then
+/// decided by the software `NG` (USER_OWNED) tag, NOT by AP: `prot_to_l2_flags`
+/// sets NG on every user page (image, stack, heap/mmap), while the kernel fills
+/// (`KERNEL_DEFAULT_PAGE`, `wx_page_attrs`, the shared `KERNEL_L2`) never do.
+///
+/// WHY NG and not AP (#496): a PROT_NONE user page maps to AP=0b01
+/// (`AP_KERNEL_ONLY`) -- byte-identical to a kernel fill -- so the old AP >= 0b10
+/// test dropped it from fork's deep-copy and from exit/exec teardown. Keying on
+/// the ownership tag enumerates PROT_NONE user pages while still rejecting every
+/// kernel entry.
 pub(crate) fn l2_entry_is_user(entry: u32) -> bool {
-    entry & 0b10 != 0 && (entry >> 4) & 0b11 >= 0b10
+    entry & page_flags::SMALL_PAGE != 0 && entry & page_flags::NG != 0
 }
 
 /// Visit every PL0-accessible small page in `l1_phys`, calling `f(va, phys,
@@ -780,6 +825,22 @@ unsafe fn program_translation() {
         core::arch::asm!(
             "mcr p15, 0, {val}, c3, c0, 0",
             val = in(reg) 1u32,  // NOTE: domain 0 = client access
+        );
+    }
+
+    // CONTEXTIDR = 0 (ASID 0). #496: user L2 descriptors carry the nG bit as a
+    // software USER_OWNED tag (page_flags::NG); nG makes the TLB entry ASID-tagged,
+    // so flush_tlb_page/TLBIMVA -- which passes a page-aligned VA whose ASID field
+    // is 0 -- only invalidates a user entry when that entry's ASID is also 0. With
+    // no ASID scheme (constant CONTEXTIDR + TLBIALL on every address-space switch)
+    // that just requires CONTEXTIDR to be 0. QEMU resets it to 0; this makes the
+    // invariant explicit and hardens hardware whose reset value is UNKNOWN per ARMv7.
+    // SAFETY: CP15 CONTEXTIDR (c13, c0, 1); privileged, once at boot before enable.
+    unsafe {
+        core::arch::asm!(
+            "mcr p15, 0, {zero}, c13, c0, 1",  // CONTEXTIDR = 0
+            "isb",
+            zero = in(reg) 0u32,
         );
     }
 
@@ -1576,6 +1637,58 @@ mod tests {
     }
 
     #[test]
+    fn ensure_page_mappable_shatters_a_section_and_tolerates_an_absent_entry() {
+        // #496: sys_mmap maps into a window the identity map covers with a 1 MB
+        // SECTION, and map_page refuses to overlay a section -- so mmap failed on
+        // every REAL table (it only ever worked against synthetic host tables
+        // whose L1 entries are absent). ensure_page_mappable is that missing step.
+        // Unlike shatter_section it treats an ABSENT entry as success, because
+        // map_page allocates the L2 itself in that case.
+        reset();
+        unsafe {
+            init_and_enable();
+            let dst = alloc_addr_space().unwrap();
+            clone_addr_space(table_base(), dst);
+            let attrs = prot_to_l2_flags(prot::PROT_READ);
+
+            // A cloned identity MB is a SECTION -> shattered, then mappable.
+            let section_mb = 0x505usize << 20;
+            assert!(
+                ensure_page_mappable(dst, section_mb),
+                "a section must be shattered"
+            );
+            let page = section_mb + 3 * 0x1000;
+            assert!(
+                map_page(dst, page, page, attrs),
+                "map_page must overlay the now-shattered MB"
+            );
+            // Idempotent: the MB is a page table now, and the grant survives.
+            assert!(
+                ensure_page_mappable(dst, section_mb),
+                "an already-shattered MB is a no-op"
+            );
+            assert_eq!(
+                read_l2_entry(dst, page).unwrap(),
+                (page as u32) | attrs,
+                "the user grant must survive"
+            );
+
+            // An ABSENT L1 entry is not an error -- map_page allocates the L2.
+            let absent_mb = 0x900usize << 20;
+            (dst as *mut u32).add(absent_mb >> 20).write_volatile(0);
+            assert!(
+                ensure_page_mappable(dst, absent_mb),
+                "an absent entry is not an error"
+            );
+            assert!(
+                map_page(dst, absent_mb, absent_mb, attrs),
+                "map_page allocates the L2 for an absent entry"
+            );
+            free_addr_space(dst);
+        }
+    }
+
+    #[test]
     fn user_page_attrs_grant_pl0_and_are_write_xor_execute() {
         // #482: user segment permissions via prot_to_l2_flags -- text RX,
         // rodata RO+XN, data/stack RW+XN; W|X degrades to RW+XN (W^X); and each
@@ -1763,19 +1876,32 @@ mod tests {
         // XN), so an execute-never DATA/stack page is 0b11 -- NOT 0b10. The
         // enumerator must catch it, or a fork would silently skip every user
         // data/stack page (the bug this test pins).
-        // User RX (.text): SMALL_PAGE | AP_READ_ONLY, XN clear -> bits 0b10.
+        // User RX (.text): SMALL_PAGE | AP_READ_ONLY | NG, XN clear -> bits 0b10.
         assert!(l2_entry_is_user(
-            page_flags::SMALL_PAGE | page_flags::AP_READ_ONLY
+            page_flags::SMALL_PAGE | page_flags::AP_READ_ONLY | page_flags::NG
         ));
-        // User RW+XN (.data/stack): SMALL_PAGE | XN | AP_FULL -> bits 0b11.
+        // User RW+XN (.data/stack): SMALL_PAGE | XN | AP_FULL | NG -> bits 0b11.
         assert!(l2_entry_is_user(
-            page_flags::SMALL_PAGE | page_flags::XN | page_flags::AP_FULL
+            page_flags::SMALL_PAGE | page_flags::XN | page_flags::AP_FULL | page_flags::NG
         ));
+        // #496: ownership is the NG tag, NOT the AP bits -- a PROT_NONE user page
+        // (AP 0b01, byte-identical in AP to a kernel fill) IS user, and an
+        // untagged PL0-accessible descriptor is NOT (nothing mints one).
+        assert!(
+            l2_entry_is_user(prot_to_l2_flags(0)),
+            "PROT_NONE user page must enumerate (#496)"
+        );
+        assert!(
+            !l2_entry_is_user(page_flags::SMALL_PAGE | page_flags::AP_FULL),
+            "untagged descriptor is not user-owned"
+        );
         // Real attrs from prot_to_l2_flags must all count as user.
         for prot in [
             prot::PROT_READ | prot::PROT_EXEC,
             prot::PROT_READ,
             prot::PROT_READ | prot::PROT_WRITE,
+            prot::PROT_EXEC,
+            0,
         ] {
             assert!(l2_entry_is_user(prot_to_l2_flags(prot)), "prot {prot:#x}");
         }

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -2143,16 +2143,19 @@ mod tests {
             let pt = proc.page_table_phys;
             assert_ne!(pt, mmu::table_base(), "must have its own address space");
 
-            // .text page: user RX (0x46E); .data page: user RW+XN (0x47F).
+            // .text page: user RX (0x46E); .data page: user RW+XN (0x47F). Both
+            // carry the #496 NG (USER_OWNED) tag at bit 11 (0x800), so enumeration
+            // sees them by ownership rather than by AP: 0x46E|0x800 = 0xC6E,
+            // 0x47F|0x800 = 0xC7F.
             assert_eq!(
                 mmu::read_l2_entry(pt, 0x7FF0_0000).unwrap(),
-                0x7FF0_0000u32 | 0x46E,
-                ".text must be user read-execute"
+                0x7FF0_0000u32 | 0xC6E,
+                ".text must be user read-execute + USER_OWNED-tagged"
             );
             assert_eq!(
                 mmu::read_l2_entry(pt, 0x7FF0_1000).unwrap(),
-                0x7FF0_1000u32 | 0x47F,
-                ".data must be user read-write + execute-never"
+                0x7FF0_1000u32 | 0xC7F,
+                ".data must be user read-write + execute-never + USER_OWNED-tagged"
             );
             // Device MMIO stays a PL1-only SECTION (never a user page table) --
             // a PL0 access to it faults. (Extends the #323 regression.)

--- a/crates/thumos/src/syscall.rs
+++ b/crates/thumos/src/syscall.rs
@@ -1140,12 +1140,26 @@ fn sys_mmap(arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> u32 {
         return MAP_FAILED;
     }
 
-    // #496: PROT_NONE (and exec-only) are now allowed. Such a page maps to
-    // AP[1:0]=0b01 -- byte-identical to a shattered MB's KERNEL_DEFAULT fill --
-    // but `prot_to_l2_flags` tags every user page with the software nG
-    // (USER_OWNED) bit, so `mmu::l2_entry_is_user` recognises it and fork's
-    // deep-copy + exit/exec teardown enumerate it. The page still gets a real
-    // zeroed frame; it just faults on any PL0 access (a guard page).
+    // #496: PROT_NONE is now allowed. Such a page maps to AP[1:0]=0b01 --
+    // byte-identical to a shattered MB's KERNEL_DEFAULT fill -- but
+    // `prot_to_l2_flags` tags every user page with the software nG (USER_OWNED)
+    // bit, so `mmu::l2_entry_is_user` recognises it and fork's deep-copy +
+    // exit/exec teardown enumerate it. The page still gets a real zeroed frame;
+    // it just faults on any PL0 access -- which is exactly a guard page.
+    //
+    // EXEC-ONLY is still refused, and deliberately so: ARMv7 AP governs PL0
+    // instruction fetch and data read TOGETHER (XN can only add a restriction,
+    // never grant execute where AP denies read), so "execute but not read" is
+    // INEXPRESSIBLE here -- prot_to_l2_flags would encode it as AP=0b01, i.e. a
+    // page with NO PL0 access at all. Accepting it would hand back success for a
+    // mapping that can never be executed (a silently-broken capability), and
+    // silently upgrading it to read+exec would grant a permission the caller did
+    // not ask for. Fail closed instead.
+    if prot_flags & (mmu::prot::PROT_READ | mmu::prot::PROT_WRITE) == 0
+        && prot_flags & mmu::prot::PROT_EXEC != 0
+    {
+        return MAP_FAILED;
+    }
 
     // Round length up to page boundary
     let page_count = (length + page::PAGE_SIZE - 1) / page::PAGE_SIZE;
@@ -1393,10 +1407,20 @@ fn sys_mprotect(arg0: u32, arg1: u32, arg2: u32) -> u32 {
         return EINVAL;
     }
 
-    // #496: PROT_NONE (and exec-only) are now allowed -- the nG (USER_OWNED) tag
-    // on every user descriptor keeps such a page enumerable by fork/exit/exec
-    // even though its AP (0b01) matches a kernel fill. mprotect to PROT_NONE
-    // turns a live mapping into a guard page (faults on any PL0 access).
+    // #496: PROT_NONE is now allowed -- the nG (USER_OWNED) tag on every user
+    // descriptor keeps such a page enumerable by fork/exit/exec even though its
+    // AP (0b01) matches a kernel fill. mprotect to PROT_NONE turns a live mapping
+    // into a guard page (faults on any PL0 access).
+    //
+    // EXEC-ONLY stays refused: ARMv7 AP governs PL0 instruction fetch and data
+    // read together, so "execute but not read" is inexpressible -- it would
+    // encode as AP=0b01 (no PL0 access at all), i.e. a mapping that reports
+    // success but can never be executed. Same rationale as sys_mmap.
+    if new_prot & (mmu::prot::PROT_READ | mmu::prot::PROT_WRITE) == 0
+        && new_prot & mmu::prot::PROT_EXEC != 0
+    {
+        return EINVAL;
+    }
 
     // Find the mapping
     let Some(mapping) = process::find_mapping(addr) else {
@@ -2028,6 +2052,40 @@ mod tests {
         assert!(
             mmu::l2_entry_is_user(entry),
             "a PROT_NONE page must still enumerate as user-owned"
+        );
+    }
+
+    #[test]
+    fn mmap_and_mprotect_refuse_exec_only() {
+        // #496: ARMv7 AP governs PL0 instruction fetch and data read TOGETHER (XN
+        // only ever ADDS a restriction), so "execute but not read" is
+        // INEXPRESSIBLE: prot_to_l2_flags encodes PROT_EXEC-alone as AP=0b01 --
+        // a page with NO PL0 access at all. Accepting it would return success for
+        // a mapping that can never be executed (a silently-broken capability);
+        // silently upgrading it to read+exec would grant a permission the caller
+        // never requested. Fail closed. PROT_NONE, by contrast, is honest -- a
+        // guard page that faults BY DESIGN -- and stays allowed.
+        unsafe {
+            setup_mm();
+        }
+        let flags_and_fd: u32 = MAP_ANONYMOUS | (0xFFFF << 16);
+        let len = u32::try_from(crate::page::PAGE_SIZE).unwrap_or_default();
+        assert_eq!(
+            sys_mmap(0, len, mmu::prot::PROT_EXEC, flags_and_fd),
+            MAP_FAILED,
+            "exec-only mmap must be refused (inexpressible on ARMv7 AP)"
+        );
+        let addr = sys_mmap(0, len, mmu::prot::PROT_READ, flags_and_fd);
+        assert_ne!(addr, MAP_FAILED, "setup mmap must succeed");
+        assert_eq!(
+            sys_mprotect(addr, len, mmu::prot::PROT_EXEC),
+            EINVAL,
+            "exec-only mprotect must be refused"
+        );
+        assert_ne!(
+            sys_mmap(0, len, 0, flags_and_fd),
+            MAP_FAILED,
+            "PROT_NONE must still be allowed (#496)"
         );
     }
 

--- a/crates/thumos/src/syscall.rs
+++ b/crates/thumos/src/syscall.rs
@@ -1140,18 +1140,12 @@ fn sys_mmap(arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> u32 {
         return MAP_FAILED;
     }
 
-    // WHY (#478): reject a mapping with NO PL0 access (no PROT_READ and no
-    // PROT_WRITE -- i.e. PROT_NONE or exec-only, both AP[1:0]=0b01, which is
-    // PL0-inaccessible and indistinguishable from a shattered MB's
-    // KERNEL_DEFAULT fill). Such a page cannot be told apart from kernel-owned
-    // scaffolding, so fork's page-table enumeration (mmu::l2_entry_is_user)
-    // would silently omit it from the deep copy AND from teardown. Denying it
-    // keeps the invariant "every user page has AP >= 0b10", so enumeration is
-    // complete. PROT_NONE guard-page support needs membership-based
-    // enumeration -- TODO(#496).
-    if prot_flags & (mmu::prot::PROT_READ | mmu::prot::PROT_WRITE) == 0 {
-        return MAP_FAILED;
-    }
+    // #496: PROT_NONE (and exec-only) are now allowed. Such a page maps to
+    // AP[1:0]=0b01 -- byte-identical to a shattered MB's KERNEL_DEFAULT fill --
+    // but `prot_to_l2_flags` tags every user page with the software nG
+    // (USER_OWNED) bit, so `mmu::l2_entry_is_user` recognises it and fork's
+    // deep-copy + exit/exec teardown enumerate it. The page still gets a real
+    // zeroed frame; it just faults on any PL0 access (a guard page).
 
     // Round length up to page boundary
     let page_count = (length + page::PAGE_SIZE - 1) / page::PAGE_SIZE;
@@ -1232,9 +1226,18 @@ fn sys_mmap(arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> u32 {
             return MAP_FAILED;
         };
 
+        // #496: the mmap window is identity SECTION-mapped in every real process
+        // L1, and map_page REFUSES to overlay a section -- so mmap failed for
+        // EVERY prot on a real table (it only ever worked against the synthetic
+        // tables in host tests). ensure_page_mappable shatters such a section
+        // first, exactly as map_user_image / map_user_stack do at spawn; it is
+        // idempotent (one L2 per MB, shared by the region's other pages and
+        // reclaimed at exit by free_addr_space) and a no-op for an absent entry.
         // SAFETY: pt is the current process's valid L1 table, vaddr is
         // page-aligned within the anonymous mmap region, phys is freshly allocated.
-        let ok = unsafe { mmu::map_page(pt, vaddr, phys, l2_attrs) };
+        let ok = unsafe {
+            mmu::ensure_page_mappable(pt, vaddr) && mmu::map_page(pt, vaddr, phys, l2_attrs)
+        };
         if !ok {
             // map_page failed. #497: free the just-allocated frame + roll back
             // every prior frame under the kernel L1 (zero-on-free aliasing),
@@ -1271,6 +1274,13 @@ fn sys_mmap(arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> u32 {
                 mmu::switch_addr_space(pt);
             }
             return MAP_FAILED;
+        }
+        // #496: this table is LIVE, and the MB was a section until the shatter
+        // above -- invalidate the stale section TLB entry so the access resolves
+        // through the freshly-installed page descriptor.
+        // SAFETY: vaddr is page-aligned in the current process's address space.
+        unsafe {
+            mmu::flush_tlb_page(vaddr);
         }
     }
 
@@ -1383,14 +1393,10 @@ fn sys_mprotect(arg0: u32, arg1: u32, arg2: u32) -> u32 {
         return EINVAL;
     }
 
-    // WHY (#478): reject a new protection with NO PL0 access (PROT_NONE /
-    // exec-only). Same reason as sys_mmap -- an AP[1:0]=0b01 user page is
-    // indistinguishable from kernel scaffolding, so fork's enumeration would
-    // drop it. Keeping every user page at AP >= 0b10 makes the deep copy
-    // complete.
-    if new_prot & (mmu::prot::PROT_READ | mmu::prot::PROT_WRITE) == 0 {
-        return EINVAL;
-    }
+    // #496: PROT_NONE (and exec-only) are now allowed -- the nG (USER_OWNED) tag
+    // on every user descriptor keeps such a page enumerable by fork/exit/exec
+    // even though its AP (0b01) matches a kernel fill. mprotect to PROT_NONE
+    // turns a live mapping into a guard page (faults on any PL0 access).
 
     // Find the mapping
     let Some(mapping) = process::find_mapping(addr) else {
@@ -1956,6 +1962,72 @@ mod tests {
         assert!(
             addr >= process::MMAP_BASE && addr < 0x3000_0000,
             "mmap address 0x{addr:08x} must be in user mmap range"
+        );
+    }
+
+    #[test]
+    fn mmap_prot_none_guard_page_succeeds_and_stays_enumerable() {
+        // #496: a PROT_NONE guard page used to be rejected (MAP_FAILED) because
+        // its AP (0b01) is byte-identical to a shattered MB's KERNEL_DEFAULT fill,
+        // so the old AP-based enumeration would have dropped it from fork's
+        // deep-copy AND from teardown. It is allowed now because
+        // prot_to_l2_flags tags every user page NG (USER_OWNED) -- which is what
+        // l2_entry_is_user keys on -- so the guard page stays enumerable while
+        // still denying PL0 access.
+        unsafe {
+            setup_mm();
+        }
+        let flags_and_fd: u32 = MAP_ANONYMOUS | (0xFFFF << 16);
+        let result = sys_mmap(
+            0,
+            u32::try_from(crate::page::PAGE_SIZE).unwrap_or_default(),
+            0, // PROT_NONE
+            flags_and_fd,
+        );
+        assert_ne!(result, MAP_FAILED, "PROT_NONE mmap must succeed (#496)");
+        let addr = result as usize;
+        let pt = process::current_page_table();
+        // SAFETY: pt is the current process's table and addr was just mapped.
+        let entry = unsafe { mmu::read_l2_entry(pt, addr) }.expect("guard page must be mapped");
+        assert!(
+            mmu::l2_entry_is_user(entry),
+            "guard page must enumerate as user-owned, else fork/exit silently drop it"
+        );
+        assert_eq!(
+            entry & (0b11 << 4),
+            mmu::page_flags::AP_KERNEL_ONLY,
+            "PROT_NONE must grant PL0 no access"
+        );
+    }
+
+    #[test]
+    fn mprotect_to_prot_none_succeeds_and_stays_enumerable() {
+        // #496: mprotect to PROT_NONE (turning a live mapping into a guard page)
+        // was rejected with EINVAL for the same enumeration reason.
+        unsafe {
+            setup_mm();
+        }
+        let flags_and_fd: u32 = MAP_ANONYMOUS | (0xFFFF << 16);
+        let len = u32::try_from(crate::page::PAGE_SIZE).unwrap_or_default();
+        let addr = sys_mmap(
+            0,
+            len,
+            mmu::prot::PROT_READ | mmu::prot::PROT_WRITE,
+            flags_and_fd,
+        );
+        assert_ne!(addr, MAP_FAILED, "setup mmap must succeed");
+        assert_eq!(
+            sys_mprotect(addr, len, 0),
+            0,
+            "mprotect to PROT_NONE must succeed (#496)"
+        );
+        let pt = process::current_page_table();
+        // SAFETY: pt is the current process's table and addr is a live mapping.
+        let entry =
+            unsafe { mmu::read_l2_entry(pt, addr as usize) }.expect("page must stay mapped");
+        assert!(
+            mmu::l2_entry_is_user(entry),
+            "a PROT_NONE page must still enumerate as user-owned"
         );
     }
 


### PR DESCRIPTION
## Finding

`mmap`/`mprotect` rejected PROT_NONE (and exec-only): such a page maps to `AP[1:0]=0b01` — byte-identical to a shattered MB's `KERNEL_DEFAULT` fill — so the AP-based enumeration primitive `mmu::l2_entry_is_user` could not tell a PL0-inaccessible **user** page from kernel scaffolding. It would have silently dropped the page from fork's deep-copy **and** from exit/exec teardown, so the gates denied it to keep the invariant "every user page has AP ≥ 0b10".

## Fix — ownership becomes a tag, not a permission

`prot_to_l2_flags` — the **sole funnel** every user descriptor is minted through (image, stack, brk, mmap, mprotect; fork inherits attrs via `entry & 0xFFF`, which includes bit 11) — now sets the ARMv7 **nG bit (11)** as a software `USER_OWNED` marker, and `l2_entry_is_user` keys on that instead of AP. The kernel fills (`KERNEL_DEFAULT_PAGE`, `wx_page_attrs`, `KERNEL_L2`) never route through the funnel, so they stay invisible to enumeration *by construction*.

This fixes all four consumers at once: fork deep-copy, exit teardown, exec's image-window free (#502), and the `stack_l2_backed` probe.

**The nG hardware caveat (handled):** nG's only effect is ASID-tagging the TLB entry. thumos has no ASID scheme (no CONTEXTIDR write anywhere; `switch_addr_space` = TTBR0 + TLBIALL), so translation is unaffected — but `flush_tlb_page`/TLBIMVA passes a page-aligned VA whose ASID field is 0 and would miss nG entries if CONTEXTIDR were nonzero. `program_translation` now pins **CONTEXTIDR = 0** before MMU enable. QEMU resets it to 0, so that write is hardware-only hardening (ARMv7 leaves the reset value UNKNOWN).

*Rejected alternative — membership-based enumeration* (walk `mappings[]`+stack+heap+image): it splits ownership between PCB fields and the table, and breaks fork's rollback, which calls `free_user_pages(child_pt)` **before any child PCB exists**.

## Also: sys_mmap never worked on a real table

The witness surfaced a latent bug. The mmap window is identity **SECTION**-mapped and `map_page` refuses to overlay a section, so every `mmap` returned `MAP_FAILED` outside host tests (whose synthetic tables have *absent* L1 entries). mmap now calls the new `mmu::ensure_page_mappable` — shatter an actual section; no-op for absent (map_page allocates the L2) or already-shattered — and flushes the stale section TLB entry, mirroring `map_user_image`/`map_user_stack`.

## Evidence — the fault status is the proof

New `guard` variant: /init mmaps a PROT_NONE guard, forks, the child reads it. CI pins the DFSR status:

- `status=0x0000000f` (**PERMISSION**) → the child has its **own copy** of the guard: fork enumerated + deep-copied a PL0-inaccessible page. **This is the fix.**
- `status=0x00000007` (**TRANSLATION**) → the page was dropped from the deep-copy — the exact #496 bug, regressed. CI asserts this is absent.

Observed: `USERFAULT: pid=3 kind=data-abort addr=0x20000000 status=0x0000000f killed`, then the parent reaps the child (SIGSEGV 139) and mprotects the guard NONE→READ and reads it (frame survived).

## Verification

- **All 10 QEMU variants green** (default/kread/kwrite/kexec/cp15/sleep/fork/exec/forkexec/guard) with exact USERFAULT counts and `/shell` coexisting in each — the NG change touches every enumeration path, so the whole matrix was run.
- **2219 host tests** (3 new: PROT_NONE mmap stays enumerable, mprotect-to-NONE, `ensure_page_mappable` across section/absent/shattered).
- armv7a zero-warning; full `kanon gate` green.

## Done when

- [x] A userspace program can `mmap(PROT_NONE)` a guard page, fork, and both processes have independent guard pages that fault on access.
- [x] Exit frees them (tag-based enumeration covers PROT_NONE).
- [x] No kernel page is ever enumerated (kernel fills carry no tag, asserted).