### PR TITLE
testing(kernel): restore the target-executed test obligation (#551, #124)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,12 @@ jobs:
         # WHY (#546): canonical script shared with the forge admission gate —
         # both surfaces execute the identical suite.
         run: scripts/kernel-host-tests.sh
+      - name: Target-test ledger check (#551)
+        # WHY (#551, restoring #124): declared-vs-executed must be auditable —
+        # reds when a test-bearing or target-sensitive module has no ledger
+        # row, a witness name rots, a sensitive host-only row loses its
+        # fidelity label, or a tests count drifts. Cheap, source-level.
+        run: scripts/check-target-test-ledger.sh
       - name: Kernel cross-compile (armv7a) + zero-warning gate (#431)
         # WHY (#431): the zero-warning gate lives in crates/thumos/.cargo/
         # config.toml's rustflags; scripts/kernel-build.sh builds through it

--- a/.kanon-ci.toml
+++ b/.kanon-ci.toml
@@ -30,6 +30,7 @@ stages = [
     "kernel host tests",
     "kernel qemu witnesses",
     "wiring inventory",
+    "target test ledger",
     "cargo clippy",
     "cargo nextest",
     "kanon lint",
@@ -62,6 +63,12 @@ timeout_secs = 900
 [stages."kernel host tests"]
 cmd = "sh -c 'rustup target add i686-unknown-linux-gnu && scripts/kernel-host-tests.sh'"
 timeout_secs = 1800
+
+# WHY (#551): declared-vs-executed audit for the kernel test obligations —
+# source-level, cheap, runs before the expensive witness stages.
+[stages."target test ledger"]
+cmd = "scripts/check-target-test-ledger.sh"
+timeout_secs = 300
 
 # WHY (#546): the full QEMU witness matrix (boot + fault + sleep + fork +
 # exec + forkexec + guard + brk + crashloop) as one canonical runner — the

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -1,0 +1,675 @@
+# Target-executed test ledger (issue #551, restoring the #124 obligation)
+# Per test-bearing (or target-sensitive) module: the declared execution
+# mechanism (host / target / both), the witness script(s) covering the
+# target side, and the fidelity limits of any host fixture. Enforced by
+# scripts/check-target-test-ledger.sh: every such module has a row, 'both'
+# rows name real witness scripts, sensitive host-only rows carry a fidelity
+# note, and the tests count matches the source tree.
+#
+# #528/#533 are the proof-by-incident: host fixtures green while real-table
+# behavior was broken on every boot — host tests are structurally blind to
+# the section-overlay class. The 'both' rows are where that class lives.
+
+[[module]]
+name = "audio"
+tests = 29
+mechanism = "both"
+witness = "boot.sh"
+
+[[module]]
+name = "audio_codec"
+tests = 16
+mechanism = "both"
+witness = "boot.sh"
+
+[[module]]
+name = "audio_route"
+tests = 22
+mechanism = "both"
+witness = "boot.sh"
+
+[[module]]
+name = "audit"
+tests = 27
+mechanism = "host"
+
+[[module]]
+name = "avdtp"
+tests = 2
+mechanism = "host"
+
+[[module]]
+name = "battery"
+tests = 11
+mechanism = "host"
+
+[[module]]
+name = "bfu_timer"
+tests = 17
+mechanism = "host"
+
+[[module]]
+name = "block"
+tests = 11
+mechanism = "host"
+
+[[module]]
+name = "bluetooth"
+tests = 25
+mechanism = "host"
+
+[[module]]
+name = "briar"
+tests = 30
+mechanism = "host"
+
+[[module]]
+name = "bt_audio"
+tests = 19
+mechanism = "both"
+witness = "boot.sh"
+
+[[module]]
+name = "cache"
+tests = 11
+mechanism = "host"
+
+[[module]]
+name = "capability"
+tests = 8
+mechanism = "host"
+
+[[module]]
+name = "ccci"
+tests = 77
+mechanism = "host"
+fidelity = "host tests cover frame codec; the live channel is hardware-gated"
+
+[[module]]
+name = "ccci_logger"
+tests = 42
+mechanism = "host"
+
+[[module]]
+name = "clock"
+tests = 17
+mechanism = "both"
+witness = "boot.sh"
+
+[[module]]
+name = "console"
+tests = 4
+mechanism = "host"
+fidelity = "host-testability + presence-sequence resurrection is #459"
+
+[[module]]
+name = "contacts"
+tests = 25
+mechanism = "host"
+
+[[module]]
+name = "csprng"
+tests = 16
+mechanism = "both"
+witness = "boot.sh"
+fidelity = "host tests use the deterministic seed path; hardware entropy health is device-bound"
+
+[[module]]
+name = "devfs"
+tests = 27
+mechanism = "host"
+
+[[module]]
+name = "device"
+tests = 7
+mechanism = "host"
+
+[[module]]
+name = "dhcp"
+tests = 4
+mechanism = "host"
+
+[[module]]
+name = "display"
+tests = 32
+mechanism = "host"
+fidelity = "DDP pipeline hardware-gated; the synthetic framebuffer covers the render witness"
+
+[[module]]
+name = "dns"
+tests = 29
+mechanism = "host"
+
+[[module]]
+name = "dns_tls"
+tests = 28
+mechanism = "host"
+
+[[module]]
+name = "ekphrasis"
+tests = 59
+mechanism = "host"
+
+[[module]]
+name = "elf"
+tests = 18
+mechanism = "both"
+witness = "boot.sh+exec.sh+forkexec.sh"
+fidelity = "loader correctness against real page tables is witness-only (exec/forkexec); host tests cover header/segment parsing"
+
+[[module]]
+name = "emmc"
+tests = 31
+mechanism = "both"
+witness = "boot.sh"
+fidelity = "driver register paths are hardware-gated; host tests cover protocol logic"
+
+[[module]]
+name = "encryption"
+tests = 14
+mechanism = "host"
+fidelity = "cipher/KDF correctness is host+fuzz covered; on-device key/salt persistence is #449"
+
+[[module]]
+name = "exceptions"
+tests = 0
+mechanism = "target"
+witness = "boot.sh+kfault.sh"
+
+[[module]]
+name = "exceptions_stub"
+tests = 4
+mechanism = "host"
+fidelity = "the stub IS the host fixture for the exceptions module — see exceptions for the witness side"
+
+[[module]]
+name = "fd"
+tests = 69
+mechanism = "host"
+
+[[module]]
+name = "firewall"
+tests = 30
+mechanism = "both"
+witness = "boot.sh"
+
+[[module]]
+name = "fm_radio"
+tests = 25
+mechanism = "host"
+
+[[module]]
+name = "futex"
+tests = 7
+mechanism = "both"
+witness = "sleep.sh"
+fidelity = "WAIT/WAKE logic host-covered; the IRQ-masked sleep/wake path is sleep-witnessed"
+
+[[module]]
+name = "gic"
+tests = 0
+mechanism = "host"
+fidelity = "register interaction is not exercised host-side; the PL0 probes cover the live GIC path"
+
+[[module]]
+name = "gps"
+tests = 25
+mechanism = "host"
+
+[[module]]
+name = "gsm7"
+tests = 8
+mechanism = "host"
+
+[[module]]
+name = "harmostes"
+tests = 36
+mechanism = "host"
+
+[[module]]
+name = "heap"
+tests = 0
+mechanism = "target"
+witness = "brk.sh"
+
+[[module]]
+name = "heorte"
+tests = 17
+mechanism = "both"
+witness = "boot.sh"
+
+[[module]]
+name = "heorte_alarm"
+tests = 7
+mechanism = "host"
+
+[[module]]
+name = "heorte_timer"
+tests = 14
+mechanism = "host"
+
+[[module]]
+name = "http_client"
+tests = 47
+mechanism = "host"
+
+[[module]]
+name = "ipc"
+tests = 11
+mechanism = "host"
+
+[[module]]
+name = "irq"
+tests = 4
+mechanism = "both"
+witness = "boot.sh"
+fidelity = "GIC register interaction is not exercised host-side; the PL0 probes cover the live IRQ path"
+
+[[module]]
+name = "json_mini"
+tests = 66
+mechanism = "host"
+
+[[module]]
+name = "kardia"
+tests = 0
+mechanism = "target"
+witness = "boot.sh+crashloop.sh"
+
+[[module]]
+name = "kconfig"
+tests = 4
+mechanism = "host"
+fidelity = "constant table only — nothing target-executed to diverge"
+
+[[module]]
+name = "key_manager"
+tests = 12
+mechanism = "host"
+fidelity = "KDF correctness is host-covered; on-device salt persistence is #449"
+
+[[module]]
+name = "kinit"
+tests = 0
+mechanism = "target"
+witness = "boot.sh"
+
+[[module]]
+name = "kinit_plan"
+tests = 22
+mechanism = "host"
+
+[[module]]
+name = "lfs"
+tests = 33
+mechanism = "host"
+
+[[module]]
+name = "lfs_checkpoint"
+tests = 9
+mechanism = "host"
+
+[[module]]
+name = "lfs_compact"
+tests = 9
+mechanism = "host"
+
+[[module]]
+name = "lfs_imap"
+tests = 11
+mechanism = "host"
+
+[[module]]
+name = "lfs_segment"
+tests = 12
+mechanism = "host"
+
+[[module]]
+name = "lfs_writer"
+tests = 7
+mechanism = "host"
+
+[[module]]
+name = "lock_screen"
+tests = 20
+mechanism = "host"
+fidelity = "policy logic host-covered; boot-time passphrase input is #446"
+
+[[module]]
+name = "main"
+tests = 0
+mechanism = "target"
+witness = "boot.sh"
+fidelity = "module wiring only — the boot witness is its proof"
+
+[[module]]
+name = "matrix_crypto"
+tests = 37
+mechanism = "host"
+
+[[module]]
+name = "matrix_ids"
+tests = 11
+mechanism = "host"
+
+[[module]]
+name = "memguard"
+tests = 13
+mechanism = "host"
+
+[[module]]
+name = "meshtastic"
+tests = 36
+mechanism = "host"
+
+[[module]]
+name = "mic_audit"
+tests = 18
+mechanism = "host"
+
+[[module]]
+name = "mmio"
+tests = 4
+mechanism = "host"
+fidelity = "register access helpers — production paths are board/hardware-gated"
+
+[[module]]
+name = "mmu"
+tests = 35
+mechanism = "both"
+witness = "fork.sh+exec.sh+guard.sh+brk.sh"
+
+[[module]]
+name = "net"
+tests = 18
+mechanism = "host"
+
+[[module]]
+name = "nous"
+tests = 38
+mechanism = "host"
+
+[[module]]
+name = "page"
+tests = 9
+mechanism = "both"
+witness = "fork.sh+guard.sh"
+fidelity = "real-table behavior is fork/guard-witnessed; host fixtures use absent-entry tables (#533 class)"
+
+[[module]]
+name = "panic_wipe"
+tests = 18
+mechanism = "host"
+
+[[module]]
+name = "pipe"
+tests = 12
+mechanism = "host"
+
+[[module]]
+name = "power"
+tests = 29
+mechanism = "host"
+fidelity = "PMIC/DVFS telemetry and control are hardware-gated"
+
+[[module]]
+name = "process"
+tests = 53
+mechanism = "both"
+witness = "boot.sh+fork.sh+exec.sh+forkexec.sh+guard.sh+brk.sh+crashloop.sh"
+
+[[module]]
+name = "provision"
+tests = 29
+mechanism = "host"
+
+[[module]]
+name = "qemu"
+tests = 0
+mechanism = "target"
+witness = "boot.sh"
+fidelity = "emulation shim itself — exercised by every witness run"
+
+[[module]]
+name = "ramfs"
+tests = 35
+mechanism = "both"
+witness = "boot.sh"
+
+[[module]]
+name = "reflex"
+tests = 4
+mechanism = "host"
+
+[[module]]
+name = "sbc"
+tests = 9
+mechanism = "host"
+
+[[module]]
+name = "screen_alarm"
+tests = 16
+mechanism = "host"
+
+[[module]]
+name = "screen_calendar"
+tests = 8
+mechanism = "host"
+
+[[module]]
+name = "screen_call"
+tests = 16
+mechanism = "host"
+
+[[module]]
+name = "screen_contacts"
+tests = 16
+mechanism = "host"
+
+[[module]]
+name = "screen_dialer"
+tests = 14
+mechanism = "host"
+
+[[module]]
+name = "screen_fm"
+tests = 15
+mechanism = "host"
+
+[[module]]
+name = "screen_home"
+tests = 19
+mechanism = "both"
+witness = "boot.sh"
+
+[[module]]
+name = "screen_messages"
+tests = 42
+mechanism = "host"
+
+[[module]]
+name = "screen_nous"
+tests = 42
+mechanism = "host"
+
+[[module]]
+name = "screen_privacy"
+tests = 33
+mechanism = "host"
+
+[[module]]
+name = "screen_radio"
+tests = 13
+mechanism = "host"
+
+[[module]]
+name = "screen_search"
+tests = 14
+mechanism = "host"
+
+[[module]]
+name = "screen_settings"
+tests = 14
+mechanism = "host"
+
+[[module]]
+name = "screen_threat"
+tests = 18
+mechanism = "host"
+
+[[module]]
+name = "secure_boot"
+tests = 22
+mechanism = "both"
+witness = "boot.sh"
+
+[[module]]
+name = "security"
+tests = 29
+mechanism = "host"
+
+[[module]]
+name = "security_mode"
+tests = 38
+mechanism = "both"
+witness = "boot.sh"
+
+[[module]]
+name = "signal"
+tests = 7
+mechanism = "host"
+
+[[module]]
+name = "sim"
+tests = 12
+mechanism = "both"
+witness = "boot.sh"
+
+[[module]]
+name = "slab"
+tests = 15
+mechanism = "host"
+fidelity = "allocator-on-real-tables is brk-witnessed; host tests cover size-class logic"
+
+[[module]]
+name = "sms"
+tests = 20
+mechanism = "both"
+witness = "boot.sh"
+
+[[module]]
+name = "socket"
+tests = 24
+mechanism = "host"
+
+[[module]]
+name = "status_bar"
+tests = 13
+mechanism = "both"
+witness = "boot.sh"
+
+[[module]]
+name = "supervisor"
+tests = 12
+mechanism = "both"
+witness = "crashloop.sh"
+
+[[module]]
+name = "syscall"
+tests = 70
+mechanism = "both"
+witness = "boot.sh+fork.sh+exec.sh+sleep.sh"
+fidelity = "trap entry / exception return is witness-only (PL0 probes); host tests cover dispatch logic via the uart stub"
+
+[[module]]
+name = "t9"
+tests = 14
+mechanism = "host"
+
+[[module]]
+name = "telephony"
+tests = 38
+mechanism = "both"
+witness = "boot.sh"
+
+[[module]]
+name = "telephony_mock"
+tests = 0
+mechanism = "target"
+witness = "boot.sh"
+
+[[module]]
+name = "telephony_parser"
+tests = 19
+mechanism = "host"
+
+[[module]]
+name = "time"
+tests = 13
+mechanism = "host"
+fidelity = "CLOCK_REALTIME/ClockManager unification is #506 (blocked by #461); host tests cover offset math"
+
+[[module]]
+name = "timer"
+tests = 0
+mechanism = "target"
+witness = "boot.sh"
+fidelity = "host tests exercise the stub surface (timer_stub); CNTPCT/elapsed_ms semantics under QEMU are #461; the tick-driven loop is boot-witnessed"
+
+[[module]]
+name = "timer_stub"
+tests = 5
+mechanism = "host"
+fidelity = "the stub is the host fixture — see timer"
+
+[[module]]
+name = "uart"
+tests = 0
+mechanism = "target"
+witness = "boot.sh"
+fidelity = "production UART is hardware-gated; the stub covers host tests"
+
+[[module]]
+name = "uart_pl011"
+tests = 0
+mechanism = "host"
+fidelity = "production UART runs only on the qemu board (boot witness)"
+
+[[module]]
+name = "uart_stub"
+tests = 0
+mechanism = "host"
+
+[[module]]
+name = "ui"
+tests = 20
+mechanism = "both"
+witness = "boot.sh"
+
+[[module]]
+name = "usb"
+tests = 29
+mechanism = "host"
+fidelity = "MMIO/ISR paths are not exercised host-side; EP1 ring sync is #437 remnant 2"
+
+[[module]]
+name = "vfs"
+tests = 16
+mechanism = "host"
+
+[[module]]
+name = "watchdog"
+tests = 3
+mechanism = "host"
+fidelity = "watchdog peripheral is hardware-gated; host tests cover arming logic"
+
+[[module]]
+name = "watchdog_qemu"
+tests = 0
+mechanism = "host"
+
+[[module]]
+name = "wifi"
+tests = 37
+mechanism = "host"
+fidelity = "WPA/PTK logic is host+fuzz covered; radio I/O is hardware-gated"

--- a/scripts/check-target-test-ledger.sh
+++ b/scripts/check-target-test-ledger.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# check-target-test-ledger.sh — declared-vs-executed audit for the kernel's
+# test obligations (#551, restoring #124). Fails when:
+#   (a) a module with #[test]s or target-sensitive patterns has no ledger row
+#   (b) a 'both'/'target' row names a witness script that does not exist
+#   (c) a target-sensitive host-only row carries no fidelity note
+#   (d) a row's tests count drifts from the source tree
+# Ledger: docs/target-test-ledger.toml. #528/#533 are the proof-by-incident:
+# host fixtures green while real-table behavior was broken on every boot.
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+LEDGER="$REPO_ROOT/docs/target-test-ledger.toml"
+SRC="$REPO_ROOT/crates/thumos/src"
+WITNESS_DIR="$REPO_ROOT/scripts/witness"
+
+python3 - "$LEDGER" "$SRC" "$WITNESS_DIR" <<'PYEOF'
+import re, sys, tomllib, glob, os
+
+ledger_path, src_dir, wit_dir = sys.argv[1:4]
+try:
+    rows = tomllib.load(open(ledger_path, "rb")).get("module", [])
+except Exception as e:
+    print(f"LEDGER DRIFT: docs/target-test-ledger.toml is not parseable TOML: {e}", file=sys.stderr)
+    sys.exit(1)
+by_name = {}
+for r in rows:
+    n = r.get("name")
+    if not n:
+        print(f"LEDGER DRIFT: a [[module]] row has no name key: {r}", file=sys.stderr)
+        sys.exit(1)
+    by_name[n] = r
+if len(by_name) != len(rows):
+    print("LEDGER DRIFT: duplicate module rows in the ledger", file=sys.stderr); sys.exit(1)
+
+rc = 0
+def fail(msg):
+    global rc
+    print(f"LEDGER DRIFT: {msg}", file=sys.stderr)
+    rc = 1
+
+TARGET_PAT = re.compile(r'asm!|core::arch|global_asm|0x[0-9A-Fa-f]{6,}|read_volatile|write_volatile|page_table|l1_section|l2_entry|ttbr|cp15', re.I)
+
+witness_files = {os.path.basename(f) for f in glob.glob(os.path.join(wit_dir, "*.sh"))}
+
+for f in sorted(glob.glob(os.path.join(src_dir, "*.rs"))):
+    m = os.path.basename(f)[:-3]
+    text = open(f, errors="ignore").read()
+    tests = len(re.findall(r'#\[test\]', text))
+    sensitive = bool(TARGET_PAT.search(text))
+    row = by_name.get(m)
+    if (tests or sensitive) and row is None:
+        fail(f"module '{m}' (tests={tests}, target-sensitive={sensitive}) has no ledger row")
+        continue
+    if row is None:
+        continue
+    if row.get("tests", -1) != tests:
+        fail(f"module '{m}': ledger says {row.get('tests')} tests, source has {tests}")
+    mech = row.get("mechanism", "")
+    if mech in ("both", "target"):
+        wits = row.get("witness", "")
+        named = re.split(r'[+]', wits)
+        if not wits or any(w.strip() not in witness_files for w in named if w.strip()):
+            fail(f"module '{m}' mechanism={mech} but witness '{wits}' names scripts not in scripts/witness/")
+    if mech == "host" and sensitive and not row.get("fidelity"):
+        fail(f"module '{m}' is host-only with target-sensitive patterns but carries no fidelity note")
+
+for m in by_name:
+    if not os.path.exists(os.path.join(src_dir, m + ".rs")):
+        fail(f"ledger row '{m}' has no source file")
+
+if rc == 0:
+    n_both = sum(1 for r in rows if r.get("mechanism") == "both")
+    n_target = sum(1 for r in rows if r.get("mechanism") == "target")
+    print(f"target-test ledger: {len(rows)} rows checked, {n_both} both-mechanism, {n_target} target-only, no drift")
+sys.exit(rc)
+PYEOF


### PR DESCRIPTION
## Summary

The #124 obligation — some kernel properties must execute on the real target, not host fixtures — was lost in tracker migration. #528/#533 proved its worth: host fixtures stayed green while the section-overlay bug broke brk/mmap on every real boot.

**`docs/target-test-ledger.toml`** is the restored obligation, derived per module from the source: **120 rows** over every test-bearing or target-sensitive module, each declaring its execution mechanism — host / target / both — with **fidelity labels on every host fixture that stubs target behavior**. The 26-row 'both' set is exactly the #533-class surface: syscall trap paths, ELF loader on real page tables, MMU/allocator behavior, IRQ/GIC, CSPRNG-on-hardware, eMMC/LFS-at-boot.

**`scripts/check-target-test-ledger.sh`** makes declared-vs-executed auditable in both CI surfaces (ci.yml kernel job, `.kanon-ci.toml` 'target test ledger' stage):
- red on a test-bearing/target-sensitive module with no row
- red on a witness script name that rots
- red on a sensitive host-only row missing its fidelity note
- red on a drifted tests count or malformed TOML

**Harness decision**: the issue's nightly-`custom_test_frameworks` vs witness-pattern question is answered by the shape that already proved itself — the #546 witness scripts ARE the target-execution mechanism; this ledger makes their obligation auditable instead of adding a second harness on a nightly pin.

## Verification

- every failure class proven red locally (row removal, nameless row, bad witness name, stripped fidelity, drifted count, malformed TOML) before the green run: 120 rows, 26 both-mechanism, 9 target-only, no drift

Closes #551