### PR TITLE
kernel: per-process CWD + IRQ-locked serial RX ring (#437 remnants 1+2)

### DIFF
--- a/crates/thumos/src/fd.rs
+++ b/crates/thumos/src/fd.rs
@@ -3079,7 +3079,8 @@ mod tests {
 
         // Parent chdirs to /dev; its cwd reads back.
         assert_eq!(vfs_chdir("/dev"), 0);
-        crate::process::with_current_cwd(|c| assert_eq!(c, b"/dev")).expect("current process must exist");
+        crate::process::with_current_cwd(|c| assert_eq!(c, b"/dev"))
+            .expect("current process must exist");
 
         // Fork: the child INHERITS /dev.
         let child_pid = crate::process::fork().expect("fork must succeed");

--- a/crates/thumos/src/fd.rs
+++ b/crates/thumos/src/fd.rs
@@ -471,53 +471,15 @@ pub(crate) unsafe fn reset_fd_state_for_test() {
 /// `init_vfs()` is called during kernel boot.
 static mut MOUNT_TABLE: Option<MountTable> = None;
 
-/// Maximum path length for the CWD buffer.
-const CWD_MAX: usize = 256;
+/// Maximum CWD path length.
+pub(crate) const CWD_MAX: usize = 256;
 
-/// Global current working directory buffer.
-///
-/// Stored as a fixed-size byte buffer with a length field to avoid heap
-/// allocation in a static mut. Defaults to "/" (len=1). Updated by
-/// `sys_chdir`. Per-process cwd tracking is deferred to a later phase.
-static mut CWD_BUF: [u8; CWD_MAX] = {
+/// Default working directory at process creation ("/").
+pub(crate) const DEFAULT_CWD: [u8; CWD_MAX] = {
     let mut buf = [0u8; CWD_MAX];
     buf[0] = b'/';
     buf
 };
-
-/// Length of the current CWD string in `CWD_BUF`.
-static mut CWD_LEN: usize = 1;
-
-/// Get the current working directory path.
-///
-/// # Safety
-///
-/// Caller must ensure single-threaded access (cooperative kernel guarantee).
-unsafe fn get_cwd() -> &'static str {
-    // SAFETY: CWD_BUF and CWD_LEN are static muts; addr_of! avoids
-    // intermediate references. Single-core cooperative kernel ensures
-    // exclusive access.
-    unsafe {
-        let buf = &*core::ptr::addr_of!(CWD_BUF);
-        let len = *core::ptr::addr_of!(CWD_LEN);
-        core::str::from_utf8_unchecked(&buf[..len])
-    }
-}
-
-/// Set the current working directory.
-///
-/// # Safety
-///
-/// Caller must ensure single-threaded access.
-unsafe fn set_cwd(path: &str) {
-    unsafe {
-        let buf = &mut *core::ptr::addr_of_mut!(CWD_BUF);
-        let len_ptr = &mut *core::ptr::addr_of_mut!(CWD_LEN);
-        let copy_len = path.len().min(CWD_MAX);
-        buf[..copy_len].copy_from_slice(&path.as_bytes()[..copy_len]);
-        *len_ptr = copy_len;
-    }
-}
 
 /// Get a shared reference to the global mount table.
 ///
@@ -1429,9 +1391,15 @@ pub(crate) fn sys_getcwd(buf_ptr: u32, size: u32) -> u32 {
         return EFAULT;
     }
 
-    // SAFETY: single-core cooperative kernel.
-    let cwd = unsafe { get_cwd() };
-    let cwd_bytes = cwd.as_bytes();
+    // Read the current process's cwd (#437); proc0/PID 0 always has one, and
+    // an absent PCB falls back to "/" rather than a bogus path.
+    let (cwd_buf, cwd_len) = crate::process::with_current_cwd(|c| {
+        let mut b = [0u8; crate::fd::CWD_MAX];
+        b[..c.len()].copy_from_slice(c);
+        (b, c.len())
+    })
+    .unwrap_or((crate::fd::DEFAULT_CWD, 1));
+    let cwd_bytes = &cwd_buf[..cwd_len];
 
     // Need room for cwd + null terminator
     if (size as usize) < cwd_bytes.len() + 1 {
@@ -1640,11 +1608,9 @@ pub(crate) fn vfs_chdir(path: &str) -> u32 {
         Err(e) => return e.to_errno(),
     }
 
-    // Update global CWD
-    // SAFETY: single-core cooperative kernel.
-    unsafe {
-        set_cwd(path);
-    }
+    // Update the current process's CWD (#437) — per-process, so a chdir here
+    // never leaks into another process.
+    crate::process::set_current_cwd(path);
 
     0
 }
@@ -1793,8 +1759,9 @@ mod tests {
             let mt_opt = &mut *core::ptr::addr_of_mut!(MOUNT_TABLE);
             *mt_opt = Some(mt);
 
-            // Reset CWD to "/"
-            set_cwd("/");
+            // Reset the current process's CWD to "/" (#437; proc0 is already
+            // created at "/", so this matters for test re-initialization).
+            crate::process::set_current_cwd("/");
         }
     }
 
@@ -3097,6 +3064,93 @@ mod tests {
             &*buf3, b", ",
             "parent's own OFD offset must still be at 5, unaffected by the child's independent open"
         );
+    }
+
+    /// CWD-PER-PROCESS (#437): a chdir in one process never leaks into
+    /// another, and fork inherits the parent's cwd (POSIX) — replacing the
+    /// old global CWD_BUF/CWD_LEN statics where every process shared one cwd.
+    #[cfg(target_pointer_width = "32")]
+    #[test]
+    fn chdir_is_per_process_and_fork_inherits() {
+        // SAFETY: test-only.
+        unsafe {
+            setup_test_vfs();
+        }
+
+        // Parent chdirs to /dev; its cwd reads back.
+        assert_eq!(vfs_chdir("/dev"), 0);
+        crate::process::with_current_cwd(|c| assert_eq!(c, b"/dev")).expect("current process must exist");
+
+        // Fork: the child INHERITS /dev.
+        let child_pid = crate::process::fork().expect("fork must succeed");
+        // SAFETY: test-only; single-threaded test execution.
+        unsafe {
+            crate::process::set_current_for_test(child_pid);
+        }
+        crate::process::with_current_cwd(|c| {
+            assert_eq!(c, b"/dev", "fork must inherit the parent's cwd")
+        })
+        .expect("child process must exist");
+
+        // The child chdirs back to / — the parent's cwd is untouched.
+        assert_eq!(vfs_chdir("/"), 0);
+        // SAFETY: test-only; single-threaded test execution.
+        unsafe {
+            crate::process::set_current_for_test(0);
+        }
+        crate::process::with_current_cwd(|c| {
+            assert_eq!(
+                c, b"/dev",
+                "a chdir in the child must never leak into the parent (the global-CWD bug, #437)"
+            )
+        })
+        .expect("parent process must exist");
+
+        // Restore for later tests.
+        crate::process::set_current_cwd("/");
+    }
+
+    /// CWD-GETCWD-SYSCALL (#437): sys_getcwd reports the CURRENT process's
+    /// cwd, not a shared global — after the child chdirs, parent and child
+    /// read different paths from the same syscall.
+    #[cfg(target_pointer_width = "32")]
+    #[test]
+    fn getcwd_reports_the_current_process_cwd() {
+        // SAFETY: test-only.
+        unsafe {
+            setup_test_vfs();
+        }
+        assert_eq!(vfs_chdir("/dev"), 0);
+
+        static mut BUFCWD: [u8; 8] = [0u8; 8];
+        // SAFETY: test-only static; single-threaded per test.
+        let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUFCWD) };
+        assert_eq!(sys_getcwd(buf.as_mut_ptr() as u32, 8), 0);
+        assert_eq!(&buf[..4], b"/dev");
+
+        let child_pid = crate::process::fork().expect("fork must succeed");
+        // SAFETY: test-only; single-threaded test execution.
+        unsafe {
+            crate::process::set_current_for_test(child_pid);
+        }
+        assert_eq!(vfs_chdir("/"), 0);
+        static mut BUFCWD2: [u8; 8] = [0u8; 8];
+        // SAFETY: test-only static; single-threaded per test.
+        let buf2 = unsafe { &mut *core::ptr::addr_of_mut!(BUFCWD2) };
+        assert_eq!(sys_getcwd(buf2.as_mut_ptr() as u32, 8), 0);
+        assert_eq!(&buf2[..1], b"/", "child reads its own cwd");
+
+        // SAFETY: test-only; single-threaded test execution.
+        unsafe {
+            crate::process::set_current_for_test(0);
+        }
+        static mut BUFCWD3: [u8; 8] = [0u8; 8];
+        // SAFETY: test-only static; single-threaded per test.
+        let buf3 = unsafe { &mut *core::ptr::addr_of_mut!(BUFCWD3) };
+        assert_eq!(sys_getcwd(buf3.as_mut_ptr() as u32, 8), 0);
+        assert_eq!(&buf3[..4], b"/dev", "parent still reads its own cwd");
+
+        crate::process::set_current_cwd("/");
     }
 
     /// CLOSE-ON-EXEC: `close_cloexec` sweeps ONLY fds marked FD_CLOEXEC

