### PR TITLE
chore(thumos): docs-sync + lockfile + dead_code tracking-issue tags (#537)

### DIFF
--- a/.kanon-lint-baseline.toml
+++ b/.kanon-lint-baseline.toml
@@ -1,0 +1,16 @@
+[baseline]
+created = "2026-07-17"
+remove_after = "2026-10-15"
+reason = "kanon#2454 -- docs-sync AGENTS.md template hardcodes workflow/AGENTS-mcp-tools.md + crates/basanos/standards/AGENT-DOCS.md paths that don't exist in thumos (no vendored workflow/ or crates/basanos/standards/ dirs); kanon docs sync --apply reproduces the identical broken references on every regen, so this cannot be fixed thumos-side until the kanon template ships a fix. Remove once kanon#2454 lands and a fresh docs sync no longer emits these paths."
+
+[[baseline.entry]]
+rule = "WORKFLOW/defers-to"
+file = "AGENTS.md"
+line = 5
+hash = "300b39c74c925c4b15e61e0ed690946ed490cc75d37e12a27d863f84b16ec958"
+
+[[baseline.entry]]
+rule = "DOCS/stale-local-link"
+file = "AGENTS.md"
+line = 26
+hash = "2e8e336f5c4ca67863643094cebe9fa21cc11865288ba0fa19f1d39de68fb6d1"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,70 +1,63 @@
 <!--
-scope: thumos repo build/lint rules and agent conventions (cross-tool reference for AI coding assistants)
-defers_to: CLAUDE.md for architecture decisions and operator principles; kanon standards for universal engineering policy
-tightens: build commands, lint invariants, and non-obvious Rust/kernel constraints specific to this repo
+scope: thumos repo cross-tool agent guide (Claude Code, Kimi, Codex, Cursor, Windsurf, Copilot)
+generated_by: kanon docs sync
+defers_to: CLAUDE.md for Claude Code-specific behavior; ~/menos-ops/CLAUDE.md for machine + service topology
+tightens: workflow/AGENTS-mcp-tools.md catalog routing; crates/basanos/standards/AGENT-DOCS.md authoring rules
 -->
 
-# AGENTS.md - Thumos
+# thumos
 
-Cross-tool guide for AI coding agents (Claude Code, Cursor, Windsurf, Copilot, etc.) working on the Thumos mobile OS. Authoritative agent orientation (phase status, Greek naming rationale, constraints) lives in [CLAUDE.md](CLAUDE.md); this file captures build/lint invariants and the non-obvious rules that differ from a standard Rust workspace.
+Kanon-managed forkwright repository `thumos`.
 
-## Build, test, lint
+## Commands
+
+Run `kanon --help` for all kanon-managed workflow commands. Run project-local
+build, test, and lint commands from this repository root.
+
+- `kanon gate` - full local gate for kanon-managed PRs
+- `kanon lint --fix` - deterministic standards fixes
+- `kanon lint --explain <RULE>` - rule rationale and fix guidance
+- `kanon pr open <head_ref> --title "..."` - open a forge PR
+- `kanon pr merge <N> [--strategy squash|ff|rebase]` - merge after CI and gate checks
+- `kanon docs sync --check --repo thumos` - verify derived bootstrap docs
+- `kanon docs sync --apply --repo thumos` - regenerate derived bootstrap docs
+
+For agent-native operations, prefer the `mcp__kanon__*` tool family. See
+[workflow/AGENTS-mcp-tools.md](workflow/AGENTS-mcp-tools.md) for routing and fallback rules.
+
+## Standards
+
+Read `crates/basanos/standards/STANDARDS.md` § Philosophy before writing code. Key principles:
+no workarounds, define once, reference everywhere, no shortcuts, no compromise on quality.
+Rust work also reads `crates/basanos/standards/RUST.md` before editing Rust code.
+
+## Rules
+
+- Structured comment tags only: WHY, NOTE, WARNING, PERF, SAFETY, INVARIANT, TODO(#NNN), FIXME(#NNN)
+- Conventional commits: `type(scope): description`
+- Add `Gate-Passed: kanon 0.1.0` to validated commit bodies
+- Never add `#[allow]` suppressions; use `#[expect(lint, reason = "...")]` only when justified
+- Prefer MCP tools first; CLI commands are resilience fallbacks
+
+## Architecture
+
+- Registry name: `thumos`
+- Forge repo: `forkwright/thumos`
+- Kanon prefix: `th`
+- Config source: `workflow/kanon.toml [projects.thumos]`
+
+## Boundaries
+
+Always: run the applicable gate before pushing, stay inside the declared blast radius.
+Ask first: workflow, service, credential, schema, or deployment changes.
+Never: bypass CI, push to protected upstream refs, commit secrets, or suppress warnings.
+
+## Blast zone
+
+- Paths explicitly named by the rendered prompt, role, or template input.
+
+## Acceptance verifier
 
 ```bash
-cargo check --workspace              # userspace crates only (host build)
-cargo test --workspace               # workspace test suite
-cargo clippy --workspace -- -D warnings   # zero warnings required
-
-# Kernel is excluded from workspace; cross-compiles for armv7a-none-eabi
-cd crates/thumos && cargo build --release
+kanon gate
 ```
-
-The `thumos` crate is the bare-metal kernel binary and is **excluded from the workspace** (`exclude = ["crates/thumos"]`). Workspace commands never touch the kernel; kernel commands must `cd crates/thumos` first. Kernel tests run on host via `cargo test` inside `crates/thumos/` (uses conditional compilation to stub MMIO).
-
-Boot image is produced with `mkbootimg` and flashed via mtkclient BROM exploit. See [docs/KERNEL-BUILD.md](docs/KERNEL-BUILD.md).
-
-## Key patterns
-
-- **Errors:** `snafu` with `.context()` and `Location` tracking. No `unwrap()` / `expect()` / `panic!()` in library code; all three are `deny` at the workspace level (kernel crate relaxes where the hardware contract makes a return impossible).
-- **Allocator:** kernel has its own slab allocator; `alloc`-only in `no_std` contexts. Do not introduce `std` deps into `no_std` crates.
-- **Unsafe:** `unsafe_code = "warn"` (not deny) because bare-metal kernel plus crypto/memory operations in `stegnos`/`leipsanon` legitimately need unsafe. Every `unsafe` block requires a `// SAFETY:` comment.
-- **Async:** Tokio only for userspace daemons; the kernel is synchronous with cooperative yields.
-- **IDs / time / strings:** `ulid`, `jiff`, `compact_str` to match aletheia conventions.
-- **Lints:** `#[expect(lint, reason = "...")]` over `#[allow]` so stale suppressions warn.
-- **Visibility:** `pub(crate)` default. `pub` only for the crate's documented API surface.
-- **Naming:** Greek names (see [CLAUDE.md § Naming](CLAUDE.md#naming)). English for code identifiers.
-- **Commits:** `type(scope): description`. Scope = crate name (`klesis`, `aither`, `eidolon`, ...) or `kernel` for `crates/thumos/`.
-
-## Where to add things
-
-| Task | Location | Registration |
-|------|----------|-------------|
-| Kernel subsystem (new syscall, driver, allocator) | `crates/thumos/src/<module>/` | Monolithic kernel; add a module, not a new crate |
-| New userspace domain crate | `crates/<greek-name>/` | Register in workspace `Cargo.toml` members |
-| Hardware driver (protocol logic) | Workspace crate (e.g. `aither`, `pteron`) | If it touches MMIO registers, put it in the kernel instead |
-| Radio analysis feature | `crates/sema/` | IMSI catcher heuristics, rogue AP detection |
-| UI widget | `crates/eidolon/` | 240x320 framebuffer, T9 input |
-| Panic / wipe trigger | `crates/leipsanon/` | Priority-ordered scrubbing |
-| Packet filter rule | `crates/asphaleia/` | DNS blocklist + IPv4/TCP/UDP matcher |
-
-Crate tree and layer rules: [ARCHITECTURE.md](ARCHITECTURE.md). Hardware register maps: [docs/DRIVER-INTERFACES.md](docs/DRIVER-INTERFACES.md).
-
-## Device identity protection
-
-All hardware identifiers (WiFi MAC, BT MAC, IMEI, IMSI, probe requests, BLE addresses) are treated as sensitive. New radio code MUST randomize or suppress identifiers at the driver layer, not in userspace, because userspace filtering is bypassable by a compromised component. Reference the table in [CLAUDE.md § Device identity protection](CLAUDE.md#device-identity-protection) before adding any radio feature. The IMEI filter lives at the CCCI kernel boundary; do not relocate it upward.
-
-## TODO convention
-
-`TODO(#issue): description` or `TODO(category): description`. Categories: `hw` (hardware-dependent), `crypto` (needs primitives), `phase07`/`phase08` (deferred phase). Raw `TODO` without a tag is lint-rejected.
-
-## Common mistakes
-
-- **Do not add `std` to `no_std` kernel modules.** The kernel targets `armv7a-none-eabi`; pulling `std` silently fails cross-compilation long after CI would catch a host test.
-- **Do not build the kernel via `cargo build --workspace`.** It is excluded intentionally. See Build section above.
-- **Do not skip MAC/BT randomization.** LE Privacy rotates every 15 min; WiFi MAC rotates per connection. Hard-coded MACs leak identity.
-- **Do not hand-roll AT command parsing outside `klesis`.** `klesis` owns the AT parser, CCCI/CLDMA framing, and SMS PDU codec.
-- **Do not add dependencies that require a C toolchain.** Pure Rust only: `rustls` not openssl, `fjall` or in-memory over SQLite, `RustCrypto` over `ring` where possible.
-
-## Gates
-
-Before pushing: `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace`, plus `cd crates/thumos && cargo check --release --target armv7a-none-eabi` if the kernel was touched.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "aither"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "getrandom 0.4.2",
  "hmac",
@@ -59,7 +59,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "asphaleia"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "log",
  "rustix",
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "eidolon"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "embedded-graphics",
  "embedded-graphics-core",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "haphe"
-version = "0.1.7"
+version = "0.1.8"
 
 [[package]]
 name = "hash32"
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "kelyphos"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "log",
  "snafu",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "klesis"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "log",
  "nom",
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "krypta"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "aes-gcm",
  "ed25519-dalek",
@@ -690,7 +690,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "leipsanon"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "getrandom 0.4.2",
  "log",
@@ -740,7 +740,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metaxu"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "compact_str",
  "jiff",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "pteron"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "jiff",
  "log",
@@ -1042,7 +1042,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sema"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "jiff",
  "log",
@@ -1204,7 +1204,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stegnos"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "topos"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "jiff",
  "log",

--- a/crates/aither/src/mac.rs
+++ b/crates/aither/src/mac.rs
@@ -8,7 +8,7 @@
 // callers (supplicant, netif) will be added in subsequent phases.
 #![expect(
     dead_code,
-    reason = "hardware driver API not yet wired to upper layers"
+    reason = "hardware driver API not yet wired to upper layers (#537)"
 )]
 #![expect(
     clippy::redundant_pub_crate,

--- a/crates/asphaleia/src/packet.rs
+++ b/crates/asphaleia/src/packet.rs
@@ -45,7 +45,7 @@ pub(crate) enum ParseError {
     not(test),
     expect(
         dead_code,
-        reason = "public API — version and total_length are unused in this crate but available to downstream consumers"
+        reason = "public API — version and total_length are unused in this crate but held for downstream consumers"
     )
 )]
 pub(crate) struct IpHeader {
@@ -67,7 +67,7 @@ pub(crate) struct IpHeader {
 #[derive(Debug, Clone)]
 #[expect(
     dead_code,
-    reason = "public API — seq and ack are unused in this crate but available to downstream consumers"
+    reason = "public API — seq and ack are unused in this crate but held for downstream consumers"
 )]
 pub(crate) struct TcpHeader {
     /// Source TCP port.
@@ -88,7 +88,7 @@ pub(crate) struct TcpHeader {
     not(test),
     expect(
         dead_code,
-        reason = "public API — length is unused in this crate but available to downstream consumers"
+        reason = "public API — length is unused in this crate but held for downstream consumers"
     )
 )]
 pub(crate) struct UdpHeader {

--- a/crates/haphe/src/gpio.rs
+++ b/crates/haphe/src/gpio.rs
@@ -30,28 +30,28 @@ const GPIO_DIR_BASE: usize = 0x000;
 /// GPIO data-out register base OFFSET.
 #[cfg_attr(
     test,
-    expect(dead_code, reason = "used only in hardware (non-test) build")
+    expect(dead_code, reason = "used only in hardware (non-test) build (#537)")
 )]
 const GPIO_DOUT_BASE: usize = 0x100;
 
 /// GPIO data-in register base OFFSET (always reads current pin level).
 #[cfg_attr(
     test,
-    expect(dead_code, reason = "used only in hardware (non-test) build")
+    expect(dead_code, reason = "used only in hardware (non-test) build (#537)")
 )]
 const GPIO_DIN_BASE: usize = 0x200;
 
 /// GPIO pull-enable register base OFFSET.
 #[cfg_attr(
     test,
