### PR TITLE
console: host-testable debug console via the stub pattern (#459)

### DIFF
--- a/crates/thumos/src/console.rs
+++ b/crates/thumos/src/console.rs
@@ -223,9 +223,15 @@ impl Console {
         }
         loop {
             // SAFETY: wfi is a safe wait-for-interrupt instruction accessible at EL1.
+            #[cfg(not(test))]
             unsafe {
                 core::arch::asm!("wfi");
             }
+            // WHY(#459): wfi has no i686 encoding, so the host-test build gates
+            // it out; the reboot path never returns in production anyway, and
+            // no host test calls cmd_reboot.
+            #[cfg(test)]
+            break;
         }
     }
 }

--- a/crates/thumos/src/heap_stub.rs
+++ b/crates/thumos/src/heap_stub.rs
@@ -1,0 +1,19 @@
+//! Host-test stub for the ARM-target `heap` module (#459).
+//!
+//! The real `heap` module initializes the slab allocator over kernel page
+//! tables, which do not exist on the host test target (host tests link the
+//! std allocator). Under test this stub exposes only the `stats()` surface
+//! host-testable modules (the debug console's `cmd_mem`) reference.
+//!
+//! WHY(pattern): a gated-out hardware dependency is made test-visible by a
+//! parallel `#[cfg(test)] #[path = "..._stub.rs"] mod x;` binding in main.rs
+//! (see exceptions_stub.rs / timer_stub.rs / uart_stub.rs).
+
+/// Return `(total_allocs, total_frees)` for leak detection.
+///
+/// The stub reports a balanced `(0, 0)`: no kernel heap exists on the host
+/// target, so nothing can leak from it, and callers comparing the two values
+/// for equality (the leak check) see the correct zero-leak answer.
+pub(crate) fn stats() -> (u64, u64) {
+    (0, 0)
+}

--- a/crates/thumos/src/main.rs
+++ b/crates/thumos/src/main.rs
@@ -76,15 +76,14 @@ compile_error!(
     "crashloop-probe is a CI crash-loop harness; a production image must not spawn a deliberately faulting service."
 );
 
-// WHY (issue #372): also gated `not(test)` — the console's command methods
-// (cmd_mem/cmd_ps/…) read kernel state via `crate::heap`/`page`/`process`,
-// several of which are themselves `#[cfg(not(test))]`, so the module cannot
-// compile under the host-test cfg. Making the console host-testable (to
-// resurrect the #337 receive_byte tests + the new presence test) needs
-// heap/page/process host stubs — tracked separately; out of #372's
-// structural-gate scope. The armv7a `--features debug-console` build proves
-// the console compiles for its real target.
-#[cfg(all(feature = "debug-console", not(test)))]
+// WHY (issue #459): the console is host-testable via the heap/page/process
+// stub pattern — `mod heap` binds heap_stub under cfg(test), and page/process
+// compile on the host target already. The debug-console feature selects the
+// module on every target; the armv7a `--features debug-console` build proves
+// it compiles for the real one, and the i686 `--features debug-console`
+// nextest pass runs its line-buffer + presence tests (they were dead source
+// under the old `not(test)` gate, #337's class).
+#[cfg(feature = "debug-console")]
 mod console;
 mod contacts;
 mod csprng;
@@ -132,6 +131,9 @@ mod matrix_ids;
 #[cfg(not(test))]
 mod gic;
 #[cfg(not(test))]
+mod heap;
+#[cfg(test)]
+#[path = "heap_stub.rs"]
 mod heap;
 mod heorte_alarm;
 mod heorte_timer;

--- a/scripts/kernel-host-tests.sh
+++ b/scripts/kernel-host-tests.sh
@@ -28,3 +28,18 @@ command -v cargo-nextest >/dev/null || { echo "FAIL: cargo-nextest not installed
 
 (cd "$KERNEL_DIR" && cargo nextest run --bin thumos --target i686-unknown-linux-gnu \
     --build-jobs "${THUMOS_BUILD_JOBS:-8}" --test-threads "${THUMOS_TEST_THREADS:-8}")
+
+# WHY (#459): the debug console is now host-testable (heap/page/process stub
+# pattern), but its tests only exist under `--features debug-console`. A
+# second pass runs them — and asserts they actually execute, since this class
+# of bug is "tests never ran" (the gate left them dead source for weeks).
+out=$(cd "$KERNEL_DIR" && cargo nextest run --bin thumos --target i686-unknown-linux-gnu \
+    --features debug-console --build-jobs "${THUMOS_BUILD_JOBS:-8}" --test-threads "${THUMOS_TEST_THREADS:-8}" 2>&1)
+printf '%s\n' "$out"
+# WHY a herestring, not a pipe: under `set -o pipefail`, `printf | grep -q`
+# returns 141 when grep exits on the first match and printf dies of SIGPIPE —
+# the guard would fire on the very success it checks for (#459's own witness).
+grep -q 'console::tests' <<<"$out" || {
+    echo "FAIL #459: --features debug-console pass ran zero console::tests — the tests are dead again" >&2
+    exit 1
+}


### PR DESCRIPTION
## Summary

The debug console's mod was gated `all(feature="debug-console", not(test))` because its cmd methods read heap/page/process state and heap was itself test-gated — so the module's line-buffer and presence-sequence tests were **dead source that no CI pass ever executed** (the #337 class: tests that never ran).

- **`heap_stub.rs`** joins the stub family (exceptions/timer/uart): `stats()` reports a balanced `(0,0)` — no kernel heap exists on the host target, so the leak check sees the correct zero-leak answer. `main.rs` binds `mod heap` to it under cfg(test); page/process already compile host-side.
- **`mod console`** un-gates to `#[cfg(feature = "debug-console")]` on every target; its one ARM-only path (cmd_reboot's trailing wfi) cfg-gates the asm for the host build (no host test calls it).
- **`scripts/kernel-host-tests.sh`** gains a second nextest pass with `--features debug-console` plus a guard that fails when zero `console::tests` execute — the exact 'tests never ran' class, guarded forever. The guard uses a herestring, not a pipe: under pipefail, `printf|grep -q` returns 141 when grep exits on first match and printf dies of SIGPIPE (the guard fired on its own success during development — a lesson kept in the comment).

## Verification

The debug-console pass runs **2274 tests** locally — the 2270 baseline plus all 4 resurrected console tests (receive_byte buffer/overflow/backspace + wait_for_physical_presence fail-closed timeout) — and the guard passes. The LSR_DR register bit remains bench/TRM-verify per the issue (fail-safe if wrong); the qemu PL011 path never exercised it regardless.

Closes #459