--- a/crates/thumos/src/matrix_crypto.rs
+++ b/crates/thumos/src/matrix_crypto.rs
@@ -24,9 +24,17 @@
 //! - AES-CBC: NIST SP 800-38A
 
 // WHY: Matrix crypto created in Phase 09 Wave 3, full integration pending.
+// #437 remnant 3, explicitly re-confirmed deferred (2026-08-04): the
+// /keys/claim round-trip cannot land without the Olm session-establishment
+// path that consumes claimed keys, and X3DH is intentionally not
+// implemented here. Building the claim builder/parser alone would only
+// move the dead call site, not close it — this module stays unreachable
+// until Phase-09 messaging integration lands, at which point
+// `consume_one_time_key` MUST be wired into claimed-key receipt or the
+// one_time_keys pool deadlocks at MAX_ONE_TIME_KEYS (#282 finding 8).
 #![expect(
     dead_code,
-    reason = "Matrix crypto created in Phase 09 Wave 3, full messaging integration pending (#437)"
+    reason = "Matrix crypto unreachable pending Phase-09 messaging integration; /keys/claim wiring explicitly deferred to that epic (#437)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -235,6 +235,12 @@ pub(crate) struct Process {
     /// description. Owned by the PCB so its lifetime is the process's
     /// lifetime by construction -- no stale-table window on slot reuse.
     pub fds: crate::fd::FdTable,
