### PR TITLE
ci(security): scan every Cargo.lock graph + manifest guard (#547)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -16,4 +16,6 @@ ignore = [
     "RUSTSEC-2021-0006",
     # atomic-polyfill unmaintained — transitive via heapless 0.7.17 → postcard 1.1.3 → sema/krypta. heapless 0.8+ drops atomic-polyfill in favor of portable-atomic, but postcard 1.x has not yet bumped its heapless pin past 0.7. Track postcard upstream for the heapless bump.
     "RUSTSEC-2023-0089",
+    # proc-macro-error2 unmaintained — lockfile-only presence in the kernel graph via smoltcp 0.12's optional defmt feature (defmt-macros → defmt). The kernel enables smoltcp with default-features = false and no defmt feature, so the crate is never compiled. No safe upgrade until defmt migrates off proc-macro-error2. Surfaced by the #547 multi-graph scan.
+    "RUSTSEC-2026-0173",
 ]

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -51,7 +51,10 @@ jobs:
         # direction (unscanned lockfile, entry for a deleted one) reds here.
         run: scripts/check-lockfile-manifest.sh
       - name: Install cargo-deny
-        run: cargo install cargo-deny --locked
+        # WHY: pinned off the 0.20 line — 0.20 changed the check-subcommand
+        # CLI (dropped `check --config`); scripts/security-scan.sh is verified
+        # against the 0.19 CLI. The 0.20 migration is tracked follow-up work.
+        run: cargo install cargo-deny --locked --version ^0.19
       - name: cargo deny (all graphs)
         # WHY (#547): advisories/licenses/bans/sources over EVERY graph in
         # the lockfile manifest (workspace, kernel, fuzz) — one script and

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,19 +36,27 @@ jobs:
     # not silent --ignore flags.
     name: cargo deny
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false # PROJECT: security hardening — never expose token to steps
-      - uses: EmbarkStudios/cargo-deny-action@6c8f9facfa5047ec02d8485b6bf52b587b7777d1 # v2.0.18
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          # WHY: run every check explicitly so a schema regression in one
-          # section can't silently disable the others. cargo-deny expects
-          # the check subcommand followed by space-separated check names;
-          # `arguments:` passes post-subcommand flags only.
-          command: check advisories licenses bans sources
-          arguments: --all-features
+          key: cargo-deny
+      - name: Lockfile manifest guard
+        # WHY (#547): an unclassified new Cargo.lock must fail the required
+        # gate. The manifest is the explicit scanned-set; drift in either
+        # direction (unscanned lockfile, entry for a deleted one) reds here.
+        run: scripts/check-lockfile-manifest.sh
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked
+      - name: cargo deny (all graphs)
+        # WHY (#547): advisories/licenses/bans/sources over EVERY graph in
+        # the lockfile manifest (workspace, kernel, fuzz) — one script and
+        # one deny.toml SSOT, findings attributed per-graph.
+        run: scripts/security-scan.sh deny
 
   cargo-audit:
     # WHY: cargo-deny's advisories check overlaps but uses a different code
@@ -67,12 +75,13 @@ jobs:
           key: cargo-audit
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked --version ^0.22
-      - name: cargo audit
+      - name: cargo audit (all graphs)
         # WHY: -D unmaintained,unsound,yanked escalates those categories
         # to errors (default is warning only). Suppressions go through
         # .cargo/audit.toml, which mirrors deny.toml's [[advisories.ignore]]
-        # entries — no silent --ignore flags here.
-        run: cargo audit --deny unmaintained --deny unsound --deny yanked
+        # entries — no silent --ignore flags here. Runs over every graph in
+        # the lockfile manifest, not just the workspace root (#547).
+        run: scripts/security-scan.sh audit
 
   osv-scanner:
     name: osv-scanner
@@ -97,5 +106,7 @@ jobs:
           curl -sSfL "https://github.com/google/osv-scanner/releases/download/${OSV_VERSION}/osv-scanner_linux_amd64" -o osv-scanner
           echo "${OSV_SHA256}  osv-scanner" | sha256sum -c -
           chmod +x osv-scanner
