### PR TITLE
fix(release): keep eidolon's haphe pin in step with the workspace version

### DIFF
--- a/crates/eidolon/Cargo.toml
+++ b/crates/eidolon/Cargo.toml
@@ -10,7 +10,11 @@ repository.workspace = true
 [dependencies]
 embedded-graphics = { workspace = true }
 embedded-graphics-core = { workspace = true }
-haphe = { path = "../haphe", version = "0.1.3" }
+# WARNING: the version here duplicates `[workspace.package].version` and has
+# no other source of truth. release-please patches it via the `extra-files`
+# entry in release-please-config.json; if that entry is removed the pin goes
+# stale silently and stops resolving at the next minor bump (#571).
+haphe = { path = "../haphe", version = "0.1.11" }
 
 [lints]
 workspace = true

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,6 +23,11 @@
           "type": "toml",
           "path": "Cargo.toml",
           "jsonpath": "$.workspace.package.version"
+        },
+        {
+          "type": "toml",
+          "path": "crates/eidolon/Cargo.toml",
+          "jsonpath": "$..[?(@.path)].version"
         }
       ]
     }


### PR DESCRIPTION
Closes the imminent break described in #571. Not a latent issue — it lands on the first `feat` commit that reaches a release.

## Cause

`crates/eidolon/Cargo.toml:13` pinned `haphe = { path = "../haphe", version = "0.1.3" }`. `haphe` takes its version from `[workspace.package]`, which is at `0.1.11`. It has resolved for eight patch releases purely because `^0.1.3` matches `0.1.x`.

`release-please-config.json` patched only `$.workspace.package.version` in the root manifest, so every release moved the workspace and left the pin behind. `bump-minor-pre-major: true` means the next `feat` produces `0.2.0`, which `^0.1.3` does not match.

The failure is at dependency resolution, so it precedes compilation and takes every stage with it — `check`, `clippy`, `nextest`, the armv7a cross-build, the QEMU boot test — and it lands on the release PR itself, where the natural reading is "the release tooling is broken" rather than "a pin two files away went stale".

## Change

- Repairs the pin to `0.1.11`.
- Adds the `extra-files` entry that keeps it there:

```json
{ "type": "toml", "path": "crates/eidolon/Cargo.toml", "jsonpath": "$..[?(@.path)].version" }
```

  Recursive descent onto any dependency table carrying a `path` key, rather than naming `haphe`. `eidolon` → `haphe` is currently the only intra-workspace path dependency in the repo; writing it this way means a second one would be covered without another config edit and another chance to forget.

- A `WARNING` above the pin naming the config entry as its only keeper, so deleting that entry is not a silent removal.

## Verification

On a throwaway detached worktree, setting `[workspace.package].version = "0.2.0"` and changing nothing else:

```
$ cargo metadata --format-version 1 --offline
error: failed to select a version for the requirement `haphe = "^0.1.3"`
candidate versions found which didn't match: 0.2.0
required by package `eidolon v0.2.0`
exit 101
```

With the pin tracking the workspace version, the same simulated bump resolves — `cargo metadata` exits 0.

**Stated as unverified:** that release-please's TOML updater applies this jsonpath the way I read it. That is only observable on the next real release PR. The resolution failure above is exactly what it looks like if it does not, so the next release PR is the falsifier and it fails loudly rather than silently.

## Not in this change

Two things deliberately left alone, both argued in #571:

- **Deleting the `version` field entirely.** The workspace is `publish = false`, a path dep needs no version to build, and under `PHILOSOPHY.md` § Declarativeness hierarchy the pin is a hardcoded duplicate of a fact the workspace already owns — this PR is machinery for keeping two copies in sync rather than removing the second copy. It is the better fix. It also changes what `cargo package` does, which is inside #536's reserved decision, so it is the operator's call.
- **#536** — `cargo package` needing `haphe` on crates.io. Same line, unrelated failure, untouched.

## Fleet note

kanon has the identical shape at scale: 27 intra-workspace path deps pinned at `version = "0.1.0"` against a workspace at `0.1.12`, with a `0.2.0` release PR open. Per-repo config is the fix that has to be remembered once per repo with nothing noticing when it is not, so the durable instrument is a lint rule; filing that against kanon separately.

Refs #571