### PR TITLE
fix(release): keep Cargo.lock's local packages on the workspace version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "aither"
-version = "0.1.8"
+version = "0.1.12"
 dependencies = [
  "getrandom 0.4.2",
  "hmac",
@@ -59,7 +59,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "asphaleia"
-version = "0.1.8"
+version = "0.1.12"
 dependencies = [
  "log",
  "rustix",
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "eidolon"
-version = "0.1.8"
+version = "0.1.12"
 dependencies = [
  "embedded-graphics",
  "embedded-graphics-core",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "haphe"
-version = "0.1.8"
+version = "0.1.12"
 
 [[package]]
 name = "hash32"
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "kelyphos"
-version = "0.1.8"
+version = "0.1.12"
 dependencies = [
  "log",
  "snafu",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "klesis"
-version = "0.1.8"
+version = "0.1.12"
 dependencies = [
  "log",
  "nom",
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "krypta"
-version = "0.1.8"
+version = "0.1.12"
 dependencies = [
  "aes-gcm",
  "ed25519-dalek",
@@ -690,7 +690,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "leipsanon"
-version = "0.1.8"
+version = "0.1.12"
 dependencies = [
  "getrandom 0.4.2",
  "log",
@@ -740,7 +740,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metaxu"
-version = "0.1.8"
+version = "0.1.12"
 dependencies = [
  "compact_str",
  "jiff",
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "pteron"
-version = "0.1.8"
+version = "0.1.12"
 dependencies = [
  "jiff",
  "log",
@@ -1042,7 +1042,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sema"
-version = "0.1.8"
+version = "0.1.12"
 dependencies = [
  "jiff",
  "log",
@@ -1204,7 +1204,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stegnos"
-version = "0.1.8"
+version = "0.1.12"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "topos"
-version = "0.1.8"
+version = "0.1.12"
 dependencies = [
  "jiff",
  "log",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -28,6 +28,11 @@
           "type": "toml",
           "path": "crates/eidolon/Cargo.toml",
           "jsonpath": "$..[?(@.path)].version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[?(!@.source)].version"
         }
       ]
     }


### PR DESCRIPTION
`Cargo.lock` recorded all thirteen workspace-local packages at 0.1.8 while `workspace.package.version` was 0.1.12. `release-please-config.json` rewrites the workspace version and eidolon's haphe pin, and nothing targets the lock, so it drifts one release at a time and nothing goes red.

## What changed

- `{"type":"toml","path":"Cargo.lock","jsonpath":"$.package[?(!@.source)].version"}` — the `!@.source` filter selects exactly the workspace-local packages, since every registry package carries a `source` key.
- The thirteen current entries move to 0.1.12. Only `version` lines change; the dependency graph is untouched.

## The eidolon pin is already fixed

The fleet-level note on thumos's release config still lists `crates/eidolon/Cargo.toml`'s `haphe = { path = "../haphe", version = "0.1.3" }` as outstanding. It is not: #572 added the extra-file entry, and the 0.1.12 release (#573) exercised it — the release commit's diffstat includes `crates/eidolon/Cargo.toml`, and `git merge-base --is-ancestor 3bf8660 7f3c705` confirms the entry was in place when that release was cut. The pin reads 0.1.12 on `main` today. That jsonpath works, so this PR leaves it alone.

## Scope

Deliberately does not touch the packaging story in #536 — that needs a decision about what release attestation should cover, and repairing the lock does not change its failure mode.

No enforcing test here. thumos has no `tests/` directory and no lint surface of its own to hang one on, and picking an arbitrary crate to host a workspace-wide invariant would put it in the wrong place. The general shape — a `kanon lint` rule that holds intra-workspace versions in lockstep, which would cover kanon, theatron, thumos and the four repos carrying the latent gap — is filed against kanon.

Refs #574