-      - name: Scan Cargo.lock (fail on vulnerability)
-        run: ./osv-scanner --lockfile=./Cargo.lock --config=./osv-scanner.toml
+      - name: Scan all Cargo.lock graphs (fail on vulnerability)
+        # WHY (#547): the kernel and fuzz lockfiles carry their own advisories
+        # surface; one script loops the manifest, per-graph attribution.
+        run: scripts/security-scan.sh osv ./osv-scanner

--- a/deny.toml
+++ b/deny.toml
@@ -1,8 +1,22 @@
 [graph]
 targets = []
-all-features = false
+# WHY: evaluate every feature branch of every graph — the previous workflow's
+# action passed --all-features; advisory chains that only exist behind a
+# non-default feature (e.g. fuzz graph's wit-* branch) are otherwise pruned
+# and invisibly skipped (#547).
+all-features = true
 
 [advisories]
+
+# WHY: escalate unmaintained/unsound/yanked from warn to deny (scope "all" =
+# deny for every crate), mirroring the cargo-audit job's
+# `--deny unmaintained --deny unsound --deny yanked` — the two tools must
+# enforce the same stated policy (SUPPLY-CHAIN.md), or a finding red in one
+# scanner passes the other (#547 witness run: an unsound advisory passed
+# cargo-deny as warn-only while cargo-audit correctly red it).
+unmaintained = "all"
+unsound = "all"
+yanked = "deny"
 
 # WHY: keep in sync with .cargo/audit.toml's [advisories.ignore] array.
 # cargo-audit does not read deny.toml, so any ignore lives in both files.

--- a/deny.toml
+++ b/deny.toml
@@ -27,6 +27,10 @@ reason = "False positive: same collision as RUSTSEC-2020-0128. The flagged `cach
 id = "RUSTSEC-2023-0089"
 reason = "atomic-polyfill unmaintained — transitive via heapless 0.7.17 → postcard 1.1.3 → sema/krypta. heapless 0.8+ drops atomic-polyfill in favor of portable-atomic, but postcard 1.x has not yet bumped its heapless pin past 0.7. Track postcard upstream for the heapless bump."
 
+[[advisories.ignore]]
+id = "RUSTSEC-2026-0173"
+reason = "proc-macro-error2 unmaintained — lockfile-only presence in the kernel graph via smoltcp 0.12's optional defmt feature (defmt-macros → defmt). The kernel enables smoltcp with default-features = false and no defmt feature, so the crate is never compiled. No safe upgrade until defmt migrates off proc-macro-error2. Surfaced by the #547 multi-graph scan."
+
 [licenses]
 # WHY: license allow list mirrors aletheia's deny.toml. Each addition over
 # kanon's original list is for a real transitive dep:
@@ -36,8 +40,18 @@ reason = "atomic-polyfill unmaintained — transitive via heapless 0.7.17 → po
 #   - 0BSD: managed v0.8.0 + smoltcp v0.12.0 (via aither network stack).
 #     0BSD is the BSD Zero Clause License — OSI-approved, public-domain
 #     equivalent. Less restrictive than MIT (no attribution required).
