### PR TITLE
fix(release): root eidolon's version jsonpath at [dependencies]

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -27,7 +27,7 @@
         {
           "type": "toml",
           "path": "crates/eidolon/Cargo.toml",
-          "jsonpath": "$..[?(@.path)].version"
+          "jsonpath": "$.dependencies[?(@.path)].version"
         },
         {
           "type": "toml",


### PR DESCRIPTION
`release-please-config.json` patched eidolon's haphe pin with `$..[?(@.path)].version`. Recursive descent reaches every table carrying a `path` key — `[lib]`, `[[bin]]`, `[[bench]]`, `[[example]]`, `[[test]]` — not just path-dependencies. It is correct today only because eidolon's manifest happens to hold exactly one `path` key.

Evaluated with the `jsonpath` package against eidolon's shape plus the `[lib]` and `[[bin]]` tables a member crate may gain at any time:

```
$..[?(@.path)]            -> ["$.lib", "$.dependencies.haphe", "$.bin.0"]
$.dependencies[?(@.path)] -> ["$.dependencies.haphe"]
```

So the current filter would write a `version` key into `[lib]`/`[[bin]]` as soon as one exists, producing a manifest that does not parse — and it would surface during a release.

Rooting the filter matches the form theatron already uses; thumos was the only fleet repo on the recursive variant. Selection is unchanged against the manifest as it stands.

Does not add a per-repo lockstep check: that detection capability is owned by forkwright/kanon#2689.

Refs #577