### PR TITLE
fix(device): derive GIC base addresses from kconfig, not a local literal (#463)

### DIFF
--- a/crates/thumos/src/device.rs
+++ b/crates/thumos/src/device.rs
@@ -8,6 +8,7 @@
 //! keypad, touch, modem, WiFi, BT, GPS, FM, USB, and eMMC.
 
 extern crate alloc;
+use crate::kconfig::{GICC_BASE, GICD_BASE};
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -114,24 +115,10 @@ pub(crate) const MT6739_CLDMA_AP: usize = 0x200F_0000;
 pub(crate) const MT6739_CCIF: usize = 0x2051_0000;
 
 /// GIC distributor MMIO base.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "canonical reference; driver uses local const (#463)"
-    )
-)]
-pub(crate) const MT6739_GIC_DIST: usize = 0x0C00_0000;
+pub(crate) const MT6739_GIC_DIST: usize = GICD_BASE;
 
 /// GIC CPU interface MMIO base.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "canonical reference; driver uses local const (#463)"
-    )
-)]
-pub(crate) const MT6739_GIC_CPU: usize = 0x0C00_2000;
+pub(crate) const MT6739_GIC_CPU: usize = GICC_BASE;
 
 /// Keypad (KPD) controller MMIO base.
 pub(crate) const MT6739_KPD: usize = 0x1001_0000;
@@ -298,8 +285,8 @@ impl DeviceRegistry {
         self.register("msdc0", 0x1123_0000, 0); // eMMC controller
 
         // GIC
-        self.register("gic-dist", 0x0C00_0000, 0);
-        self.register("gic-cpu", 0x0C00_2000, 0);
+        self.register("gic-dist", MT6739_GIC_DIST, 0);
+        self.register("gic-cpu", MT6739_GIC_CPU, 0);
     }
 }
 


### PR DESCRIPTION
## Fix
`device.rs` hardcoded the GIC distributor/CPU-interface MMIO base addresses in TWO places (the top-of-file `MT6739_GIC_DIST`/`MT6739_GIC_CPU` consts + a separate literal pair in `register_mt6739_devices()`), kept in sync only by a pinned test — while `gic.rs` already derives them from `kconfig::{GICD_BASE, GICC_BASE}` (which remap under the `qemu` feature to the virt-board GICv2 addresses). Both const definitions now derive from kconfig and the registry uses them, so the qemu remap stays consistent across the crate.

The consts' `#[cfg_attr(not(test), expect(dead_code, ...))]` markers are removed — obsolete once the (non-test) `register_mt6739_devices` reads them, and leaving them would become an unfulfilled `#[expect]` that the armv7a `-D warnings` gate turns fatal. GIC-only scope; the other MT6739_* consts and kconfig.rs/gic.rs are untouched.

Refs #463