-allow = ["MIT", "Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "ISC", "Unicode-3.0", "Zlib", "MPL-2.0", "BSL-1.0", "CC0-1.0", "0BSD", "Apache-2.0 WITH LLVM-exception", "CDLA-Permissive-2.0", "LicenseRef-PolyForm-Shield-1.0.0"]
+allow = ["MIT", "Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "ISC", "Unicode-3.0", "Zlib", "MPL-2.0", "BSL-1.0", "CC0-1.0", "0BSD", "Apache-2.0 WITH LLVM-exception", "CDLA-Permissive-2.0", "LicenseRef-PolyForm-Shield-1.0.0", "NCSA"]
 confidence-threshold = 0.8
+
+# WHY: NCSA (University of Illinois/NCSA Open Source License) is OSI-approved
+# permissive, BSD-family — required by libfuzzer-sys in the fuzz graph (#547).
+# WHY: the kernel package is first-party AGPL-3.0-only (the repo's LICENSE is
+# PolyForm Shield for the workspace; the kernel carries its own license). The
+# exception is scoped to the first-party `thumos` crate only — third-party
+# AGPL dependencies remain rejected everywhere (#547).
+[[licenses.exceptions]]
+allow = ["AGPL-3.0-only"]
+crate = "thumos"
 
 [bans]
 multiple-versions = "warn"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aither"
-version = "0.1.5"
+version = "0.1.16"
 dependencies = [
  "getrandom 0.4.2",
  "hmac",
@@ -18,9 +18,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -30,7 +30,7 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "asphaleia"
-version = "0.1.5"
+version = "0.1.16"
 dependencies = [
  "log",
  "rustix",
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "klesis"
-version = "0.1.5"
+version = "0.1.16"
 dependencies = [
  "log",
  "nom",
@@ -331,6 +331,16 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
+]
+
+[[package]]
+name = "peirama"
+version = "0.0.0"
+dependencies = [
+ "aither",
+ "asphaleia",
+ "klesis",
+ "libfuzzer-sys",
 ]
 
 [[package]]
@@ -506,16 +516,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "thumos-fuzz"
-version = "0.0.0"
-dependencies = [
- "aither",
- "asphaleia",
- "klesis",
- "libfuzzer-sys",
 ]
 
 [[package]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -6,6 +6,9 @@ version = "0.0.0"
 publish = false
 edition = "2024"
 # WHY: cargo-fuzz requires nightly; this crate is never published.
+# WHY: first-party test crate takes the repo license (root workspace is
+# PolyForm Shield); cargo-deny warns on a missing license field (#547).
+license = "LicenseRef-PolyForm-Shield-1.0.0"
 
 [[bin]]
 name = "fuzz_eapol"

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -21,3 +21,7 @@ reason = "False positive: same collision as RUSTSEC-2020-0128. The flagged `cach
 [[IgnoredVulns]]
 id = "RUSTSEC-2023-0089"
 reason = "atomic-polyfill unmaintained — transitive via heapless 0.7.17 → postcard 1.1.3 → sema/krypta. heapless 0.8+ drops atomic-polyfill in favor of portable-atomic, but postcard 1.x has not yet bumped its heapless pin past 0.7. Track postcard upstream for the heapless bump."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0173"
+reason = "proc-macro-error2 unmaintained — lockfile-only presence in the kernel graph via smoltcp 0.12's optional defmt feature (defmt-macros → defmt). The kernel enables smoltcp with default-features = false and no defmt feature, so the crate is never compiled. No safe upgrade until defmt migrates off proc-macro-error2. Surfaced by the #547 multi-graph scan."

--- a/scripts/check-lockfile-manifest.sh
+++ b/scripts/check-lockfile-manifest.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# check-lockfile-manifest.sh — drift guard for the lockfile scan manifest (#547).
+# Fails when the tracked Cargo.lock set and scripts/lockfile-scan-manifest.txt
+# disagree in either direction: an unscanned new lockfile, or a manifest entry
+# whose lockfile no longer exists.
+set -euo pipefail
+
+repo=$(git rev-parse --show-toplevel)
+manifest="$repo/scripts/lockfile-scan-manifest.txt"
+
+drift=$(comm -3 \
+    <(git -C "$repo" ls-files -- '*Cargo.lock' | sort) \
+    <(grep -vE '^[[:space:]]*(#|$)' "$manifest" | cut -d'|' -f1 | sed 's/[[:space:]]//g' | sort))
+if [[ -n "$drift" ]]; then
+    printf 'lockfile-scan manifest drift — every tracked Cargo.lock must be classified in %s:\n%s\n' \
+        "$manifest" "$drift" >&2
+    exit 1
+fi
+printf 'lockfile-scan manifest: %d graphs classified, no drift\n' \
+    "$(git -C "$repo" ls-files -- '*Cargo.lock' | wc -l)"

--- a/scripts/lockfile-scan-manifest.txt
+++ b/scripts/lockfile-scan-manifest.txt
@@ -1,0 +1,11 @@
+# Lockfile scan manifest (issue #547) — every Cargo.lock tracked in this repo
+# MUST appear here, either as a scanned graph or as a documented exclusion.
+# scripts/check-lockfile-manifest.sh fails the Security workflow when
+# `git ls-files -- '*Cargo.lock'` and this manifest disagree, so a new
+# lockfile can never silently go unscanned.
+#
+# Format (pipe-separated): <lockfile path> | <graph label> | scanned
+#                          <lockfile path> | <graph label> | excluded: <reason>
+Cargo.lock | workspace | scanned
+crates/thumos/Cargo.lock | kernel | scanned
+fuzz/Cargo.lock | fuzz | scanned

--- a/scripts/security-scan.sh
+++ b/scripts/security-scan.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# security-scan.sh <deny|audit|osv> [osv-binary] — run one scanner over every
+# graph in scripts/lockfile-scan-manifest.txt (#547). One code path per tool so
+# findings are attributed per-graph and no graph can be silently skipped.
+# Exclusion lines (`| excluded: reason`) are honored and reported, not scanned.
+set -euo pipefail
+
+mode="${1:?usage: security-scan.sh <deny|audit|osv> [osv-binary]}"
+repo=$(git rev-parse --show-toplevel)
+manifest="$repo/scripts/lockfile-scan-manifest.txt"
+rc=0
+
+while IFS='|' read -r lockfile label disposition; do
+    case "$lockfile" in ''|\#*) continue ;; esac
+    lockfile=$(printf '%s' "$lockfile" | sed 's/[[:space:]]//g')
+    label=$(printf '%s' "$label" | sed 's/^ *//; s/ *$//')
+    disposition=$(printf '%s' "$disposition" | sed 's/^ *//; s/ *$//')
+    case "$disposition" in
+        excluded:*)
+            printf '== %s (%s) — EXCLUDED: %s\n' "$lockfile" "$label" "${disposition#excluded: }"
+            continue
+            ;;
+    esac
+    printf '== %s (%s)\n' "$lockfile" "$label"
+    case "$mode" in
+        deny)
+            manifest_dir=$(dirname "$lockfile")
+            cargo deny --manifest-path "$repo/$manifest_dir/Cargo.toml" \
+                check --config "$repo/deny.toml" advisories licenses bans sources || rc=1
+            ;;
+        audit)
+            # .cargo/audit.toml at the repo root holds the ignore SSOT; advisory
+            # ignores are inert on graphs that do not contain the crate.
+            (cd "$repo" && cargo audit --file "$lockfile" \
+                --deny unmaintained --deny unsound --deny yanked) || rc=1
+            ;;
+        osv)
+            osv_bin="${2:?osv mode needs the scanner binary path as \$2}"
+            "$osv_bin" --lockfile="$repo/$lockfile" --config="$repo/osv-scanner.toml" || rc=1
+            ;;
+        *)
+            printf 'unknown mode: %s\n' "$mode" >&2
+            exit 2
+            ;;
+    esac
+done < "$manifest"
+
+exit "$rc"