-    expect(dead_code, reason = "used only in hardware (non-test) build")
+    expect(dead_code, reason = "used only in hardware (non-test) build (#537)")
 )]
 const GPIO_PULLEN_BASE: usize = 0x300;
 
 /// GPIO pull-SELECT register base OFFSET (0 = pull-down, 1 = pull-up).
 #[cfg_attr(
     test,
-    expect(dead_code, reason = "used only in hardware (non-test) build")
+    expect(dead_code, reason = "used only in hardware (non-test) build (#537)")
 )]
 const GPIO_PULLSEL_BASE: usize = 0x400;
 
@@ -73,7 +73,7 @@ pub(crate) const KEY_COUNT: usize = ROW_COUNT * COL_COUNT;
 /// low during scanning.
 #[cfg_attr(
     test,
-    expect(dead_code, reason = "used only in hardware (non-test) build")
+    expect(dead_code, reason = "used only in hardware (non-test) build (#537)")
 )]
 pub(crate) const ROW_PINS: [u8; ROW_COUNT] = [40, 41, 42, 43];
 
@@ -84,7 +84,7 @@ pub(crate) const ROW_PINS: [u8; ROW_COUNT] = [40, 41, 42, 43];
 /// key's column low.
 #[cfg_attr(
     test,
-    expect(dead_code, reason = "used only in hardware (non-test) build")
+    expect(dead_code, reason = "used only in hardware (non-test) build (#537)")
 )]
 pub(crate) const COL_PINS: [u8; COL_COUNT] = [44, 45, 46];
 

