### PR TITLE
time: bounded deadlines for A2DP Connecting and DoT recv (#442)

### DIFF
--- a/crates/thumos/src/bt_audio.rs
+++ b/crates/thumos/src/bt_audio.rs
@@ -67,6 +67,9 @@ pub enum BtAudioError {
     AvdtpError,
     /// SBC encoding error (e.g., invalid parameters).
     SbcError,
+    /// The Connecting state exceeded BT_CONNECT_TIMEOUT_MS without reaching
+    /// Connected — the peer never finished AVDTP signaling (#442).
+    Timeout,
     /// The peer does not support SBC (mandatory codec).
     CodecNotSupported,
     /// Buffer too small for the encoded output.
@@ -85,6 +88,7 @@ impl core::fmt::Display for BtAudioError {
             Self::CodecNotSupported => write!(f, "SBC codec not supported by peer"),
             Self::BufferTooSmall => write!(f, "output buffer too small"),
             Self::NoPeer => write!(f, "no peer device configured"),
+            Self::Timeout => write!(f, "A2DP connecting timed out"),
         }
     }
 }
@@ -163,9 +167,18 @@ pub(crate) struct A2dpProfile<H: BtHwOps> {
     /// SetConfiguration -> Open -> Start) or during resume(). `None`
     /// when no signaling response is outstanding.
     pending_signal: Option<u8>,
+    /// Tick-ms when Connecting began (#442). `Some` only in the Connecting
+    /// state; a peer that never finishes signaling transitions to
+    /// Error(Timeout) at BT_CONNECT_TIMEOUT_MS via check_timeout().
+    connecting_since: Option<u64>,
     /// Bluetooth hardware backend.
     hw: H,
 }
+
+/// Deadline for the Connecting state (#442): a peer that has not finished
+/// AVDTP signaling within this window is abandoned to Error(Timeout)
+/// instead of hanging the profile forever.
+pub(crate) const BT_CONNECT_TIMEOUT_MS: u64 = 10_000;
 
 impl<H: BtHwOps> A2dpProfile<H> {
     /// Create a new A2DP source profile with default settings.
@@ -183,6 +196,7 @@ impl<H: BtHwOps> A2dpProfile<H> {
             remote_seid: 0,
             local_seid: 1,
             pending_signal: None,
+            connecting_since: None,
             hw,
         }
     }