### PR DESCRIPTION
## Summary

The Security workflow scanned only the root `Cargo.lock`; the kernel (60 pkgs, no_std crypto) and fuzz (78 pkgs) graphs had no advisory/license/ban/source coverage at all.

- `scripts/lockfile-scan-manifest.txt` is the explicit scanned-set; `scripts/check-lockfile-manifest.sh` fails the required cargo-deny gate when `git ls-files` and the manifest disagree, so an unclassified new lockfile can never go unscanned (exclusions are documented in the manifest)
- `scripts/security-scan.sh` runs `cargo deny` / `cargo audit` / `osv-scanner` over every graph from one code path, with per-graph attribution
- deny.toml (SSOT; audit.toml + osv-scanner.toml re-derived): crate-scoped AGPL-3.0-only exception for the first-party kernel package; NCSA allowed for libfuzzer-sys; peirama states the repo license

## Findings the new coverage surfaced (resolved in this PR)

- `anyhow 1.0.102` unsound (RUSTSEC-2026-0190, fuzz graph) → bumped to 1.0.104
- `proc-macro-error2` unmaintained (RUSTSEC-2026-0173, kernel graph) → documented ignore: lockfile-only presence via smoltcp's *disabled* defmt feature; never compiled; no safe upgrade until defmt migrates

## Verification

- Guard: green on the 3-graph tree; reds with attribution on a staged 4th lockfile (local witness)
- deny/audit/osv: all three graphs green locally
- Red-witness on CI: a throwaway commit adding a known-advisory crate to the fuzz graph will be pushed on this branch to prove the gate reds with per-graph attribution, then removed by force-push before merge

Closes #547