### PR TITLE
feat(thumos): PID-0 fault supervisor — consume + act on fault reports (#492)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,3 +447,47 @@ jobs:
           grep -q 'init: guard readable after mprotect' guard.log || { echo 'FAIL #496: mprotect(PROT_NONE -> PROT_READ) failed, or the guard frame did not survive'; exit 1; }
           grep -q 'shell: hello from userspace' guard.log || { echo 'FAIL #496: /shell did not coexist (#526)'; exit 1; }
           grep -q 'THUMOS-QEMU: service-loop ticks=' guard.log || { echo 'FAIL #496: kernel did not survive the guard fault'; exit 1; }
+      - name: QEMU PID-0 fault supervisor + crash-loop rate limit (#492)
+        working-directory: crates/thumos
+        # WHY: #492. notify_fault used to ipc::send its report to PID 0's inbox,
+        # which NOTHING drained -- so reports piled up until the inbox filled and
+        # legitimate user->PID0 IPC then failed too. PID 0 now drains a dedicated
+        # fault ring each tick: it audit-logs every report and RESTARTS a
+        # supervised service that crashed, rate-limited.
+        #
+        # The crashloop-probe feature makes kinit spawn + supervise /crasher, a
+        # program that data-aborts on EVERY launch. That turns the policy into an
+        # observable sequence: launch, restart x3, give up. The counts are the
+        # assertion -- 'crasher: start' proves the relaunched IMAGE actually ran
+        # (not merely that spawn returned a pid).
+        #
+        # The /shell assertions are the reconciliation with #526: /shell exits
+        # CLEANLY, and a clean exit must NEVER be restarted -- the supervisor keys
+        # on fault reports, never on PCB Dead state. /init is deliberately
+        # unsupervised (supervising it would crash-loop every isolation probe).
+        run: |
+          set -uo pipefail
+          cargo build --release --target armv7a-none-eabi --features qemu,crashloop-probe --jobs 8
+          crc=0
+          THUMOS_QEMU_TIMEOUT=60 ../../scripts/qemu-runner.sh target/armv7a-none-eabi/release/thumos | tee crashloop.log || crc=$?
+          echo "=== crashloop: runner rc=$crc (want 0) ==="
+          test "$crc" -eq 0 || { echo "FAIL #492: kernel did not survive the crash loop (rc=$crc; 124=hang 2/3=abort)"; exit 1; }
+          ! grep -q 'crasher: NOT killed' crashloop.log || { echo 'FAIL #492: /crasher read kernel memory WITHOUT faulting (ISOLATION BROKEN)'; exit 1; }
+          ! grep -q 'supervisor FAILED to restart' crashloop.log || { echo 'FAIL #492: a relaunch failed (ramfs re-plan / load_confined under the kernel L1 broke)'; exit 1; }
+          starts=$(grep -c 'crasher: start' crashloop.log)
+          test "$starts" -eq 4 || { echo "FAIL #492: /crasher ran $starts times (want 4 = initial + 3 restarts) -- the restart policy or the relaunched image is wrong"; exit 1; }
+          restarts=$(grep -c 'kardia: supervisor restarted /crasher' crashloop.log)
+          test "$restarts" -eq 3 || { echo "FAIL #492: $restarts restarts (want 3 = MAX_RESTARTS)"; exit 1; }
+          audited=$(grep -c 'kardia: fault audited pid=' crashloop.log)
+          test "$audited" -eq 4 || { echo "FAIL #492: $audited faults audited (want 4) -- every report must reach the audit trail"; exit 1; }
+          grep -q 'kardia: supervisor giving up on /crasher after 3 restarts' crashloop.log || { echo 'FAIL #492: the crash loop was never rate-limited (no give-up)'; exit 1; }
+          # Give-up must be FINAL: a 5th launch means the limit did not hold.
+          faults=$(grep -c 'USERFAULT:.*kind=data-abort.*killed' crashloop.log)
+          test "$faults" -eq 4 || { echo "FAIL #492: $faults data-abort kills (want 4) -- a 5th means give-up did not stop the loop"; exit 1; }
+          # #526 reconciliation: a CLEAN exit is never a restart trigger.
+          ! grep -q 'supervisor restarted /shell' crashloop.log || { echo 'FAIL #492: /shell exited CLEANLY and was restarted -- the supervisor is keying on Dead state, not on fault reports'; exit 1; }
+          shells=$(grep -c 'shell: hello from userspace' crashloop.log)
+          test "$shells" -eq 1 || { echo "FAIL #492: /shell ran $shells times (want 1) -- a clean exit must not be relaunched"; exit 1; }
+          grep -q 'init: hello from userspace' crashloop.log || { echo 'FAIL #492: /init did not run (unsupervised, must be unaffected)'; exit 1; }
+          grep -q 'kardia: reaped' crashloop.log || { echo 'FAIL #492: the reaper stopped reclaiming slots (the supervisor must not replace it)'; exit 1; }
+          grep -q 'THUMOS-QEMU: service-loop ticks=' crashloop.log || { echo 'FAIL #492: kernel did not survive'; exit 1; }

--- a/crates/thumos/Cargo.toml
+++ b/crates/thumos/Cargo.toml
@@ -35,6 +35,13 @@ qemu = []
 # branch (qemu exit 4, no service-loop resume). Only meaningful with `qemu`;
 # mutually exclusive with `production` (main.rs compile_error!).
 kfault-probe = []
+# WHY (#492 fault supervision): CI crash-loop harness -- kinit spawns /crasher
+# (a program that data-aborts on every launch) and registers it SUPERVISED, so
+# CI can witness PID 0's restart policy end to end: restart x3, then give up.
+# A THUMOS_INIT_VARIANT cannot do this -- variants only select /init's `_start`
+# body, while supervised registration is kinit behaviour. Only meaningful with
+# `qemu`; mutually exclusive with `production` (main.rs compile_error!).
+crashloop-probe = []
 
 [dependencies]
 aes = { version = "0.8", default-features = false }

--- a/crates/thumos/build.rs
+++ b/crates/thumos/build.rs
@@ -273,6 +273,15 @@ fn generate_initramfs(manifest_dir: &Path, out_dir: &Path) {
     let shell_elf = out_dir.join("shell.elf");
     compile_init_binary(&rustc, &shell_src, &init_ld, &shell_elf, None);
 
+    // #492: /crasher -- the fault-supervisor witness. Always embedded (tiny;
+    // inert unless spawned), but kinit only spawns + supervises it under the
+    // `crashloop-probe` feature, so it never runs in a normal boot. It faults on
+    // every launch, letting CI witness restart/restart/restart/give-up.
+    let crasher_src = manifest_dir.join("init/crasher.rs");
+    println!("cargo:rerun-if-changed={}", crasher_src.display());
+    let crasher_elf = out_dir.join("crasher.elf");
+    compile_init_binary(&rustc, &crasher_src, &init_ld, &crasher_elf, None);
+
     let elf = match fs::read(&init_elf) {
         Ok(b) => b,
         Err(e) => die(&format!("#474: cannot read built /init ELF: {e}")),
@@ -285,10 +294,15 @@ fn generate_initramfs(manifest_dir: &Path, out_dir: &Path) {
         Ok(b) => b,
         Err(e) => die(&format!("#526: cannot read built /shell ELF: {e}")),
     };
+    let elf_crasher = match fs::read(&crasher_elf) {
+        Ok(b) => b,
+        Err(e) => die(&format!("#492: cannot read built /crasher ELF: {e}")),
+    };
 
     let mut archive = cpio_newc_entry("init", &elf, 0o100_755);
     archive.extend_from_slice(&cpio_newc_entry("init2", &elf2, 0o100_755));
     archive.extend_from_slice(&cpio_newc_entry("shell", &elf_shell, 0o100_755));
+    archive.extend_from_slice(&cpio_newc_entry("crasher", &elf_crasher, 0o100_755));
     archive.extend_from_slice(&cpio_newc_entry("TRAILER!!!", &[], 0));
     if let Err(e) = fs::write(out_dir.join("initramfs.cpio"), &archive) {
         die(&format!("#474: cannot write initramfs.cpio: {e}"));

--- a/crates/thumos/init/crasher.rs
+++ b/crates/thumos/init/crasher.rs
@@ -1,0 +1,69 @@
+//! thumos /crasher (#492): the fault-supervisor witness.
+//!
+//! A supervised service that FAULTS on every launch. It prints a marker first --
+//! so the log proves the image actually RAN, not merely that spawn returned --
+//! then reads kernel memory, which data-aborts at PL0 (0x4000_8000 is PL1-only
+//! in every process table, #482), killing it every time.
+//!
+//! kinit spawns + registers it supervised ONLY under the `crashloop-probe`
+//! feature, so PID 0's restart policy can be witnessed end to end in QEMU:
+//! restart, restart, restart, then give up. It is never in a normal boot.
+#![no_std]
+#![no_main]
+
+/// write(fd, buf, len) via the thumos ABI (r7 = num, r0-r2 = args).
+///
+/// # Safety
+/// `buf` must point to `len` readable bytes in the loaded image.
+#[inline(always)]
+unsafe fn sys_write(fd: u32, buf: *const u8, len: u32) -> u32 {
+    let ret;
+    // SAFETY: SVC #1 (Write); the kernel validates the buffer.
+    unsafe {
+        core::arch::asm!(
+            "svc #0",
+            in("r7") 1u32,
+            inlateout("r0") fd => ret,
+            in("r1") buf,
+            in("r2") len,
+            options(nostack),
+        );
+    }
+    ret
+}
+
+/// exit(code): never returns.
+///
+/// # Safety
+/// Ends the process; the kernel switches away.
+#[inline(always)]
+unsafe fn sys_exit(code: u32) -> ! {
+    // SAFETY: SVC #0 (Exit); does not return.
+    unsafe {
+        core::arch::asm!("svc #0", in("r7") 0u32, in("r0") code, options(noreturn, nostack));
+    }
+}
+
+/// ELF entry point.
+#[unsafe(no_mangle)]
+pub extern "C" fn _start() -> ! {
+    let msg = b"crasher: start\n";
+    // SAFETY: msg is a .rodata literal in the loaded image; the kernel read below
+    // data-aborts at PL0, so control never falls through on a correctly-isolated
+    // kernel -- this process is killed on every launch, by design.
+    unsafe {
+        sys_write(1, msg.as_ptr(), u32::try_from(msg.len()).unwrap_or(0));
+        core::ptr::read_volatile(0x4000_8000 as *const u32);
+        // Only reached if the kernel read did NOT fault (isolation broken).
+        let bad = b"crasher: NOT killed\n";
+        sys_write(1, bad.as_ptr(), u32::try_from(bad.len()).unwrap_or(0));
+        sys_exit(1);
+    }
+}
+
+/// Panic handler: exit(1). no_std has no unwinding.
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    // SAFETY: exit is the only action available; nothing reads its result.
+    unsafe { sys_exit(1) }
+}

--- a/crates/thumos/src/audit.rs
+++ b/crates/thumos/src/audit.rs
@@ -106,6 +106,9 @@ pub enum AuditEventType {
     ModemTraffic,
     /// Firewall packet forwarded and logged by a `Log`-actioned rule (#403).
     PacketLog,
+    /// A PL0 process faulted and was killed (#492). Logged by the PID-0 fault
+    /// supervisor for EVERY fault report, supervised service or not.
+    UserFault,
 }
 
 impl fmt::Display for AuditEventType {
@@ -123,6 +126,7 @@ impl fmt::Display for AuditEventType {
             Self::ModemAnomaly => write!(f, "MODEM_ANOMALY"),
             Self::ModemTraffic => write!(f, "MODEM_TRAFFIC"),
             Self::PacketLog => write!(f, "PACKET_LOG"),
+            Self::UserFault => write!(f, "USER_FAULT"),
         }
     }
 }
@@ -254,6 +258,7 @@ const fn event_type_discriminant(event: AuditEventType) -> u8 {
         // WHY append-only: discriminants are stable wire/HMAC identifiers -- a
         // new variant takes the next integer; existing values never change.
         AuditEventType::PacketLog => 11,
+        AuditEventType::UserFault => 12,
     }
 }
 
@@ -766,6 +771,7 @@ mod tests {
             AuditEventType::ModemAnomaly,
             AuditEventType::ModemTraffic,
             AuditEventType::PacketLog,
+            AuditEventType::UserFault,
         ];
 
         for (i, &et) in event_types.iter().enumerate() {

--- a/crates/thumos/src/kardia.rs
+++ b/crates/thumos/src/kardia.rs
@@ -709,6 +709,45 @@ fn emit_marker(serial: &mut Uart, args: core::fmt::Arguments) {
 /// INVARIANT: entered with scheduling already enabled (kinit calls
 /// `process::enable_scheduling()` first); everything here tolerates preemption
 /// at any instruction outside an `IrqSpinlock` critical section.
+/// Relaunch a supervised service from the boot ramfs (#492); returns its new pid.
+///
+/// A restart cannot be reconstructed from the dead PCB -- it retains no image
+/// identity (no path, no entry, no image frame) -- so it re-plans from the ramfs
+/// by name, exactly as kinit's original spawn did.
+///
+/// WHY the explicit kernel-L1 switch under an `IrqGuard`: `switch_to` SKIPS the
+/// TTBR0 write for PID 0 (its `page_table_phys` is 0), so the service loop runs
+/// under whatever table the last user process installed -- but
+/// `elf::load_confined` writes the fresh image frame through raw PHYSICAL
+/// addresses and requires the identity kernel L1 (the #497 aliasing class).
+/// Nothing needs restoring afterwards: the kernel table IS PID 0's canonical
+/// table, and the next `switch_to` installs the successor's. The guard keeps the
+/// load+spawn window atomic against preemption.
+fn restart_supervised(path: &'static str) -> Option<crate::process::Pid> {
+    let _irq = crate::irq::IrqGuard::new();
+    // SAFETY: table_base() is the always-valid identity kernel L1; PID 0 owns no
+    // table of its own, so there is nothing to restore.
+    unsafe {
+        crate::mmu::switch_addr_space(crate::mmu::table_base());
+    }
+    let crate::kinit::UserspaceSpawnPlan::Elf(elf_data) =
+        crate::kinit::plan_userspace_spawn_from_vfs(path)
+    else {
+        return None;
+    };
+    // SAFETY: the identity kernel L1 is live (switched above), satisfying
+    // load_confined's TTBR0 precondition.
+    let loaded = unsafe {
+        crate::elf::load_confined(
+            elf_data,
+            crate::kconfig::USER_TEXT_BASE,
+            crate::kconfig::RAM_END,
+        )
+    }
+    .ok()?;
+    crate::process::spawn_user(&loaded)
+}
+
 pub(crate) fn service_loop(mut kernel: KernelState, mut serial: Uart) -> ! {
     let _ = serial.write_str("[kardia] service loop running\r\n"); // WHY: best-effort loop diagnostic; must not block on a failed UART write
     // #403: install the runtime firewall policy through the production add_rule
@@ -854,6 +893,61 @@ pub(crate) fn service_loop(mut kernel: KernelState, mut serial: Uart) -> ! {
             // otherwise a fault-killed PCB slot leaks and the process table
             // exhausts at MAX_PROCS after repeated user faults. The marker is
             // the reaped-half witness the CI isolation matrix asserts.
+            // #492: drain the fault ring BEFORE the reaper frees any slot, so a
+            // drained report's pid cannot alias a slot this same pass reuses.
+            // Every report is audit-logged; a SUPERVISED service that crashed is
+            // relaunched, rate-limited. The supervisor keys on fault reports and
+            // never on PCB Dead state, so a service that exits CLEANLY (as /shell
+            // does today) is provably never relaunched.
+            while let Some(report) = crate::supervisor::pop_report() {
+                let (detail, detail_len) = crate::supervisor::audit_detail(&report);
+                {
+                    // Split the borrow: log_event needs &mut audit AND &audit_key.
+                    let KernelState {
+                        audit, audit_key, ..
+                    } = &mut kernel;
+                    let _ = audit.log_event(
+                        crate::audit::AuditEventType::UserFault,
+                        u32::from(report.pid),
+                        &detail[..detail_len],
+                        now,
+                        audit_key.as_bytes(),
+                    );
+                }
+                let _ = write!(
+                    serial,
+                    "kardia: fault audited pid={} kind={}\r\n",
+                    report.pid, report.kind
+                ); // WHY: best-effort diagnostic + the #492 audit witness
+                match crate::supervisor::decide(&report, now) {
+                    crate::supervisor::Decision::None => {}
+                    crate::supervisor::Decision::Restart(path) => {
+                        let new_pid = restart_supervised(path);
+                        crate::supervisor::set_current_pid(path, new_pid);
+                        match new_pid {
+                            Some(pid) => {
+                                let _ = write!(
+                                    serial,
+                                    "kardia: supervisor restarted {path} (PID {pid})\r\n"
+                                );
+                            }
+                            None => {
+                                let _ = write!(
+                                    serial,
+                                    "kardia: supervisor FAILED to restart {path}\r\n"
+                                );
+                            }
+                        }
+                    }
+                    crate::supervisor::Decision::GiveUp(path) => {
+                        let _ = write!(
+                            serial,
+                            "kardia: supervisor giving up on {path} after {} restarts\r\n",
+                            crate::supervisor::max_restarts()
+                        );
+                    }
+                }
+            }
             let reaped = crate::process::reap_dead_children();
             if reaped > 0 {
                 let _ = write!(

--- a/crates/thumos/src/kardia.rs
+++ b/crates/thumos/src/kardia.rs
@@ -745,7 +745,17 @@ fn restart_supervised(path: &'static str) -> Option<crate::process::Pid> {
         )
     }
     .ok()?;
-    crate::process::spawn_user(&loaded)
+    let pid = crate::process::spawn_user(&loaded)?;
+    // #492: record the new pid BEFORE the guard drops -- spawn-then-register must
+    // be ATOMIC against preemption. The relaunched service is by definition one
+    // that crashes; if the timer IRQ landed between the spawn and this write, the
+    // scheduler could run it and its fault would resolve to no claim
+    // (service=None), so the crash would be audited but never counted against the
+    // budget -- silently ending supervision without ever reaching give-up. The
+    // early returns above leave the claim as the fault path already released it
+    // (None), which is correct: no relaunch happened.
+    crate::supervisor::set_current_pid(path, Some(pid));
+    Some(pid)
 }
 
 pub(crate) fn service_loop(mut kernel: KernelState, mut serial: Uart) -> ! {
@@ -922,8 +932,9 @@ pub(crate) fn service_loop(mut kernel: KernelState, mut serial: Uart) -> ! {
                 match crate::supervisor::decide(&report, now) {
                     crate::supervisor::Decision::None => {}
                     crate::supervisor::Decision::Restart(path) => {
+                        // restart_supervised records the new pid itself, inside its
+                        // IrqGuard -- spawn-then-register must be atomic (see there).
                         let new_pid = restart_supervised(path);
-                        crate::supervisor::set_current_pid(path, new_pid);
                         match new_pid {
                             Some(pid) => {
                                 let _ = write!(

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -377,7 +377,7 @@ fn halt_boot(serial: &mut Uart, display_ok: bool) -> ! {
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum UserspaceSpawnPlan<'a> {
+pub(crate) enum UserspaceSpawnPlan<'a> {
     Elf(&'a [u8]),
     Missing,
 }
@@ -390,7 +390,7 @@ fn plan_userspace_spawn_from_ramfs<'a>(fs: &'a RamFs, path: &str) -> UserspaceSp
     }
 }
 
-fn plan_userspace_spawn_from_vfs(path: &str) -> UserspaceSpawnPlan<'static> {
+pub(crate) fn plan_userspace_spawn_from_vfs(path: &str) -> UserspaceSpawnPlan<'static> {
     // SAFETY: the VFS mount table is initialized before userspace spawn.
     match unsafe { fd::ramfs_find(path) } {
         Some(elf_data) => UserspaceSpawnPlan::Elf(elf_data),
@@ -1371,6 +1371,14 @@ pub unsafe fn run() -> ! {
                         if let Some(pid) = process::spawn_user(&loaded) {
                             let _ = write!(serial, "       /shell spawned PL0 (PID {})\r\n", pid);
                             state.processes_spawned += 1;
+                            // #492: /shell is a SUPERVISED service -- if it
+                            // CRASHES, PID 0 relaunches it (rate-limited). A clean
+                            // exit never triggers a restart: the supervisor keys on
+                            // fault reports, not on Dead state. /init is
+                            // deliberately NOT supervised -- the isolation-probe
+                            // variants fault it on purpose and CI asserts exactly
+                            // one USERFAULT, which supervising it would crash-loop.
+                            crate::supervisor::register("/shell", pid);
                         } else {
                             let _ = serial.write_str("  WARN /shell spawn failed\r\n");
                         }
@@ -1384,6 +1392,33 @@ pub unsafe fn run() -> ! {
                 let _ =
                     serial.write_str("  WARN /shell missing from root ramfs; no shell spawned\r\n");
                 state.userspace_entries_missing += 1;
+            }
+        }
+
+        // #492: the crash-loop witness, spawned + SUPERVISED only under the
+        // crashloop-probe feature (never in a normal boot). /crasher data-aborts
+        // on every launch, so PID 0's restart policy becomes observable in QEMU:
+        // restart up to the limit, then give up. This has to live in kinit rather
+        // than a THUMOS_INIT_VARIANT -- a variant only selects /init's `_start`
+        // body, whereas supervised registration is kinit behaviour.
+        #[cfg(feature = "crashloop-probe")]
+        if let UserspaceSpawnPlan::Elf(elf_data) = plan_userspace_spawn_from_vfs("/crasher") {
+            // SAFETY (#502): kinit runs under the kernel L1 (proc0's table,
+            // scheduling disabled), satisfying load_confined's TTBR0 precondition.
+            match unsafe { elf::load_confined(elf_data, kconfig::USER_TEXT_BASE, kconfig::RAM_END) }
+            {
+                Ok(loaded) => {
+                    if let Some(pid) = process::spawn_user(&loaded) {
+                        let _ = write!(serial, "       /crasher spawned PL0 (PID {})\r\n", pid);
+                        state.processes_spawned += 1;
+                        crate::supervisor::register("/crasher", pid);
+                    } else {
+                        let _ = serial.write_str("  WARN /crasher spawn failed\r\n");
+                    }
+                }
+                Err(e) => {
+                    let _ = write!(serial, "  WARN /crasher ELF load failed: {:?}\r\n", e);
+                }
             }
         }
 

--- a/crates/thumos/src/main.rs
+++ b/crates/thumos/src/main.rs
@@ -68,6 +68,14 @@ compile_error!(
     "kfault-probe is a CI fault-injection harness; a production image must not contain a deliberate kernel fault."
 );
 
+// WHY (#492 fault supervision): crashloop-probe makes kinit spawn + supervise a
+// program that faults on every launch, purely so CI can witness the restart
+// policy. A production image must never boot a deliberate crash loop.
+#[cfg(all(feature = "crashloop-probe", feature = "production"))]
+compile_error!(
+    "crashloop-probe is a CI crash-loop harness; a production image must not spawn a deliberately faulting service."
+);
+
 // WHY (issue #372): also gated `not(test)` — the console's command methods
 // (cmd_mem/cmd_ps/…) read kernel state via `crate::heap`/`page`/`process`,
 // several of which are themselves `#[cfg(not(test))]`, so the module cannot
@@ -182,6 +190,10 @@ mod slab;
 mod sms;
 mod socket;
 mod status_bar;
+// NOTE (#492/#528): deliberately NOT cfg(not(test)) like kardia/kinit -- the
+// fault ring + restart policy are pure logic, and gating them out of the test
+// build would make their tests dead source (the #528 trap).
+mod supervisor;
 mod syscall;
 mod t9;
 mod telephony;

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -459,21 +459,55 @@ unsafe fn revoke_user_pages(pt: usize, base: usize, pages: usize) {
 /// (svc/IRQ) while the process data/prefetch-aborts on any access to kernel
 /// memory. The #465 trap frame carries the per-process cpsr, so switching
 /// between PID 0 (System) and a PL0 process needs no asm change.
+/// Free the image frame `load_confined` allocated for an ELF that will NOT be
+/// spawned (#502).
+///
+/// INVARIANT: the page table takes ownership of that frame only once
+/// `map_user_image` succeeds -- after which exit's L2 walk reclaims it. EVERY
+/// `spawn_user` failure return before that point must come through here, or the
+/// run is orphaned for the rest of the boot: there is no PCB and no page table
+/// left that could ever reclaim it.
+///
+/// WHY this matters now (#492): spawn_user used to be called only by kinit's
+/// one-shot boot spawns, where a full process table / exhausted address-space
+/// pool is not a realistic condition. The fault supervisor relaunches a
+/// crash-looping service through the same path repeatedly, so a leak per
+/// attempt is a real drain under pressure.
+///
+/// # Safety
+///
+/// `loaded.image_phys` must name the still-unmapped contiguous run
+/// `load_confined` allocated, and the caller must run under the identity kernel
+/// L1 (the zero-on-free writes through raw physical addresses).
+unsafe fn free_unspawned_image(loaded: &crate::elf::LoadedElf) {
+    if loaded.image_pages > 0 {
+        // SAFETY: per this function's contract.
+        unsafe { page::free_contiguous(loaded.image_phys, loaded.image_pages) };
+    }
+}
+
 pub(crate) fn spawn_user(loaded: &crate::elf::LoadedElf) -> Option<Pid> {
     // SAFETY: PROCS/CURRENT via the established addr_of_mut! pattern; single
     // core, no concurrent access at spawn.
     unsafe {
         let procs = &mut *addr_of_mut!(PROCS);
-        let slot = procs.iter().position(|p| p.is_none())?;
+        let Some(slot) = procs.iter().position(|p| p.is_none()) else {
+            free_unspawned_image(loaded); // process table full
+            return None;
+        };
         let pid = slot as Pid;
 
-        let new_pt = mmu::alloc_addr_space()?;
+        let Some(new_pt) = mmu::alloc_addr_space() else {
+            free_unspawned_image(loaded); // address-space pool exhausted
+            return None;
+        };
         mmu::clone_addr_space(mmu::table_base(), new_pt);
 
         // Stack: a CONTIGUOUS run (#475) so stack_top arithmetic and
         // exit_cleanup's free loop (base + i*PAGE_SIZE) hold, and the PL0 stack
         // has no unmapped hole SP could descend into.
         let Some(stack_base) = page::alloc_contiguous(STACK_PAGES) else {
+            free_unspawned_image(loaded);
             mmu::free_addr_space(new_pt);
             return None;
         };
@@ -483,13 +517,7 @@ pub(crate) fn spawn_user(loaded: &crate::elf::LoadedElf) -> Option<Pid> {
             // free_addr_space also reclaims the L2 tables the shatters allocated
             // (the shared KERNEL_L2 is skipped -- free_l2_table no-ops on
             // non-pool addresses).
-            // #502: on success the page table owns the image frame (freed at
-            // exit by the L2 walk); on THIS failure the mapping is incomplete,
-            // so free the frame load_confined allocated here (spawn_user runs
-            // under the kernel L1 via kinit, so the zero-on-free is identity).
-            if loaded.image_pages > 0 {
-                page::free_contiguous(loaded.image_phys, loaded.image_pages);
-            }
+            free_unspawned_image(loaded);
             page::free_contiguous(stack_base, STACK_PAGES);
             mmu::free_addr_space(new_pt);
             return None;
@@ -1579,6 +1607,13 @@ pub unsafe fn deliver_signal_to(pid: Pid, sig: Signal) -> u32 {
             // wakes a dead process, and sys_futex_wake only frees a slot on
             // a matching wake (#364).
             crate::futex::free_waiters_for_pid(u32::from(pid));
+            // #492: every Dead transition also releases the pid's supervised
+            // claim. A KILLED service files no fault report (so report_fault
+            // never releases it) and never runs exit_cleanup, so without this a
+            // stale claim would misattribute a later fault on the reused pid to
+            // this service -- the pid-reuse class the fault-time resolution and
+            // exit_cleanup's clear_pid close on the other two death paths.
+            crate::supervisor::clear_pid(pid);
             return 0;
         }
         match proc.signal_state.action(sig) {
@@ -1593,6 +1628,10 @@ pub unsafe fn deliver_signal_to(pid: Pid, sig: Signal) -> u32 {
                     crate::fd::close_all(&mut proc.fds);
                     // WHY: see the SIGKILL branch above (#364).
                     crate::futex::free_waiters_for_pid(u32::from(pid));
+                    // #492: release the supervised claim -- see the SIGKILL
+                    // branch above (a default-Terminate is the same death path
+                    // for supervision purposes: no fault report, no exit_cleanup).
+                    crate::supervisor::clear_pid(pid);
                 }
                 crate::signal::DefaultAction::Ignore => {}
             },
@@ -3704,6 +3743,41 @@ mod tests {
             assert!(
                 !crate::futex::has_waiter_for_pid(u32::from(child_pid)),
                 "SIGKILL must free the dying process's futex waiter slot"
+            );
+        }
+    }
+
+    #[test]
+    fn sigkill_releases_the_dying_pids_supervised_claim() {
+        // #492: a KILLED service files no fault report and never runs
+        // exit_cleanup, so the signal path is the ONLY place that can release its
+        // supervised claim. Without this, the claim outlives the process and a
+        // later fault on the REUSED pid resolves to the dead service -- the
+        // pid-reuse misattribution the fault-time resolution + exit_cleanup's
+        // clear_pid close on the other two death paths.
+        // SAFETY: test-only; reset_all reinitialises global state; nextest runs
+        // each test in its own process.
+        unsafe {
+            reset_all();
+            crate::supervisor::reset();
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            let pt = mmu::alloc_addr_space().unwrap();
+            procs[0] = Some(test_process(pt));
+            CURRENT = 0;
+
+            let child_pid = fork().unwrap_or_default();
+            crate::supervisor::register("/svc", child_pid);
+
+            let ret = deliver_signal_to(child_pid, crate::signal::Signal::Sigkill);
+            assert_eq!(ret, 0, "SIGKILL delivery should succeed");
+
+            // The pid is now reusable: a fault on it must resolve to NOTHING.
+            crate::supervisor::report_fault(child_pid, 1, 0, 0);
+            let report = crate::supervisor::pop_report().expect("report");
+            assert_eq!(
+                report.service, None,
+                "SIGKILL must release the supervised claim, so a reused pid cannot \
+                 misattribute a later fault to the killed service"
             );
         }
     }

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -945,41 +945,37 @@ pub(crate) fn reap_dead_children() -> usize {
     reaped
 }
 
-/// Notify kinit (PID 0) that process `faulting_pid` has faulted.
-/// Marks the faulting process Dead and delivers a fault message to PID 0's inbox.
+/// Notify PID 0 that process `faulting_pid` has faulted.
 ///
-/// Payload layout (9 bytes): [pid:1, fault_addr:4 LE, fault_status:4 LE]
+/// Marks the faulting process Dead (releasing its fds) and pushes a
+/// [`crate::supervisor::FaultReport`] onto the dedicated fault ring, which the
+/// service loop drains once per tick: it audit-logs every report and applies the
+/// restart policy to a supervised service (#492).
+///
+/// WHY the ring and not PID 0's IPC inbox (#492): the old protocol
+/// `ipc::send(0, ..)`-ed a 9-byte payload that NOTHING ever drained, so reports
+/// accumulated until the inbox filled -- after which both the reports and any
+/// legitimate userspace `send(0, ..)` were rejected. Draining the inbox instead
+/// is not an option: `ipc::recv` pops the FRONT regardless of tag, so it would
+/// discard real user->PID0 IPC. A separate channel is what makes the drain safe,
+/// and it removes the `CURRENT`-swap this function needed only so `ipc::send`
+/// would stamp the faulting pid as the sender.
 pub(crate) fn notify_fault(faulting_pid: Pid, kind: FaultKind) {
     let (tag, fault_addr, fault_status) = match kind {
         FaultKind::DataAbort {
             fault_addr,
             fault_status,
-        } => (1u32, fault_addr, fault_status),
+        } => (1u8, fault_addr, fault_status),
         FaultKind::PrefetchAbort {
             fault_addr,
             fault_status,
-        } => (2u32, fault_addr, fault_status),
-        FaultKind::UndefinedInstruction => (3u32, 0u32, 0u32),
+        } => (2u8, fault_addr, fault_status),
+        FaultKind::UndefinedInstruction => (3u8, 0u32, 0u32),
     };
 
-    let payload: [u8; 9] = [
-        faulting_pid,
-        (fault_addr & 0xFF) as u8,
-        ((fault_addr >> 8) & 0xFF) as u8,
-        ((fault_addr >> 16) & 0xFF) as u8,
-        ((fault_addr >> 24) & 0xFF) as u8,
-        (fault_status & 0xFF) as u8,
-        ((fault_status >> 8) & 0xFF) as u8,
-        ((fault_status >> 16) & 0xFF) as u8,
-        ((fault_status >> 24) & 0xFF) as u8,
-    ];
-
-    let msg = ipc::Message::new(tag, &payload);
-
-    // SAFETY: current process PCB pointer is valid; set by the scheduler on
-    // context switch. Temporarily mutating CURRENT to deliver the fault message
-    // with the faulting PID as sender; CURRENT is restored before returning.
-    let sent = unsafe {
+    // SAFETY: the PCB table is only mutated from kernel mode on this single-core
+    // kernel, and this runs in abort context with IRQs masked.
+    unsafe {
         let procs = &mut *addr_of_mut!(PROCS);
         if let Some(ref mut proc) = procs[usize::from(faulting_pid)] {
             proc.state = State::Dead;
@@ -987,35 +983,22 @@ pub(crate) fn notify_fault(faulting_pid: Pid, kind: FaultKind) {
             // its fds here so OFDs (and pipe/socket ends) do not leak.
             crate::fd::close_all(&mut proc.fds);
         }
-        // WHY: ipc::send stamps msg.from = current_pid(); temporarily set CURRENT
-        // to faulting_pid so the message arrives with the correct sender identity.
-        let saved = CURRENT;
-        CURRENT = faulting_pid;
-        let sent = ipc::send(0, msg).is_ok();
-        CURRENT = saved;
-        sent
-    };
-
-    // WHY: kinit (PID 0) is the userspace fault supervisor; a full inbox
-    // means this fault notification is silently lost and the Dead process
-    // (already marked above) is never reaped (#252). Surface the drop on
-    // UART, matching the CAPDEN diagnostic pattern in capability.rs.
-    if !sent {
-        use core::fmt::Write;
-
-        use crate::uart::Uart;
-        let mut serial = Uart::new();
-        write!(
-            serial,
-            "FAULTDROP pid={faulting_pid} tag={tag} kinit-inbox-full\r\n"
-        )
-        .ok();
     }
+
+    // A full ring drops the report (and says so on the UART); the scan-based
+    // reaper still reclaims the slot, so only the notification is lost.
+    crate::supervisor::report_fault(faulting_pid, tag, fault_addr, fault_status);
 }
 
 /// Perform exit teardown without the diverging `-> !` signature.
 /// Marks the process Dead, reclaims its page table, and frees stack pages.
 pub(crate) fn exit_cleanup(status: i32) {
+    // #492: this pid is about to be reusable -- drop any supervised claim on it,
+    // so a service that exits CLEANLY (and therefore files no fault report) does
+    // not leave a stale pid an unrelated process could inherit and alias into a
+    // spurious restart. A fault-exit reaches here too, but `report_fault` already
+    // released the claim in abort context, so this is a no-op on that path.
+    crate::supervisor::clear_pid(current_pid());
     // SAFETY: current process PCB pointer is valid; set by the scheduler on
     // context switch. Page table and stack pages are reclaimed only after
     // marking the process Dead; mmu::free_addr_space validates its input.
@@ -2265,9 +2248,17 @@ mod tests {
                 trap_switched(),
                 "the stub epilogue must see a swapped frame"
             );
-            let msg = ipc::recv().expect("PID 0 must receive the fault notification");
-            assert_eq!(msg.tag, 1, "DataAbort IPC tag");
-            assert_eq!(msg.payload()[0], pid, "payload names the faulting PID");
+            // #492: the notification lands on the fault ring the service loop
+            // drains, carrying the full report (kind + addr + status).
+            let report =
+                crate::supervisor::pop_report().expect("PID 0 must receive the fault notification");
+            assert_eq!(report.kind, 1, "DataAbort is kind 1");
+            assert_eq!(report.pid, pid, "the report names the faulting PID");
+            assert_eq!(
+                report.fault_addr, 0xDEAD_0000,
+                "the report carries the addr"
+            );
+            assert_eq!(report.fault_status, 0x80D, "the report carries the status");
             trap_leave();
         }
     }
@@ -2996,11 +2987,15 @@ mod tests {
     }
 
     #[test]
-    fn notify_fault_sends_to_pid0() {
+    fn notify_fault_reports_to_the_fault_ring_not_the_ipc_inbox() {
+        // #492: the report goes on the dedicated fault ring the service loop
+        // drains -- NOT PID 0's IPC inbox, which nothing drained (so reports
+        // accumulated until it filled and legitimate user->PID0 IPC then failed).
         // SAFETY: test-only; reset_all reinitialises global state. Single-threaded
         // test execution ensures no concurrent access to PROCS or CURRENT.
         unsafe {
             reset_all();
+            crate::supervisor::reset();
             let procs = &mut *core::ptr::addr_of_mut!(PROCS);
 
             let pt0 = mmu::alloc_addr_space().unwrap();
@@ -3015,15 +3010,17 @@ mod tests {
 
             notify_fault(1, FaultKind::UndefinedInstruction);
 
-            // PID 0 receives the message; tag must be 3 (UndefinedInstruction)
+            let report = crate::supervisor::pop_report()
+                .expect("an UndefinedInstruction fault must reach the fault ring");
+            assert_eq!(report.pid, 1, "the report names the faulting PID");
+            assert_eq!(report.kind, 3, "UndefinedInstruction is kind 3");
+
+            // PID 0's IPC inbox must be untouched -- fault reports no longer
+            // compete with real userspace IPC for its 16 slots.
             CURRENT = 0;
-            let msg =
-                ipc::recv().expect("UndefinedInstruction fault must deliver a message to pid 0");
-            assert_eq!(msg.tag, 3, "UndefinedInstruction tag must be 3");
-            assert_eq!(
-                msg.payload()[0],
-                1u8,
-                "first payload byte must be faulting PID"
+            assert!(
+                ipc::recv().is_none(),
+                "a fault must not consume a PID 0 IPC inbox slot"
             );
         }
     }

--- a/crates/thumos/src/supervisor.rs
+++ b/crates/thumos/src/supervisor.rs
@@ -1,0 +1,563 @@
+//! PID-0 fault supervision (#492): the fault channel + the restart policy.
+//!
+//! A PL0 fault reaches PID 0 as a [`FaultReport`] pushed onto a dedicated ring
+//! from the abort handler, and the service loop drains it once per tick: it
+//! audit-logs every report, and RESTARTS a supervised service that crashed --
+//! with crash-loop rate limiting.
+//!
+//! WHY a dedicated ring, not PID 0's IPC inbox: `notify_fault` used to
+//! `ipc::send(0, ..)` the report, but nothing ever drained it, so reports piled
+//! up and (at `INBOX_SIZE`) were dropped, while any legitimate userspace
+//! `send(0, ..)` then failed with InboxFull. A naive drain is not the answer
+//! either -- `ipc::recv` pops the FRONT regardless of tag, so it would discard
+//! real user->PID0 IPC. Separating the channels is what makes the drain safe,
+//! and it also drops the `CURRENT`-swap hack `notify_fault` needed only so
+//! `ipc::send` would stamp the right sender.
+//!
+//! Concurrency CONTRACT (single-core), mirroring [`crate::reflex`]: the writer
+//! ([`report_fault`]) runs in ABORT context; the drainer ([`pop_report`]) and
+//! the policy run in the service loop (PID 0). All take the same
+//! [`IrqSpinlock`] -- which masks IRQ delivery AND holds a flag for the critical
+//! section -- so a drain can never interleave with a report. The `static mut`s
+//! are never touched off-lock.
+//!
+//! WHY the abort-context writer cannot deadlock on a lock the loop already holds
+//! (this is load-bearing and NOT obvious): the spinlock's flag does NOT nest --
+//! re-entering `lock()` on a held flag would spin forever, with no other core to
+//! release it -- and an abort is an EXCEPTION, so IRQ masking does not prevent
+//! one from being taken. The argument is instead:
+//!
+//! - A PL0 fault can only be taken while a USER process is running, which
+//!   requires the loop to have been preempted by the timer IRQ. IRQ delivery is
+//!   masked for exactly as long as the loop holds this lock, so no user process
+//!   can run -- and therefore no PL0 fault can be raised -- inside that window.
+//! - A PL1 (kernel) fault taken under the lock never reaches here at all:
+//!   `process::fault_disposition` routes a non-User-mode fault to KernelHalt
+//!   (fail-closed), not to `notify_fault`.
+//!
+//! So `report_fault` only ever runs when the loop is NOT in its critical section.
+//!
+//! The reaper ([`crate::process::reap_dead_children`]) stays the slot-reclaim
+//! backstop: it scans PCB `Dead` state, so a report dropped on a full ring still
+//! costs nothing but the notification.
+
+use crate::irq::IrqSpinlock;
+use crate::process::Pid;
+
+/// Fault reports buffered between the abort handler and the service loop.
+///
+/// WHY 16: a tick drains the whole ring, so this only has to absorb the faults
+/// of one 10 ms window. A crash-looping service produces one per restart.
+const RING_SIZE: usize = 16;
+
+/// Supervised services tracked at once. /shell today (+ /crasher under the
+/// crashloop-probe feature); sized for the handful a phone would run.
+const MAX_SUPERVISED: usize = 4;
+
+/// Restarts allowed inside [`WINDOW_TICKS`] before the supervisor gives up.
+const MAX_RESTARTS: u8 = 3;
+
+/// Crash-loop window, in scheduler ticks (100 Hz -> 5 s).
+const WINDOW_TICKS: u64 = 500;
+
+/// A PL0 fault, as handed to PID 0.
+///
+/// `kind` matches the wire tags the old inbox protocol used: 1 = data abort,
+/// 2 = prefetch abort, 3 = undefined instruction.
+///
+/// `service` is resolved AT FAULT TIME, not at drain time. WHY: a pid only
+/// names one process while that process is alive, and pids are reused -- by the
+/// time the loop drains, the faulting pid may already belong to something else,
+/// so a drain-time registry lookup would restart the wrong service (observed:
+/// /crasher was relaunched into /shell's freed pid, and the next fault matched
+/// /shell's stale claim). At fault time the pid is unambiguous: the process is
+/// dying right now.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FaultReport {
+    pub(crate) pid: Pid,
+    pub(crate) kind: u8,
+    pub(crate) fault_addr: u32,
+    pub(crate) fault_status: u32,
+    /// The supervised service this pid WAS, if any.
+    pub(crate) service: Option<&'static str>,
+}
+
+/// A supervised service: a boot-resident program PID 0 relaunches when it
+/// FAULTS. Keyed by ramfs path because the PCB retains no image identity -- a
+/// restart must re-plan from the ramfs by name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SupervisedService {
+    path: &'static str,
+    current_pid: Option<Pid>,
+    restarts_in_window: u8,
+    window_start_tick: u64,
+    gave_up: bool,
+}
+
+/// What the service loop should do about a drained report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Decision {
+    /// Not a supervised service (or already given up): audit only.
+    None,
+    /// Relaunch this service from the ramfs.
+    Restart(&'static str),
+    /// The crash-loop limit is spent -- stop relaunching this service.
+    GiveUp(&'static str),
+}
+
+static LOCK: IrqSpinlock = IrqSpinlock::new();
+
+/// Guarded by [`LOCK`] -- never touch without holding it.
+static mut RING: [Option<FaultReport>; RING_SIZE] = [None; RING_SIZE];
+/// Guarded by [`LOCK`]. Head = next pop, count = live entries (FIFO).
+static mut RING_HEAD: usize = 0;
+static mut RING_COUNT: usize = 0;
+/// Guarded by [`LOCK`].
+static mut SERVICES: [Option<SupervisedService>; MAX_SUPERVISED] = [None; MAX_SUPERVISED];
+
+/// Push a fault report for PID 0. Called from the abort handler.
+///
+/// A full ring DROPS the newest report and says so on the UART: the report is
+/// only a notification, and the scan-based reaper still reclaims the slot, so
+/// dropping is survivable (and preferable to evicting an older, unserviced one).
+pub(crate) fn report_fault(pid: Pid, kind: u8, fault_addr: u32, fault_status: u32) {
+    let _guard = LOCK.lock();
+    // SAFETY: the ring + registry are only touched under LOCK, whose IrqSpinlock
+    // masks IRQ delivery for the critical section -- no abort-vs-loop
+    // interleaving is possible on this single-core kernel.
+    let full = unsafe {
+        // Resolve pid -> service NOW, while the pid still unambiguously names the
+        // dying process, and drop the claim: after this the pid is free to be
+        // reused, and no later fault may match this service through it.
+        let mut service = None;
+        for svc in (*core::ptr::addr_of_mut!(SERVICES)).iter_mut().flatten() {
+            if svc.current_pid == Some(pid) {
+                svc.current_pid = None;
+                service = Some(svc.path);
+                break;
+            }
+        }
+        let count = *core::ptr::addr_of!(RING_COUNT);
+        if count >= RING_SIZE {
+            true
+        } else {
+            let head = *core::ptr::addr_of!(RING_HEAD);
+            let slot = (head + count) % RING_SIZE;
+            (*core::ptr::addr_of_mut!(RING))[slot] = Some(FaultReport {
+                pid,
+                kind,
+                fault_addr,
+                fault_status,
+                service,
+            });
+            *core::ptr::addr_of_mut!(RING_COUNT) = count + 1;
+            false
+        }
+    };
+    if full {
+        use core::fmt::Write;
+
+        use crate::uart::Uart;
+        let mut serial = Uart::new();
+        write!(
+            serial,
+            "FAULTDROP pid={pid} kind={kind} fault-ring-full\r\n"
+        )
+        .ok();
+    }
+}
+
+/// Pop the oldest pending report, or `None` when the ring is empty.
+pub(crate) fn pop_report() -> Option<FaultReport> {
+    let _guard = LOCK.lock();
+    // SAFETY: see `report_fault` -- the ring is only touched under LOCK.
+    unsafe {
+        let count = *core::ptr::addr_of!(RING_COUNT);
+        if count == 0 {
+            return None;
+        }
+        let head = *core::ptr::addr_of!(RING_HEAD);
+        let report = (*core::ptr::addr_of_mut!(RING))[head].take();
+        *core::ptr::addr_of_mut!(RING_HEAD) = (head + 1) % RING_SIZE;
+        *core::ptr::addr_of_mut!(RING_COUNT) = count - 1;
+        report
+    }
+}
+
+/// Register `path` as supervised, currently running as `pid`.
+///
+/// Called by kinit right after a successful supervised spawn. Re-registering a
+/// known path just refreshes its pid (it does NOT reset the crash-loop window,
+/// so a service cannot escape rate limiting by re-registering).
+pub(crate) fn register(path: &'static str, pid: Pid) {
+    let _guard = LOCK.lock();
+    // SAFETY: SERVICES is only touched under LOCK (see `report_fault`).
+    unsafe {
+        let services = &mut *core::ptr::addr_of_mut!(SERVICES);
+        for slot in services.iter_mut() {
+            if let Some(svc) = slot {
+                if svc.path == path {
+                    svc.current_pid = Some(pid);
+                    return;
+                }
+            }
+        }
+        for slot in services.iter_mut() {
+            if slot.is_none() {
+                *slot = Some(SupervisedService {
+                    path,
+                    current_pid: Some(pid),
+                    restarts_in_window: 0,
+                    window_start_tick: 0,
+                    gave_up: false,
+                });
+                return;
+            }
+        }
+    }
+}
+
+/// Point a supervised service at its freshly-restarted pid (`None` if the
+/// relaunch failed, so a later fault cannot match a stale pid).
+pub(crate) fn set_current_pid(path: &'static str, pid: Option<Pid>) {
+    let _guard = LOCK.lock();
+    // SAFETY: SERVICES is only touched under LOCK (see `report_fault`).
+    unsafe {
+        let services = &mut *core::ptr::addr_of_mut!(SERVICES);
+        for svc in services.iter_mut().flatten() {
+            if svc.path == path {
+                svc.current_pid = pid;
+                return;
+            }
+        }
+    }
+}
+
+/// Decide what a drained report means for supervision.
+///
+/// Keyed on the report's fault-time-resolved `service`, never on a drain-time pid
+/// lookup (pids are reused) and never on PCB `Dead` state -- so a service that
+/// exits CLEANLY (like /shell today) is never relaunched; only a crash is.
+pub(crate) fn decide(report: &FaultReport, now: u64) -> Decision {
+    let Some(path) = report.service else {
+        return Decision::None; // not a supervised service: audit only
+    };
+    let _guard = LOCK.lock();
+    // SAFETY: SERVICES is only touched under LOCK (see `report_fault`).
+    unsafe {
+        let services = &mut *core::ptr::addr_of_mut!(SERVICES);
+        for svc in services.iter_mut().flatten() {
+            if svc.path != path {
+                continue;
+            }
+            if svc.gave_up {
+                return Decision::None;
+            }
+            // A fault outside the window opens a fresh one -- an occasional
+            // crash every few minutes is not a crash LOOP.
+            if now.saturating_sub(svc.window_start_tick) > WINDOW_TICKS {
+                svc.window_start_tick = now;
+                svc.restarts_in_window = 0;
+            }
+            if svc.restarts_in_window < MAX_RESTARTS {
+                svc.restarts_in_window += 1;
+                return Decision::Restart(svc.path);
+            }
+            svc.gave_up = true;
+            return Decision::GiveUp(svc.path);
+        }
+        Decision::None
+    }
+}
+
+/// Drop any supervised claim on `pid` -- that process is gone.
+///
+/// Called from the EXIT path, so a service that exits CLEANLY (and therefore
+/// never files a fault report) cannot leave a stale pid behind for an unrelated
+/// process to inherit and alias into a spurious restart. A fault-exit reaches
+/// here too, but `report_fault` already released the claim, so this is a no-op
+/// there -- which is why the claim must be released at fault time and not here.
+pub(crate) fn clear_pid(pid: Pid) {
+    let _guard = LOCK.lock();
+    // SAFETY: SERVICES is only touched under LOCK (see `report_fault`).
+    unsafe {
+        for svc in (*core::ptr::addr_of_mut!(SERVICES)).iter_mut().flatten() {
+            if svc.current_pid == Some(pid) {
+                svc.current_pid = None;
+            }
+        }
+    }
+}
+
+/// Restarts allowed per window, for the give-up marker.
+pub(crate) const fn max_restarts() -> u8 {
+    MAX_RESTARTS
+}
+
+/// Render a report as an audit detail: `kind=<n> addr=<hex> status=<hex>`.
+///
+/// Returns the buffer and its used length (the caller passes `&buf[..len]`).
+/// Fixed-size and allocation-free; a detail that would overrun is truncated,
+/// since a short audit record still beats no record.
+pub(crate) fn audit_detail(report: &FaultReport) -> ([u8; DETAIL_CAP], usize) {
+    struct Buf {
+        bytes: [u8; DETAIL_CAP],
+        len: usize,
+    }
+    impl core::fmt::Write for Buf {
+        fn write_str(&mut self, s: &str) -> core::fmt::Result {
+            for &b in s.as_bytes() {
+                if self.len >= self.bytes.len() {
+                    return Err(core::fmt::Error);
+                }
+                self.bytes[self.len] = b;
+                self.len += 1;
+            }
+            Ok(())
+        }
+    }
+    let mut buf = Buf {
+        bytes: [0u8; DETAIL_CAP],
+        len: 0,
+    };
+    let _ = core::fmt::Write::write_fmt(
+        &mut buf,
+        format_args!(
+            "kind={} addr={:#010x} status={:#010x}",
+            report.kind, report.fault_addr, report.fault_status
+        ),
+    );
+    (buf.bytes, buf.len)
+}
+
+/// Audit-detail buffer size; matches `audit::DETAIL_LEN`.
+const DETAIL_CAP: usize = 64;
+
+/// Drop all supervision state (tests).
+#[cfg(test)]
+pub(crate) fn reset() {
+    let _guard = LOCK.lock();
+    // SAFETY: see `report_fault` -- state is only touched under LOCK.
+    unsafe {
+        *core::ptr::addr_of_mut!(RING) = [None; RING_SIZE];
+        *core::ptr::addr_of_mut!(RING_HEAD) = 0;
+        *core::ptr::addr_of_mut!(RING_COUNT) = 0;
+        *core::ptr::addr_of_mut!(SERVICES) = [None; MAX_SUPERVISED];
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn report(pid: Pid) -> FaultReport {
+        FaultReport {
+            pid,
+            kind: 1,
+            fault_addr: 0xDEAD_0000,
+            fault_status: 0x0000_000F,
+            service: None,
+        }
+    }
+
+    /// Fault `pid` through the real path: abort-context report (which resolves
+    /// the service) -> service-loop drain.
+    fn fault(pid: Pid) -> FaultReport {
+        report_fault(pid, 1, 0xDEAD_0000, 0x0000_000F);
+        pop_report().expect("a report must reach the ring")
+    }
+
+    #[test]
+    fn ring_is_fifo_and_drains_empty() {
+        reset();
+        assert_eq!(pop_report(), None, "an empty ring yields nothing");
+        report_fault(1, 1, 0xDEAD_0000, 0x0000_000F);
+        report_fault(2, 3, 0, 0);
+        let first = pop_report().expect("first report");
+        assert_eq!(first, report(1), "oldest report pops first");
+        assert_eq!(pop_report().map(|r| r.pid), Some(2), "then the next");
+        assert_eq!(pop_report(), None, "ring drains empty");
+    }
+
+    #[test]
+    fn ring_full_drops_the_newest_and_keeps_the_backlog() {
+        reset();
+        for pid in 0..u8::try_from(RING_SIZE).unwrap_or(u8::MAX) {
+            report_fault(pid, 1, 0, 0);
+        }
+        // One past capacity: dropped, and the existing backlog is intact.
+        report_fault(99, 1, 0, 0);
+        for pid in 0..u8::try_from(RING_SIZE).unwrap_or(u8::MAX) {
+            assert_eq!(
+                pop_report().map(|r| r.pid),
+                Some(pid),
+                "the backlog must survive an overflow"
+            );
+        }
+        assert_eq!(pop_report(), None, "the overflowing report was dropped");
+    }
+
+    #[test]
+    fn an_unsupervised_pid_yields_no_decision() {
+        reset();
+        assert_eq!(
+            decide(&fault(7), 0),
+            Decision::None,
+            "unknown pid: audit only"
+        );
+        register("/shell", 2);
+        assert_eq!(
+            decide(&fault(7), 0),
+            Decision::None,
+            "a fault by another pid must not touch /shell"
+        );
+    }
+
+    #[test]
+    fn a_supervised_crash_restarts_up_to_the_limit_then_gives_up() {
+        reset();
+        register("/svc", 2);
+        for i in 1..=MAX_RESTARTS {
+            assert_eq!(
+                decide(&fault(2), 10),
+                Decision::Restart("/svc"),
+                "restart {i} must be allowed"
+            );
+            // The relaunch installs the pid the next fault resolves through.
+            set_current_pid("/svc", Some(2));
+        }
+        assert_eq!(
+            decide(&fault(2), 10),
+            Decision::GiveUp("/svc"),
+            "the {MAX_RESTARTS}th restart exhausts the window"
+        );
+    }
+
+    #[test]
+    fn give_up_is_permanent_within_a_boot() {
+        reset();
+        register("/svc", 2);
+        for _ in 0..MAX_RESTARTS {
+            let _ = decide(&fault(2), 0);
+            set_current_pid("/svc", Some(2));
+        }
+        assert_eq!(decide(&fault(2), 0), Decision::GiveUp("/svc"));
+        set_current_pid("/svc", Some(2));
+        // Far outside the window: a fresh window must NOT resurrect it.
+        assert_eq!(
+            decide(&fault(2), WINDOW_TICKS * 10),
+            Decision::None,
+            "give-up must not be undone by a window reset"
+        );
+    }
+
+    #[test]
+    fn a_crash_outside_the_window_opens_a_fresh_one() {
+        reset();
+        register("/svc", 2);
+        for _ in 0..MAX_RESTARTS {
+            assert_eq!(decide(&fault(2), 10), Decision::Restart("/svc"));
+            set_current_pid("/svc", Some(2));
+        }
+        // A crash long after the window: rate limiting resets, so an occasional
+        // crash never accumulates into a give-up.
+        assert_eq!(
+            decide(&fault(2), 10 + WINDOW_TICKS + 1),
+            Decision::Restart("/svc"),
+            "a fault past the window starts a new budget"
+        );
+    }
+
+    #[test]
+    fn re_registering_refreshes_the_pid_without_resetting_the_budget() {
+        reset();
+        register("/svc", 2);
+        assert_eq!(decide(&fault(2), 0), Decision::Restart("/svc"));
+        // Re-register (as a relaunch would) must not hand back a fresh budget.
+        register("/svc", 5);
+        assert_eq!(decide(&fault(5), 0), Decision::Restart("/svc"));
+        register("/svc", 6);
+        assert_eq!(decide(&fault(6), 0), Decision::Restart("/svc"));
+        register("/svc", 7);
+        assert_eq!(
+            decide(&fault(7), 0),
+            Decision::GiveUp("/svc"),
+            "re-registration must not escape rate limiting"
+        );
+    }
+
+    #[test]
+    fn a_fault_resolves_its_service_at_fault_time_and_releases_the_pid() {
+        reset();
+        register("/svc", 2);
+        let r = fault(2);
+        assert_eq!(
+            r.service,
+            Some("/svc"),
+            "the report must name the service while the pid is unambiguous"
+        );
+        // The claim is released immediately, so the pid may be reused freely.
+        assert_eq!(
+            fault(2).service,
+            None,
+            "the released pid must not resolve to the service again"
+        );
+    }
+
+    #[test]
+    fn a_pid_reused_after_a_clean_exit_restarts_its_current_owner_not_the_old_one() {
+        // The bug the crash-loop witness caught: /shell registered pid 2 and then
+        // exited CLEANLY -- which files no fault report, so nothing released its
+        // claim. /crasher was later relaunched INTO the freed pid 2, and its next
+        // fault matched /shell's stale claim, restarting the wrong service.
+        reset();
+        register("/shell", 2);
+        clear_pid(2); // the exit path releases the claim on a clean exit
+        register("/crasher", 2); // the pid is reused by another supervised service
+        assert_eq!(
+            decide(&fault(2), 0),
+            Decision::Restart("/crasher"),
+            "a fault on a reused pid must restart its CURRENT owner"
+        );
+    }
+
+    #[test]
+    fn a_cleanly_exited_service_is_never_restarted_by_someone_elses_fault() {
+        reset();
+        register("/shell", 2);
+        clear_pid(2); // /shell exits cleanly
+        // An unrelated, unsupervised process later inherits pid 2 and faults.
+        assert_eq!(
+            decide(&fault(2), 0),
+            Decision::None,
+            "a clean exit must never be turned into a restart by a pid reuse"
+        );
+    }
+
+    #[test]
+    fn audit_detail_carries_kind_addr_and_status() {
+        let (buf, len) = audit_detail(&report(4));
+        let text = core::str::from_utf8(&buf[..len]).expect("detail must be utf-8");
+        assert_eq!(
+            text, "kind=1 addr=0xdead0000 status=0x0000000f",
+            "the audit record must carry the forensic fields"
+        );
+        assert!(
+            len <= DETAIL_CAP,
+            "the detail must fit the audit record's field"
+        );
+    }
+
+    #[test]
+    fn a_failed_relaunch_clears_the_pid_so_no_stale_match() {
+        reset();
+        register("/svc", 2);
+        assert_eq!(decide(&fault(2), 0), Decision::Restart("/svc"));
+        set_current_pid("/svc", None); // relaunch failed
+        assert_eq!(
+            decide(&fault(2), 0),
+            Decision::None,
+            "a stale pid must not match after a failed relaunch"
+        );
+    }
+}


### PR DESCRIPTION
## Finding

`notify_fault` delivered a 9-byte report to PID 0's IPC inbox and **nothing ever drained it**: reports accumulated until the inbox filled, after which both the reports *and* any legitimate userspace `send(0, ..)` were rejected. The reaper was decoupled (it scans PCB `Dead` state), so slots were still reclaimed — the inbox-fill was the *symptom* of the missing consumer.

## Fix

PID 0 is now an actual fault **supervisor**. A new `supervisor` module carries a dedicated fault ring + a supervised-service registry + the restart policy; the service loop drains the ring each tick, audit-logs **every** report, and relaunches a supervised service that crashed — rate-limited (3 restarts per 500-tick window, then a permanent give-up for that boot).

**Why a dedicated ring, not a tag-selective inbox drain:** `ipc::recv` pops the FRONT regardless of tag, so a naive drain would discard real user→PID0 IPC, and a filtering drain needs a new non-FIFO Inbox op. A separate channel also stops fault reports competing with real IPC for 16 slots, and deletes the `CURRENT`-swap `notify_fault` needed only so `ipc::send` would stamp the right sender. The module is deliberately **not** `cfg(not(test))` (unlike kardia/kinit), so its tests actually run — the #528 trap.

**Supervised set:** `/shell` only. `/init` is deliberately **not** supervised — the isolation probes fault it on purpose and CI asserts exactly one USERFAULT; supervising it would crash-loop every probe. **Clean exits are never restarts:** the supervisor keys on fault reports, never on `Dead` state (the #526 reconciliation).

**The restart path** re-plans from the ramfs by name (the PCB retains no image identity). It must hold an `IrqGuard` and switch to the identity kernel L1 first: `switch_to` **skips** the TTBR0 write for PID 0 (`page_table_phys == 0`), so the loop may be running under a *user* table, while `load_confined` writes the fresh image frame through raw physical addresses (the #497 aliasing class).

**Audit:** new `AuditEventType::UserFault` (discriminant 12, append-only), emitted for every drained report with kind/addr/status as the detail.

## The bug the witness caught (fixed here)

**PIDs are reused.** `/shell` registered pid 2 and exited **cleanly** — which files no fault report, so nothing released its claim — then `/crasher` was relaunched into the freed pid 2, and its next fault matched `/shell`'s stale claim and **restarted the wrong service** (observed in the first crash-loop boot).

Fixed both halves, and neither suffices alone:
- `report_fault` resolves pid→service **at fault time** (when the pid unambiguously names the dying process), stamps it into the report, and releases the claim immediately. `decide()` keys on that stamped path, never a drain-time pid lookup.
- `exit_cleanup` calls `clear_pid`, so a clean exit leaves no stale pid. (Clearing *only* on exit would wipe the claim before the loop drains the ring.)

## Evidence

The `crashloop-probe` feature + `/crasher` (data-aborts on **every** launch, spawned + registered supervised by kinit) turns the policy into an observable sequence:

```
crasher: start  → supervisor restarted /crasher (PID 4)
crasher: start  → supervisor restarted /crasher (PID 1)
crasher: start  → supervisor restarted /crasher (PID 2)
crasher: start  → supervisor giving up on /crasher after 3 restarts
```

CI asserts the counts: 4 launches (initial + 3 restarts), 3 restart markers, 4 audited faults, 1 give-up, no 5th. `crasher: start` proves the relaunched **image** ran, not merely that spawn returned a pid. It also asserts `/shell` ran exactly once and was **never** restarted (the clean-exit reconciliation), and that the reaper still reclaims slots.

## Verification

- **All 10 QEMU variants green** (exact USERFAULT counts, `/shell` coexisting, reaper intact) + the crash-loop witness.
- **2232 host tests** (12 new supervisor tests, including the pid-reuse regression and the audit-detail format).
- armv7a zero-warning; full `kanon gate` green.

## Done when

- [x] PID 0 consumes every fault report (the inbox never monotonically fills — reports no longer touch it at all).
- [x] Each fault is audit-logged.
- [x] A supervised crashing service is relaunched with crash-loop rate limiting.
- [x] The scan-based reaper stays the slot-reclamation backstop.