### PR TITLE
feat(kernel)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ Categories: hw (hardware-dependent), crypto (needs crypto primitives), phase07/p
 
 ## Build
 
-Workspace compiles on host (`cargo check/test`). Kernel cross-compiles for `armv7a-none-eabi` via `cargo build --release` in `crates/thumos/` (the bare-metal kernel binary, excluded from the main workspace). Boot image created with mkbootimg, flashed via mtkclient BROM exploit.
+Workspace compiles on host (`cargo check/test`). Kernel cross-compiles for `armv7a-none-eabi` via `cargo build --release` in `crates/thumos/` (the bare-metal kernel binary, excluded from the main workspace). Boot image created with mkbootimg, flashed via mtkclient BROM exploit. Kernel-state debugging entry point: `THUMOS_QEMU_GDB=1` + `scripts/gdb-thumos.sh` (see `scripts/README.md`).
 
 ## Standards
 

--- a/docs/KERNEL-BUILD.md
+++ b/docs/KERNEL-BUILD.md
@@ -154,6 +154,12 @@ build-then-runner pattern above. See the `kernel` job in
 `.github/workflows/ci.yml` for the exact invocations; do not copy them into
 new scripts.
 
+When the boot witness above fails or a kernel-state question needs more than
+grep-able boot-log lines, reach for the GDB workflow in `scripts/README.md`
+(`THUMOS_QEMU_GDB=1 scripts/qemu-runner.sh` + `scripts/gdb-thumos.sh`) first,
+before adding a UART probe — it attaches a real debugger with symbols against
+the same QEMU boot path used above, with no kernel code changes required.
+
 A lighter smoke check that needs no kernel runtime (boot stub + UART write +
 semihosting exit only) is documented in `scripts/README.md` (a convenience
 example; not wired into CI):

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -72,3 +72,41 @@ MMU). Once it is green, the follow-up is to convert the kernel crate's
 `#[cfg(test)]` unit tests to a `custom_test_frameworks` test runner that
 dispatches through this same script. That conversion touches every kernel
 module and is tracked in issue #124 (follow-up to #117).
+
+## gdb-thumos.sh
+
+GDB attach helper for the thumos kernel under QEMU (#532).
+
+`qemu-runner.sh` free-runs the guest by default; setting `THUMOS_QEMU_GDB=1`
+switches it to boot with a GDB stub instead, halted until a debugger attaches:
+
+```bash
+THUMOS_QEMU_GDB=1 scripts/qemu-runner.sh target/armv7a-none-eabi/release/thumos &
+scripts/gdb-thumos.sh target/armv7a-none-eabi/release/thumos
+```
+
+`gdb-thumos.sh` connects to that stub with symbols loaded from the given ELF,
+sets a breakpoint at `kinit::run`, and drops into an interactive GDB session.
+Override the port with `THUMOS_QEMU_GDB_PORT` (both scripts read the same
+variable; default `1234`) or a second positional argument.
+
+### Requirements
+
+- `gdb-multiarch` (preferred) or `arm-none-eabi-gdb`. If neither is on PATH,
+  the script prints an install diagnostic and exits `127`.
+
+```bash
+# Fedora
+sudo dnf install gdb-multiarch
+
+# Debian/Ubuntu
+sudo apt-get install gdb-multiarch
+```
+
+### Exit codes
+
+| Code | Meaning                                  |
+|------|-------------------------------------------|
+| 64   | Script called without an ELF argument.     |
+| 66   | ELF path does not exist.                   |
+| 127  | No ARM-capable gdb installed.              |

--- a/scripts/gdb-thumos.sh
+++ b/scripts/gdb-thumos.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# GDB attach helper for the thumos kernel under QEMU.
+#
+# Purpose: pairs with scripts/qemu-runner.sh's THUMOS_QEMU_GDB=1 opt-in --
+# that flag halts QEMU with a GDB stub listening on a TCP port instead of
+# free-running; this script attaches a GDB (with ARM symbols) to that port
+# and sets a breakpoint at kernel entry.
+#
+# Usage:
+#   THUMOS_QEMU_GDB=1 scripts/qemu-runner.sh <kernel-elf> &
+#   scripts/gdb-thumos.sh <kernel-elf> [port]
+#
+# Requirements:
+#   - gdb-multiarch (preferred) or arm-none-eabi-gdb. If neither is on PATH,
+#     the script prints an install diagnostic and exits 127.
+
+ELF="${1:-}"
+if [[ -z "${ELF}" ]]; then
+  echo "gdb-thumos: usage: $0 <kernel-elf> [port]" >&2
+  exit 64
+fi
+
+PORT="${2:-${THUMOS_QEMU_GDB_PORT:-1234}}"
+
+if [[ ! -f "${ELF}" ]]; then
+  echo "gdb-thumos: ELF not found: ${ELF}" >&2
+  exit 66
+fi
+
+GDB_BIN=""
+if command -v gdb-multiarch >/dev/null 2>&1; then
+  GDB_BIN="gdb-multiarch"
+elif command -v arm-none-eabi-gdb >/dev/null 2>&1; then
+  GDB_BIN="arm-none-eabi-gdb"
+else
+  cat >&2 <<'EOF'
+gdb-thumos: no ARM-capable gdb found on PATH (tried gdb-multiarch,
+arm-none-eabi-gdb).
+
+Install on Fedora:
+  sudo dnf install gdb-multiarch
+
+Install on Debian/Ubuntu:
+  sudo apt-get install gdb-multiarch
+EOF
+  exit 127
+fi
+
+exec "${GDB_BIN}" "${ELF}" \
+  -ex "target remote :${PORT}" \
+  -ex "break kinit::run" \
+  -ex "echo ...attached..."

--- a/scripts/qemu-runner.sh
+++ b/scripts/qemu-runner.sh
@@ -83,6 +83,15 @@ fi
 # test harness grows.
 TIMEOUT_SECS="${THUMOS_QEMU_TIMEOUT:-60}"
 
+# WHY (#532): THUMOS_QEMU_GDB=1 halts QEMU waiting for a debugger instead of
+# free-running — scripts/gdb-thumos.sh attaches to this port. Unset/0
+# (the default) leaves every existing invocation, including CI, unchanged.
+GDB_ARGS=()
+if [[ "${THUMOS_QEMU_GDB:-0}" == "1" ]]; then
+  GDB_PORT="${THUMOS_QEMU_GDB_PORT:-1234}"
+  GDB_ARGS=(-gdb "tcp::${GDB_PORT}" -S)
+fi
+
 exec timeout --kill-after=5 "${TIMEOUT_SECS}" \
   qemu-system-arm \
     -machine virt \
@@ -91,4 +100,5 @@ exec timeout --kill-after=5 "${TIMEOUT_SECS}" \
     -nographic \
     -semihosting-config enable=on,target=native \
     -kernel "${BINARY}" \
+    "${GDB_ARGS[@]}" \
     "$@"


### PR DESCRIPTION
## Fix
 add an opt-in qemu gdb stub for kernel debugging (#532):`scripts/qemu-runner.sh` never passed `-s`/`-S`/`-gdb`, so every kernel bug was printf-bisected. `THUMOS_QEMU_GDB=1` now halts QEMU waiting for a debugger and `scripts/gdb-thumos.sh` attaches with DWARF symbols + a breakpoint on `kinit::run`. Default-off (unset env var) so CI and every existing invocation run a byte-identical qemu command line. Shell + docs only, no Rust/clippy surface.

Refs #532