### PR TITLE
fix(telephony)

### DIFF
--- a/crates/thumos/src/telephony.rs
+++ b/crates/thumos/src/telephony.rs
@@ -838,7 +838,7 @@ impl<T: ModemTransport> Telephony<T> {
         let creg_query = send_with_info(&mut self.transport, "AT+CREG?", 5000);
         if let Ok((AtResponse::Ok, ref info_line, info_len)) = creg_query
             && info_len > 0
-            && let Some((stat, act)) = parse_creg_response(&info_line[..info_len])
+            && let Some((stat, act)) = parse_creg_query_response(&info_line[..info_len])
         {
             self.apply_reg_status(stat, act);
         }
@@ -1364,8 +1364,8 @@ mod tests {
         mock.queue_ok();
         // Step 9: AT+CSQ -> +CSQ: 18,99 + OK
         mock.queue_info_ok(b"+CSQ: 18,99");
-        // Step 10: AT+CREG? -> +CREG: 1 (registered home) + OK
-        mock.queue_info_ok(b"+CREG: 1");
+        // Step 10: AT+CREG? -> +CREG: 0,1 (registered home) + OK
+        mock.queue_info_ok(b"+CREG: 0,1");
         mock
     }
 
@@ -1864,7 +1864,7 @@ mod tests {
         mock.queue_response(b"ERROR"); // AT+CREG=1 -> ERROR
         mock.queue_response(b"ERROR"); // AT+CLIP=1 -> ERROR
         mock.queue_info_ok(b"+CSQ: 18,99");
-        mock.queue_info_ok(b"+CREG: 0");
+        mock.queue_info_ok(b"+CREG: 0,0");
 
         let mut tel = Telephony::new(mock);
         let result = tel.initialize();
@@ -1904,8 +1904,8 @@ mod tests {
         mock.queue_ok();
         // Step 9: AT+CSQ -> +CSQ: 18,99 + OK
         mock.queue_info_ok(b"+CSQ: 18,99");
-        // Step 10: AT+CREG? -> +CREG: 1 (registered home) + OK
-        mock.queue_info_ok(b"+CREG: 1");
+        // Step 10: AT+CREG? -> +CREG: 0,1 (registered home) + OK
+        mock.queue_info_ok(b"+CREG: 0,1");
 
         let mut tel = Telephony::new(mock);
         let result = tel.initialize();
@@ -2023,7 +2023,7 @@ mod tests {
         mock.queue_ok(); // AT+CREG=1
         mock.queue_ok(); // AT+CLIP=1
         mock.queue_info_ok(b"+CSQ: 18,99");
-        mock.queue_info_ok(b"+CREG: 2"); // searching, not registered
+        mock.queue_info_ok(b"+CREG: 0,2"); // searching, not registered
 
         let mut tel = Telephony::new(mock);
         let result = tel.initialize();
@@ -2082,7 +2082,7 @@ mod tests {
         mock.queue_ok();
         mock.queue_ok();
         mock.queue_info_ok(b"+CSQ: 18,99");
-        mock.queue_info_ok(b"+CREG: 2"); // searching at init time
+        mock.queue_info_ok(b"+CREG: 0,2"); // searching at init time
 
         let mut tel = Telephony::new(mock);
         tel.initialize().ok();
@@ -2157,7 +2157,7 @@ mod tests {
 
     #[test]
     fn rat_is_seeded_from_creg_query_at_init() {
-        let mock = mock_for_init_with_creg(b"+CREG: 1,\"1A2B\",\"0100CE01\",7");
+        let mock = mock_for_init_with_creg(b"+CREG: 1,1,\"1A2B\",\"0100CE01\",7");
         let mut tel = Telephony::new(mock);
         tel.initialize().ok();
         assert!(tel.is_registered(), "must be registered (stat=1)");
@@ -2171,7 +2171,7 @@ mod tests {
     #[test]
     fn rat_tracks_urc_updates_and_clears_on_deregistration() {
         // Init registered on LTE.
-        let mock = mock_for_init_with_creg(b"+CREG: 1,\"1A2B\",\"0100CE01\",7");
+        let mock = mock_for_init_with_creg(b"+CREG: 1,1,\"1A2B\",\"0100CE01\",7");
         let mut tel = Telephony::new(mock);
         tel.initialize().ok();
         assert_eq!(tel.rat(), Some(RadioAccessTech::EUtran), "seeded LTE");

--- a/crates/thumos/src/telephony_mock.rs
+++ b/crates/thumos/src/telephony_mock.rs
@@ -86,7 +86,7 @@ impl MockModemTransport {
         // 10: AT+CREG? (registered home on E-UTRAN/LTE, <AcT>=7) -- the <AcT>
         // field lets a booted qemu kernel exercise the RAT-parsing path so the
         // status bar's network label is RAT-derived, not hardcoded.
-        mock.queue_info_ok(b"+CREG: 1,\"1A2B\",\"0100CE01\",7");
+        mock.queue_info_ok(b"+CREG: 1,1,\"1A2B\",\"0100CE01\",7");
         // A queued ICCID response for the boot-time SimManager query (#398).
         mock.queue_info_ok(b"+ICCID: 8901410321111851072");
         // Post-init responses for the boot-time SIM-management smoke (#398), in

--- a/crates/thumos/src/telephony_parser.rs
+++ b/crates/thumos/src/telephony_parser.rs
@@ -73,6 +73,26 @@ pub(crate) fn parse_creg_response(line: &[u8]) -> Option<(RegStatus, Option<Radi
     Some((stat, act))
 }
 
+/// Parse a +CREG QUERY response line (issue #514): "+CREG: <n>,<stat>[,<lac>,<ci>[,<AcT>]]"
+///
+/// The `AT+CREG?` query reply carries a leading `<n>` field (the URC-mode
+/// setting echoed back, 3GPP TS 27.007 §7.2) that the unsolicited `+CREG`
+/// URC does not -- every field [`parse_creg_response`] reads is shifted one
+/// position later here: `<stat>` is field 1 (not field 0) and `<AcT>` is
+/// field 4 (not field 3). Calling [`parse_creg_response`] on a query reply
+/// misreads `<n>` as `<stat>`.
+pub(crate) fn parse_creg_query_response(
+    line: &[u8],
+) -> Option<(RegStatus, Option<RadioAccessTech>)> {
+    let rest = strip_prefix(line, b"+CREG: ")?;
+    let stat = RegStatus::from(parse_u8(nth_field(rest, 1)?)?);
+    let act = nth_field(rest, 4)
+        .filter(|field| !field.is_empty())
+        .and_then(parse_u8)
+        .and_then(RadioAccessTech::from_act);
+    Some((stat, act))
+}
+
 /// Return the Nth (0-indexed) comma-separated field of `input`, or `None` when
 /// fewer than `n + 1` fields are present. Fields are returned verbatim (quotes
 /// on `<lac>`/`<ci>` are left intact -- the caller parses only the fields it
@@ -431,6 +451,23 @@ mod tests {
             parse_creg_response(b"+CREG: 1,,,7"),
             Some((RegStatus::RegisteredHome, Some(RadioAccessTech::EUtran))),
             "AcT must parse from field 3 even when lac/ci are empty"
+        );
+    }
+
+    #[test]
+    fn parse_creg_query_response_extracts_stat_and_access_technology() {
+        // issue #514: the AT+CREG? query reply carries a leading <n> field
+        // that the +CREG URC does not, so <stat> and <AcT> sit one field
+        // later than in parse_creg_response.
+        assert_eq!(
+            parse_creg_query_response(b"+CREG: 2,5,\"1A2B\",\"0100CE01\",7"),
+            Some((RegStatus::RegisteredRoaming, Some(RadioAccessTech::EUtran))),
+            "query stat=5 (field 1) and AcT=7 (field 4) must parse despite the leading <n> field"
+        );
+        assert_eq!(
+            parse_creg_query_response(b"+CREG: 0,5"),
+            Some((RegStatus::RegisteredRoaming, None)),
+            "a short-form query reply with no lac/ci/AcT must still extract stat from field 1"
         );
     }
 


### PR DESCRIPTION
## Fix
 parse AT+CREG query responses with their own field layout (#514):The kernel telephony driver used one parser for both the +CREG URC layout and the AT+CREG? *query* response, but the query form carries a leading `<n>` field — so `<stat>` is at field 1 (not 0) and `<AcT>` at field 4. `initialize()` Step 10 misread `<n>` as `<stat>` on real hardware (e.g. `+CREG: 0,5` = registered-roaming read as NotRegistered). Adds a dedicated `parse_creg_query_response`, swaps the Step-10 call to it, and updates the query mocks to the query wire form. `parse_creg_response` (URC path) + all `queue_urc` sites are untouched.

Refs #514