### PR TITLE
fix(thumos): repair rustfmt drift in device.rs + kinit.rs (kanon#2522)

### DIFF
--- a/crates/thumos/src/device.rs
+++ b/crates/thumos/src/device.rs
@@ -23,66 +23,111 @@ use alloc::vec::Vec;
 // cross-module reference and kinit boot validation.
 
 /// UART0 (ttyMT0) MMIO base.
-#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
+#[expect(
+    dead_code,
+    reason = "canonical reference; driver uses local const (#463)"
+)]
 pub(crate) const MT6739_UART0: usize = 0x1100_2000;
 
 /// UART1 (ttyMT1) MMIO base.
-#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
+#[expect(
+    dead_code,
+    reason = "canonical reference; driver uses local const (#463)"
+)]
 pub(crate) const MT6739_UART1: usize = 0x1100_3000;
 
 /// MSDC0 eMMC controller MMIO base.
-#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
+#[expect(
+    dead_code,
+    reason = "canonical reference; driver uses local const (#463)"
+)]
 pub(crate) const MT6739_MSDC0: usize = 0x1123_0000;
 
 /// MUSB OTG USB controller MMIO base.
-#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
+#[expect(
+    dead_code,
+    reason = "canonical reference; driver uses local const (#463)"
+)]
 pub(crate) const MT6739_MUSB: usize = 0x1121_0000;
 
 /// MMSYS configuration base (display pipeline).
-#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
+#[expect(
+    dead_code,
+    reason = "canonical reference; driver uses local const (#463)"
+)]
 pub(crate) const MT6739_MMSYS: usize = 0x1400_0000;
 
 /// OVL0 (overlay engine) MMIO base.
-#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
+#[expect(
+    dead_code,
+    reason = "canonical reference; driver uses local const (#463)"
+)]
 pub(crate) const MT6739_OVL0: usize = 0x1400_7000;
 
 /// RDMA0 (read DMA engine) MMIO base.
-#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
+#[expect(
+    dead_code,
+    reason = "canonical reference; driver uses local const (#463)"
+)]
 pub(crate) const MT6739_RDMA0: usize = 0x1400_8000;
 
 /// DSI0 controller MMIO base.
-#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
+#[expect(
+    dead_code,
+    reason = "canonical reference; driver uses local const (#463)"
+)]
 pub(crate) const MT6739_DSI0: usize = 0x1400_D000;
 
 /// CLDMA AP-side register base (modem DMA).
-#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
+#[expect(
+    dead_code,
+    reason = "canonical reference; driver uses local const (#463)"
+)]
 pub(crate) const MT6739_CLDMA_AP: usize = 0x200F_0000;
 
 /// CCIF peer register base (modem mailbox).
-#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
+#[expect(
+    dead_code,
+    reason = "canonical reference; driver uses local const (#463)"
+)]
 pub(crate) const MT6739_CCIF: usize = 0x2051_0000;
 
 /// GIC distributor MMIO base.
-#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
+#[expect(
+    dead_code,
+    reason = "canonical reference; driver uses local const (#463)"
+)]
 pub(crate) const MT6739_GIC_DIST: usize = 0x0C00_0000;
 
 /// GIC CPU interface MMIO base.
-#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
+#[expect(
+    dead_code,
+    reason = "canonical reference; driver uses local const (#463)"
+)]
 pub(crate) const MT6739_GIC_CPU: usize = 0x0C00_2000;
 
 /// Keypad (KPD) controller MMIO base.
 pub(crate) const MT6739_KPD: usize = 0x1001_0000;
 
 /// WMT combo-chip (CONSYS) MMIO base.
-#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
+#[expect(
+    dead_code,
+    reason = "canonical reference; driver uses local const (#463)"
+)]
 pub(crate) const MT6739_CONSYS: usize = 0x1800_0000;
 
 /// WiFi MMIO base.
-#[expect(dead_code, reason = "canonical reference; driver uses local const (#463)")]
+#[expect(
+    dead_code,
+    reason = "canonical reference; driver uses local const (#463)"
+)]
 pub(crate) const MT6739_WLAN: usize = 0x180F_0000;
 
 /// Framebuffer physical address (set by LK bootloader).
-#[expect(dead_code, reason = "canonical reference; kconfig has matching const (#463)")]
+#[expect(
+    dead_code,
+    reason = "canonical reference; kconfig has matching const (#463)"
+)]
 pub(crate) const MT6739_FB: usize = 0x77EE_0000;
 
 /// KPD enable register offset.

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -66,14 +66,20 @@ pub(crate) static DISPLAY_AVAILABLE: AtomicBool = AtomicBool::new(false);
 /// USB ACM serial link established.
 #[cfg_attr(
     feature = "qemu",
-    expect(dead_code, reason = "set by the USB init step, which is qemu-gated (#463)")
+    expect(
+        dead_code,
+        reason = "set by the USB init step, which is qemu-gated (#463)"
+    )
 )]
 pub(crate) static USB_SERIAL_AVAILABLE: AtomicBool = AtomicBool::new(false);
 
 /// Modem CCCI link established.
 #[cfg_attr(
     feature = "qemu",
-    expect(dead_code, reason = "set by the CCCI init step, which is qemu-gated (#463)")
+    expect(
+        dead_code,
+        reason = "set by the CCCI init step, which is qemu-gated (#463)"
+    )
 )]
 pub(crate) static MODEM_AVAILABLE: AtomicBool = AtomicBool::new(false);
 
@@ -85,7 +91,10 @@ pub(crate) static MODEM_AVAILABLE: AtomicBool = AtomicBool::new(false);
 /// depends on all preceding steps HAVING been attempted.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u8)]
-#[expect(dead_code, reason = "used by tests and future boot progress reporting (test-fixture)")]
+#[expect(
+    dead_code,
+    reason = "used by tests and future boot progress reporting (test-fixture)"
+)]
 pub(crate) enum BootStep {
     /// MMU and caches.
     Mmu = 0,
@@ -137,7 +146,10 @@ pub(crate) enum BootStep {
     Complete = 23,
 }
 
-#[expect(dead_code, reason = "used by tests and future boot progress reporting (test-fixture)")]
+#[expect(
+    dead_code,
+    reason = "used by tests and future boot progress reporting (test-fixture)"
+)]
 impl BootStep {
     /// Total number of boot steps.
     pub(crate) const COUNT: usize = 24;


### PR DESCRIPTION
## Summary

`cargo fmt --manifest-path crates/thumos/Cargo.toml --check` (edition 2024, per both `Cargo.toml` and `rustfmt.toml`) was failing on main. Several long `#[expect(dead_code, reason = "...")]` attributes in `device.rs` and `kinit.rs` exceeded rustfmt's line-width limit and needed multi-line wrapping.

Applied `rustfmt --edition 2024` directly to the two affected files — no other change.

Note: the kernel crate (`crates/thumos`) is excluded from the workspace, so `cargo fmt --all` alone never catches this; the CI `fmt` job's second, manifest-path-scoped invocation is what actually enforces it.

## Test plan

- [ ] CI `fmt` job (both the workspace `--all --check` step and the `crates/thumos` manifest-path step) goes green