### PR TITLE
fix(thumos): restore pub(crate) on kinit_plan consts dropped by #561

### DIFF
--- a/crates/thumos/src/kinit_plan.rs
+++ b/crates/thumos/src/kinit_plan.rs
@@ -248,11 +248,11 @@ impl BootState {
         reason = "consumed by the CCCI init step, which is qemu-gated (#463)"
     )
 )]
-const MODEM_BOOT_TIMEOUT_MS: u64 = 10_000;
+pub(crate) const MODEM_BOOT_TIMEOUT_MS: u64 = 10_000;
 
 /// Framebuffer RGB565 colour: solid red (panic and secure-boot-halt
-/// indicator). main.rs's panic handler uses the literal directly.
-const PANIC_RED_RGB565: u16 = 0xF800;
+/// indicator).
+pub(crate) const PANIC_RED_RGB565: u16 = 0xF800;
 
 // ---------------------------------------------------------------------------
 // Userspace spawn planning


### PR DESCRIPTION
## Regression

`main` has been red since #561 (the `kinit_plan` extraction). The refactor moved `MODEM_BOOT_TIMEOUT_MS` and `PANIC_RED_RGB565` out of `kinit.rs` into `kinit_plan.rs` but left them **private**, while every sibling extracted item (`BootState`, `BootStep`, the boot-state methods) correctly received `pub(crate)`. `kinit.rs` still imports both consts, so the `armv7a-none-eabi` build fails `E0603` in the "kernel (i686 tests + armv7a build)" job:

- `MODEM_BOOT_TIMEOUT_MS` — imported by the `#[cfg(not(feature = "qemu"))]` path in `kinit.rs`
- `PANIC_RED_RGB565` — imported unconditionally, used by the panic-framebuffer fill

## Fix

Restore `pub(crate)` on both consts, matching their extracted siblings. Also drops the now-inaccurate "main.rs's panic handler uses the literal directly" note from the `PANIC_RED_RGB565` doc comment (it justified a privacy that no longer holds).

## Verification (local, at this branch)

- `cargo build --release --target armv7a-none-eabi --jobs 8` → compiles clean
- `cargo build --release --target armv7a-none-eabi --features qemu --jobs 8` → compiles clean
- `THUMOS_QEMU_TIMEOUT=60 scripts/qemu-runner.sh …/release/thumos` → boots to `THUMOS v0.1.0`, `THUMOS-QEMU: boot-complete`, `THUMOS-QEMU: service-loop ticks=50`, exit 0

Refs #528