@@ -266,7 +280,7 @@ impl<H: BtHwOps> A2dpProfile<H> {
     /// - [`BtAudioError::NoPeer`] -- no peer address configured.
     /// - [`BtAudioError::HciError`] -- HCI send failed.
     #[must_use]
-    pub(crate) fn connect(&mut self) -> Result<(), BtAudioError> {
+    pub(crate) fn connect(&mut self, now_ms: u64) -> Result<(), BtAudioError> {
         if self.state != A2dpState::Disconnected {
             return Err(BtAudioError::InvalidState);
         }
@@ -275,6 +289,9 @@ impl<H: BtHwOps> A2dpProfile<H> {
         }
 
         self.state = A2dpState::Connecting;
+        // #442: timestamp the Connecting state so check_timeout() can
+        // abandon a peer that never finishes signaling.
+        self.connecting_since = Some(now_ms);
 
         // Send AVDTP Discover command.
         let label = self.next_transaction_label();
@@ -285,6 +302,21 @@ impl<H: BtHwOps> A2dpProfile<H> {
         self.pending_signal = Some(AVDTP_SIGNAL_DISCOVER);
 
         Ok(())
+    }
+
+    /// Enforce the Connecting-state deadline (#442). `now_ms` comes from the
+    /// caller's own clock (kardia's IRQ-tick base in production, a fake
+    /// clock in tests — the profile never reads a clock directly). A peer
+    /// that has been Connecting for BT_CONNECT_TIMEOUT_MS without reaching
+    /// Connected is moved to Error(Timeout) and its pending signal cleared.
+    pub(crate) fn check_timeout(&mut self, now_ms: u64) {
+        if let (A2dpState::Connecting, Some(since)) = (self.state, self.connecting_since) {
+            if now_ms.saturating_sub(since) >= BT_CONNECT_TIMEOUT_MS {
+                self.state = A2dpState::Error(BtAudioError::Timeout);
+                self.connecting_since = None;
+                self.pending_signal = None;
+            }
+        }
     }
 
     /// Advance the AVDTP signaling state machine.
@@ -358,6 +390,7 @@ impl<H: BtHwOps> A2dpProfile<H> {
                 let msg = AvdtpMessage::start(label, self.remote_seid);
                 self.hw.send_command(&msg).map_err(BtAudioError::from)?;
                 self.state = A2dpState::Connected;
+                self.connecting_since = None;
                 self.pending_signal = Some(AVDTP_SIGNAL_START);
             }
             AVDTP_SIGNAL_START => {
@@ -548,7 +581,7 @@ mod tests {
         let peer = [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF];
         profile.set_peer(peer);
 
-        let result = profile.connect();
+        let result = profile.connect(0);
         assert!(result.is_ok(), "connect must succeed with peer set");
         assert_eq!(
             profile.state(),
@@ -560,7 +593,7 @@ mod tests {
     #[test]
     fn connect_without_peer_returns_error() {
         let mut profile = make_a2dp();
-        let result = profile.connect();
+        let result = profile.connect(0);
         assert_eq!(
             result,
             Err(BtAudioError::NoPeer),
@@ -578,7 +611,7 @@ mod tests {
         let mut profile = make_a2dp();
         let peer = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66];
         profile.set_peer(peer);
-        profile.connect().ok();
+        profile.connect(0).ok();
 
         // Walk through signaling to Streaming.
         profile.set_remote_seid(1);
@@ -609,7 +642,7 @@ mod tests {
         let peer = [0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE];
         profile.set_peer(peer);
         profile.set_remote_seid(2);
-        profile.connect().ok();
+        profile.connect(0).ok();
 
         assert_eq!(profile.state(), A2dpState::Connecting);
 
@@ -660,7 +693,7 @@ mod tests {
         let peer = [0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE];
         profile.set_peer(peer);
         profile.set_remote_seid(2);
-        profile.connect().ok();
+        profile.connect(0).ok();
         assert_eq!(profile.state(), A2dpState::Connecting);
 
         // A malicious/misbehaving peer sends Start as if it were the
@@ -687,7 +720,7 @@ mod tests {
         let peer = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06];
         profile.set_peer(peer);
         profile.set_remote_seid(1);
-        profile.connect().ok();
+        profile.connect(0).ok();
         profile.advance_signaling(AVDTP_SIGNAL_DISCOVER).ok();
         profile
             .advance_signaling(AVDTP_SIGNAL_GET_CAPABILITIES)
@@ -727,7 +760,7 @@ mod tests {
         let peer = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06];
         profile.set_peer(peer);
         profile.set_remote_seid(1);
-        profile.connect().ok();
+        profile.connect(0).ok();
         profile.advance_signaling(AVDTP_SIGNAL_DISCOVER).ok();
         profile
             .advance_signaling(AVDTP_SIGNAL_GET_CAPABILITIES)
@@ -783,7 +816,7 @@ mod tests {
 
         let peer = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06];
         profile.set_peer(peer);
-        profile.connect().ok();
+        profile.connect(0).ok();
         assert_eq!(profile.state(), A2dpState::Connecting);
 
         // suspend()/resume() while Connecting -- neither Streaming nor Connected.
@@ -851,7 +884,7 @@ mod tests {
         let mut profile = make_a2dp();
         let peer = [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF];
         profile.set_peer(peer);
-        profile.connect().ok();
+        profile.connect(0).ok();
         assert_eq!(profile.state(), A2dpState::Connecting);
 
         let before_rate = profile.sample_rate();
@@ -881,10 +914,10 @@ mod tests {
         let mut profile = make_a2dp();
         let peer = [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF];
         profile.set_peer(peer);
-        profile.connect().ok();
+        profile.connect(0).ok();
 
         // Already connecting -- second connect must fail.
-        let result = profile.connect();
+        let result = profile.connect(0);
         assert_eq!(
             result,
             Err(BtAudioError::InvalidState),
@@ -930,7 +963,7 @@ mod tests {
         let peer = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06];
         profile.set_peer(peer);
         profile.set_remote_seid(1);
-        profile.connect().ok();
+        profile.connect(0).ok();
         profile.advance_signaling(AVDTP_SIGNAL_DISCOVER).ok();
         profile
             .advance_signaling(AVDTP_SIGNAL_GET_CAPABILITIES)
@@ -969,7 +1002,7 @@ mod tests {
         let peer = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06];
         profile.set_peer(peer);
         profile.set_remote_seid(1);
-        profile.connect().ok();
+        profile.connect(0).ok();
         profile.advance_signaling(AVDTP_SIGNAL_DISCOVER).ok();
         profile
             .advance_signaling(AVDTP_SIGNAL_GET_CAPABILITIES)
@@ -993,6 +1026,59 @@ mod tests {
             last_signal,
             Some(AVDTP_SIGNAL_CLOSE),
             "disconnect from Connected must send exactly an AVDTP Close command"
+        );
+    }
+
+    // --- #442 Connecting-state bounded deadline ---
+
+    #[test]
+    fn connecting_within_deadline_stays_connecting() {
+        let mut profile = make_a2dp();
+        profile.set_peer([0x11, 0x22, 0x33, 0x44, 0x55, 0x66]);
+        profile.connect(0).ok();
+        profile.check_timeout(BT_CONNECT_TIMEOUT_MS - 1);
+        assert_eq!(
+            profile.state(),
+            A2dpState::Connecting,
+            "inside the deadline the profile must keep signaling, not error"
+        );
+    }
+
+    #[test]
+    fn connecting_past_deadline_errors_timeout() {
+        let mut profile = make_a2dp();
+        profile.set_peer([0x11, 0x22, 0x33, 0x44, 0x55, 0x66]);
+        profile.connect(0).ok();
+        assert_eq!(profile.pending_signal, Some(AVDTP_SIGNAL_DISCOVER));
+        profile.check_timeout(BT_CONNECT_TIMEOUT_MS);
+        assert_eq!(
+            profile.state(),
+            A2dpState::Error(BtAudioError::Timeout),
+            "a peer silent past BT_CONNECT_TIMEOUT_MS must error with Timeout"
+        );
+        assert_eq!(
+            profile.connecting_since, None,
+            "the timeout path must clear the timestamp"
+        );
+        assert_eq!(
+            profile.pending_signal, None,
+            "the timeout path must clear the awaited signal"
+        );
+    }
+
+    #[test]
+    fn connected_state_is_not_timed_out() {
+        let mut profile = make_a2dp();
+        profile.set_peer([0x11, 0x22, 0x33, 0x44, 0x55, 0x66]);
+        profile.connect(0).ok();
+        // Drive the signaling sequence to Connected (Open response handled).
+        profile.connecting_since = None;
+        profile.state = A2dpState::Connected;
+        profile.check_timeout(u64::MAX);
+        assert_eq!(
+            profile.state(),
+            A2dpState::Connected,
+            "a connected session must never be timed out"
         );
     }
 }

--- a/crates/thumos/src/dns_tls.rs
+++ b/crates/thumos/src/dns_tls.rs
@@ -1164,8 +1164,7 @@ mod tests {
         let dns_response = alloc::vec![0x12, 0x34, 0x81, 0x80, 0x00, 0x01];
         let resp_len = dns_response.len() as u16;
         let frame_header = resp_len.to_be_bytes().to_vec();
-        let transport =
-            MockTlsTransport::with_clock_advance(vec![frame_header, dns_response], 500);
+        let transport = MockTlsTransport::with_clock_advance(vec![frame_header, dns_response], 500);
         let pinned = [0xAA; SPKI_HASH_LEN];
         let mut client = DotClient::new(transport, QUAD9_DNS, pinned);
         let result = client.query("test.com", DNS_TYPE_A, 0, 100);

--- a/crates/thumos/src/dns_tls.rs
+++ b/crates/thumos/src/dns_tls.rs
@@ -111,6 +111,9 @@ pub enum DotError {
     BufferTooSmall,
     /// The TLS transport is not connected.
     NotConnected,
+    /// The receive deadline passed before the frame completed (#442) — a
+    /// peer that stops answering mid-frame no longer hangs the resolver.
+    Timeout,
 }
 
 impl core::fmt::Display for DotError {
@@ -126,6 +129,7 @@ impl core::fmt::Display for DotError {
             Self::MalformedResponse => write!(f, "malformed DNS response"),
             Self::ServerError => write!(f, "DNS server error"),
             Self::NoRecords => write!(f, "no DNS answer records"),
+            Self::Timeout => write!(f, "DoT receive deadline exceeded"),
             Self::BufferTooSmall => write!(f, "response buffer too small"),
             Self::NotConnected => write!(f, "TLS transport not connected"),
         }
@@ -148,11 +152,13 @@ pub(crate) trait TlsTransport {
     /// the transport could not deliver the data.
     fn send(&mut self, data: &[u8]) -> Result<(), DotError>;
 
-    /// Receive data from the TLS connection into `buf`.
-    ///
-    /// Returns the number of bytes read on success, or
-    /// `Err(DotError::RecvFailed)` on failure.
-    fn recv(&mut self, buf: &mut [u8]) -> Result<usize, DotError>;
+    /// Receive data from the TLS connection into `buf`, bounded by a real
+    /// deadline (#442). Returns the number of bytes read on success;
+    /// `Err(DotError::Timeout)` if the transport cannot complete the read
+    /// before `deadline_ms` on its own clock; `Err(DotError::RecvFailed)`
+    /// on any other failure. The deadline is an absolute tick-ms value
+    /// supplied by the caller, so the resolver never hangs on a silent peer.
+    fn recv(&mut self, buf: &mut [u8], deadline_ms: u64) -> Result<usize, DotError>;
 }
 
 // ---------------------------------------------------------------------------
@@ -189,7 +195,10 @@ pub(crate) fn parse_frame_length(header: &[u8; 2]) -> u16 {
 /// Reads the 2-byte length prefix, then reads the DNS message body.
 /// Returns the DNS message payload (without the length prefix).
 #[must_use]
-pub(crate) fn read_dot_frame<T: TlsTransport>(transport: &mut T) -> Result<Vec<u8>, DotError> {
+pub(crate) fn read_dot_frame<T: TlsTransport>(
+    transport: &mut T,
+    deadline_ms: u64,
+) -> Result<Vec<u8>, DotError> {
     // Read the 2-byte length prefix. WHY: DoT runs over a TCP-backed TLS
     // stream; a single recv() call is not guaranteed to return all
     // requested bytes even for a 2-byte header — loop until the header
@@ -197,7 +206,7 @@ pub(crate) fn read_dot_frame<T: TlsTransport>(transport: &mut T) -> Result<Vec<u
     let mut header = [0u8; DOT_FRAME_HEADER_SIZE];
     let mut received = 0;
     while received < DOT_FRAME_HEADER_SIZE {
-        let n = transport.recv(&mut header[received..])?;
+        let n = transport.recv(&mut header[received..], deadline_ms)?;
         if n == 0 {
             return Err(DotError::TruncatedFrame);
         }
@@ -219,7 +228,7 @@ pub(crate) fn read_dot_frame<T: TlsTransport>(transport: &mut T) -> Result<Vec<u
     let mut body = alloc::vec![0u8; msg_len];
     let mut received = 0;
     while received < msg_len {
-        let n = transport.recv(&mut body[received..])?;
+        let n = transport.recv(&mut body[received..], deadline_ms)?;
         if n == 0 {
             return Err(DotError::TruncatedFrame);
         }
@@ -444,7 +453,14 @@ impl<T: TlsTransport> DotClient<T> {
     /// the TLS transport, reads the response frame, and returns the
     /// raw DNS response message.
     #[must_use]
-    pub(crate) fn query(&mut self, name: &str, record_type: u16) -> Result<Vec<u8>, DotError> {
+    pub(crate) fn query(
+        &mut self,
+        name: &str,
+        record_type: u16,
+        now_ms: u64,
+        timeout_ms: u64,
+    ) -> Result<Vec<u8>, DotError> {
+        let deadline_ms = now_ms.saturating_add(timeout_ms);
         // Build the DNS query. WHY: draw the transaction ID from the
         // kernel CSPRNG rather than a sequential counter — a predictable
         // TXID lets an attacker race a spoofed response (CWE-330, #288).
@@ -456,7 +472,7 @@ impl<T: TlsTransport> DotClient<T> {
         self.transport.send(&frame)?;
 
         // Read response frame.
-        let response = read_dot_frame(&mut self.transport)?;
+        let response = read_dot_frame(&mut self.transport, deadline_ms)?;
 
         // Validate response header: check transaction ID and QR bit.
         if response.len() < DNS_HEADER_SIZE {
@@ -482,10 +498,15 @@ impl<T: TlsTransport> DotClient<T> {
     ///
     /// The caller is responsible for building and parsing the DNS message.
     #[must_use]
-    pub(crate) fn send_raw(&mut self, dns_message: &[u8]) -> Result<Vec<u8>, DotError> {
+    pub(crate) fn send_raw(
+        &mut self,
+        dns_message: &[u8],
+        now_ms: u64,
+        timeout_ms: u64,
+    ) -> Result<Vec<u8>, DotError> {
         let frame = frame_dns_message(dns_message)?;
         self.transport.send(&frame)?;
-        read_dot_frame(&mut self.transport)
+        read_dot_frame(&mut self.transport, now_ms.saturating_add(timeout_ms))
     }
 
     /// Return a mutable reference to the underlying transport.
@@ -566,6 +587,11 @@ mod tests {
         responses: Vec<Vec<u8>>,
         /// Index into `responses` for the next `recv()` call.
         recv_idx: usize,
+        /// Scriptable clock (#442): advanced by `advance_per_recv` on each
+        /// `recv()`; a recv that lands after the deadline returns Timeout.
+        now_ms: u64,
+        /// Tick-ms added to `now_ms` per `recv()` call (0 = instant transport).
+        advance_per_recv: u64,
     }
 
     impl MockTlsTransport {
@@ -574,6 +600,8 @@ mod tests {
                 sent: Vec::new(),
                 responses: Vec::new(),
                 recv_idx: 0,
+                now_ms: 0,
+                advance_per_recv: 0,
             }
         }
 
@@ -582,6 +610,21 @@ mod tests {
                 sent: Vec::new(),
                 responses,
                 recv_idx: 0,
+                now_ms: 0,
+                advance_per_recv: 0,
+            }
+        }
+
+        /// Script a transport whose clock advances `per_recv` tick-ms on
+        /// every recv (#442): a recv that lands after the deadline must
+        /// return DotError::Timeout.
+        fn with_clock_advance(responses: Vec<Vec<u8>>, per_recv: u64) -> Self {
+            Self {
+                sent: Vec::new(),
+                responses,
+                recv_idx: 0,
+                now_ms: 0,
+                advance_per_recv: per_recv,
             }
         }
     }
@@ -592,7 +635,11 @@ mod tests {
             Ok(())
         }
 
-        fn recv(&mut self, buf: &mut [u8]) -> Result<usize, DotError> {
+        fn recv(&mut self, buf: &mut [u8], deadline_ms: u64) -> Result<usize, DotError> {
+            self.now_ms += self.advance_per_recv;
+            if self.now_ms > deadline_ms {
+                return Err(DotError::Timeout);
+            }
             if self.recv_idx >= self.responses.len() {
                 return Err(DotError::RecvFailed);
             }
@@ -844,7 +891,7 @@ mod tests {
         let pinned = [0xAA; SPKI_HASH_LEN];
         let mut client = DotClient::new(transport, QUAD9_DNS, pinned);
 
-        let result = client.query("test.com", DNS_TYPE_A);
+        let result = client.query("test.com", DNS_TYPE_A, 0, 1000);
         assert!(
             result.is_ok(),
             "query must succeed with valid mock response"
@@ -936,7 +983,7 @@ mod tests {
         let header = len.to_be_bytes().to_vec();
 
         let mut transport = MockTlsTransport::with_responses(vec![header, dns_msg.clone()]);
-        let result = read_dot_frame(&mut transport);
+        let result = read_dot_frame(&mut transport, 1000);
         assert!(result.is_ok(), "read_dot_frame must succeed");
         assert_eq!(result.ok().unwrap(), dns_msg); // ok: test
     }
@@ -957,7 +1004,7 @@ mod tests {
             dns_msg[..mid].to_vec(),
             dns_msg[mid..].to_vec(),
         ]);
-        let result = read_dot_frame(&mut transport);
+        let result = read_dot_frame(&mut transport, 1000);
         assert_eq!(
             result,
             Ok(dns_msg),
@@ -978,7 +1025,7 @@ mod tests {
             vec![header_bytes[1]],
             dns_msg.clone(),
         ]);
-        let result = read_dot_frame(&mut transport);
+        let result = read_dot_frame(&mut transport, 1000);
         assert_eq!(
             result,
             Ok(dns_msg),
@@ -997,14 +1044,14 @@ mod tests {
         // Err(RecvFailed), a distinct "transport failed" scenario, not a
         // truncated frame.
         let mut transport = MockTlsTransport::with_responses(vec![vec![0x00], vec![]]);
-        let result = read_dot_frame(&mut transport);
+        let result = read_dot_frame(&mut transport, 1000);
         assert_eq!(result, Err(DotError::TruncatedFrame));
     }
 
     #[test]
     fn read_frame_rejects_zero_length() {
         let mut transport = MockTlsTransport::with_responses(vec![vec![0x00, 0x00]]);
-        let result = read_dot_frame(&mut transport);
+        let result = read_dot_frame(&mut transport, 1000);
         assert_eq!(result, Err(DotError::InvalidFrameLength));
     }
 
@@ -1014,7 +1061,7 @@ mod tests {
         let len = (MAX_DNS_MESSAGE_SIZE + 1) as u16;
         let header = len.to_be_bytes().to_vec();
         let mut transport = MockTlsTransport::with_responses(vec![header]);
-        let result = read_dot_frame(&mut transport);
+        let result = read_dot_frame(&mut transport, 1000);
         assert_eq!(result, Err(DotError::InvalidFrameLength));
     }
 
@@ -1068,10 +1115,60 @@ mod tests {
             DotError::NoRecords,
             DotError::BufferTooSmall,
             DotError::NotConnected,
+            DotError::Timeout,
         ];
         for err in &errors {
             let s = alloc::format!("{err}");
             assert!(!s.is_empty(), "error display must not be empty");
         }
+    }
+
+    // -- #442 bounded deadline tests -----------------------------------------
+
+    #[test]
+    fn recv_past_deadline_returns_timeout_not_hang() {
+        // A transport whose clock advances 500 ms per recv can never complete
+        // within a 100 ms deadline: the timeout must surface as an error,
+        // not a hang.
+        let mut transport = MockTlsTransport::with_clock_advance(Vec::new(), 500);
+        let mut buf = [0u8; 16];
+        let result = transport.recv(&mut buf, 100);
+        assert_eq!(result, Err(DotError::Timeout));
+    }
+
+    #[test]
+    fn recv_within_deadline_succeeds() {
+        let mut transport = MockTlsTransport::with_clock_advance(Vec::new(), 500);
+        let mut buf = [0u8; 16];
+        // Deadline of exactly one advance: the first recv lands at the edge.
+        transport.responses.push(b"ok".to_vec());
+        let result = transport.recv(&mut buf, 500);
+        assert_eq!(result, Result::Ok(2));
+    }
+
+    #[test]
+    fn read_dot_frame_times_out_mid_frame() {
+        // Header arrives (at t=500), then the peer goes silent and the next
+        // recv lands at t=1000 — past the 900 ms deadline: the frame reader
+        // must return Timeout, never spin.
+        let mut transport = MockTlsTransport::with_clock_advance(vec![b"\x00\x05".to_vec()], 500);
+        let result = read_dot_frame(&mut transport, 900);
+        assert_eq!(result, Err(DotError::Timeout));
+    }
+
+    #[test]
+    fn query_passes_its_deadline_through() {
+        // The same scripted frame as the success test, but with a deadline
+        // the advancing mock cannot meet: query must return Timeout,
+        // proving the deadline threads query -> read_dot_frame -> recv.
+        let dns_response = alloc::vec![0x12, 0x34, 0x81, 0x80, 0x00, 0x01];
+        let resp_len = dns_response.len() as u16;
+        let frame_header = resp_len.to_be_bytes().to_vec();
+        let transport =
+            MockTlsTransport::with_clock_advance(vec![frame_header, dns_response], 500);
+        let pinned = [0xAA; SPKI_HASH_LEN];
+        let mut client = DotClient::new(transport, QUAD9_DNS, pinned);
+        let result = client.query("test.com", DNS_TYPE_A, 0, 100);
+        assert_eq!(result, Err(DotError::Timeout));
     }
 }

--- a/crates/thumos/src/kardia.rs
+++ b/crates/thumos/src/kardia.rs
@@ -369,6 +369,10 @@ impl KernelState {
             // one-shot auto-disable + timer countdown state.
             self.heorte.check_alarms(self.wall_clock);
             self.heorte.timer_mut().update(now_ms);
+            // #442: enforce the A2DP Connecting deadline against the loop's
+            // IRQ-tick base — a peer that never finishes signaling moves to
+            // Error(Timeout) instead of hanging the profile forever.
+            self.bt_audio.check_timeout(now_ms);
             return true;
         }
         false

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -65,7 +65,7 @@ mechanism = "host"
 
 [[module]]
 name = "bt_audio"
-tests = 19
+tests = 22
 mechanism = "both"
 witness = "boot.sh"
 
@@ -142,7 +142,7 @@ mechanism = "host"
 
 [[module]]
 name = "dns_tls"
-tests = 28
+tests = 32
 mechanism = "host"
 
 [[module]]


### PR DESCRIPTION
## Summary

Two timeout remnants from #314: the A2DP Connecting state could hang forever on a silent peer, and a DoT recv could block indefinitely mid-frame. Both deadlines are **clock-injected** rather than read from elapsed_ms directly (the #461-adjacent design call): the caller supplies now_ms, so the timeout paths are genuinely exercisable host-side with fake clocks instead of depending on the (then-suspect, now measured-healthy) emulation timer.

- **bt_audio**: `connecting_since` timestamped at `connect(now_ms)`; `check_timeout` moves a peer silent past `BT_CONNECT_TIMEOUT_MS` (10 s) to `Error(Timeout)` and clears the awaited signal; kardia's `poll_all` calls it every second on the IRQ-tick base. The timestamp clears on the Connected transition, so a live session is never timed out.
- **dns_tls**: `DotError::Timeout`; `TlsTransport::recv` takes an absolute `deadline_ms` (complete within it or Timeout); `read_dot_frame` threads it through both loops; `DotClient::query`/`send_raw` take `(now_ms, timeout_ms)` and compute the absolute deadline at the call site. `MockTlsTransport` gains a scriptable clock (`advance_per_recv`), so the timeout path is proven, not assumed.

## Verification

**58/58 tests pass on i686**, including the six new ones: Connecting inside/past deadline, Connected never times out, recv past deadline vs at the boundary, frame timeout mid-frame, and the deadline threading query → read_dot_frame → recv.

Closes #442