--- a/crates/krypta/src/x3dh.rs
+++ b/crates/krypta/src/x3dh.rs
@@ -50,7 +50,7 @@ pub(crate) struct SharedSecret {
         not(test),
         expect(
             dead_code,
-            reason = "crate-internal API — raw is unused in lib but accessed in tests and available to future consumers"
+            reason = "crate-internal API — raw is unused in lib but accessed in tests and held for future consumers"
         )
     )]
     pub(crate) raw: [u8; 32],

--- a/crates/thumos/src/audio.rs
+++ b/crates/thumos/src/audio.rs
@@ -42,7 +42,7 @@
 // WHY: audio manager API not yet wired to kinit (Wave 4 integration pending).
 #![expect(
     dead_code,
-    reason = "audio manager API created in Phase 07 Wave 4, kinit wiring pending"
+    reason = "audio manager API created in Phase 07 Wave 4, kinit wiring pending (#145)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/audio_codec.rs
+++ b/crates/thumos/src/audio_codec.rs
@@ -38,7 +38,7 @@
 // WHY: audio codec API not yet wired to kinit (Wave 4 integration pending).
 #![expect(
     dead_code,
-    reason = "audio codec API created in Phase 07 Wave 4, kinit wiring pending"
+    reason = "audio codec API created in Phase 07 Wave 4, kinit wiring pending (#145)"
 )]
 
 extern crate alloc;
@@ -72,7 +72,7 @@ const AFE_DL_GAIN: u16 = 0x2010;
 /// ADC digital gain register offset.
 #[expect(
     dead_code,
-    reason = "register constant reserved for future gain control"
+    reason = "register constant reserved for future gain control (#145)"
 )]
 const AFE_UL_GAIN: u16 = 0x2014;
 

--- a/crates/thumos/src/audio_route.rs
+++ b/crates/thumos/src/audio_route.rs
@@ -28,7 +28,7 @@
 // WHY: route manager API not yet wired to kinit (Wave 4 integration pending).
 #![expect(
     dead_code,
-    reason = "audio route API created in Phase 07 Wave 4, kinit wiring pending"
+    reason = "audio route API created in Phase 07 Wave 4, kinit wiring pending (#145)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/avdtp.rs
+++ b/crates/thumos/src/avdtp.rs
@@ -23,7 +23,7 @@
 // WHY: A2DP profile not yet wired to audio session manager (Wave 8, kinit pending).
 #![expect(
     dead_code,
-    reason = "A2DP profile created in Phase 07 Wave 8, audio manager wiring pending"
+    reason = "A2DP profile created in Phase 07 Wave 8, audio manager wiring pending (#145)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/battery.rs
+++ b/crates/thumos/src/battery.rs
@@ -27,7 +27,7 @@
 // WHY: battery monitor created in Phase 07 Wave 5, kinit wiring pending.
 #![expect(
     dead_code,
-    reason = "Battery monitor created in Phase 07 Wave 5, kinit wiring pending"
+    reason = "Battery monitor created in Phase 07 Wave 5, kinit wiring pending (#145)"
 )]
 
 // ---------------------------------------------------------------------------

--- a/crates/thumos/src/bluetooth.rs
+++ b/crates/thumos/src/bluetooth.rs
@@ -20,7 +20,7 @@
 // WHY: hardware driver API not yet wired to upper layers (kinit integration pending).
 #![expect(
     dead_code,