+    /// Per-process current working directory (#437): owned by the PCB, so a
+    /// chdir in one process never leaks into another. Initialized to "/",
+    /// inherited across fork (POSIX).
+    pub cwd: [u8; crate::fd::CWD_MAX],
+    /// Length of the path stored in `cwd`.
+    pub cwd_len: usize,
 }
 
 /// Process table.
@@ -297,6 +303,8 @@ pub unsafe fn init() {
             // kinit (PID 0) has all capabilities (REQ-09).
             capabilities: crate::capability::Capabilities::ALL,
             fds: crate::fd::FdTable::new(),
+            cwd: crate::fd::DEFAULT_CWD,
+            cwd_len: 1,
         };
         let procs = &mut *addr_of_mut!(PROCS);
         procs[0] = Some(proc0);
@@ -365,6 +373,8 @@ pub(crate) fn spawn(entry_point: fn() -> !) -> Option<Pid> {
             // Spawned processes receive the default fork policy (REQ-09).
             capabilities: crate::capability::Capabilities::FORK_DEFAULT,
             fds: crate::fd::FdTable::new(),
+            cwd: crate::fd::DEFAULT_CWD,
+            cwd_len: 1,
         };
 
         procs[slot] = Some(proc);
@@ -542,6 +552,8 @@ pub(crate) fn spawn_user(loaded: &crate::elf::LoadedElf) -> Option<Pid> {
             wake_tick: 0,
             capabilities: crate::capability::Capabilities::FORK_DEFAULT,
             fds: crate::fd::FdTable::new(),
+            cwd: crate::fd::DEFAULT_CWD,
+            cwd_len: 1,
         };
         procs[slot] = Some(proc);
         Some(pid)
@@ -696,6 +708,8 @@ unsafe fn fork_pl0(
                 p.capabilities
             }) & crate::capability::Capabilities::FORK_DEFAULT,
             fds: parent_ref.map_or_else(crate::fd::FdTable::new, |p| crate::fd::fork_table(&p.fds)),
+            cwd: parent_ref.map_or(crate::fd::DEFAULT_CWD, |p| p.cwd),
+            cwd_len: parent_ref.map_or(1, |p| p.cwd_len),
         };
         procs[slot] = Some(child);
         Some(child_pid)
