### PR TITLE
docs(thumos): refresh generated AGENTS.md + sync Cargo.lock to 0.1.8

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,70 +1,63 @@
 <!--
-scope: thumos repo build/lint rules and agent conventions (cross-tool reference for AI coding assistants)
-defers_to: CLAUDE.md for architecture decisions and operator principles; kanon standards for universal engineering policy
-tightens: build commands, lint invariants, and non-obvious Rust/kernel constraints specific to this repo
+scope: thumos repo cross-tool agent guide (Claude Code, Kimi, Codex, Cursor, Windsurf, Copilot)
+generated_by: kanon docs sync
+defers_to: CLAUDE.md for Claude Code-specific behavior; ~/menos-ops/CLAUDE.md for machine + service topology
+tightens: workflow/AGENTS-mcp-tools.md catalog routing; crates/basanos/standards/AGENT-DOCS.md authoring rules
 -->
 
-# AGENTS.md - Thumos
+# thumos
 
-Cross-tool guide for AI coding agents (Claude Code, Cursor, Windsurf, Copilot, etc.) working on the Thumos mobile OS. Authoritative agent orientation (phase status, Greek naming rationale, constraints) lives in [CLAUDE.md](CLAUDE.md); this file captures build/lint invariants and the non-obvious rules that differ from a standard Rust workspace.
+Kanon-managed forkwright repository `thumos`.
 