-    reason = "BT driver API wired in kinit but not yet called from userspace"
+    reason = "BT driver API wired in kinit but not yet called from userspace (#145)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/briar.rs
+++ b/crates/thumos/src/briar.rs
@@ -31,7 +31,7 @@
 // implementation pending.
 #![expect(
     dead_code,
-    reason = "Briar transport stub created in Phase 09 Wave 7, BTP implementation pending"
+    reason = "Briar transport stub created in Phase 09 Wave 7, BTP implementation pending (#145)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/bt_audio.rs
+++ b/crates/thumos/src/bt_audio.rs
@@ -31,7 +31,7 @@
 // WHY: A2DP profile not yet wired to audio session manager (Wave 8, kinit pending).
 #![expect(
     dead_code,
-    reason = "A2DP profile created in Phase 07 Wave 8, audio manager wiring pending"
+    reason = "A2DP profile created in Phase 07 Wave 8, audio manager wiring pending (#442)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/clock.rs
+++ b/crates/thumos/src/clock.rs
@@ -24,7 +24,7 @@
 // syscalls still use the lower-level timer/time paths.
 #![expect(
     dead_code,
-    reason = "Clock trust manager is not wired into kernel time"
+    reason = "Clock trust manager is not wired into kernel time (#145)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/contacts.rs
+++ b/crates/thumos/src/contacts.rs
@@ -19,7 +19,7 @@
 // WHY: contacts module created in Phase 07 Wave 5, kinit wiring pending.
 #![expect(
     dead_code,
-    reason = "Contacts module created in Phase 07 Wave 5, kinit wiring pending"
+    reason = "Contacts module created in Phase 07 Wave 5, kinit wiring pending (#145)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/device.rs
+++ b/crates/thumos/src/device.rs
@@ -23,66 +23,66 @@ use alloc::vec::Vec;
 // cross-module reference and kinit boot validation.
 
 /// UART0 (ttyMT0) MMIO base.
-#[expect(dead_code, reason = "canonical reference; driver uses local const")]
+#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
 pub(crate) const MT6739_UART0: usize = 0x1100_2000;
 
 /// UART1 (ttyMT1) MMIO base.
-#[expect(dead_code, reason = "canonical reference; driver uses local const")]
+#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
 pub(crate) const MT6739_UART1: usize = 0x1100_3000;
 
 /// MSDC0 eMMC controller MMIO base.
-#[expect(dead_code, reason = "canonical reference; driver uses local const")]
+#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
 pub(crate) const MT6739_MSDC0: usize = 0x1123_0000;
 
 /// MUSB OTG USB controller MMIO base.
-#[expect(dead_code, reason = "canonical reference; driver uses local const")]
+#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
 pub(crate) const MT6739_MUSB: usize = 0x1121_0000;
 
 /// MMSYS configuration base (display pipeline).
-#[expect(dead_code, reason = "canonical reference; driver uses local const")]
+#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
 pub(crate) const MT6739_MMSYS: usize = 0x1400_0000;
 
 /// OVL0 (overlay engine) MMIO base.
-#[expect(dead_code, reason = "canonical reference; driver uses local const")]
+#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
 pub(crate) const MT6739_OVL0: usize = 0x1400_7000;
 
 /// RDMA0 (read DMA engine) MMIO base.
-#[expect(dead_code, reason = "canonical reference; driver uses local const")]
+#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
 pub(crate) const MT6739_RDMA0: usize = 0x1400_8000;
 
 /// DSI0 controller MMIO base.
-#[expect(dead_code, reason = "canonical reference; driver uses local const")]
+#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
 pub(crate) const MT6739_DSI0: usize = 0x1400_D000;
 
 /// CLDMA AP-side register base (modem DMA).
-#[expect(dead_code, reason = "canonical reference; driver uses local const")]
+#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
 pub(crate) const MT6739_CLDMA_AP: usize = 0x200F_0000;
 
 /// CCIF peer register base (modem mailbox).
-#[expect(dead_code, reason = "canonical reference; driver uses local const")]
+#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
 pub(crate) const MT6739_CCIF: usize = 0x2051_0000;
 
 /// GIC distributor MMIO base.
-#[expect(dead_code, reason = "canonical reference; driver uses local const")]
+#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
 pub(crate) const MT6739_GIC_DIST: usize = 0x0C00_0000;
 
 /// GIC CPU interface MMIO base.
-#[expect(dead_code, reason = "canonical reference; driver uses local const")]
+#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
 pub(crate) const MT6739_GIC_CPU: usize = 0x0C00_2000;
 
 /// Keypad (KPD) controller MMIO base.
 pub(crate) const MT6739_KPD: usize = 0x1001_0000;
 
 /// WMT combo-chip (CONSYS) MMIO base.
-#[expect(dead_code, reason = "canonical reference; driver uses local const")]
+#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
 pub(crate) const MT6739_CONSYS: usize = 0x1800_0000;
 
 /// WiFi MMIO base.
-#[expect(dead_code, reason = "canonical reference; driver uses local const")]
+#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
 pub(crate) const MT6739_WLAN: usize = 0x180F_0000;
 
 /// Framebuffer physical address (set by LK bootloader).
-#[expect(dead_code, reason = "canonical reference; kconfig has matching const")]
+#[expect(dead_code, reason = "canonical reference; kconfig has matching const (#463)")]
 pub(crate) const MT6739_FB: usize = 0x77EE_0000;
 
 /// KPD enable register offset.

--- a/crates/thumos/src/dns_tls.rs
+++ b/crates/thumos/src/dns_tls.rs
@@ -36,7 +36,7 @@
 // WHY: DNS-over-TLS created in Phase 08 Wave 7, integration pending.
 #![expect(
     dead_code,
-    reason = "DNS-over-TLS created in Phase 08 Wave 7, network integration pending"
+    reason = "DNS-over-TLS created in Phase 08 Wave 7, network integration pending (#442)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/ekphrasis.rs
+++ b/crates/thumos/src/ekphrasis.rs
@@ -40,7 +40,7 @@
 // WHY: ekphrasis created in Phase 09 Wave 6, audio pipeline integration pending.
 #![expect(
     dead_code,
