### PR TITLE
security(krypta): stop claiming Signal Double Ratchet without a DH ratchet (#543)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -36,7 +36,7 @@ Thumos is a full-Rust mobile OS targeting the AGM M7 (MT6739). No C authored, no
 
 | Crate | Description |
 |-------|-------------|
-| `krypta` | Signal protocol: X3DH key exchange, double ratchet, session management |
+| `krypta` | X3DH key exchange, directional symmetric chain ratchets (NOT the Signal Double Ratchet — no DH ratchet, #543), session management |
 | `stegnos` | Encrypted storage: AES-256-XTS block cipher, LUKS key derivation, secure erase |
 
 **Radio**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ Full Rust from kernel to UI. No C we author, no Linux in the final system. Monol
 | UI (eidolon) | Substantial | Framebuffer 240x320, widgets, dialer, status bar |
 | Firewall (asphaleia) | Substantial | Packet filter, DNS blocklist, IPv4/TCP/UDP parsing |
 | Encrypted storage (stegnos) | Substantial | AES-256-XTS, LUKS key derivation, secure erase |
-| Signal protocol (krypta) | Substantial | X3DH, double ratchet, session management |
+| E2E encryption (krypta) | Substantial | X3DH, directional symmetric chain ratchets (no DH ratchet, #543), session management |
 | Panic mode (leipsanon) | Substantial | Priority-ordered wipe, triggers, memory scrubbing |
 | Radio tools (sema) | Substantial | WiFi scanner, IMSI catcher detection, rogue AP detection |
 | GPS (topos) | Substantial | NMEA parser, geofencing, multi-constellation |

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A custom Rust OS for the AGM M7 (MT6739, 1 GB RAM, 240x320 QVGA, IP68). Full Rus
 eidolon (framebuffer UI, widget system)
 asphaleia (packet filter) + stegnos (encrypted storage) + leipsanon (panic mode)
 sema (radio tools) + aither (WiFi) + pteron (BT) + topos (GPS)
-klesis (AT commands, CCCI transport, SMS PDU) + krypta (Signal protocol)
+klesis (AT commands, CCCI transport, SMS PDU) + krypta (X3DH + symmetric chain ratchets)
 kelyphos (WMT combo chip STP framing) + haphe (input routing)
 ──────────────────────────────────────────────
 thumos kernel (MMU, slab allocator, scheduler, IPC, signals, syscalls,

--- a/crates/krypta/Cargo.toml
+++ b/crates/krypta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krypta"
-description = "Encrypted communication: Signal protocol, P2P messaging"
+description = "Encrypted communication: X3DH key exchange + directional symmetric chain ratchets, P2P messaging"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/krypta/src/lib.rs
+++ b/crates/krypta/src/lib.rs
@@ -4,7 +4,16 @@
     reason = "public API surface for future kernel binary integration (#126)"
 )]
 #![allow(unfulfilled_lint_expectations)]
-//! End-to-end encrypted communication. Signal protocol key exchange and message encryption, peer-to-peer messaging over `WiFi` Direct and Bluetooth.
+//! End-to-end encrypted communication: X3DH key exchange plus message
+//! encryption via directional symmetric chain ratchets (one HMAC chain per
+//! direction, forward secrecy per message). Peer-to-peer messaging over
+//! `WiFi` Direct and Bluetooth.
+//!
+//! NOT the Signal Double Ratchet: there is no DH ratchet or root chain here
+//! (#543). X3DH is implemented per spec; the ratchet is a simpler symmetric
+//! chain and is named that way everywhere in this crate. The surface is
+//! non-production and unreachable from the kernel until the declared
+//! protocol is mechanically verified end-to-end.
 
 pub mod error;
 pub mod identity;

--- a/crates/krypta/src/session.rs
+++ b/crates/krypta/src/session.rs
@@ -12,11 +12,14 @@ pub(crate) struct EncryptedMessage {
     pub(crate) inner: CiphertextMessage,
 }
 
-/// Two-party encrypted session backed by a symmetric double ratchet.
+/// Two-party encrypted session backed by directional symmetric chain
+/// ratchets (one HMAC chain per direction).
 ///
 /// The initiator (Alice) calls [`Session::initiate`]; the responder (Bob)
 /// calls [`Session::respond`]. After setup both sessions share the same
-/// root key material and can exchange encrypted messages.
+/// root key material and can exchange encrypted messages. This is NOT the
+/// Signal Double Ratchet — the chains advance symmetrically with no DH
+/// ratchet step (#543).
 pub(crate) struct Session {
     identity: IdentityKeyPair,
     peer_identity: PublicIdentityKey,


### PR DESCRIPTION
## Summary

krypta implements two directional HMAC chain ratchets — **not** the Signal Double Ratchet, which needs a DH ratchet + root chain it does not have. The repo nonetheless claimed "Signal protocol" and "double ratchet" in six places (crate docs, session docs, Cargo.toml, ARCHITECTURE, CLAUDE, README).

The issue's option 2 is the honest contract for a pre-hardware, zero-caller surface:
- name the primitive what it is — **directional symmetric chain ratchets** (one HMAC chain per direction, forward secrecy per message)
- keep X3DH accurately described (it IS implemented per spec)
- forbid the "symmetric double ratchet" bridge term everywhere
- name the limitation explicitly in each doc rather than dropping it silently
- crate docs state the surface stays non-production/unreachable until the declared protocol is mechanically verified end-to-end

Prose-only change: no type or identifier renames (`RatchetState` was never misnamed), so behavior and tests are unchanged. A real Double Ratchet adoption is a separate protocol-direction decision at integration time.

Closes #543