### PR TITLE
fix(thumos): faithful mm syscall fixture + sys_brk section shatter (#533)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,6 +447,35 @@ jobs:
           grep -q 'init: guard readable after mprotect' guard.log || { echo 'FAIL #496: mprotect(PROT_NONE -> PROT_READ) failed, or the guard frame did not survive'; exit 1; }
           grep -q 'shell: hello from userspace' guard.log || { echo 'FAIL #496: /shell did not coexist (#526)'; exit 1; }
           grep -q 'THUMOS-QEMU: service-loop ticks=' guard.log || { echo 'FAIL #496: kernel did not survive the guard fault'; exit 1; }
+      - name: QEMU brk heap growth on a real page table (#533)
+        working-directory: crates/thumos
+        # WHY: #533. sys_brk growth maps into the heap window (mb 0x100), which
+        # every real process L1 covers with a 1 MB identity SECTION -- and
+        # map_page refuses to overlay a section, so brk growth failed on every
+        # real boot while host tests (absent-entry fixture) stayed green. Host
+        # tests are structurally incapable of catching this class; this
+        # witness is the only real-table proof for heap growth, mirroring the
+        # #496 guard witness for mmap. The /init brk variant grows the heap by
+        # two pages (sys_brk reports failure by returning the UNCHANGED break,
+        # so the return check catches the overlay refusal directly), writes +
+        # reads a canary in BOTH new pages at PL0 (a missing or kernel-only
+        # grant data-aborts -> USERFAULT red), then shrinks back.
+        run: |
+          set -uo pipefail
+          THUMOS_INIT_VARIANT=brk cargo build --release --target armv7a-none-eabi --features qemu --jobs 8
+          brc=0
+          THUMOS_INIT_VARIANT=brk THUMOS_QEMU_TIMEOUT=60 ../../scripts/qemu-runner.sh target/armv7a-none-eabi/release/thumos | tee brk.log || brc=$?
+          echo "=== brk: runner rc=$brc (want 0) ==="
+          test "$brc" -eq 0 || { echo "FAIL #533: kernel did not survive (rc=$brc; 124=hang 2/3=abort)"; exit 1; }
+          grep -q 'init: brk grown' brk.log || { echo 'FAIL #533: brk grow did not advance the break on a real table (section-overlay bug)'; exit 1; }
+          ! grep -q 'init: brk grow FAILED' brk.log || { echo 'FAIL #533: sys_brk grow returned the unchanged break -- map_page could not overlay the heap section'; exit 1; }
+          grep -q 'init: brk canary ok' brk.log || { echo 'FAIL #533: heap canary readback failed -- the grown pages are not PL0-accessible'; exit 1; }
+          ! grep -q 'init: brk canary BROKEN' brk.log || { echo 'FAIL #533: explicit heap canary mismatch'; exit 1; }
+          ! grep -q 'USERFAULT:' brk.log || { echo 'FAIL #533: touching the grown heap faulted -- the user grant never landed'; exit 1; }
+          grep -q 'init: brk shrunk' brk.log || { echo 'FAIL #533: brk shrink back to the initial break failed'; exit 1; }
+          grep -q 'init: hello from userspace' brk.log || { echo 'FAIL #533: /init did not continue past the brk harness'; exit 1; }
+          grep -q 'shell: hello from userspace' brk.log || { echo 'FAIL #533: /shell (PID 2) did not coexist (#526)'; exit 1; }
+          grep -q 'THUMOS-QEMU: service-loop ticks=' brk.log || { echo 'FAIL #533: kernel did not survive the brk harness'; exit 1; }
       - name: QEMU PID-0 fault supervisor + crash-loop rate limit (#492)
         working-directory: crates/thumos
         # WHY: #492. notify_fault used to ipc::send its report to PID 0's inbox,

--- a/crates/thumos/build.rs
+++ b/crates/thumos/build.rs
@@ -193,7 +193,7 @@ fn compile_init_binary(
     .arg("link-arg=max-page-size=0x100")
     // WHY (#487): declare the probe cfgs so a direct rustc compile does not warn.
     .arg("--check-cfg")
-    .arg("cfg(thumos_init_kread, thumos_init_kwrite, thumos_init_kexec, thumos_init_cp15, thumos_init_sleep, thumos_init_fork, thumos_init_exec, thumos_init_forkexec, thumos_init_guard)");
+    .arg("cfg(thumos_init_kread, thumos_init_kwrite, thumos_init_kexec, thumos_init_cp15, thumos_init_sleep, thumos_init_fork, thumos_init_exec, thumos_init_forkexec, thumos_init_guard, thumos_init_brk)");
     if let Some(cfg) = variant_cfg {
         cmd.arg("--cfg").arg(cfg);
     }
@@ -229,11 +229,12 @@ fn generate_initramfs(manifest_dir: &Path, out_dir: &Path) {
         Ok(v) if !v.is_empty() => {
             if ![
                 "kread", "kwrite", "kexec", "cp15", "sleep", "fork", "exec", "forkexec", "guard",
+                "brk",
             ]
             .contains(&v.as_str())
             {
                 die(&format!(
-                    "#487: unknown THUMOS_INIT_VARIANT '{v}' (expected kread|kwrite|kexec|cp15|sleep|fork|exec|forkexec|guard)"
+                    "#487: unknown THUMOS_INIT_VARIANT '{v}' (expected kread|kwrite|kexec|cp15|sleep|fork|exec|forkexec|guard|brk)"
                 ));
             }
             Some(format!("thumos_init_{v}"))

--- a/crates/thumos/init/init.rs
+++ b/crates/thumos/init/init.rs
@@ -188,6 +188,29 @@ unsafe fn sys_mprotect(addr: u32, len: u32, prot: u32) -> u32 {
     ret
 }
 
+/// brk(new_break) -> the (possibly updated) program break. The kernel reports
+/// failure by returning the UNCHANGED break (Linux convention), never an
+/// errno.
+///
+/// # Safety
+/// Adjusts this process's heap break; pages at/above the new break are
+/// unmapped and freed.
+#[cfg(thumos_init_brk)]
+#[inline(always)]
+unsafe fn sys_brk(new_break: u32) -> u32 {
+    let ret;
+    // SAFETY: SVC #22 (Brk) per the thumos ABI.
+    unsafe {
+        core::arch::asm!(
+            "svc #0",
+            in("r7") 22u32,
+            inlateout("r0") new_break => ret,
+            options(nostack),
+        );
+    }
+    ret
+}
+
 /// ELF entry point (e_entry). The kernel transmutes the loaded entry to
 /// PL0 isolation probe (#487): under a `thumos_init_<variant>` cfg (set by
 /// build.rs from THUMOS_INIT_VARIANT), attempt a kernel-memory or privileged
@@ -438,6 +461,50 @@ pub extern "C" fn _start() -> ! {
             }
             core::ptr::read_volatile(guard_addr);
             let m = b"init: guard readable after mprotect\n";
+            sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+        }
+        // #533 brk harness: grow the heap by two pages on a REAL process table
+        // -- a cloned identity map whose heap window (mb 0x100) is a 1 MB
+        // SECTION that map_page refuses to overlay, so brk growth failed on
+        // every real boot while host tests (absent-entry fixture) stayed
+        // green. sys_brk reports failure by returning the UNCHANGED break, so
+        // the return-value checks catch that directly; the canary then proves
+        // the new pages are genuinely PL0-writable (a missing or kernel-only
+        // grant data-aborts here -> USERFAULT, which CI reds on). Finally
+        // shrink back, proving the teardown half on the same table shape.
+        #[cfg(thumos_init_brk)]
+        {
+            let initial = sys_brk(0);
+            let grown = initial + 2 * 4096;
+            if initial == 0 || sys_brk(grown) != grown {
+                let m = b"init: brk grow FAILED\n";
+                sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+                sys_exit(1);
+            }
+            let m = b"init: brk grown\n";
+            sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+            // The heap VA as a pointer, converted once (brk returned != 0).
+            // .add(1024) steps one u32 page (1024 * 4 = 4096 bytes). Both
+            // pages [initial, grown) were just mapped user-RW by the
+            // successful grow above; a broken grant faults here (by design).
+            let heap = usize::try_from(initial).unwrap_or(0) as *mut u32;
+            core::ptr::write_volatile(heap, 0xCAFE_0001);
+            core::ptr::write_volatile(heap.add(1024), 0xCAFE_0002);
+            let ok = core::ptr::read_volatile(heap) == 0xCAFE_0001
+                && core::ptr::read_volatile(heap.add(1024)) == 0xCAFE_0002;
+            if !ok {
+                let m = b"init: brk canary BROKEN\n";
+                sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+                sys_exit(1);
+            }
+            let m = b"init: brk canary ok\n";
+            sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+            if sys_brk(initial) != initial {
+                let m = b"init: brk shrink FAILED\n";
+                sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+                sys_exit(1);
+            }
+            let m = b"init: brk shrunk\n";
             sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
         }
         sys_write(1, msg.as_ptr(), u32::try_from(msg.len()).unwrap_or(0));

--- a/crates/thumos/src/syscall.rs
+++ b/crates/thumos/src/syscall.rs
@@ -1039,9 +1039,19 @@ fn sys_brk(new_break_raw: u32) -> u32 {
                 return current_u32;
             };
 
+            // #533: the heap window (mb 0x100) is identity SECTION-mapped in
+            // every real process L1, and map_page REFUSES to overlay a section
+            // -- so brk growth failed on every real table (it only ever worked
+            // against the synthetic absent-entry tables of the pre-#533 host
+            // fixture). ensure_page_mappable shatters such a section first,
+            // exactly as map_user_image / map_user_stack do at spawn and
+            // sys_mmap does since #496; it is idempotent (one L2 per MB) and a
+            // no-op for an absent entry.
             // SAFETY: pt is the current process's valid L1 table, vaddr is
             // page-aligned within the heap region, phys is freshly allocated.
-            let ok = unsafe { mmu::map_page(pt, vaddr, phys, l2_attrs) };
+            let ok = unsafe {
+                mmu::ensure_page_mappable(pt, vaddr) && mmu::map_page(pt, vaddr, phys, l2_attrs)
+            };
             if !ok {
                 // Mapping failed (e.g., L2 pool exhausted) -- free the page
                 // under the kernel L1 (#497 zero-on-free aliasing), restoring
@@ -1058,6 +1068,15 @@ fn sys_brk(new_break_raw: u32) -> u32 {
                     return EINVAL;
                 };
                 return current_u32;
+            }
+            // #533: this table is LIVE, and the MB was a section until the
+            // shatter above -- invalidate the stale section TLB entry so the
+            // heap access resolves through the freshly-installed page
+            // descriptor (same live-table obligation as sys_mmap).
+            // SAFETY: vaddr is page-aligned in the current process's address
+            // space.
+            unsafe {
+                mmu::flush_tlb_page(vaddr);
             }
         }
         process::set_heap_break(new_break);
@@ -1920,9 +1939,53 @@ mod tests {
     // ---- Memory management syscall tests ----
 
     /// Set up process 0 with a valid page table for memory management tests.
+    ///
+    /// WHY (#533): the table must have the shape a REAL spawn leaves behind --
+    /// `alloc_addr_space()` + `clone_addr_space(mmu::table_base(), pt)`
+    /// (process.rs's spawn/fork), i.e. a clone of the kernel identity map in
+    /// which the heap window (mb 0x100) and the mmap window (mb 0x200) are
+    /// 1 MB SECTIONS that `map_page` refuses to overlay. The old fixture
+    /// stopped at `reset_for_test`'s absent-entry table, so `map_page` only
+    /// ever took its "no mapping -> allocate an L2" branch: every
+    /// mmap/brk/mprotect test passed against an L1 shape no real process has,
+    /// while sys_mmap returned MAP_FAILED on every real boot (#496) and
+    /// sys_brk growth never worked at all. mmu.rs's own tests build the
+    /// faithful shape exactly this way.
     unsafe fn setup_mm() {
         unsafe {
             process::reset_for_test();
+            // Populate the kernel L1 with the identity sections (host: table
+            // writes only -- program_translation is an off-ARM no-op), then
+            // clone it into process 0's freshly allocated table, as spawn does.
+            mmu::init_and_enable();
+            let pt = process::current_page_table();
+            mmu::clone_addr_space(mmu::table_base(), pt);
+        }
+    }
+
+    /// #533 fixture-faithfulness guard: setup_mm() must produce a CLONED
+    /// IDENTITY table -- the heap and mmap windows covered by 1 MB SECTION
+    /// descriptors (bits[1:0]=0b10), not the absent entries the old synthetic
+    /// fixture had. A fixture regression fails THIS test with a clear message
+    /// instead of silently re-opening the mmap/brk test gap.
+    #[test]
+    fn fixture_table_is_a_cloned_identity_map_with_sections() {
+        unsafe {
+            setup_mm();
+        }
+        let pt = process::current_page_table();
+        assert_ne!(pt, 0, "process 0 must have a page table");
+        for (window, name) in [
+            (process::DEFAULT_HEAP_BREAK, "heap"),
+            (process::MMAP_BASE, "mmap"),
+        ] {
+            // SAFETY: pt is process 0's valid L1 table; the index is < 4096.
+            let entry = unsafe { (pt as *const u32).add(window >> 20).read_volatile() };
+            assert_eq!(
+                entry & 0b11,
+                0b10,
+                "the {name} window must be an identity SECTION in a faithful process table (#533) -- an absent entry would re-open the synthetic-fixture test gap"
+            );
         }
     }
 


### PR DESCRIPTION
Kimi lane fix, T0-reviewed. Hosted CI (gate full-gate-build + QEMU witnesses) is the proof.

Refs #533