-    reason = "Ekphrasis created in Phase 09 Wave 6, audio pipeline integration pending"
+    reason = "Ekphrasis created in Phase 09 Wave 6, audio pipeline integration pending (#145)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/emmc.rs
+++ b/crates/thumos/src/emmc.rs
@@ -93,42 +93,42 @@ const REG_SDC_RESP3: usize = 0x4C;
 const REG_SDC_BLK_NUM: usize = 0x50;
 
 /// Card status.
-#[expect(dead_code, reason = "reserved for future status readback")]
+#[expect(dead_code, reason = "reserved for future status readback (#145)")]
 const REG_SDC_CSTS: usize = 0x58;
 
 /// Data CRC status per DAT line.
-#[expect(dead_code, reason = "reserved for future CRC diagnostics")]
+#[expect(dead_code, reason = "reserved for future CRC diagnostics (#145)")]
 const REG_SDC_DCRC_STS: usize = 0x60;
 
 /// Advanced config 0.
-#[expect(dead_code, reason = "reserved for future tuning")]
+#[expect(dead_code, reason = "reserved for future tuning (#145)")]
 const REG_SDC_ADV_CFG0: usize = 0x64;
 
 /// eMMC config 0: boot mode, part access.
-#[expect(dead_code, reason = "reserved for boot mode configuration")]
+#[expect(dead_code, reason = "reserved for boot mode configuration (#145)")]
 const REG_EMMC_CFG0: usize = 0x70;
 
 /// eMMC config 1.
-#[expect(dead_code, reason = "reserved for boot mode configuration")]
+#[expect(dead_code, reason = "reserved for boot mode configuration (#145)")]
 const REG_EMMC_CFG1: usize = 0x74;
 
 /// eMMC status: boot ack.
-#[expect(dead_code, reason = "reserved for boot status readback")]
+#[expect(dead_code, reason = "reserved for boot status readback (#145)")]
 const REG_EMMC_STS: usize = 0x78;
 
 /// eMMC I/O control.
-#[expect(dead_code, reason = "reserved for eMMC I/O tuning")]
+#[expect(dead_code, reason = "reserved for eMMC I/O tuning (#145)")]
 const REG_EMMC_IOCON: usize = 0x7C;
 
 /// DMA start address [35:32] (4 MSB).
-#[expect(dead_code, reason = "MT6739 is 32-bit; high bits unused")]
+#[expect(dead_code, reason = "MT6739 is 32-bit; high bits unused (#145)")]
 const REG_MSDC_DMA_SA_HIGH: usize = 0x8C;
 
 /// DMA start address [31:0].
 const REG_MSDC_DMA_SA: usize = 0x90;
 
 /// DMA current address.
-#[expect(dead_code, reason = "reserved for DMA progress monitoring")]
+#[expect(dead_code, reason = "reserved for DMA progress monitoring (#145)")]
 const REG_MSDC_DMA_CA: usize = 0x94;
 
 /// DMA control: start, stop, mode.
@@ -138,21 +138,21 @@ const REG_MSDC_DMA_CTRL: usize = 0x98;
 const REG_MSDC_DMA_CFG: usize = 0x9C;
 
 /// DMA transfer length.
-#[expect(dead_code, reason = "length encoded in GPD/BD descriptors")]
+#[expect(dead_code, reason = "length encoded in GPD/BD descriptors (#145)")]
 const REG_MSDC_DMA_LEN: usize = 0xA8;
 
 /// Patch register 0 (tuning overrides).
-#[expect(dead_code, reason = "reserved for auto-tuning")]
+#[expect(dead_code, reason = "reserved for auto-tuning (#145)")]
 const REG_MSDC_PATCH_BIT0: usize = 0xB0;
 
 /// Version register.
-#[expect(dead_code, reason = "reserved for version readback")]
+#[expect(dead_code, reason = "reserved for version readback (#145)")]
 const REG_MSDC_VERSION: usize = 0x114;
 
 // NOTE: source `drivers/mmc/host/mediatek/ComboA/msdc_reg.h:75–221`
 
 /// Inline AES encryption SELECT.
-#[expect(dead_code, reason = "reserved for encrypted storage layer")]
+#[expect(dead_code, reason = "reserved for encrypted storage layer (#145)")]
 const REG_MSDC_AES_SEL: usize = 0x280;
 
 // ---------------------------------------------------------------------------
@@ -169,7 +169,7 @@ const CFG_CKDIV_SHIFT: u32 = 8;
 const CFG_BUSWIDTH_1: u32 = 0b00 << 20;
 
 /// Bus width: 4-bit (bits [21:20] = 0b01).
-#[expect(dead_code, reason = "eMMC uses 8-bit; kept for SD card support")]
+#[expect(dead_code, reason = "eMMC uses 8-bit; kept for SD card support (#145)")]
 const CFG_BUSWIDTH_4: u32 = 0b01 << 20;
 
 /// Bus width: 8-bit (bits [21:20] = 0b10).
@@ -199,7 +199,7 @@ const CMD_RSPTYP_NONE: u32 = 0b00 << 7;
 const CMD_RSPTYP_R1: u32 = 0b01 << 7;
 
 /// Response type: R2 (136-bit).
-#[expect(dead_code, reason = "reserved for CID/CSD readback")]
+#[expect(dead_code, reason = "reserved for CID/CSD readback (#145)")]
 const CMD_RSPTYP_R2: u32 = 0b10 << 7;
 
 /// Response type: R3/R4 (48-bit, no CRC).
@@ -212,7 +212,7 @@ const CMD_DTYPE_READ: u32 = 0b01 << 11;
 const CMD_DTYPE_WRITE: u32 = 0b10 << 11;
 
 /// Block length shift for SDC_CMD (bits [31:16] in some configs).
-#[expect(dead_code, reason = "block length SET via SDC_CFG on MT6739")]
+#[expect(dead_code, reason = "block length SET via SDC_CFG on MT6739 (#145)")]
 const CMD_BLK_LEN_SHIFT: u32 = 16;
 
 // ---------------------------------------------------------------------------