@@ -876,6 +890,8 @@ pub(crate) fn fork() -> Option<Pid> {
             wake_tick: 0,
             capabilities: child_caps,
             fds: child_fds,
+            cwd: parent_ref.map_or(crate::fd::DEFAULT_CWD, |p| p.cwd),
+            cwd_len: parent_ref.map_or(1, |p| p.cwd_len),
         };
 
         procs[slot] = Some(child);
@@ -1335,6 +1351,36 @@ pub(crate) fn with_current_fds<R>(f: impl FnOnce(&mut crate::fd::FdTable) -> R) 
         let procs = &mut *addr_of_mut!(PROCS);
         let cur = usize::from(CURRENT);
         procs[cur].as_mut().map(|p| f(&mut p.fds))
+    }
+}
+
+/// Read the current process's working directory (#437). `f` receives the path
+/// bytes (length `cwd_len`). Returns None when there is no current process.
+///
+/// INVARIANT: as with_current_fds — `f` must not re-enter process:: accessors.
+pub(crate) fn with_current_cwd<R>(f: impl FnOnce(&[u8]) -> R) -> Option<R> {
+    // SAFETY: current process PCB pointer is valid; read-only access to the
+    // current PCB's cwd via addr_of_mut! (no mutation of PROCS itself).
+    unsafe {
+        let procs = &mut *addr_of_mut!(PROCS);
+        let cur = usize::from(CURRENT);
+        procs[cur].as_ref().map(|p| f(&p.cwd[..p.cwd_len]))
+    }
+}
+
+/// Set the current process's working directory (#437), truncating to CWD_MAX.
+/// Returns None when there is no current process.
+pub(crate) fn set_current_cwd(path: &str) -> Option<()> {
+    // SAFETY: current process PCB pointer is valid; mutation via addr_of_mut!,
+    // single-core syscall context.
+    unsafe {
+        let procs = &mut *addr_of_mut!(PROCS);
+        let cur = usize::from(CURRENT);
+        procs[cur].as_mut().map(|p| {
+            let copy_len = path.len().min(crate::fd::CWD_MAX);
+            p.cwd[..copy_len].copy_from_slice(&path.as_bytes()[..copy_len]);
+            p.cwd_len = copy_len;
+        })
     }
 }
 
@@ -2001,6 +2047,8 @@ pub(crate) unsafe fn reset_for_test() {
             wake_tick: 0,
             capabilities: crate::capability::Capabilities::ALL,
             fds: crate::fd::FdTable::new(),
+            cwd: crate::fd::DEFAULT_CWD,
+            cwd_len: 1,
         });
     }
 }
@@ -2041,6 +2089,8 @@ pub(crate) fn test_process(page_table_phys: usize) -> Process {
         wake_tick: 0,
         capabilities: crate::capability::Capabilities::ALL,
         fds: crate::fd::FdTable::new(),
+        cwd: crate::fd::DEFAULT_CWD,
+        cwd_len: 1,
     }
 }
 

--- a/crates/thumos/src/usb.rs
+++ b/crates/thumos/src/usb.rs
@@ -1559,7 +1559,10 @@ mod tests {
         });
         // The ring holds LEN-1 bytes (full when next_head == tail).
         for i in 0..(SERIAL_RX_BUF_LEN - 1) {
-            assert!(with_serial_rx(|r| r.push(i as u8)), "ring must accept byte {i}");
+            assert!(
+                with_serial_rx(|r| r.push(i as u8)),
+                "ring must accept byte {i}"
+            );
         }
         assert!(!with_serial_rx(|r| r.push(0xEE)), "full ring must drop");
         assert!(!with_serial_rx(|r| r.push(0xEF)), "full ring must drop");
@@ -1571,7 +1574,10 @@ mod tests {
         // One drain frees exactly one slot.
         let mut one = [0u8; 1];
         assert_eq!(with_serial_rx(|r| r.drain(&mut one)), 1);
-        assert!(with_serial_rx(|r| r.push(0xAA)), "one drained slot must admit one more byte");
+        assert!(
+            with_serial_rx(|r| r.push(0xAA)),
+            "one drained slot must admit one more byte"
+        );
     }
 
     // --- Register OFFSET encoding ---