-## Build, test, lint
+## Commands
+
+Run `kanon --help` for all kanon-managed workflow commands. Run project-local
+build, test, and lint commands from this repository root.
+
+- `kanon gate` - full local gate for kanon-managed PRs
+- `kanon lint --fix` - deterministic standards fixes
+- `kanon lint --explain <RULE>` - rule rationale and fix guidance
+- `kanon pr open <head_ref> --title "..."` - open a forge PR
+- `kanon pr merge <N> [--strategy squash|ff|rebase]` - merge after CI and gate checks
+- `kanon docs sync --check --repo thumos` - verify derived bootstrap docs
+- `kanon docs sync --apply --repo thumos` - regenerate derived bootstrap docs
+
+For agent-native operations, prefer the `mcp__kanon__*` tool family. See
+[workflow/AGENTS-mcp-tools.md](workflow/AGENTS-mcp-tools.md) for routing and fallback rules.
+
+## Standards
+
+Read `crates/basanos/standards/STANDARDS.md` § Philosophy before writing code. Key principles:
+no workarounds, define once, reference everywhere, no shortcuts, no compromise on quality.
+Rust work also reads `crates/basanos/standards/RUST.md` before editing Rust code.
+
+## Rules
+
+- Structured comment tags only: WHY, NOTE, WARNING, PERF, SAFETY, INVARIANT, TODO(#NNN), FIXME(#NNN)
+- Conventional commits: `type(scope): description`
+- Add `Gate-Passed: kanon 0.1.0` to validated commit bodies
+- Never add `#[allow]` suppressions; use `#[expect(lint, reason = "...")]` only when justified
+- Prefer MCP tools first; CLI commands are resilience fallbacks
+
+## Architecture
+
+- Registry name: `thumos`
+- Forge repo: `forkwright/thumos`
+- Kanon prefix: `th`
+- Config source: `workflow/kanon.toml [projects.thumos]`
+
+## Boundaries
+
+Always: run the applicable gate before pushing, stay inside the declared blast radius.
+Ask first: workflow, service, credential, schema, or deployment changes.
+Never: bypass CI, push to protected upstream refs, commit secrets, or suppress warnings.
+
+## Blast zone
+
+- Paths explicitly named by the rendered prompt, role, or template input.
+
+## Acceptance verifier
 
 ```bash
-cargo check --workspace              # userspace crates only (host build)
-cargo test --workspace               # workspace test suite
-cargo clippy --workspace -- -D warnings   # zero warnings required
-
-# Kernel is excluded from workspace; cross-compiles for armv7a-none-eabi
-cd crates/thumos && cargo build --release
+kanon gate
 ```
-
-The `thumos` crate is the bare-metal kernel binary and is **excluded from the workspace** (`exclude = ["crates/thumos"]`). Workspace commands never touch the kernel; kernel commands must `cd crates/thumos` first. Kernel tests run on host via `cargo test` inside `crates/thumos/` (uses conditional compilation to stub MMIO).
-
-Boot image is produced with `mkbootimg` and flashed via mtkclient BROM exploit. See [docs/KERNEL-BUILD.md](docs/KERNEL-BUILD.md).
-
-## Key patterns
-
-- **Errors:** `snafu` with `.context()` and `Location` tracking. No `unwrap()` / `expect()` / `panic!()` in library code; all three are `deny` at the workspace level (kernel crate relaxes where the hardware contract makes a return impossible).
-- **Allocator:** kernel has its own slab allocator; `alloc`-only in `no_std` contexts. Do not introduce `std` deps into `no_std` crates.
-- **Unsafe:** `unsafe_code = "warn"` (not deny) because bare-metal kernel plus crypto/memory operations in `stegnos`/`leipsanon` legitimately need unsafe. Every `unsafe` block requires a `// SAFETY:` comment.
-- **Async:** Tokio only for userspace daemons; the kernel is synchronous with cooperative yields.
-- **IDs / time / strings:** `ulid`, `jiff`, `compact_str` to match aletheia conventions.
-- **Lints:** `#[expect(lint, reason = "...")]` over `#[allow]` so stale suppressions warn.
-- **Visibility:** `pub(crate)` default. `pub` only for the crate's documented API surface.
-- **Naming:** Greek names (see [CLAUDE.md § Naming](CLAUDE.md#naming)). English for code identifiers.
-- **Commits:** `type(scope): description`. Scope = crate name (`klesis`, `aither`, `eidolon`, ...) or `kernel` for `crates/thumos/`.
-
-## Where to add things
-
-| Task | Location | Registration |
-|------|----------|-------------|
-| Kernel subsystem (new syscall, driver, allocator) | `crates/thumos/src/<module>/` | Monolithic kernel; add a module, not a new crate |
-| New userspace domain crate | `crates/<greek-name>/` | Register in workspace `Cargo.toml` members |
-| Hardware driver (protocol logic) | Workspace crate (e.g. `aither`, `pteron`) | If it touches MMIO registers, put it in the kernel instead |
-| Radio analysis feature | `crates/sema/` | IMSI catcher heuristics, rogue AP detection |
-| UI widget | `crates/eidolon/` | 240x320 framebuffer, T9 input |
-| Panic / wipe trigger | `crates/leipsanon/` | Priority-ordered scrubbing |
-| Packet filter rule | `crates/asphaleia/` | DNS blocklist + IPv4/TCP/UDP matcher |
-
-Crate tree and layer rules: [ARCHITECTURE.md](ARCHITECTURE.md). Hardware register maps: [docs/DRIVER-INTERFACES.md](docs/DRIVER-INTERFACES.md).
-
-## Device identity protection
-
-All hardware identifiers (WiFi MAC, BT MAC, IMEI, IMSI, probe requests, BLE addresses) are treated as sensitive. New radio code MUST randomize or suppress identifiers at the driver layer, not in userspace, because userspace filtering is bypassable by a compromised component. Reference the table in [CLAUDE.md § Device identity protection](CLAUDE.md#device-identity-protection) before adding any radio feature. The IMEI filter lives at the CCCI kernel boundary; do not relocate it upward.
-
-## TODO convention
-
-`TODO(#issue): description` or `TODO(category): description`. Categories: `hw` (hardware-dependent), `crypto` (needs primitives), `phase07`/`phase08` (deferred phase). Raw `TODO` without a tag is lint-rejected.
-
-## Common mistakes
-
-- **Do not add `std` to `no_std` kernel modules.** The kernel targets `armv7a-none-eabi`; pulling `std` silently fails cross-compilation long after CI would catch a host test.
-- **Do not build the kernel via `cargo build --workspace`.** It is excluded intentionally. See Build section above.
-- **Do not skip MAC/BT randomization.** LE Privacy rotates every 15 min; WiFi MAC rotates per connection. Hard-coded MACs leak identity.
-- **Do not hand-roll AT command parsing outside `klesis`.** `klesis` owns the AT parser, CCCI/CLDMA framing, and SMS PDU codec.
-- **Do not add dependencies that require a C toolchain.** Pure Rust only: `rustls` not openssl, `fjall` or in-memory over SQLite, `RustCrypto` over `ring` where possible.
-
-## Gates
-
-Before pushing: `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace`, plus `cd crates/thumos && cargo check --release --target armv7a-none-eabi` if the kernel was touched.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "aither"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "getrandom 0.4.2",
  "hmac",
@@ -59,7 +59,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "asphaleia"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "log",
  "rustix",
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "eidolon"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "embedded-graphics",
  "embedded-graphics-core",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "haphe"
-version = "0.1.7"
+version = "0.1.8"
 
 [[package]]
 name = "hash32"
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "kelyphos"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "log",
  "snafu",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "klesis"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "log",
  "nom",
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "krypta"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "aes-gcm",
  "ed25519-dalek",
@@ -690,7 +690,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "leipsanon"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "getrandom 0.4.2",
  "log",
@@ -740,7 +740,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metaxu"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "compact_str",
  "jiff",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "pteron"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "jiff",
  "log",
@@ -1042,7 +1042,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sema"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "jiff",
  "log",
@@ -1204,7 +1204,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stegnos"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "topos"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "jiff",
  "log",


### PR DESCRIPTION
## Summary
- `kanon docs sync --check --repo thumos` flags `AGENTS.md` as drifted from the current `workflow/kanon.toml [projects.thumos]` template. Regenerated via `kanon docs sync --apply --repo thumos`, scoped to just `AGENTS.md` (the file `--check` actually flagged).
- `Cargo.lock` still carried `0.1.7` for every workspace-member package entry after the v0.1.8 release-please bump (e261d18) updated `Cargo.toml`'s `workspace.package.version`. Synced the lockfile to match.

## Notes
- `kanon docs sync --apply` also inserts new `kanon:auto-start` blocks into `CLAUDE.md`/`README.md` (a "Generated kanon context" / "Blast zone" / "Acceptance verifier" section). `--check` doesn't flag *missing* auto-blocks as drift (only mismatched ones), and no other fleet repo (aletheia, harmonia) carries these blocks yet — left those two files untouched to avoid an unrequested fleet-wide template rollout riding on a docs-drift fix.
- `vgate kanon gate --stamp` fails locally on this branch, but only on the pre-existing `kanon lint` stage (`WORKFLOW/unwired-dead-code-untracked`, 87 violations, zero of them touched by this diff) — tracked separately in #537. Every other stage (fmt, check, clippy, nextest, dependency audit, kanon fitness) passes. GitHub Actions `ci.yml` does not run `kanon lint` at all, so this is not expected to affect required checks.

## Test plan
- [x] `cargo fmt --all --check` (via gate)
- [x] `cargo check --workspace --all-targets` (via gate)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (via gate)
- [x] `cargo nextest run --workspace` (via gate)
- [ ] GitHub Actions CI green (docs/lockfile-only change, no code touched)