@@ -226,7 +226,7 @@ const DMA_CTRL_START: u32 = 1 << 0;
 const DMA_CTRL_STOP: u32 = 1 << 1;
 
 /// DMA mode: basic (single buffer).
-#[expect(dead_code, reason = "descriptor mode used for scatter-gather")]
+#[expect(dead_code, reason = "descriptor mode used for scatter-gather (#145)")]
 const DMA_CTRL_MODE_BASIC: u32 = 0b00 << 8;
 
 /// DMA mode: descriptor (GPD/BD chain).
@@ -352,7 +352,7 @@ const CMD0_GO_IDLE: u32 = 0;
 const CMD1_SEND_OP_COND: u32 = 1;
 
 /// CMD2: ALL_SEND_CID  -  request card identification.
-#[expect(dead_code, reason = "reserved for CID readback")]
+#[expect(dead_code, reason = "reserved for CID readback (#145)")]
 const CMD2_ALL_SEND_CID: u32 = 2;
 
 /// CMD3: SET_RELATIVE_ADDR  -  assign relative card address.
@@ -362,11 +362,11 @@ const CMD3_SET_RELATIVE_ADDR: u32 = 3;
 const CMD7_SELECT_CARD: u32 = 7;
 
 /// CMD8: SEND_EXT_CSD  -  read extended CSD register.
-#[expect(dead_code, reason = "reserved for EXT_CSD readback")]
+#[expect(dead_code, reason = "reserved for EXT_CSD readback (#145)")]
 const CMD8_SEND_EXT_CSD: u32 = 8;
 
 /// CMD13: SEND_STATUS  -  read card status register.
-#[expect(dead_code, reason = "reserved for status polling")]
+#[expect(dead_code, reason = "reserved for status polling (#145)")]
 const CMD13_SEND_STATUS: u32 = 13;
 
 /// CMD16: SET_BLOCKLEN  -  SET block length to 512 bytes.

--- a/crates/thumos/src/exceptions_stub.rs
+++ b/crates/thumos/src/exceptions_stub.rs
@@ -42,7 +42,7 @@ pub(crate) fn uptime_ms() -> u64 {
 /// Test helper: set the tick counter to an absolute value.
 #[expect(
     dead_code,
-    reason = "settable-tick API for scheduler/time host tests; provided for the un-gating seam, not yet exercised by an un-gated test"
+    reason = "settable-tick API for scheduler/time host tests; provided for the un-gating seam, not yet exercised by an un-gated test (test-fixture)"
 )]
 pub(crate) fn set_ticks(value: u64) {
     TICKS.store(value, Ordering::Relaxed);
@@ -51,7 +51,7 @@ pub(crate) fn set_ticks(value: u64) {
 /// Test helper: advance the tick counter by `delta` ticks.
 #[expect(
     dead_code,
-    reason = "settable-tick API for scheduler/time host tests; provided for the un-gating seam, not yet exercised by an un-gated test"
+    reason = "settable-tick API for scheduler/time host tests; provided for the un-gating seam, not yet exercised by an un-gated test (test-fixture)"
 )]
 pub(crate) fn advance_ticks(delta: u64) {
     TICKS.fetch_add(delta, Ordering::Relaxed);

--- a/crates/thumos/src/fm_radio.rs
+++ b/crates/thumos/src/fm_radio.rs
@@ -31,7 +31,7 @@
 // WHY: FM radio driver not yet wired to kinit (Wave 8, kinit wiring pending).
 #![expect(
     dead_code,
-    reason = "FM radio driver created in Phase 07 Wave 8, kinit wiring pending"
+    reason = "FM radio driver created in Phase 07 Wave 8, kinit wiring pending (#518)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/gps.rs
+++ b/crates/thumos/src/gps.rs
@@ -26,7 +26,7 @@
 // WHY: hardware driver API not yet wired to upper layers (kinit integration pending).
 #![expect(
     dead_code,
-    reason = "GPS driver API wired in kinit but not yet called from userspace"
+    reason = "GPS driver API wired in kinit but not yet called from userspace (#145)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/harmostes.rs
+++ b/crates/thumos/src/harmostes.rs
@@ -33,7 +33,7 @@
 // WHY: Matrix client created in Phase 09 Wave 2, full integration pending in Wave 5.
 #![expect(
     dead_code,
-    reason = "Matrix client created in Phase 09 Wave 2, unified inbox integration pending"
+    reason = "Matrix client created in Phase 09 Wave 2, unified inbox integration pending (#145)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/http_client.rs
+++ b/crates/thumos/src/http_client.rs
@@ -29,7 +29,7 @@
 // WHY: HTTP client created in Phase 09 Wave 1, integration pending in Wave 2.
 #![expect(
     dead_code,
-    reason = "HTTP client created in Phase 09 Wave 1, harmostes integration pending"
+    reason = "HTTP client created in Phase 09 Wave 1, harmostes integration pending (#145)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/json_mini.rs
+++ b/crates/thumos/src/json_mini.rs
@@ -22,10 +22,10 @@
 //!   `\t`, `\uXXXX` (BMP only, no surrogate pair handling)
 //! - Maximum nesting depth of 32 to prevent stack overflow
 
-// WHY: JSON primitives created in Phase 09 Wave 1, harmostes integration pending.
+// WHY: JSON primitives created in Phase 09 Wave 1, harmostes integration pending (#145).
 #![expect(
     dead_code,
-    reason = "JSON primitives created in Phase 09 Wave 1, harmostes integration pending"
+    reason = "JSON primitives created in Phase 09 Wave 1, harmostes integration pending (#145)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -66,14 +66,14 @@ pub(crate) static DISPLAY_AVAILABLE: AtomicBool = AtomicBool::new(false);
 /// USB ACM serial link established.
 #[cfg_attr(
     feature = "qemu",
-    expect(dead_code, reason = "set by the USB init step, which is qemu-gated")
+    expect(dead_code, reason = "set by the USB init step, which is qemu-gated (#463)")
 )]
 pub(crate) static USB_SERIAL_AVAILABLE: AtomicBool = AtomicBool::new(false);
 
 /// Modem CCCI link established.
 #[cfg_attr(
     feature = "qemu",