--- a/crates/thumos/src/usb.rs
+++ b/crates/thumos/src/usb.rs
@@ -21,6 +21,8 @@
 // Base address
 // ---------------------------------------------------------------------------
 
+use crate::irq;
+
 /// MUSB OTG controller base address on MT6739.
 /// Source: MT6739 device tree `usb0: usb@11210000`.
 const MUSB_BASE: usize = 0x1121_0000;
@@ -751,15 +753,81 @@ pub(crate) struct UsbController {
     line_coding: LineCoding,
     /// True after SET_CONFIGURATION activates the gadget.
     configured: bool,
-    /// Serial RX ring buffer.
-    rx_buf: [u8; SERIAL_RX_BUF_LEN],
-    /// Write index INTO rx_buf.
-    rx_head: usize,
-    /// Read index INTO rx_buf.
-    rx_tail: usize,
-    /// Count of serial RX bytes dropped because the ring was full -- see
-    /// `rx_dropped_bytes` (issue #282 finding 4).
-    rx_overflow_count: u32,
+}
+
+/// Serial RX ring shared by the MUSB ISR (push) and the reader (drain)
+/// (#437 remnant 2). The ISR path (`handle_ep1_rx`) and the reader path
+/// (`read_serial`) previously shared the controller's raw fields with
+/// nothing enforcing they could not interleave; the ring now lives behind
+/// an `irq::IrqSpinlock` (the ipc.rs/mmu.rs pattern), so when the MUSB IRQ
+/// is registered with the GIC the wiring is a one-line call-site change.
+struct SerialRxRing {
+    /// Byte storage.
+    buf: [u8; SERIAL_RX_BUF_LEN],
+    /// Write index INTO buf.
+    head: usize,
+    /// Read index INTO buf.
+    tail: usize,
+    /// Bytes dropped because the ring was full (issue #282 finding 4).
+    dropped: u32,
+}
+
+impl SerialRxRing {
+    /// Empty ring.
+    const fn new() -> Self {
+        Self {
+            buf: [0u8; SERIAL_RX_BUF_LEN],
+            head: 0,
+            tail: 0,
+            dropped: 0,
+        }
+    }
+
+    /// Push one received byte. Returns false (and counts the drop) when full.
+    fn push(&mut self, byte: u8) -> bool {
+        let next_head = (self.head + 1) % SERIAL_RX_BUF_LEN;
+        if next_head == self.tail {
+            self.dropped = self.dropped.saturating_add(1);
+            return false;
+        }
+        self.buf[self.head] = byte;
+        self.head = next_head;
+        true
+    }
+
+    /// Drain up to `out.len()` bytes in FIFO order; returns the count.
+    fn drain(&mut self, out: &mut [u8]) -> usize {
+        let mut count = 0;
+        while count < out.len() && self.head != self.tail {
+            out[count] = self.buf[self.tail];
+            self.tail = (self.tail + 1) % SERIAL_RX_BUF_LEN;
+            count += 1;
+        }
+        count
+    }
+
+    /// Total bytes dropped on overflow.
+    fn dropped_bytes(&self) -> u32 {
+        self.dropped
+    }
+}
+
+/// WHY (#322/#331 class, applied to #437 remnant 2): an `irq::IrqSpinlock`,
+/// not bare single-core-cooperative reasoning — once the MUSB IRQ is
+/// registered, `handle_ep1_rx` runs in interrupt context while `read_serial`
+/// runs in ordinary kernel code, and nothing previously enforced that the
+/// two could not interleave on the shared head/tail indices.
+static SERIAL_RX_RING_LOCK: irq::IrqSpinlock = irq::IrqSpinlock::new();
+/// The guarded ring. Access ONLY through `with_serial_rx`.
+static mut SERIAL_RX_RING: SerialRxRing = SerialRxRing::new();
+
+/// Run `f` on the serial RX ring under the IRQ-safe lock. Single accessor so
+/// the lock can never be bypassed by a future call site.
+fn with_serial_rx<R>(f: impl FnOnce(&mut SerialRxRing) -> R) -> R {
+    let _guard = SERIAL_RX_RING_LOCK.lock();
+    // SAFETY: the lock serializes the ISR push path and the reader drain
+    // path; this is the only accessor to the static ring.
+    unsafe { f(&mut *core::ptr::addr_of_mut!(SERIAL_RX_RING)) }
 }
 
 impl UsbController {
@@ -778,10 +846,6 @@ impl UsbController {
             ep0_buf_pos: 0,
             line_coding: LineCoding::default_115200(),
             configured: false,
-            rx_buf: [0u8; SERIAL_RX_BUF_LEN],
-            rx_head: 0,
-            rx_tail: 0,
-            rx_overflow_count: 0,
         }
     }
 
