### PR TITLE
docs(wiring): derive capability reachability from code + executable witnesses (#550)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,11 @@ jobs:
         # script (#546); runner exit codes: 0=loop ran; 5=loop-stall (#461);
         # 1=panic; 2/3/4=aborts; 124=hang.
         run: scripts/witness/boot.sh
+      - name: Capability-reachability inventory check (#550)
+        # WHY (#550): the inventory is the SSOT for what is wired; reds when a
+        # module is unclassified, a witness is claimed but not asserted, or an
+        # asserted witness did not fire in the boot.log just produced above.
+        run: scripts/check-wiring-inventory.sh
       - name: Kernel-fault halts (PL1 fault must NEVER be recovered)
         run: scripts/witness/kfault.sh
       - name: Userspace sleep really yields (#477, no busy-wait deadlock)

--- a/.kanon-ci.toml
+++ b/.kanon-ci.toml
@@ -29,6 +29,7 @@ stages = [
     "kernel trust anchor",
     "kernel host tests",
     "kernel qemu witnesses",
+    "wiring inventory",
     "cargo clippy",
     "cargo nextest",
     "kanon lint",
@@ -68,6 +69,13 @@ timeout_secs = 1800
 [stages."kernel qemu witnesses"]
 cmd = "scripts/witness-run-all.sh"
 timeout_secs = 3600
+
+# WHY (#550): the capability inventory is the SSOT for what is wired; reds
+# on unclassified modules, phantom entries, or a witness that did not fire
+# in the boot.log the witness stage just produced.
+[stages."wiring inventory"]
+cmd = "scripts/check-wiring-inventory.sh"
+timeout_secs = 300
 
 [stages."cargo clippy"]
 cmd = "cargo clippy --workspace --all-targets --jobs 8 -- -D warnings"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Higher-level capabilities - multi-screen UI routing, Bluetooth/GPS userspace con
 thumos is pre-hardware. What is proven is the boot path under emulation and the unit-tested subsystem surfaces; the open work:
 
 - **Hardware validation** on a physical AGM M7 - the frontier. QEMU exercises the boot path, not the MT6739's binary-only modem/WiFi/BT/GPS blobs.
-- **Boot-wiring**: implemented capabilities are not all reachable from the boot/service loop or from userspace yet; the wiring lands incrementally. See the [kernel wiring audit](docs/KERNEL-WIRING-AUDIT.md).
+- **Boot-wiring**: implemented capabilities are not all reachable from the boot/service loop or from userspace yet; the wiring lands incrementally. Reachability is machine-checked, not prose: see the [capability inventory](docs/capability-inventory.toml) (every module classified; CI fails on drift).
 - **Real radio I/O**: WiFi packet TX/RX, scan, and association over WMT/STP are hardware work; boot degrades to a fail-closed loopback path when the data path is absent.
 - **Aletheia live runtime** ([docs/ALETHEIA-BRIDGE.md](docs/ALETHEIA-BRIDGE.md), `metaxu`): live transport, grant verification, and UI wiring are future work.
 

--- a/docs/KERNEL-WIRING-AUDIT.md
+++ b/docs/KERNEL-WIRING-AUDIT.md
@@ -1,46 +1,14 @@
 # Kernel Wiring Audit
 
-This is the issue #145 reality check for advertised kernel capabilities that compile but are not yet fully wired into boot, userspace, or hardware-backed runtime paths.
+Superseded by [`capability-inventory.toml`](capability-inventory.toml) (issue
+#550): the machine-checked capability-reachability inventory. The hand counts
+that lived here drifted — the module set, the `expect(dead_code)` shape, and
+the wiring state all moved while the prose did not.
 
-The counts below are from `origin/main` as checked on 2026-05-26:
-
-```bash
-rg '^#!\[expect\(dead_code' crates/thumos/src | wc -l
-rg '^\s*#\[expect\(dead_code' crates/thumos/src | wc -l
-```
-
-Current result: 8 crate-level expectations and 48 item-level expectations.
-
-## Crate-Level Expectations
-
-| Module | Current reality |
-|---|---|
-| `ui.rs` | `kinit` renders an initial home/status frame, but full screen routing and input dispatch through `UiManager` are not wired. |
-| `heorte.rs` | Calendar/alarm/timer/stopwatch engine compiles and has tests, but no boot-time runtime manager owns the state. |
-| `heorte_timer.rs` | Timer/stopwatch logic compiles and has tests, but runtime ownership is pending with `heorte`. |
-| `screen_calendar.rs` | Renderable screen exists, but there is no `kinit` route/input path to show it. |
-| `screen_alarm.rs` | Renderable alarm/timer/stopwatch screen exists, but there is no `kinit` route/input path to show it. |
-| `clock.rs` | Wall-clock trust policy exists, but kernel time and userspace syscalls still use lower-level timer/time paths. |
-| `bluetooth.rs` | `kinit` attempts adapter initialization, but userspace control and higher-level audio/profile paths are not wired. |
-| `gps.rs` | `kinit` attempts receiver initialization, but userspace access and clock/topos integration are not wired. |
-
-## Item-Level Expectations
-
-These are lower-level dead-code suppressions, not proof that whole advertised features are production-ready.
-
-| File | Count | Meaning |
-|---|---:|---|
-| `audio_codec.rs` | 1 | Reserved register constant for future gain control. |
-| `device.rs` | 15 | Canonical address constants retained while drivers use local or `kconfig` constants. |
-| `emmc.rs` | 20 | Reserved register fields and commands for diagnostics, tuning, boot mode, CID/CSD readback, and storage-layer follow-up. |
-| `firewall.rs` | 3 | Dynamic policy and audit-key plumbing are not connected at the net device hook. |
-| `kinit.rs` | 2 | Boot progress types are tested but not yet emitted as runtime progress reporting. |
-| `power.rs` | 2 | Per-core power-down and DSI0 helper are reserved for follow-up hardware bring-up. |
-| `screen_home.rs` | 2 | Home screen modes await security-mode manager state wiring. |
-| `status_bar.rs` | 3 | Service-level badges await modem registration state wiring. |
-
-## Accounting Rules
-
-- A module being compiled and tested means the Rust surface exists; it does not imply boot reachability, userspace reachability, or hardware readiness.
-- Hardware/radio claims should be treated as ready only when the driver has a production call path and identity-protection behavior at the driver boundary.
-- Issue #143 owns the network path, issue #144 owns userspace spawn, and issue #141 owns the agent runtime bridge. This audit does not reclassify those paths as ready.
+The inventory classifies every `main.rs` module into compiled-only /
+kernel-wired / emulated-mock-proven / hardware-proven, and
+`scripts/check-wiring-inventory.sh` fails CI on drift in either direction
+(unclassified modules, phantom entries, witness markers claimed but not
+asserted, or asserted but not fired in the QEMU boot log). Its accounting
+rules are unchanged: compiled+tested means the Rust surface exists; it does
+not imply boot, userspace, or hardware readiness.

--- a/docs/MANIFEST.toml
+++ b/docs/MANIFEST.toml
@@ -55,11 +55,11 @@ description = "Stock Linux 4.4.95 kernel config for the AGM M7, frozen as-shippe
 decided = "2026-04-11"
 
 [[doc]]
-path = "docs/KERNEL-WIRING-AUDIT.md"
+path = "docs/capability-inventory.toml"
 type = "decision-record"
 evergreen = true
-description = "Issue #145 reality check: advertised kernel capabilities not yet wired to hardware."
-decided = "2026-05-26"
+description = "Machine-checked capability-reachability inventory (#550); scripts/check-wiring-inventory.sh fails CI on drift."
+decided = "2026-08-04"
 
 [[doc]]
 path = "docs/PROBE.md"

--- a/docs/capability-inventory.toml
+++ b/docs/capability-inventory.toml
@@ -1,0 +1,141 @@
+# Capability reachability inventory (issue #550) — the machine-checked answer
+# to "is this capability real?" Tiers:
+#   compiled-only        — the Rust surface exists; nothing reachable from boot/loop
+#   kernel-wired         — reachable from boot or the service loop (module-graph
+#                          reachability from main/kinit/kardia), no executable witness
+#   emulated-mock-proven — a named witness marker asserted in the QEMU boot log
+#                          by scripts/witness/*.sh (emulation, not hardware)
+#   hardware-proven      — validated on the physical AGM M7 (none today;
+#                          hardware-gated entries carry hardware_reason instead)
+# scripts/check-wiring-inventory.sh enforces: every main.rs module classified,
+# every witness marker present in the witness scripts AND in the boot log.
+
+[[capability]]
+id = "kernel-core"
+modules = ["kinit", "kinit_plan", "kardia", "exceptions", "irq", "gic", "mmu", "slab", "page", "heap", "process", "fd", "signal", "elf", "futex", "ipc", "pipe", "socket", "supervisor", "syscall", "reflex", "mmio", "memguard"]
+tier = "emulated-mock-proven"
+witness = ["THUMOS-QEMU: boot-complete", "THUMOS-QEMU: service-loop ticks=", "/init spawned", "shell: hello from userspace", "USERFAULT:"]
+notes = "PL0 isolation, graceful kill, fork/exec/brk/guard witnesses live in the per-probe scripts (kfault/sleep/fork/exec/forkexec/guard/brk/crashloop)."
+
+[[capability]]
+id = "memory-fs"
+modules = ["block", "cache", "vfs", "devfs", "lfs", "lfs_imap", "lfs_segment", "lfs_checkpoint", "lfs_writer", "lfs_compact", "emmc", "ramfs"]
+tier = "kernel-wired"
+notes = "LFS mounts at boot (kinit Step 8c); no witness marker asserts persistence behavior in emulation yet."
+
+[[capability]]
+id = "time"
+modules = ["timer", "time", "clock"]
+tier = "emulated-mock-proven"
+witness = ["kardia: clock src=manual"]
+notes = "ClockManager trust hierarchy wired + seeded (#402). sys_clock_gettime unification is #506; QEMU timer fidelity is #461."
+
+[[capability]]
+id = "telephony"
+modules = ["telephony", "telephony_parser", "telephony_mock", "sim", "sms", "ccci", "ccci_logger", "gsm7"]
+tier = "emulated-mock-proven"
+witness = ["kardia: modem ready state=Registered", "kardia: incoming call -> ringtone", "kardia: sim iccid_len="]
+notes = "Seeded mock transport; the live CCCI wire is hardware-gated. SIM PIN/PUK unlock is #517."
+
+[[capability]]
+id = "audio"
+modules = ["audio", "audio_codec", "audio_route", "bt_audio", "avdtp", "sbc", "mic_audit"]
+tier = "emulated-mock-proven"
+witness = ["kardia: audio ready sessions=", "kardia: bt_audio sample_rate=44100 channels=2"]
+notes = "NullCodec in emulation; MT6357 codec + BT HCI are hardware-gated."
+
+[[capability]]
+id = "ui"
+modules = ["ui", "status_bar", "screen_home"]
+tier = "emulated-mock-proven"
+witness = ["kardia: frame rendered painted_px=", "kardia: nav Home -> Search", "kardia: nav Search -> Home", "kardia: statusbar net=Lte"]
+notes = "Render + input dispatch + navigation through the real screen path (#400)."
+
+[[capability]]
+id = "heorte"
+modules = ["heorte", "heorte_timer", "heorte_alarm"]
+tier = "emulated-mock-proven"
+witness = ["kardia: heorte events="]
+notes = "Calendar/alarm engine + calendar screen render wired."
+
+[[capability]]
+id = "firewall"
+modules = ["firewall"]
+tier = "emulated-mock-proven"
+witness = ["kardia: firewall rules="]
+notes = "Loop-persistent policy + verified HMAC audit chain (#403)."
+
+[[capability]]
+id = "secure-boot"
+modules = ["secure_boot"]
+tier = "emulated-mock-proven"
+witness = ["Secure boot: DEGRADED", "image-resident initramfs signature verified"]
+notes = "Fail-closed medium trust; production-signed verified boot on live eMMC is #467 (hardware-gated)."
+
+[[capability]]
+id = "security-subsystems"
+modules = ["security", "security_mode", "lock_screen", "key_manager", "audit", "capability", "panic_wipe", "bfu_timer", "csprng"]
+tier = "kernel-wired"
+notes = "Security-mode manager drives the status bar (#404); encryption/key paths land with the boot-time passphrase subsystem (#446) and per-device salt (#449)."
+hardware_reason = "panic wipe + tamper evidence need the physical eMMC/sensors"
+
+[[capability]]
+id = "power"
+modules = ["power", "battery", "watchdog"]
+tier = "kernel-wired"
+hardware_reason = "PMIC/battery telemetry needs the physical device"
+
+[[capability]]
+id = "display-input"
+modules = ["display"]
+tier = "kernel-wired"
+notes = "Rendered via the ui capability's synthetic framebuffer in emulation; the DDP pipeline is hardware-gated."
+
+[[capability]]
+id = "connectivity"
+modules = ["wifi", "bluetooth", "gps", "net", "dns", "dns_tls", "dhcp"]
+tier = "kernel-wired"
+notes = "State machines + parsers wired; packet filter consumes them. Radio I/O is hardware-gated (fail-closed loopback in emulation)."
+hardware_reason = "WiFi TX/RX/scan, BT RF, GPS NMEA need the combo chip + antennas"
+
+[[capability]]
+id = "comms-matrix"
+modules = ["matrix_crypto", "http_client", "json_mini", "harmostes", "matrix_ids"]
+tier = "kernel-wired"
+notes = "Olm/Megolm + HTTP/JSON surfaces compiled; /keys/claim consumption is #437 remnant 3."
+
+[[capability]]
+id = "screens-extended"
+modules = ["screen_search", "screen_settings", "screen_dialer", "screen_calendar", "screen_alarm", "screen_messages"]
+tier = "kernel-wired"
+notes = "screen_calendar renders via the heorte witness; the rest are routed but unwitnessed."
+
+[[capability]]
+id = "screens-compiled-only"
+modules = ["screen_call", "screen_contacts", "screen_fm", "screen_nous", "screen_privacy", "screen_radio", "screen_threat"]
+tier = "compiled-only"
+notes = "No route/input path reaches them today (#400 routing only covers the wired set). FM screen becomes reachable under #518; threat screen waits on #555's calibrated scores; nous/privacy/radio screens wait on their owning subsystems."
+
+[[capability]]
+id = "apps-compiled-only"
+modules = ["contacts", "t9", "fm_radio", "briar", "meshtastic", "ekphrasis", "provision", "encryption", "nous"]
+tier = "compiled-only"
+notes = "No production call path from boot/loop. Owners: fm_radio #518, encryption #449/#446, nous #552, ekphrasis #553, provision USB OTG (Phase 8 deferral), briar/meshtastic Phase 9 stubs."
+
+[[capability]]
+id = "hardware-support"
+modules = ["qemu", "console", "uart", "usb"]
+tier = "kernel-wired"
+notes = "console host-testability is #459; USB EP1 ISR/reader sync is #437 remnant 2."
+
+[[capability]]
+id = "board-platform"
+modules = ["device", "kconfig"]
+tier = "kernel-wired"
+notes = "Board constants consolidate under board:: in #534."
+
+# Accounting rules (from the retired KERNEL-WIRING-AUDIT.md):
+# - compiled+tested means the Rust surface exists; it does not imply boot,
+#   userspace, or hardware readiness.
+# - A capability is hardware-ready only with a production call path and
+#   identity-protection behavior at the driver boundary.

--- a/scripts/check-wiring-inventory.sh
+++ b/scripts/check-wiring-inventory.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# check-wiring-inventory.sh [boot.log] — capability-reachability drift check
+# (#550). Fails when:
+#   (a) a main.rs module is not classified in docs/capability-inventory.toml
+#   (b) an inventory witness marker is absent from scripts/witness/*.sh
+#       (the witness is claimed but nothing asserts it), or
+#   (c) a witness marker is absent from the QEMU boot log (default ./boot.log;
+#       pass --no-log to skip (c) when no boot has run yet)
+# The inventory is the SSOT for capability reachability; README's capability
+# section and docs/KERNEL-WIRING-AUDIT.md's successor point at it.
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+INV="$REPO_ROOT/docs/capability-inventory.toml"
+MAIN="$REPO_ROOT/crates/thumos/src/main.rs"
+WITNESS_DIR="$REPO_ROOT/scripts/witness"
+LOG=""
+[[ "${1:-}" == "--no-log" ]] && shift || LOG="${1:-$REPO_ROOT/boot.log}"
+
+python3 - "$INV" "$MAIN" "$WITNESS_DIR" "$LOG" <<'PYEOF'
+import re, sys, tomllib, glob, os
+
+inv_path, main_path, wit_dir, log_path = sys.argv[1:5]
+inv = tomllib.load(open(inv_path, "rb"))
+caps = inv.get("capability", [])
+
+rc = 0
+def fail(msg):
+    global rc
+    print(f"INVENTORY DRIFT: {msg}", file=sys.stderr)
+    rc = 1
+
+# (a) every main.rs module classified
+mods = set(re.findall(r'^(?:pub )?mod ([a-z_0-9]+);', open(main_path).read(), re.M))
+classified = {}
+for c in caps:
+    for m in c.get("modules", []):
+        if m in classified:
+            fail(f"module '{m}' classified twice ({classified[m]} and {c['id']})")
+        classified[m] = c["id"]
+for m in sorted(mods):
+    if m not in classified:
+        fail(f"main.rs module '{m}' has no [[capability]] entry")
+for m in sorted(classified):
+    if m not in mods:
+        fail(f"inventory lists module '{m}' (capability {classified[m]}) that no longer exists in main.rs")
+
+# (b) witness markers exist in the witness scripts
+scripts_text = ""
+for f in glob.glob(os.path.join(wit_dir, "*.sh")):
+    scripts_text += open(f, errors="ignore").read()
+markers = []
+for c in caps:
+    for w in c.get("witness", []):
+        markers.append((c["id"], w))
+        if w not in scripts_text:
+            fail(f"witness '{w}' (capability {c['id']}) is not asserted by any script in scripts/witness/")
+
+# (c) witness markers fired in the boot logs (when provided). boot.sh
+# produces boot.log (main boot) plus probe-*.log (the four PL0 isolation
+# probes); both are boot.sh outputs, so markers may live in either.
+if log_path:
+    if not os.path.exists(log_path):
+        fail(f"boot log not found at {log_path} — run scripts/witness/boot.sh first (or pass --no-log)")
+    else:
+        log = open(log_path, errors="ignore").read()
+        for probe in glob.glob(os.path.join(os.path.dirname(log_path) or ".", "probe-*.log")):
+            log += open(probe, errors="ignore").read()
+        for cid, w in markers:
+            # markers carry assertion-regex fragments; match literally except
+            # the trailing value patterns (>=, numbers) which are regex-friendly
+            if w not in log:
+                fail(f"witness '{w}' (capability {cid}) did not fire in the boot log")
+
+if rc == 0:
+    print(f"wiring inventory: {len(mods)} modules classified in {len(caps)} capabilities, {len(markers)} witness markers verified")
+sys.exit(rc)
+PYEOF


### PR DESCRIPTION
## Summary

The wiring audit (and README's capability claims) were hand-maintained and stale **by construction**: the 2026-05-26 counts measured an `expect(dead_code)` shape that no longer exists, the doc was marked `evergreen` in MANIFEST.toml, and nothing failed when either drifted from reality.

**`docs/capability-inventory.toml`** is the SSOT replacement: all **114 main.rs modules** classified into **19 capabilities** across four tiers (compiled-only / kernel-wired / emulated-mock-proven / hardware-proven — the last empty today, hardware-gated entries carrying explicit reasons). Tiers are grounded in module-graph reachability from the boot/service-loop entry points plus named witness markers, not prose.

**`scripts/check-wiring-inventory.sh`** enforces it in both CI surfaces (ci.yml after the boot witness; `.kanon-ci.toml` `wiring inventory` stage):
- (a) every main.rs module classified — no phantoms, no double-assignment
- (b) every claimed witness marker asserted by `scripts/witness/*.sh`
- (c) every asserted marker fired in the boot log the witness run produced (boot.log + the four PL0 probe logs, all boot.sh outputs)

First run caught **22 real classification defects** in the initial draft (11 unclassified modules, 11 phantoms from file-vs-module naming through `#[path]` declarations) — the checker earning its keep before it ever saw CI.

`KERNEL-WIRING-AUDIT.md` is retired to a pointer; MANIFEST.toml and README now name the inventory, with the same accounting rules carried into its footer.

## Verification

- (a)+(b)+(c) all green locally against a **real boot.sh run** (114 modules, 19 capabilities, 19 markers verified)
- ci.yml + .kanon-ci.toml parse clean

Closes #550