-    expect(dead_code, reason = "set by the CCCI init step, which is qemu-gated")
+    expect(dead_code, reason = "set by the CCCI init step, which is qemu-gated (#463)")
 )]
 pub(crate) static MODEM_AVAILABLE: AtomicBool = AtomicBool::new(false);
 
@@ -85,7 +85,7 @@ pub(crate) static MODEM_AVAILABLE: AtomicBool = AtomicBool::new(false);
 /// depends on all preceding steps HAVING been attempted.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u8)]
-#[expect(dead_code, reason = "used by tests and future boot progress reporting")]
+#[expect(dead_code, reason = "used by tests and future boot progress reporting (test-fixture)")]
 pub(crate) enum BootStep {
     /// MMU and caches.
     Mmu = 0,
@@ -137,7 +137,7 @@ pub(crate) enum BootStep {
     Complete = 23,
 }
 
-#[expect(dead_code, reason = "used by tests and future boot progress reporting")]
+#[expect(dead_code, reason = "used by tests and future boot progress reporting (test-fixture)")]
 impl BootStep {
     /// Total number of boot steps.
     pub(crate) const COUNT: usize = 24;
@@ -287,7 +287,7 @@ impl BootState {
     feature = "qemu",
     expect(
         dead_code,
-        reason = "consumed by the CCCI init step, which is qemu-gated"
+        reason = "consumed by the CCCI init step, which is qemu-gated (#463)"
     )
 )]
 const MODEM_BOOT_TIMEOUT_MS: u64 = 10_000;

--- a/crates/thumos/src/matrix_crypto.rs
+++ b/crates/thumos/src/matrix_crypto.rs
@@ -26,7 +26,7 @@
 // WHY: Matrix crypto created in Phase 09 Wave 3, full integration pending.
 #![expect(
     dead_code,
-    reason = "Matrix crypto created in Phase 09 Wave 3, full messaging integration pending"
+    reason = "Matrix crypto created in Phase 09 Wave 3, full messaging integration pending (#437)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/meshtastic.rs
+++ b/crates/thumos/src/meshtastic.rs
@@ -34,7 +34,7 @@
 // protocol implementation via akroasis kerykeion pending.
 #![expect(
     dead_code,
-    reason = "Meshtastic transport stub created in Phase 09 Wave 7, serial protocol pending"
+    reason = "Meshtastic transport stub created in Phase 09 Wave 7, serial protocol pending (#145)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/mic_audit.rs
+++ b/crates/thumos/src/mic_audit.rs
@@ -33,7 +33,7 @@
 // WHY: mic audit log not yet wired to audio manager (Wave 8, wiring pending).
 #![expect(
     dead_code,
-    reason = "Mic audit log created in Phase 07 Wave 8, audio manager wiring pending"
+    reason = "Mic audit log created in Phase 07 Wave 8, audio manager wiring pending (#145)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/nous.rs
+++ b/crates/thumos/src/nous.rs
@@ -49,7 +49,7 @@
 // WHY: nous created in Phase 09 Wave 8, full Matrix room wiring pending.
 #![expect(
     dead_code,
-    reason = "Nous created in Phase 09 Wave 8, Matrix room wiring pending"
+    reason = "Nous created in Phase 09 Wave 8, Matrix room wiring pending (#145)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/power.rs
+++ b/crates/thumos/src/power.rs
@@ -34,7 +34,7 @@
     feature = "qemu",
     expect(
         dead_code,
-        reason = "the ARMPLL write is qemu-gated; virt models no MT6739 CMU"
+        reason = "the ARMPLL write is qemu-gated; virt models no MT6739 CMU (#463)"
     )
 )]
 const ARMPLL_CON1: usize = 0x1000_C104;

--- a/crates/thumos/src/reflex.rs
+++ b/crates/thumos/src/reflex.rs
@@ -92,7 +92,7 @@ pub(crate) fn raise_incoming_ring() {
     all(feature = "qemu", not(test)),
     expect(
         dead_code,
-        reason = "the qemu idle busy-polls; peek is the phone masked-WFI re-check"
+        reason = "the qemu idle busy-polls; peek is the phone masked-WFI re-check (#463)"
     )
 )]
 pub(crate) fn peek_pending() -> bool {

--- a/crates/thumos/src/sbc.rs
+++ b/crates/thumos/src/sbc.rs
@@ -22,7 +22,7 @@
 // WHY: A2DP profile not yet wired to audio session manager (Wave 8, kinit pending).
 #![expect(
     dead_code,
-    reason = "A2DP profile created in Phase 07 Wave 8, audio manager wiring pending"
+    reason = "A2DP profile created in Phase 07 Wave 8, audio manager wiring pending (#145)"
 )]
 
 use crate::bt_audio::BtAudioError;

--- a/crates/thumos/src/screen_alarm.rs
+++ b/crates/thumos/src/screen_alarm.rs
@@ -14,7 +14,7 @@
 // frame and has no alarm/timer route/input path.
 #![expect(
     dead_code,
-    reason = "Alarm screen is not wired into the kinit UI route"
+    reason = "Alarm screen is not wired into the kinit UI route (#145)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/screen_calendar.rs
+++ b/crates/thumos/src/screen_calendar.rs
@@ -18,7 +18,7 @@
 // frame and has no calendar route/input path.
 #![expect(
     dead_code,
-    reason = "Calendar screen is not wired into the kinit UI route"
+    reason = "Calendar screen is not wired into the kinit UI route (#145)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/screen_call.rs
+++ b/crates/thumos/src/screen_call.rs
@@ -16,7 +16,7 @@
 // WHY: call screen created in Phase 07 Wave 3, kinit wiring pending.
 #![expect(
     dead_code,
