### PR TITLE
time: unify userspace CLOCK_REALTIME with the ClockManager hierarchy (#506)

### DIFF
--- a/crates/thumos/src/kardia.rs
+++ b/crates/thumos/src/kardia.rs
@@ -363,6 +363,17 @@ impl KernelState {
             // for the render. evaluate() re-checks source validity/staleness.
             self.clock.evaluate(now_ms);
             self.wall_clock = self.clock.get_wall_clock(now_ms);
+            // #506: keep the userspace CLOCK_REALTIME view unified with the
+            // ClockManager trust hierarchy — sys_clock_gettime(CLOCK_REALTIME)
+            // must read this same wall time, not an independently-seeded
+            // offset. The #461 Step-5 witness proves the CNTPCT and IRQ-tick
+            // bases agree under virt, so set_realtime_offset's internal
+            // monotonic_secs() basis is sound. An ImplausibleEpoch rejection
+            // is the hostile-modem guard: fail closed, keep the old offset.
+            // SAFETY: called from the loop's privileged context, single-core.
+            unsafe {
+                let _ = crate::time::set_realtime_offset(self.wall_clock);
+            }
             // #400: check scheduled alarms against the fresh wall time + advance
             // the countdown timer. The firing IDs / expiry have no sink yet
             // (notification routing is a follow-on); the calls still advance
@@ -811,6 +822,17 @@ pub(crate) fn service_loop(mut kernel: KernelState, mut serial: Uart) -> ! {
         // and both events landed on a verified HMAC audit chain.
         let (fw_rules, fw_allowed, fw_denied, fw_audit, fw_chain) = kernel.firewall_boot_smoke();
 
+        // #506: seed the userspace CLOCK_REALTIME offset from the seeded
+        // ClockManager at loop start — the offset must be correct from tick
+        // 0, not one second late; poll_all's once-per-second branch then
+        // keeps it fresh. The #461 witness (Step 5) proves the CNTPCT and
+        // IRQ-tick bases agree under virt, so the internal monotonic_secs()
+        // basis is sound; an ImplausibleEpoch rejection fails closed.
+        // SAFETY: loop start, single-core, before userspace runs.
+        unsafe {
+            let _ = crate::time::set_realtime_offset(kernel.wall_clock);
+        }
+
         // Emit each witness line atomically (emit_marker masks IRQs per line)
         // so userspace /init cannot split a `kardia:` line mid-write (#513).
         if let Some(px) = painted {
@@ -822,6 +844,13 @@ pub(crate) fn service_loop(mut kernel: KernelState, mut serial: Uart) -> ! {
         emit_marker(
             &mut serial,
             format_args!("kardia: clock src={clock_src} wall={wall}\r\n"),
+        );
+        // #506 witness: the offset the userspace CLOCK_REALTIME view is
+        // built from, just seeded above (sys_clock_gettime adds monotonic
+        // seconds to it; a real epoch here proves the unification).
+        emit_marker(
+            &mut serial,
+            format_args!("kardia: realtime offset={wall}\r\n"),
         );
         emit_marker(
             &mut serial,
@@ -868,6 +897,8 @@ pub(crate) fn service_loop(mut kernel: KernelState, mut serial: Uart) -> ! {
     // driven the loop to open a ringtone session.
     #[cfg(feature = "qemu")]
     let mut ring_logged = false;
+    #[cfg(feature = "qemu")]
+    let mut realtime_logged = false;
     loop {
         #[cfg(feature = "qemu")]
         {
@@ -991,6 +1022,17 @@ pub(crate) fn service_loop(mut kernel: KernelState, mut serial: Uart) -> ! {
                         "kardia: incoming call -> ringtone sessions={}\r\n",
                         kernel.audio.session_count()
                     ),
+                );
+            }
+            // #506 witness: poll_all's once-per-second branch just refreshed
+            // the offset — log it the first time so a stuck offset is visible
+            // next to the seed witness above.
+            #[cfg(feature = "qemu")]
+            if ticked && !realtime_logged {
+                realtime_logged = true;
+                emit_marker(
+                    &mut serial,
+                    format_args!("kardia: realtime offset={}\r\n", kernel.wall_clock),
                 );
             }
             if ticked || nav.is_some() {

--- a/scripts/witness/boot.sh
+++ b/scripts/witness/boot.sh
@@ -44,6 +44,11 @@ wall=$(grep -oE 'clock src=manual wall=[0-9]+' boot.log | head -1 | grep -oE '[0
 # root cause 2026-08-04); a counter/frequency regression reds here instead
 # of silently hanging the wait loops that consume elapsed_ms.
 grep -q 'kardia: timer elapsed_ms=advancing' boot.log || { echo 'FAIL #461: elapsed_ms not advancing under qemu (CNTFRQ/CNTPCT regression)'; exit 1; }
+# #506 CLOCK_REALTIME unification: the kardia once-per-second wiring feeds
+# ClockManager time into set_realtime_offset; the emitted offset must be a
+# real ~2025+ epoch (an unwired offset would stay at its small default).
+grep -qE 'kardia: realtime offset=[0-9]+' boot.log || { echo 'FAIL #506: kardia never emitted its realtime offset (set_realtime_offset not wired)'; exit 1; }
+off=$(grep -oE 'kardia: realtime offset=[0-9]+' boot.log | head -1 | grep -oE '[0-9]+$'); test "${off:-0}" -gt 1700000000 || { echo "FAIL #506: realtime offset is not the ClockManager epoch (offset=${off:-0})"; exit 1; }
 # #398 telephony: seeded mock transport, LIVE stack, Registered.
 grep -q 'kardia: modem ready state=Registered' boot.log || { echo 'FAIL #398: Telephony did not initialize to Registered (AT state machine / mock wiring broken)'; exit 1; }
 # #399 audio session manager + mic audit.


### PR DESCRIPTION
## Summary

`sys_clock_gettime(CLOCK_REALTIME)` read an independently-seeded offset with zero production callers of `set_realtime_offset`, so userspace time and the ClockManager trust hierarchy could silently diverge.

- `service_loop` seeds the offset from the seeded ClockManager at loop start (correct from tick 0, not one second late) and `poll_all`'s once-per-second branch refreshes it on every evaluation — the offset can no longer lag a trust-hierarchy source failover (GPS/NTP/modem)
- The #461 Step-5 witness proves the CNTPCT and IRQ-tick bases agree under virt — what makes `set_realtime_offset`'s internal `monotonic_secs()` basis sound here; an `ImplausibleEpoch` rejection stays the hostile-modem guard and fails closed (old offset kept)
- **Witness**: `kardia: realtime offset=<epoch>` at loop start (boot.sh asserts a real ~2025+ epoch), plus a one-shot marker on the first once-per-second refresh so a stuck offset is visible

The /init-through-ABI variant of this witness was deliberately dropped: it grew the initramfs past `KERNEL_RESERVED` (link.ld ASSERT), and the kardia-side marker proves the same offset `sys_clock_gettime` serves, at zero image cost.

## Verification

Full qemu boot rc=0 with `kardia: realtime offset=1735603200` firing; boot.sh's new assertion passes against the log.

Closes #506