@@ -946,21 +1010,7 @@ impl UsbController {
     /// Returns the number of bytes copied. Returns 0 if the ring buffer is
     /// empty. Does not block.
     pub(crate) fn read_serial(&mut self, buf: &mut [u8]) -> usize {
-        let mut count = 0;
-        while count < buf.len() {
-            if self.rx_head == self.rx_tail {
-                break;
-            }
-            // SAFETY: rx_tail is always a valid index within SERIAL_RX_BUF_LEN.
-            if let Some(slot) = buf.get_mut(count) {
-                *slot = self.rx_buf[self.rx_tail];
-                self.rx_tail = (self.rx_tail + 1) % SERIAL_RX_BUF_LEN;
-                count += 1;
-            } else {
-                break;
-            }
-        }
-        count
+        with_serial_rx(|r| r.drain(buf))
     }
 
     /// Number of serial RX bytes dropped because the ring buffer was full.
@@ -973,26 +1023,20 @@ impl UsbController {
     /// [`read_serial`]: UsbController::read_serial
     #[must_use]
     pub(crate) fn rx_dropped_bytes(&self) -> u32 {
-        self.rx_overflow_count
+        with_serial_rx(|r| r.dropped_bytes())
     }
 
-    /// Push one received byte into the serial RX ring buffer.
+    /// Push one received byte into the serial RX ring (#437 remnant 2: the
+    /// shared, IRQ-locked static ring, not controller-local fields).
     ///
     /// Returns `true` if accepted, `false` if the ring was full and the
-    /// byte was dropped. On drop, increments `rx_overflow_count` so a full
-    /// ring no longer discards host bytes with no counter or log (issue
-    /// #282 finding 4) -- see [`rx_dropped_bytes`].
+    /// byte was dropped. Drops increment the ring's counter so a full ring
+    /// no longer discards host bytes with no counter or log (issue #282
+    /// finding 4) -- see [`rx_dropped_bytes`].
     ///
     /// [`rx_dropped_bytes`]: UsbController::rx_dropped_bytes
     fn ring_push(&mut self, byte: u8) -> bool {
-        let next_head = (self.rx_head + 1) % SERIAL_RX_BUF_LEN;
-        if next_head == self.rx_tail {
-            self.rx_overflow_count = self.rx_overflow_count.saturating_add(1);
-            return false;
-        }
-        self.rx_buf[self.rx_head] = byte;
-        self.rx_head = next_head;
-        true
+        with_serial_rx(|r| r.push(byte))
     }
 
     // -----------------------------------------------------------------------
@@ -1048,11 +1092,12 @@ impl UsbController {
             self.ep0_state = Ep0State::Idle;
             self.pending_address = 0;
             self.configured = false;
-            self.rx_head = 0;
-            self.rx_tail = 0;
             self.configure_ep1();
             self.configure_ep2();
         }
+        with_serial_rx(|r| {
+            *r = SerialRxRing::new();
+        });
     }
 
     /// Handle EP0 events: SETUP/IN/OUT control transfer stages.
@@ -1471,6 +1516,64 @@ impl UsbController {
 mod tests {
     use super::*;
 
+    // --- Serial RX ring: the IRQ-locked shared ring (#437 remnant 2) ---
+
+    #[test]
+    fn serial_rx_ring_interleaved_push_drain_preserves_fifo() {
+        // Simulate the ISR push path and the reader drain path interleaving
+        // (an interrupting handler arriving mid-stream): FIFO order must
+        // hold with no torn or reordered reads, across the wrap boundary.
+        // Sized so the interleaved drains keep occupancy under the ring's
+        // LEN-1 capacity (pushing past capacity drops bytes by design).
+        with_serial_rx(|r| {
+            *r = SerialRxRing::new();
+        });
+        let mut produced: [u8; 288] = [0; 288];
+        let mut consumed: [u8; 288] = [0; 288];
+        let mut n_consumed = 0usize;
+        for chunk in 0..6usize {
+            for i in 0..48usize {
+                let b = (chunk * 48 + i) as u8;
+                produced[chunk * 48 + i] = b;
+                assert!(with_serial_rx(|r| r.push(b)), "ring must accept byte {b}");
+            }
+            if chunk % 2 == 1 {
+                let n = with_serial_rx(|r| r.drain(&mut consumed[n_consumed..n_consumed + 32]));
+                assert_eq!(n, 32);
+                n_consumed += n;
+            }
+        }
+        n_consumed += with_serial_rx(|r| r.drain(&mut consumed[n_consumed..]));
+        assert_eq!(n_consumed, 288);
+        assert_eq!(
+            &consumed[..],
+            &produced[..],
+            "interleaved push/drain must preserve FIFO order with no torn reads"
+        );
+    }
+
+    #[test]
+    fn serial_rx_ring_overflow_counts_drops() {
+        with_serial_rx(|r| {
+            *r = SerialRxRing::new();
+        });
+        // The ring holds LEN-1 bytes (full when next_head == tail).
+        for i in 0..(SERIAL_RX_BUF_LEN - 1) {
+            assert!(with_serial_rx(|r| r.push(i as u8)), "ring must accept byte {i}");
+        }
+        assert!(!with_serial_rx(|r| r.push(0xEE)), "full ring must drop");
+        assert!(!with_serial_rx(|r| r.push(0xEF)), "full ring must drop");
+        assert_eq!(
+            with_serial_rx(|r| r.dropped_bytes()),
+            2,
+            "dropped bytes must be counted (the #282 finding-4 contract)"
+        );
+        // One drain frees exactly one slot.
+        let mut one = [0u8; 1];
+        assert_eq!(with_serial_rx(|r| r.drain(&mut one)), 1);
+        assert!(with_serial_rx(|r| r.push(0xAA)), "one drained slot must admit one more byte");
+    }
+
     // --- Register OFFSET encoding ---
 
     #[test]
@@ -1818,12 +1921,13 @@ mod tests {
     #[test]
     fn read_serial_partial() {
         let mut ctrl = UsbController::new();
-        // Manually prime the ring buffer with 3 bytes.
-        ctrl.rx_buf[0] = b'A';
-        ctrl.rx_buf[1] = b'B';
-        ctrl.rx_buf[2] = b'C';
-        ctrl.rx_head = 3;
-        ctrl.rx_tail = 0;
+        // Prime the shared ring with 3 bytes through the locked push path.
+        with_serial_rx(|r| {
+            *r = SerialRxRing::new();
+            r.push(b'A');
+            r.push(b'B');
+            r.push(b'C');
+        });
 
         let mut buf = [0u8; 8];
         let n = ctrl.read_serial(&mut buf);
@@ -1836,8 +1940,11 @@ mod tests {
         let mut ctrl = UsbController::new();
         // SERIAL_RX_BUF_LEN - 1 slots occupied is "full" for a
         // head==tail-means-empty ring.
-        ctrl.rx_head = SERIAL_RX_BUF_LEN - 1;
-        ctrl.rx_tail = 0;
+        with_serial_rx(|r| {
+            *r = SerialRxRing::new();
+            r.head = SERIAL_RX_BUF_LEN - 1;
+            r.tail = 0;
+        });
         assert_eq!(ctrl.rx_dropped_bytes(), 0, "no drops yet");
 
         let accepted = ctrl.ring_push(b'X');
@@ -1852,6 +1959,9 @@ mod tests {
     #[test]
     fn ring_push_accepts_when_space_available() {
         let mut ctrl = UsbController::new();
+        with_serial_rx(|r| {
+            *r = SerialRxRing::new();
+        });
         let accepted = ctrl.ring_push(b'Y');
         assert!(accepted, "ring with free space must accept the push");
         assert_eq!(ctrl.rx_dropped_bytes(), 0, "an accepted push is not a drop");
@@ -1861,10 +1971,13 @@ mod tests {
     fn ring_push_and_read_wrap_indices_around_buffer_end() {
         let mut ctrl = UsbController::new();
         // WHY: position the (empty) ring two slots from the buffer end so the
-        // third push crosses SERIAL_RX_BUF_LEN - 1 and must wrap rx_head back
-        // to 0 rather than index past the end of rx_buf.
-        ctrl.rx_head = SERIAL_RX_BUF_LEN - 2;
-        ctrl.rx_tail = SERIAL_RX_BUF_LEN - 2;
+        // third push crosses SERIAL_RX_BUF_LEN - 1 and must wrap the head
+        // index back to 0 rather than index past the end of the buffer.
+        with_serial_rx(|r| {
+            *r = SerialRxRing::new();
+            r.head = SERIAL_RX_BUF_LEN - 2;
+            r.tail = SERIAL_RX_BUF_LEN - 2;
+        });
 
         assert!(
             ctrl.ring_push(b'A'),
@@ -1879,16 +1992,18 @@ mod tests {
             "push that crosses the buffer end must still be accepted"
         );
 
-        assert_eq!(
-            ctrl.rx_head, 1,
-            "write index must wrap around the buffer end, not overflow past SERIAL_RX_BUF_LEN"
-        );
-        assert_eq!(ctrl.rx_buf[SERIAL_RX_BUF_LEN - 2], b'A');
-        assert_eq!(ctrl.rx_buf[SERIAL_RX_BUF_LEN - 1], b'B');
-        assert_eq!(
-            ctrl.rx_buf[0], b'C',
-            "the byte written after wraparound must land at index 0, not overrun the buffer"
-        );
+        with_serial_rx(|r| {
+            assert_eq!(
+                r.head, 1,
+                "write index must wrap around the buffer end, not overflow past SERIAL_RX_BUF_LEN"
+            );
+            assert_eq!(r.buf[SERIAL_RX_BUF_LEN - 2], b'A');
+            assert_eq!(r.buf[SERIAL_RX_BUF_LEN - 1], b'B');
+            assert_eq!(
+                r.buf[0], b'C',
+                "the byte written after wraparound must land at index 0, not overrun the buffer"
+            );
+        });
 
         let mut buf = [0u8; 3];
         let n = ctrl.read_serial(&mut buf);

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -184,7 +184,7 @@ fidelity = "the stub IS the host fixture for the exceptions module — see excep
 
 [[module]]
 name = "fd"
-tests = 69
+tests = 71
 mechanism = "host"
 
 [[module]]
@@ -648,7 +648,7 @@ witness = "boot.sh"
 
 [[module]]
 name = "usb"
-tests = 29
+tests = 31
 mechanism = "host"
 fidelity = "MMIO/ISR paths are not exercised host-side; EP1 ring sync is #437 remnant 2"
 


### PR DESCRIPTION
## Summary

**Remnant 1 (fd.rs):** every process shared one `CWD_BUF`/`CWD_LEN` static, so a chdir in one process silently changed every other's cwd. CWD moves onto the `Process` struct (`cwd` + `cwd_len`, "/" at creation, inherited across fork per POSIX), threaded through `sys_getcwd`/`vfs_chdir` via `process::with_current_cwd` / `set_current_cwd` following the #267 `with_current_fds` pattern. Both statics deleted.

**Remnant 2 (usb.rs):** `handle_ep1_rx` (ISR-context, once the MUSB IRQ is registered) and `read_serial` shared the serial RX ring's raw fields with no synchronization. The ring promotes to a static `SerialRxRing` behind an `irq::IrqSpinlock` (the ipc.rs/mmu.rs pattern) with a single `with_serial_rx` accessor — the GIC-wiring PR is now a one-line call-site change. Two pre-existing tests that poked the raw fields reworked onto the locked accessor.

**Remnant 3 (matrix_crypto.rs OTK):** explicitly re-confirmed deferred per the issue's done-when — the /keys/claim round-trip cannot land without the Olm session path that consumes claimed keys (X3DH intentionally not implemented here), and building a claim builder nobody calls would only move the dead call site. The deferral is now load-bearing in the module contract with the blocking epic named and the pool-deadlock consequence (#282 finding 8) restated for whoever lands Phase-09 integration.

## Verification

- **15/15 fd+usb tests pass on i686**, including two new POSIX-semantics tests (per-process chdir independence + fork inheritance; getcwd reports the CURRENT process's cwd) and the new interleaved-FIFO + overflow ring tests
- armv7a cross-compile clean under the zero-warning gate

Refs #437