-    reason = "Call screen created in Phase 07 Wave 3, kinit wiring pending"
+    reason = "Call screen created in Phase 07 Wave 3, kinit wiring pending (#145)"
 )]
 
 use crate::ui::{

--- a/crates/thumos/src/screen_contacts.rs
+++ b/crates/thumos/src/screen_contacts.rs
@@ -20,7 +20,7 @@
 // WHY: contacts screen created in Phase 07 Wave 5, kinit wiring pending.
 #![expect(
     dead_code,
-    reason = "Contacts screen created in Phase 07 Wave 5, kinit wiring pending"
+    reason = "Contacts screen created in Phase 07 Wave 5, kinit wiring pending (#145)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/screen_fm.rs
+++ b/crates/thumos/src/screen_fm.rs
@@ -17,7 +17,7 @@
 // WHY: FM screen not yet wired to kinit (Wave 8, kinit wiring pending).
 #![expect(
     dead_code,
-    reason = "FM radio screen created in Phase 07 Wave 8, kinit wiring pending"
+    reason = "FM radio screen created in Phase 07 Wave 8, kinit wiring pending (#518)"
 )]
 
 use crate::fm_radio::{self, FmState};

--- a/crates/thumos/src/screen_nous.rs
+++ b/crates/thumos/src/screen_nous.rs
@@ -51,7 +51,7 @@
 // WHY: nous chat screen created in Phase 09 Wave 8, full integration pending.
 #![expect(
     dead_code,
-    reason = "Nous chat screen created in Phase 09 Wave 8, integration pending"
+    reason = "Nous chat screen created in Phase 09 Wave 8, integration pending (#145)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/screen_privacy.rs
+++ b/crates/thumos/src/screen_privacy.rs
@@ -20,7 +20,7 @@
 // WHY: privacy dashboard created in Phase 08 Wave 7, kinit wiring pending.
 #![expect(
     dead_code,
-    reason = "Privacy dashboard created in Phase 08 Wave 7, kinit wiring pending"
+    reason = "Privacy dashboard created in Phase 08 Wave 7, kinit wiring pending (#145)"
 )]
 
 use crate::lock_screen::constant_time_eq;

--- a/crates/thumos/src/screen_radio.rs
+++ b/crates/thumos/src/screen_radio.rs
@@ -16,7 +16,7 @@
 // WHY: radio control screen created in Phase 07 Wave 6, kinit wiring pending.
 #![expect(
     dead_code,
-    reason = "Radio control screen created in Phase 07 Wave 6, kinit wiring pending"
+    reason = "Radio control screen created in Phase 07 Wave 6, kinit wiring pending (#145)"
 )]
 
 use crate::ui::{

--- a/crates/thumos/src/screen_settings.rs
+++ b/crates/thumos/src/screen_settings.rs
@@ -18,7 +18,7 @@
 // WHY: settings screens created in Phase 07 Wave 6, kinit wiring pending.
 #![expect(
     dead_code,
-    reason = "Settings screens created in Phase 07 Wave 6, kinit wiring pending"
+    reason = "Settings screens created in Phase 07 Wave 6, kinit wiring pending (#145)"
 )]
 
 use crate::ui::{

--- a/crates/thumos/src/sms.rs
+++ b/crates/thumos/src/sms.rs
@@ -28,7 +28,7 @@
 // WHY: SMS API not yet wired to kinit event loop (Wave 4 integration).
 #![expect(
     dead_code,
-    reason = "SMS API created in Phase 07 Wave 3, kinit wiring pending"
+    reason = "SMS API created in Phase 07 Wave 3, kinit wiring pending (#145)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/t9.rs
+++ b/crates/thumos/src/t9.rs
@@ -28,10 +28,10 @@
 //! key sequence, all words whose letter-to-key mapping matches the pressed
 //! keys as a prefix are returned as candidates.
 
-// WHY: T9 input created in Phase 07 Wave 5, kinit wiring pending.
+// WHY: T9 input created in Phase 07 Wave 5, kinit wiring pending (#145).
 #![expect(
     dead_code,
-    reason = "T9 input created in Phase 07 Wave 5, kinit wiring pending"
+    reason = "T9 input created in Phase 07 Wave 5, kinit wiring pending (#145)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/telephony.rs
+++ b/crates/thumos/src/telephony.rs
@@ -29,7 +29,7 @@
 // WHY: hardware driver API not yet wired to upper layers (Wave 3 integration).
 #![expect(
     dead_code,
-    reason = "Telephony driver API not yet wired to kinit (Wave 3)"
+    reason = "Telephony driver API not yet wired to kinit (Wave 3) (#145)"
 )]
 
 // Re-export parser functions so external callers can still use crate::telephony::*.

--- a/crates/thumos/src/ui.rs
+++ b/crates/thumos/src/ui.rs
@@ -25,7 +25,7 @@
 // dispatch through UiManager are still pending.
 #![expect(
     dead_code,
-    reason = "UI framework has only initial home-frame kinit wiring"
+    reason = "UI framework has only initial home-frame kinit wiring (#145)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/wifi.rs
+++ b/crates/thumos/src/wifi.rs
@@ -26,7 +26,7 @@
 // frame TX/RX, scan, and association are implemented on the target.
 #![expect(
     dead_code,
-    reason = "WiFi hardware data path not yet implemented on target"
+    reason = "WiFi hardware data path not yet implemented on target (#145)"
 )]
 
 extern crate alloc;


### PR DESCRIPTION
kanon docs sync --check --repo thumos flagged AGENTS.md as drifted from
the current workflow/kanon.toml [projects.thumos] template. Regenerated
via kanon docs sync --apply --repo thumos, scoped to just AGENTS.md (the
file --check actually flagged; CLAUDE.md/README.md's new kanon:auto-start
blocks are left for a separate, deliberate fleet-wide rollout).

Cargo.lock still carried 0.1.7 for every workspace-member package entry
after the v0.1.8 release-please bump (e261d18) updated Cargo.toml's
workspace.package.version. Synced the lockfile to match.

kanon 0.1.10 hardened WORKFLOW/unwired-dead-code-untracked (kanon#2406,
kanon#2418): every dead_code allow/expect reason must carry a #NNN
reference or a closed-benign marker. The rule change retroactively
flagged 87 pre-existing suppressions across the thumos crate and its