### PR TITLE
signal: real delivery via IRQ-frame rewrite + RX sigreturn trampoline page (#446)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,8 @@ jobs:
         run: scripts/witness/guard.sh
       - name: QEMU brk heap growth on a real page table (#533)
         run: scripts/witness/brk.sh
+      - name: QEMU userspace signal delivery + sigreturn (#446)
+        run: scripts/witness/signal.sh
       - name: QEMU PID-0 fault supervisor + crash-loop rate limit (#492)
         run: scripts/witness/crashloop.sh
       - name: Witness-extraction drift guard (#546)

--- a/.kanon-ci.toml
+++ b/.kanon-ci.toml
@@ -71,7 +71,7 @@ cmd = "scripts/check-target-test-ledger.sh"
 timeout_secs = 300
 
 # WHY (#546): the full QEMU witness matrix (boot + fault + sleep + fork +
-# exec + forkexec + guard + brk + crashloop) as one canonical runner — the
+# exec + forkexec + guard + brk + signal + crashloop) as one canonical runner — the
 # exact scripts ci.yml executes step-by-step.
 [stages."kernel qemu witnesses"]
 cmd = "scripts/witness-run-all.sh"

--- a/crates/thumos/build.rs
+++ b/crates/thumos/build.rs
@@ -229,12 +229,12 @@ fn generate_initramfs(manifest_dir: &Path, out_dir: &Path) {
         Ok(v) if !v.is_empty() => {
             if ![
                 "kread", "kwrite", "kexec", "cp15", "sleep", "fork", "exec", "forkexec", "guard",
-                "brk",
+                "brk", "signal",
             ]
             .contains(&v.as_str())
             {
                 die(&format!(
-                    "#487: unknown THUMOS_INIT_VARIANT '{v}' (expected kread|kwrite|kexec|cp15|sleep|fork|exec|forkexec|guard|brk)"
+                    "#487: unknown THUMOS_INIT_VARIANT '{v}' (expected kread|kwrite|kexec|cp15|sleep|fork|exec|forkexec|guard|brk|signal)"
                 ));
             }
             Some(format!("thumos_init_{v}"))

--- a/crates/thumos/init/init.rs
+++ b/crates/thumos/init/init.rs
@@ -41,7 +41,7 @@ unsafe fn sys_write(fd: u32, buf: *const u8, len: u32) -> u32 {
 ///
 /// # Safety
 /// Yields to the scheduler; the kernel resumes this process after the interval.
-#[cfg(any(thumos_init_sleep, thumos_init_fork, thumos_init_forkexec, thumos_init_guard))]
+#[cfg(any(thumos_init_sleep, thumos_init_fork, thumos_init_forkexec, thumos_init_guard, thumos_init_signal))]
 #[inline(always)]
 unsafe fn sys_sleep(ms: u32) {
     // SAFETY: issues SVC #7 (Sleep) per the thumos ABI; the kernel marks this
@@ -54,6 +54,94 @@ unsafe fn sys_sleep(ms: u32) {
             lateout("r0") _,
             options(nostack),
         );
+    }
+}
+
+/// sigaction(signum, handler) -> 0 on success (#446 signal harness).
+///
+/// # Safety
+/// `handler` must be a PL0-executable function address in this image (or 0
+/// for the default action, 1 for ignore), per sys_sigaction's contract.
+#[cfg(thumos_init_signal)]
+#[inline(always)]
+unsafe fn sys_sigaction(signum: u32, handler: u32) -> u32 {
+    let ret;
+    // SAFETY: issues SVC #80 (Sigaction) per the thumos ABI.
+    unsafe {
+        core::arch::asm!(
+            "svc #0",
+            in("r7") 80u32,
+            inlateout("r0") signum => ret,
+            in("r1") handler,
+            options(nostack),
+        );
+    }
+    ret
+}
+
+/// kill(pid, signum) -> 0 on success, negative errno otherwise (#446 harness).
+///
+/// # Safety
+/// Raising a signal against this (or a permitted) process.
+#[cfg(thumos_init_signal)]
+#[inline(always)]
+unsafe fn sys_kill(pid: u32, signum: u32) -> u32 {
+    let ret;
+    // SAFETY: issues SVC #13 (Kill) per the thumos ABI.
+    unsafe {
+        core::arch::asm!(
+            "svc #0",
+            in("r7") 13u32,
+            inlateout("r0") pid => ret,
+            in("r1") signum,
+            options(nostack),
+        );
+    }
+    ret
+}
+
+/// getpid() -> this process's PID (#446 harness).
+///
+/// # Safety
+/// Issues SVC #3 (Getpid) per the thumos ABI.
+#[cfg(thumos_init_signal)]
+#[inline(always)]
+unsafe fn sys_getpid() -> u32 {
+    let ret;
+    // SAFETY: SVC #3.
+    unsafe {
+        core::arch::asm!(
+            "svc #0",
+            in("r7") 3u32,
+            lateout("r0") ret,
+            options(nostack),
+        );
+    }
+    ret
+}
+
+/// The SIGUSR1 handler (#446): the kernel delivers into this function with
+/// the signal frame as its stack and the sigreturn trampoline as lr. Writing
+/// a marker proves handler ENTRY; returning enters the trampoline, whose
+/// ldr+svc drives sigreturn_frame back to the interrupted flow.
+#[cfg(thumos_init_signal)]
+unsafe fn usr1_handler() {
+    let m = b"signal: handler usr1\n";
+    // SAFETY: marker literal is PL0-readable; sys_write is a plain syscall.
+    unsafe {
+        sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+    }
+}
+
+/// The SIGUSR2 handler (#446): its marker MUST appear only if SIGUSR2's
+/// pending bit survived SIGUSR1's delivery + sigreturn — the exact-clear
+/// contract (the old clear-any-pending could clear the wrong signal).
+#[cfg(thumos_init_signal)]
+unsafe fn usr2_handler() {
+    let m = b"signal: handler usr2\n";
+    // SAFETY: as usr1_handler.
+    unsafe {
+        sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
     }
 }
 
@@ -79,7 +167,7 @@ unsafe fn sys_exit(code: u32) -> ! {
 ///
 /// # Safety
 /// Creates a child process; both branches return here (the #478 ctx seed).
-#[cfg(any(thumos_init_fork, thumos_init_forkexec, thumos_init_guard))]
+#[cfg(any(thumos_init_fork, thumos_init_forkexec, thumos_init_guard, thumos_init_signal))]
 #[inline(always)]
 unsafe fn sys_fork() -> u32 {
     let ret;
@@ -95,7 +183,7 @@ unsafe fn sys_fork() -> u32 {
 ///
 /// # Safety
 /// Reads a child's exit status; reaps its slot when Dead.
-#[cfg(any(thumos_init_fork, thumos_init_forkexec, thumos_init_guard))]
+#[cfg(any(thumos_init_fork, thumos_init_forkexec, thumos_init_guard, thumos_init_signal))]
 #[inline(always)]
 unsafe fn sys_waitpid(pid: u32) -> u32 {
     let ret;
@@ -505,6 +593,76 @@ pub extern "C" fn _start() -> ! {
                 sys_exit(1);
             }
             let m = b"init: brk shrunk\n";
+            sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+        }
+        // #446 signal harness: install handlers for SIGUSR1 (10) and SIGUSR2
+        // (12), raise BOTH against self, then yield so the kernel delivers
+        // them. next_pending takes the lowest signum, so USR1 delivers first:
+        // its handler marker proves the IRQ-frame rewrite + trampoline entry,
+        // and control returning HERE after it proves sigreturn restored the
+        // interrupted context. USR2's marker then proves its pending bit
+        // survived USR1's delivery -- the exact-clear contract (the old
+        // clear-any-pending could wipe the wrong bit). "flows complete"
+        // prints only if both sigreturns returned control to this flow.
+        #[cfg(thumos_init_signal)]
+        {
+            let pid = sys_getpid();
+            // SAFETY: both handlers are PL0-executable functions in this
+            // image; the casts take their PL0 VAs (usize == u32 on armv7a).
+            let h1 = usr1_handler as usize as u32;
+            let h2 = usr2_handler as usize as u32;
+            if sys_sigaction(10, h1) != 0 || sys_sigaction(12, h2) != 0 {
+                let m = b"signal: sigaction FAILED\n";
+                sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+                sys_exit(1);
+            }
+            if sys_kill(pid, 12) != 0 || sys_kill(pid, 10) != 0 {
+                let m = b"signal: kill FAILED\n";
+                sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+                sys_exit(1);
+            }
+            // Two yields: the first gives the kernel an exception return on
+            // which to deliver USR1; the second a return for USR2 (still
+            // pending iff the delivery clear was exact).
+            sys_sleep(30);
+            sys_sleep(30);
+            let m = b"signal: flows complete\n";
+            sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+            // W^X probe: the sigreturn trampoline page (SIGNAL_TRAMPOLINE_VA
+            // = USER_TEXT_BASE - 4096 = 0x7FEF_F000, mirrored from
+            // signal.rs) is PL0 read+EXECUTE — a PL0 WRITE to it must die to
+            // a data-abort PERMISSION fault (DFSR 0x0f: mapped, write
+            // denied; a 0x07 translation fault would prove the page is not
+            // where signal.rs claims). The child forks, writes it, and must
+            // be fault-killed; the parent reaps and confirms. A writable
+            // trampoline would let userspace rewrite its own sigreturn path.
+            let probe = sys_fork();
+            if probe == 0 {
+                // CHILD: the write below must never complete.
+                let tramp = 0x7FEF_F000usize as *mut u32;
+                core::ptr::write_volatile(tramp, 0xDEAD_BEEF);
+                let m = b"signal: trampoline WRITEABLE (W^X broken)\n";
+                sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+                sys_exit(3);
+            }
+            if probe == u32::MAX {
+                let m = b"signal: rx-probe fork FAILED\n";
+                sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
+                sys_exit(1);
+            }
+            let status = loop {
+                let s = sys_waitpid(probe);
+                if s != u32::MAX {
+                    break s;
+                }
+                sys_sleep(10);
+            };
+            // Fault-killed children report 139 (the guard harness's contract).
+            let m: &[u8] = if status == 139 {
+                b"signal: trampoline rx enforced\n"
+            } else {
+                b"signal: trampoline rx probe WRONG status\n"
+            };
             sys_write(1, m.as_ptr(), u32::try_from(m.len()).unwrap_or(0));
         }
         sys_write(1, msg.as_ptr(), u32::try_from(msg.len()).unwrap_or(0));

--- a/crates/thumos/src/exceptions.rs
+++ b/crates/thumos/src/exceptions.rs
@@ -260,6 +260,15 @@ pub extern "C" fn irq_handler_rust(frame: *mut process::Context) {
     // handler re-enables it).
     unsafe { process::trap_enter(frame) };
     irq_handler_body();
+    // #446: real signal delivery, consumed at the exception return — if the
+    // current process has a handled signal pending, build its user frame and
+    // rewrite the trap frame to enter the handler (the pending bit is
+    // cleared at dispatch inside deliver()).
+    if let Some((sig, handler)) = process::check_pending_signal() {
+        // SAFETY: frame is the current process's trap Context on the IRQ
+        // stack; its sp/pc/lr are the interrupted user state.
+        unsafe { crate::signal::deliver(&mut *frame, sig, handler) };
+    }
     process::trap_leave();
 }
 
@@ -356,12 +365,11 @@ fn irq_handler_body() {
             // remains.
         }
 
-        // Check for pending signals on the current process.
-        // WHY: signals must be delivered before the next return to user mode.
-        // The timer IRQ is the primary exception return point. Full signal
-        // frame setup requires user-mode register state from the IRQ stack;
-        // that is wired through the SVC path once userspace is active.
-        let _ = process::check_pending_signal(); // WHY: signal delivery failure is non-actionable in IRQ context; will retry on next tick
+        // NOTE: signal delivery is consumed by irq_handler_rust at the
+        // exception return (#446), not here — the old discard-only peek is
+        // gone. The delivery happens on every timer IRQ once the body has
+        // done its scheduler work, so a handled signal lands in user context
+        // at the next return.
     }
 }
 
@@ -537,6 +545,17 @@ pub(crate) extern "C" fn svc_handler_rust(frame: *mut process::Context) {
     // valid and unaliased for this call (traps never nest).
     unsafe { process::trap_enter(frame) };
     let f = unsafe { &mut *frame };
+    // #446: sigreturn is special-cased before the generic dispatch — the
+    // frame restore needs THIS SVC trap frame (dispatch receives only arg
+    // registers). The trampoline entered with user sp = the signal frame and
+    // r0 = the handled signum; the pending bit was cleared at dispatch.
+    if f.r[7] == crate::signal::SIGRETURN_NUM {
+        // SAFETY: as above; the trampoline's user sp is the frame deliver()
+        // built.
+        unsafe { crate::signal::sigreturn_frame(&mut *frame) };
+        process::trap_leave();
+        return;
+    }
     let ret = crate::syscall::dispatch(f.r[7], f.r[0], f.r[1], f.r[2], f.r[3]);
     if !process::trap_switched() {
         // SAFETY: no switch occurred, so `frame` still holds this caller's

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -440,6 +440,51 @@ unsafe fn map_user_stack(pt: usize, stack_base: usize, pages: usize) -> bool {
     true
 }
 
+/// Map the per-process sigreturn trampoline page (#446): one fresh frame at
+/// the fixed `SIGNAL_TRAMPOLINE_VA` slot with PL0 read+execute / PL1
+/// read-write permissions, then the trampoline bytes written through the
+/// kernel's identity mapping. Returns the frame's physical address for
+/// rollback, or `None` on OOM / L2-pool exhaustion (already cleaned up).
+///
+/// WHY PL0-RX and not on-stack code: the user stack is RW+XN (#482 W^X), so
+/// an on-stack trampoline prefetch-aborts when the handler returns into it
+/// — the QEMU signal witness caught exactly that. The RX page survives exec
+/// (it sits below USER_TEXT_BASE's rebuilt section), is deep-copied by fork,
+/// and is reclaimed by exit's all-user-pages walk.
+///
+/// # Safety
+/// `pt` is a caller-owned process L1 not currently live in TTBR0; the caller
+/// runs under the kernel identity L1 (the trampoline write targets phys).
+#[cfg(target_arch = "arm")]
+unsafe fn map_signal_trampoline(pt: usize) -> Option<usize> {
+    let phys = page::alloc_page()?;
+    let attrs = mmu::prot_to_l2_flags(mmu::prot::PROT_READ | mmu::prot::PROT_EXEC);
+    // SAFETY: pt caller-owned; SIGNAL_TRAMPOLINE_VA is the reserved slot
+    // below USER_TEXT_BASE (signal.rs documents why nothing else maps there).
+    unsafe {
+        if !mmu::shatter_section(pt, crate::signal::SIGNAL_TRAMPOLINE_VA)
+            || !mmu::map_page(pt, crate::signal::SIGNAL_TRAMPOLINE_VA, phys, attrs)
+        {
+            page::free_page(phys);
+            return None;
+        }
+        crate::signal::write_trampoline_page(phys);
+    }
+    Some(phys)
+}
+
+/// No-op trampoline mapping for non-ARM (host test) builds: host page frames
+/// are simulated addresses — never dereference-able — and fork's deep-copy
+/// walk WOULD deref every user page's phys, so mapping a simulated frame
+/// here segfaults the host fork tests. The map_page/shatter composition is
+/// host-covered in mmu.rs's own tests; the real grant is covered end-to-end
+/// by the QEMU signal witness. `Some(0)` keeps spawn_user's rollback shape
+/// (free_page validates allocator range, so 0 is a safe no-op there).
+#[cfg(not(target_arch = "arm"))]
+unsafe fn map_signal_trampoline(_pt: usize) -> Option<usize> {
+    Some(0)
+}
+
 /// Drop the PL0 grant on `pages` frames from `base` in `pt`: rewrite each L2
 /// entry back to the identity KERNEL_DEFAULT_PAGE (PL1-only, #489). NOT
 /// unmap_page (zeroing an entry inside a shattered identity MB would fault the
@@ -523,7 +568,18 @@ pub(crate) fn spawn_user(loaded: &crate::elf::LoadedElf) -> Option<Pid> {
         };
         let stack_top = stack_base + page::PAGE_SIZE * STACK_PAGES;
 
-        if !map_user_image(new_pt, loaded) || !map_user_stack(new_pt, stack_base, STACK_PAGES) {
+        // #446: the sigreturn trampoline page (PL0-RX) every signal delivery
+        // returns through. Mapped before image+stack so a failure anywhere
+        // below has one uniform rollback.
+        let tramp_phys = map_signal_trampoline(new_pt);
+
+        if tramp_phys.is_none()
+            || !map_user_image(new_pt, loaded)
+            || !map_user_stack(new_pt, stack_base, STACK_PAGES)
+        {
+            if let Some(phys) = tramp_phys {
+                page::free_page(phys);
+            }
             // free_addr_space also reclaims the L2 tables the shatters allocated
             // (the shared KERNEL_L2 is skipped -- free_l2_table no-ops on
             // non-pool addresses).
@@ -1929,6 +1985,22 @@ pub unsafe fn clear_any_pending() {
             if let Some(sig) = proc.signal_state.next_pending() {
                 proc.signal_state.clear_pending(sig);
             }
+        }
+    }
+}
+
+/// Clear the pending bit for EXACTLY `sig` on the current process (#446).
+/// Called at dispatch time by signal::deliver, so the handler runs once per
+/// raise; distinct from clear_any_pending (next-pending semantics), which
+/// can clear the wrong signal when several are pending at once.
+pub(crate) fn clear_pending_for_current(sig: crate::signal::Signal) {
+    // SAFETY: current process PCB pointer is valid; mutation via addr_of_mut!,
+    // single-core.
+    unsafe {
+        let procs = &mut *addr_of_mut!(PROCS);
+        let cur = usize::from(CURRENT);
+        if let Some(ref mut proc) = procs[cur] {
+            proc.signal_state.clear_pending(sig);
         }
     }
 }

--- a/crates/thumos/src/signal.rs
+++ b/crates/thumos/src/signal.rs
@@ -11,8 +11,9 @@
 //!    the kernel inspects the current process's pending mask.
 //! 3. If a pending signal has a registered handler, the kernel:
 //!    a. Pushes a `SignalFrame` onto the user stack (saves all registers).
-//!    b. Sets PC to the handler address.
-//!    c. Sets LR to the sigreturn trampoline address.
+//!    b. Sets r0 to the signal number (the POSIX handler argument).
+//!    c. Sets PC to the handler address.
+//!    d. Sets LR to the sigreturn trampoline page (`SIGNAL_TRAMPOLINE_VA`).
 //! 4. The handler runs in user mode and returns via the trampoline.
 //! 5. The trampoline executes `svc #81` (Sigreturn).
 //! 6. `sys_sigreturn` restores the saved `SignalFrame` from user stack.
@@ -21,27 +22,41 @@
 //!
 //! ```text
 //! [saved r0-r12, sp, lr, pc, cpsr]   17 × 4 = 68 bytes
-//! [signal number]                      4 bytes
-//! [sigreturn trampoline code]          8 bytes (mov r7, #81; svc #0)
-//! Total: 80 bytes
+//! Total: 68 bytes
 //! ```
 //!
-//! WHY trampoline is embedded in the frame: the kernel cannot rely on a
-//! fixed trampoline address in user space (no vDSO). Embedding the code
-//! on the user stack and pointing LR at it is the standard ARM approach
-//! (matches Linux 2.6 OABI signal delivery).
+//! # The sigreturn trampoline page
+//!
+//! The trampoline (`mov r7, #81; svc #0`) lives in a dedicated per-process
+//! page at the fixed virtual address `SIGNAL_TRAMPOLINE_VA` (one page below
+//! `USER_TEXT_BASE`), mapped PL0 read+execute / PL1 read-write at process
+//! creation (`map_signal_trampoline` in process.rs). WHY a page, not code on
+//! the stack: the user stack is PL0 RW + execute-never (#482 W^X), so an
+//! on-stack trampoline prefetch-aborts the moment the handler returns into
+//! it — the QEMU signal witness caught exactly that (USERFAULT
+//! prefetch-abort status 0x0f at the stack VA). A fixed RX page is the
+//! vDSO-shaped answer: PL0 can execute but never write it, the kernel wrote
+//! it once through the PL1 mapping, the address is known without per-frame
+//! code, and fork copies it / exec inherits it (it sits outside the
+//! USER_TEXT section exec rebuilds) / exit's page walk reclaims it.
 
 /// Number of u32 registers saved in the signal frame (r0-r12, sp, lr, pc, cpsr).
 pub(crate) const SIGNAL_FRAME_REGS: usize = 17;
 
-/// Total signal frame size in bytes: 17 regs × 4 + signum × 4 + trampoline × 8.
-pub(crate) const SIGNAL_FRAME_SIZE: usize = SIGNAL_FRAME_REGS * 4 + 4 + 8;
+/// Total signal frame size in bytes: exactly the saved `Context` (17 × 4).
+/// The frame carries NO code — the trampoline lives in the RX page above.
+pub(crate) const SIGNAL_FRAME_SIZE: usize = SIGNAL_FRAME_REGS * 4;
 
-/// Offset of `signum` field within the signal frame (bytes from frame base).
-pub(crate) const SIGNAL_FRAME_SIGNUM_OFFSET: usize = SIGNAL_FRAME_REGS * 4;
-
-/// Offset of the trampoline code within the signal frame.
-pub(crate) const SIGNAL_FRAME_TRAMPOLINE_OFFSET: usize = SIGNAL_FRAME_SIGNUM_OFFSET + 4;
+/// Virtual address of the per-process sigreturn trampoline page: the page
+/// directly below `USER_TEXT_BASE`. WHY here: heap grows up from
+/// `DEFAULT_HEAP_BREAK` (0x1000_0000) and mmap from `MMAP_BASE`
+/// (0x2000_0000), so this page is unreachable by legitimate user mappings;
+/// it sits OUTSIDE the USER_TEXT 1 MB section that exec revokes and rebuilds
+/// (exec_replace_context resets only USER_TEXT_BASE's section), so the
+/// trampoline survives exec; and fork's copy-all-user-pages replicates it
+/// for the child automatically.
+pub(crate) const SIGNAL_TRAMPOLINE_VA: usize =
+    crate::kconfig::USER_TEXT_BASE - crate::page::PAGE_SIZE;
 
 /// ARM `mov r7, #81` — loads the Sigreturn syscall number into r7.
 /// Encoding: E3A07051 (MOV r7, #0x51 where 0x51 = 81).
@@ -50,6 +65,126 @@ pub(crate) const TRAMPOLINE_MOV_R7_SIGRETURN: u32 = 0xE3A0_7051;
 /// ARM `svc #0` — triggers the supervisor call using r7 as syscall number.
 /// Encoding: EF000000.
 pub(crate) const TRAMPOLINE_SVC_0: u32 = 0xEF00_0000;
+
+/// Trampoline length in bytes: mov + svc (#446).
+pub(crate) const TRAMPOLINE_LEN: usize = 8;
+
+/// Deliver a handled signal to the interrupted user context (#446).
+///
+/// Builds a signal frame on the user stack (the 17 saved `Context` words)
+/// and rewrites `frame` so the exception return lands in `handler` with the
+/// frame as its stack, r0 = the signal number (the POSIX handler argument),
+/// and lr = `SIGNAL_TRAMPOLINE_VA` (the per-process RX trampoline page). The
+/// pending bit for `sig` is cleared AT DISPATCH (here), so the handler runs
+/// once per raise and a re-raise during the handler re-delivers — never
+/// cleared-early at peek (the #446 contract; clear-on-peek loses signals).
+///
+/// `frame` is the current process's trap Context on the IRQ stack; the user
+/// stack pages it points at are PL0-mapped and thus writable from PL1 here.
+///
+/// # Safety
+///
+/// `frame` must be the live trap frame of the process the signal targets
+/// (its sp/pc/lr are the interrupted user state), and the process must own a
+/// mapped trampoline page (`map_signal_trampoline` ran at spawn).
+pub(crate) unsafe fn deliver(frame: &mut crate::process::Context, sig: Signal, handler: u32) {
+    let frame_addr = frame.sp.wrapping_sub(SIGNAL_FRAME_SIZE as u32) as *mut u32;
+    // SAFETY: the user stack range below the interrupted sp is mapped user-RW
+    // for this process (map_user_stack grants the run; sp always has
+    // SIGNAL_FRAME_SIZE of headroom in the reserved top page).
+    unsafe {
+        let dst = frame_addr;
+        for (i, word) in frame.r.iter().enumerate() {
+            dst.add(i).write_volatile(*word);
+        }
+        dst.add(13).write_volatile(frame.sp);
+        dst.add(14).write_volatile(frame.lr);
+        dst.add(15).write_volatile(frame.pc);
+        dst.add(16).write_volatile(frame.cpsr);
+    }
+    // Dispatch: handler runs with the frame as its stack, the signum as its
+    // first argument (r0), and lr at the RX trampoline page. The pending bit
+    // for THIS signal is cleared now so the handler runs exactly once per
+    // raise.
+    frame.sp = frame_addr as u32;
+    frame.pc = handler;
+    frame.lr = SIGNAL_TRAMPOLINE_VA as u32;
+    frame.r[0] = sig as u32;
+    crate::process::clear_pending_for_current(sig);
+}
+
+/// The sigreturn trampoline as machine words: `mov r7, #81; svc #0` (#446).
+/// Pure so host tests can pin the exact bytes the ARM writer emits.
+pub(crate) const fn trampoline_words() -> [u32; 2] {
+    [TRAMPOLINE_MOV_R7_SIGRETURN, TRAMPOLINE_SVC_0]
+}
+
+/// Write the sigreturn trampoline into a freshly-allocated trampoline frame
+/// (#446), then an I-cache sync so the freshly-written words are visible to
+/// instruction fetch on real hardware (D-cache writes are not
+/// architecturally coherent with the I-side).
+///
+/// # Safety
+///
+/// `phys` must name a writable page under the CURRENT (kernel identity) L1 —
+/// the caller (process creation) holds that guarantee. The page becomes
+/// PL0-executable only via the caller's later map_page grant.
+#[cfg(target_arch = "arm")]
+pub(crate) unsafe fn write_trampoline_page(phys: usize) {
+    // SAFETY: per this function's contract; phys is identity-mapped and
+    // writable from PL1 here, and TRAMPOLINE_LEN < PAGE_SIZE.
+    unsafe {
+        let dst = phys as *mut u32;
+        let words = trampoline_words();
+        dst.write_volatile(words[0]);
+        dst.add(1).write_volatile(words[1]);
+        crate::mmu::sync_icache_range(phys, TRAMPOLINE_LEN);
+    }
+}
+
+/// No-op trampoline writer for non-ARM (host test) builds: host page frames
+/// are simulated addresses that must never be dereferenced, and no
+/// instruction fetch ever reads the page.
+#[cfg(not(target_arch = "arm"))]
+pub(crate) unsafe fn write_trampoline_page(_phys: usize) {}
+
+/// Sigreturn (#446): restore the interrupted context the signal frame saved,
+/// resuming user mode exactly where the signal interrupted it. Called from
+/// svc_handler_rust's special case for syscall 81 with the SVC trap frame:
+/// the trampoline page's `svc` entered with user sp = the signal frame's
+/// base, and the pending bit was already cleared at dispatch, so this
+/// function only restores — it never touches pending state (the old
+/// clear-any-pending semantics could clear the WRONG signal when several
+/// were pending).
+///
+/// # Safety
+///
+/// `frame` must be the SVC trap frame built from the sigreturn trampoline.
+pub(crate) unsafe fn sigreturn_frame(frame: &mut crate::process::Context) {
+    let src = frame.sp as *const u32;
+    // SAFETY: the trampoline's user sp is the signal frame deliver() built;
+    // it is PL0-mapped and valid for the full 17-word saved Context.
+    unsafe {
+        for (i, word) in frame.r.iter_mut().enumerate() {
+            *word = src.add(i).read_volatile();
+        }
+        frame.sp = src.add(13).read_volatile();
+        frame.lr = src.add(14).read_volatile();
+        frame.pc = src.add(15).read_volatile();
+        frame.cpsr = src.add(16).read_volatile();
+    }
+}
+
+/// Unreachable by design: svc_handler_rust special-cases syscall 81 before
+/// the generic dispatch, because the frame restore needs the SVC trap frame
+/// (which `dispatch` does not receive). This shim exists only so the
+/// dispatcher's match stays exhaustive (#446).
+pub(crate) fn sigreturn_unreachable() -> u32 {
+    crate::syscall::ENOSYS
+}
+
+/// The sigreturn syscall number (81), for svc_handler_rust's special case.
+pub(crate) const SIGRETURN_NUM: u32 = 81;
 
 /// Recognized signal numbers.
 ///
@@ -303,22 +438,6 @@ pub(crate) fn sys_kill(pid: u32, signum: u32) -> u32 {
 /// the signal handler was invoked. The saved frame is at the current user
 /// SP; after restoring it the interrupted thread resumes where it left off.
 ///
-/// In this implementation the frame restoration is done symbolically:
-/// the kernel clears the pending bit for the signal that was being handled.
-/// Full register restoration from the user stack requires architecture-
-/// specific SVC plumbing that feeds the saved frame address into this
-/// handler — that is wired up in the exception return path in exceptions.rs.
-///
-/// Returns 0 (the value is placed in r0, but the handler will overwrite
-/// it from the restored frame before returning to user mode).
-pub(crate) fn sys_sigreturn() -> u32 {
-    // SAFETY: clear_current_pending accesses PROCS via addr_of_mut!.
-    unsafe {
-        crate::process::clear_any_pending();
-    }
-    0
-}
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -466,27 +585,14 @@ mod tests {
     // -----------------------------------------------------------------------
     #[test]
     fn signal_frame_layout() {
-        // 17 saved registers × 4 bytes.
+        // The frame is exactly the saved Context: 17 registers × 4 bytes,
+        // no code (the trampoline lives in the RX page, never on the stack).
         assert_eq!(
+            SIGNAL_FRAME_SIZE,
             SIGNAL_FRAME_REGS * 4,
-            68,
-            "saved register region should be 68 bytes"
+            "signal frame is exactly the 17-word saved Context"
         );
-
-        // signum field follows immediately.
-        assert_eq!(SIGNAL_FRAME_SIGNUM_OFFSET, 68, "signum offset should be 68");
-
-        // Trampoline follows signum (4 bytes).
-        assert_eq!(
-            SIGNAL_FRAME_TRAMPOLINE_OFFSET, 72,
-            "trampoline offset should be 72"
-        );
-
-        // Total frame: 68 + 4 + 8 = 80 bytes.
-        assert_eq!(
-            SIGNAL_FRAME_SIZE, 80,
-            "total signal frame should be 80 bytes"
-        );
+        assert_eq!(SIGNAL_FRAME_SIZE, 68, "signal frame should be 68 bytes");
 
         // Verify trampoline instruction encodings are ARM32 and correct.
         // MOV r7, #81: cond=1110, op=MOV, Rd=7, imm8=0x51.
@@ -499,5 +605,138 @@ mod tests {
             TRAMPOLINE_SVC_0, 0xEF00_0000,
             "trampoline SVC instruction encoding mismatch"
         );
+        assert_eq!(TRAMPOLINE_LEN, 8, "trampoline is mov + svc");
+    }
+
+    /// The trampoline page's VA is the reserved slot one page below
+    /// USER_TEXT_BASE — outside the section exec rebuilds, above every
+    /// growing user region (heap at 0x1000_0000, mmap at 0x2000_0000).
+    #[test]
+    fn signal_trampoline_va_is_the_reserved_slot() {
+        assert_eq!(
+            SIGNAL_TRAMPOLINE_VA,
+            crate::kconfig::USER_TEXT_BASE - crate::page::PAGE_SIZE,
+            "trampoline page sits directly below USER_TEXT_BASE"
+        );
+        assert_eq!(
+            SIGNAL_TRAMPOLINE_VA % crate::page::PAGE_SIZE,
+            0,
+            "trampoline VA is page-aligned"
+        );
+        // Outside the USER_TEXT 1 MB section exec revokes + rebuilds.
+        assert!(
+            SIGNAL_TRAMPOLINE_VA < crate::kconfig::USER_TEXT_BASE,
+            "trampoline must not share the exec-rebuilt section"
+        );
+    }
+
+    /// trampoline_words() must emit [mov r7, #81; svc #0] — the whole
+    /// trampoline, exactly what the ARM writer emits into the page.
+    #[test]
+    fn trampoline_words_are_mov_then_svc() {
+        let words = trampoline_words();
+        assert_eq!(words[0], TRAMPOLINE_MOV_R7_SIGRETURN, "word 0 = mov");
+        assert_eq!(words[1], TRAMPOLINE_SVC_0, "word 1 = svc");
+    }
+
+    // --- #446 frame build + restore ---
+
+    /// deliver() must lay out the 17 saved Context words on the user stack
+    /// and rewrite the trap frame to enter the handler with the frame as its
+    /// stack, r0 = the signum, and lr = the RX trampoline page.
+    #[test]
+    fn deliver_builds_frame_and_rewrites_context() {
+        let mut frame = crate::process::Context {
+            r: [0; 13],
+            sp: 0,
+            lr: 0,
+            pc: 0,
+            cpsr: 0,
+        };
+        frame.r[0] = 0xAAAA;
+        frame.r[5] = 0x5555;
+        frame.lr = 0xBEEF;
+        frame.pc = 0xDEAD;
+        frame.cpsr = 0x10;
+        static mut USER_STACK: [u32; 64] = [0; 64];
+        // SAFETY: test-only static; single-threaded per test.
+        let base = unsafe { core::ptr::addr_of_mut!(USER_STACK) };
+        let stack_top = base as u32 + (64 * 4);
+        frame.sp = stack_top;
+
+        // SAFETY: frame is a test Context whose sp points at the test buffer.
+        unsafe { deliver(&mut frame, Signal::Sigusr1, 0xCAFE) };
+
+        let frame_addr = stack_top - (SIGNAL_FRAME_SIZE as u32);
+        assert_eq!(frame.sp, frame_addr, "sp must land at the frame base");
+        assert_eq!(frame.pc, 0xCAFE, "pc must enter the handler");
+        assert_eq!(
+            frame.lr, SIGNAL_TRAMPOLINE_VA as u32,
+            "lr must point at the RX trampoline page"
+        );
+        assert_eq!(frame.r[0], 10, "r0 carries the signum (Sigusr1 = 10)");
+        // SAFETY: the buffer was just written by deliver().
+        let f = frame_addr as *const u32;
+        unsafe {
+            assert_eq!(f.read(), 0xAAAA, "r0 saved");
+            assert_eq!(f.add(5).read(), 0x5555, "r5 saved");
+            assert_eq!(f.add(13).read(), stack_top, "interrupted sp saved");
+            assert_eq!(f.add(14).read(), 0xBEEF, "interrupted lr saved");
+            assert_eq!(f.add(15).read(), 0xDEAD, "interrupted pc saved");
+            assert_eq!(f.add(16).read(), 0x10, "cpsr saved");
+        }
+    }
+
+    /// sigreturn_frame() must restore all 17 saved registers into the SVC
+    /// trap frame, resuming the interrupted context exactly.
+    #[test]
+    fn sigreturn_frame_restores_interrupted_context() {
+        static mut SIGFRAME: [u32; 21] = [0; 21];
+        // SAFETY: test-only static; single-threaded per test.
+        let base = unsafe { core::ptr::addr_of_mut!(SIGFRAME) };
+        let mut saved = crate::process::Context {
+            r: [0; 13],
+            sp: 0,
+            lr: 0,
+            pc: 0,
+            cpsr: 0,
+        };
+        saved.r[0] = 0x1111;
+        saved.r[9] = 0x9999;
+        saved.sp = 0x7777;
+        saved.lr = 0x6666;
+        saved.pc = 0x5555;
+        saved.cpsr = 0x10;
+        // Lay out the frame as deliver() would.
+        unsafe {
+            let dst = base as *mut u32;
+            for (i, word) in saved.r.iter().enumerate() {
+                dst.add(i).write_volatile(*word);
+            }
+            dst.add(13).write_volatile(saved.sp);
+            dst.add(14).write_volatile(saved.lr);
+            dst.add(15).write_volatile(saved.pc);
+            dst.add(16).write_volatile(saved.cpsr);
+        }
+        // The SVC trap frame: user sp = the frame base (as the trampoline left it).
+        let mut trap = crate::process::Context {
+            r: [0; 13],
+            sp: 0,
+            lr: 0,
+            pc: 0,
+            cpsr: 0,
+        };
+        trap.sp = base as u32;
+        // SAFETY: trap.sp points at the frame built above.
+        unsafe { sigreturn_frame(&mut trap) };
+        assert_eq!(trap.r[0], 0x1111);
+        assert_eq!(trap.r[9], 0x9999);
+        assert_eq!(trap.sp, 0x7777, "sp restored to the interrupted value");
+        assert_eq!(trap.lr, 0x6666, "lr restored");
+        assert_eq!(
+            trap.pc, 0x5555,
+            "pc restored to the interrupted instruction"
+        );
+        assert_eq!(trap.cpsr, 0x10, "cpsr restored");
     }
 }

--- a/crates/thumos/src/syscall.rs
+++ b/crates/thumos/src/syscall.rs
@@ -580,7 +580,7 @@ pub(crate) fn dispatch(num: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> 
 
         // ---- Signal ----
         Syscall::Sigaction => signal::sys_sigaction(arg0, arg1),
-        Syscall::Sigreturn => signal::sys_sigreturn(),
+        Syscall::Sigreturn => signal::sigreturn_unreachable(),
     }
 }
 

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -536,8 +536,9 @@ witness = "boot.sh"
 
 [[module]]
 name = "signal"
-tests = 7
-mechanism = "host"
+tests = 11
+mechanism = "both"
+witness = "signal.sh"
 
 [[module]]
 name = "sim"

--- a/scripts/check-witness-extraction.sh
+++ b/scripts/check-witness-extraction.sh
@@ -14,7 +14,7 @@ KCI="$REPO_ROOT/.kanon-ci.toml"
 rc=0
 
 # (a) Assertion markers that must exist only inside scripts/witness/.
-for marker in 'painted_px=' 'fork isolation intact' 'init2: reached via exec' 'guard child killed' 'supervisor giving up' 'KERNEL UNDEFINED INSTRUCTION' 'init: woke' 'THUMOS_BOOT_KEY_PUB=keys/dev'; do
+for marker in 'painted_px=' 'fork isolation intact' 'init2: reached via exec' 'guard child killed' 'supervisor giving up' 'KERNEL UNDEFINED INSTRUCTION' 'init: woke' 'signal: flows complete' 'signal: trampoline rx enforced' 'THUMOS_BOOT_KEY_PUB=keys/dev'; do
     if grep -qF "$marker" "$CI" || grep -qF "$marker" "$KCI"; then
         echo "DRIFT: witness assertion marker '$marker' is inline in a CI surface (must live in scripts/witness/)" >&2
         rc=1
@@ -22,7 +22,7 @@ for marker in 'painted_px=' 'fork isolation intact' 'init2: reached via exec' 'g
 done
 
 # (b) ci.yml kernel job must call the scripts, per witness.
-for w in boot kfault sleep fork exec forkexec guard brk crashloop; do
+for w in boot kfault sleep fork exec forkexec guard brk signal crashloop; do
     grep -q "scripts/witness/$w.sh" "$CI" || { echo "DRIFT: ci.yml no longer calls scripts/witness/$w.sh" >&2; rc=1; }
 done
 grep -q 'scripts/witness/trust-anchor.sh' "$CI" || { echo "DRIFT: ci.yml no longer calls scripts/witness/trust-anchor.sh" >&2; rc=1; }

--- a/scripts/witness-run-all.sh
+++ b/scripts/witness-run-all.sh
@@ -6,7 +6,7 @@
 set -uo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
-for w in boot kfault sleep fork exec forkexec guard brk crashloop; do
+for w in boot kfault sleep fork exec forkexec guard brk signal crashloop; do
     echo "===== witness: $w ====="
     "$HERE/witness/$w.sh" || exit 1
 done

--- a/scripts/witness/signal.sh
+++ b/scripts/witness/signal.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# witness/signal.sh — userspace signal delivery end-to-end (#446), verbatim
+# from ci.yml. /init installs SIGUSR1/SIGUSR2 handlers, raises BOTH against
+# itself, then yields. The kernel must rewrite the IRQ trap frame into the
+# handler (handler marker prints), the sigreturn trampoline must restore the
+# interrupted context (the flow continues to "flows complete"), and USR2's
+# marker must appear AFTER USR1's -- its pending bit surviving USR1's
+# delivery is the exact-clear contract (the old clear-any-pending could wipe
+# the wrong signal).
+set -uo pipefail
+source "$(dirname "$0")/lib.sh"
+
+witness_deps
+THUMOS_INIT_VARIANT=signal build_kernel qemu
+src=0
+THUMOS_INIT_VARIANT=signal run_qemu signal.log || src=$?
+echo "=== signal probe: runner rc=$src (want 0) ==="
+test "$src" -eq 0 || { echo "FAIL signal: kernel did not survive userspace signal delivery (rc=$src; 124=hang)"; exit 1; }
+
+usr1_line=$(awk '/signal: handler usr1/ {print NR; exit}' signal.log)
+usr2_line=$(awk '/signal: handler usr2/ {print NR; exit}' signal.log)
+flows_line=$(awk '/signal: flows complete/ {print NR; exit}' signal.log)
+test -n "$usr1_line" || { echo 'FAIL signal: SIGUSR1 handler never ran (frame rewrite into the handler is broken)'; exit 1; }
+test -n "$usr2_line" || { echo 'FAIL signal: SIGUSR2 handler never ran (pending bit lost -- exact-clear contract broken)'; exit 1; }
+test -n "$flows_line" || { echo 'FAIL signal: flows never completed (sigreturn did not restore the interrupted context)'; exit 1; }
+test "$usr1_line" -lt "$usr2_line" || { echo "FAIL signal: delivery out of order (usr1@$usr1_line, usr2@$usr2_line; lowest-signum-first contract broken)"; exit 1; }
+test "$usr2_line" -lt "$flows_line" || { echo "FAIL signal: flows complete preceded the USR2 handler (usr2@$usr2_line, flows@$flows_line)"; exit 1; }
+# DFSR 0x80f = WnR (bit 11: a WRITE faulted) | 0x0f (permission fault, page)
+# — the exact signature of a PL0 write denied by an RX mapping.
+grep -qE 'USERFAULT: pid=[0-9]+ kind=data-abort addr=0x7feff000 status=0x0000080f killed' signal.log || { echo 'FAIL signal: the trampoline-page write did not die to a write-denied data-abort PERMISSION fault (page missing, or W^X broken)'; exit 1; }
+grep -q 'signal: trampoline rx enforced' signal.log || { echo 'FAIL signal: rx probe child was not fault-killed with status 139 (trampoline page writable?)'; exit 1; }
+grep -q 'signal: trampoline WRITEABLE' signal.log && { echo 'FAIL signal: PL0 wrote the sigreturn trampoline page — W^X broken'; exit 1; }
+grep -q 'THUMOS-QEMU: service-loop ticks=' signal.log || { echo 'FAIL signal: service loop did not run (kernel hung during the yield windows)'; exit 1; }
+echo "signal witness: PASS"


### PR DESCRIPTION
## Summary

The signals half of #446. `sys_sigaction`/`sys_kill` registered actions and set pending bits, but delivery stopped at the trap frame: `check_pending_signal()`'s result was discarded on the IRQ return path (no handler ever ran), and `clear_pending` erased ANY pending signal — the wrong one when several were raised.

**Delivery mechanism**: `irq_handler_rust` consumes `check_pending_signal()` post-body; `signal::deliver()` pushes the 17-word interrupted `Context` onto the user stack and rewrites the trap frame — pc = handler, r0 = signum (POSIX handler arg), lr = the sigreturn trampoline; the bit for THIS signal clears at dispatch, never at peek. `svc_handler_rust` special-cases svc 81 (sigreturn) before dispatch; `sigreturn_frame()` restores the interrupted context exactly.

**The sigreturn trampoline is a per-process RX page at a fixed VA** (`USER_TEXT_BASE - 4096`), mapped PL0-RX / PL1-RW at spawn (`map_signal_trampoline`). The original on-stack trampoline design prefetch-aborted on the very first handler return — the user stack is RW+XN (#482 W^X), and the QEMU witness caught it (`USERFAULT prefetch-abort status=0x0f` at the stack VA) where host tests were structurally blind. The RX page survives exec (it sits outside the rebuilt USER_TEXT section), is deep-copied by fork, and is reclaimed by exit's all-user-pages walk.

**Witness** (`scripts/witness/signal.sh`): a `signal` /init variant installs USR1/USR2 handlers, raises both against itself, and the witness asserts ordered delivery (usr1 before usr2 — lowest-signum-first + the exact-clear contract), context restore (`flows complete`), and W^X enforcement (a forked child's PL0 write to the trampoline VA dies to `DFSR 0x80f` = WnR|permission-page; a translation fault or a surviving write both fail the run). Registered across ci.yml, `.kanon-ci.toml`, `witness-run-all.sh`, and the extraction guard.

## Verification

- `scripts/kernel-host-tests.sh`: **2290/2290 pass** (i686, incl. `--features debug-console` pass) — new signal tests pin the 68-byte frame layout, trampoline encodings, the reserved VA slot, and deliver/sigreturn context round-trips.
- `scripts/witness-run-all.sh`: **ALL KERNEL QEMU WITNESSES: PASS** (boot, kfault, sleep, fork, exec, forkexec, guard, brk, signal, crashloop).
- Witness log evidence: `signal: handler usr1` → `signal: handler usr2` → `signal: flows complete`, then `USERFAULT: pid=2 kind=data-abort addr=0x7feff000 status=0x0000080f killed` and `signal: trampoline rx enforced`.
- `scripts/check-target-test-ledger.sh` + `scripts/check-witness-extraction.sh`: no drift (signal row now `both` with `witness = "signal.sh"`, 11 tests).
- `cargo fmt --manifest-path crates/thumos/Cargo.toml`: clean.

The boot-passphrase half of #446 lands as a separate follow-up (needs the KPD scancode read path; ordered after #534's board seam).

Refs #446