### PR TITLE
board: consolidate the two-board seam — board::m7 + board::virt (#534)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,11 @@ jobs:
         # row, a witness name rots, a sensitive host-only row loses its
         # fidelity label, or a tests count drifts. Cheap, source-level.
         run: scripts/check-target-test-ledger.sh
+      - name: Board-seam invariant check (#534)
+        # WHY (#534): the two-board reality is structural, not prose — reds
+        # on any MT6739_* identifier outside board::m7 or any board-MMIO
+        # value re-declared as a const outside board/. Cheap, source-level.
+        run: scripts/check-board-seam.sh
       - name: Kernel cross-compile (armv7a) + zero-warning gate (#431)
         # WHY (#431): the zero-warning gate lives in crates/thumos/.cargo/
         # config.toml's rustflags; scripts/kernel-build.sh builds through it

--- a/.kanon-ci.toml
+++ b/.kanon-ci.toml
@@ -70,6 +70,13 @@ timeout_secs = 1800
 cmd = "scripts/check-target-test-ledger.sh"
 timeout_secs = 300
 
+# WHY (#534): the board seam is a structural invariant, not a promise —
+# reds on an MT6739_* identifier outside board::m7 or a board-MMIO value
+# re-declared outside board/. Source-level, cheap.
+[stages."board seam"]
+cmd = "scripts/check-board-seam.sh"
+timeout_secs = 300
+
 # WHY (#546): the full QEMU witness matrix (boot + fault + sleep + fork +
 # exec + forkexec + guard + brk + signal + crashloop) as one canonical runner — the
 # exact scripts ci.yml executes step-by-step.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,11 @@
 # Architecture
 
-Thumos is a full-Rust mobile OS targeting the AGM M7 (MT6739). No C authored, no Linux in the final system. Monolithic kernel.
+Thumos is a full-Rust small-mobile OS. No C authored, no Linux in the final system. Monolithic kernel. It boots one kernel on two boards:
+
+- **m7** — the AGM M7 feature phone (MT6739 SoC), the field board;
+- **virt** — QEMU `-machine virt` (armv7a), the dev board every CI witness boots on (selected by the kernel's `qemu` feature).
+
+Board specifics (MMIO maps, device set, bring-up behavior) live behind the `board::` module seam in the kernel crate — `board::m7` and `board::virt`, selected at one point in `board/mod.rs`. The standing invariant is structural, not prose: no `MT6739_*` identifier exists outside `board::m7`, and no board-MMIO value is re-declared as a constant outside `board/` (`scripts/check-board-seam.sh` reds on drift). Per-subsystem `HwOps` traits remain the driver seam; there is deliberately no mega-HAL, no device-tree parser, and no runtime board detection — two static boards want static config (#534).
 
 ## Crate map
 
@@ -95,7 +100,7 @@ All other workspace crates are independent of each other. External dependencies 
 +-----------------------------------------------+
 |          thumos (kernel, bare-metal)           |
 +-----------------------------------------------+
-|       MT6739 hardware / vendor blobs          |
+|        board::m7  |  board::virt (qemu)        |
 +-----------------------------------------------+
 ```
 
@@ -108,4 +113,4 @@ All other workspace crates are independent of each other. External dependencies 
 
 ## Build
 
-Workspace crates compile and test on the host: `cargo check --workspace`, `cargo test --workspace`. The kernel cross-compiles for `armv7a-none-eabi` via `cargo build --release` inside `crates/thumos/`. Boot image is created with `mkbootimg` and flashed via mtkclient BROM exploit.
+Workspace crates compile and test on the host: `cargo check --workspace`, `cargo test --workspace`. The kernel cross-compiles for `armv7a-none-eabi` via `cargo build --release` inside `crates/thumos/` — the same source builds both boards: default is the m7 field board, `--features qemu` selects the virt dev board (CI boots that image on every push). Boot image is created with `mkbootimg` and flashed via mtkclient BROM exploit.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A privacy-first mobile OS for the AGM M7 (MediaTek MT6739), written in Rust from
 
 A custom Rust OS for the AGM M7 (MT6739, 1 GB RAM, 240x320 QVGA, IP68). Full Rust from kernel to UI - no C the project authors, no Linux underneath (the MT6739's modem/WiFi/BT/GPS vendor blobs are binary-only and cannot be replaced). The feature surface targets secure communication and counter-surveillance: on-device radio intelligence (IMSI-catcher scoring, silent-SMS detection, 2G refusal), hardware-identifier protection at the register level (WiFi/BT MAC randomization, IMEI/IMSI containment), encrypted storage, and a modem firewalled at the CCCI driver boundary.
 
+Structurally it is a general small-mobile OS, M7 first: one kernel boots two boards behind the `board::` seam - **m7** (the field board) and **virt** (QEMU `-machine virt`, the dev board CI boots on every push). Board facts live only under `board::*`; the kernel core names no SoC directly (#534).
+
 > **Maturity:** a broad compiled-and-tested software surface with an **executable boot** - the kernel boots end-to-end under emulation (see [Status](#status)). Hardware validation and boot/userspace wiring remain open. A named capability is a compiled/tested surface unless a boot or userspace call path reaches it.
 
 ## Name

--- a/crates/thumos/src/audio_codec.rs
+++ b/crates/thumos/src/audio_codec.rs
@@ -52,8 +52,6 @@ use super::audio_route::AudioRoute;
 /// PWRAP (PMIC Wrapper) base address on MT6739.
 ///
 /// All PMIC register accesses go through PWRAP MMIO.
-const PWRAP_BASE: usize = 0x1000_D000;
-
 /// Audio top-level power control register offset.
 const AUD_TOP_CON0: u16 = 0x2000;
 
@@ -261,7 +259,7 @@ pub(crate) trait AudioCodecOps {
 /// Accesses PMIC registers through the PWRAP bus on the MT6739.
 /// Manages LDO power gating, DAC/ADC enable, amplifier routing,
 /// volume control, and mic bias.
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "qemu")))]
 pub(crate) struct Mt6357Codec {
     /// Whether the codec is powered on (LDO active).
     powered: bool,
@@ -277,7 +275,7 @@ pub(crate) struct Mt6357Codec {
     route: AudioRoute,
 }
 
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "qemu")))]
 impl Mt6357Codec {
     /// Create a new MT6357 codec handle.
     ///
@@ -303,8 +301,8 @@ impl Mt6357Codec {
     /// and that PWRAP is initialized.
     #[inline]
     unsafe fn pmic_write(offset: u16, value: u32) {
-        let addr = PWRAP_BASE + offset as usize;
-        // SAFETY: PWRAP_BASE + offset is a valid MMIO address in the
+        let addr = crate::board::PWRAP_BASE + offset as usize;
+        // SAFETY: board::PWRAP_BASE + offset is a valid MMIO address in the
         // MT6739 address map.  Volatile write ensures the compiler does
         // not reorder or elide the store.
         unsafe {
@@ -320,7 +318,7 @@ impl Mt6357Codec {
     /// and that PWRAP is initialized.
     #[inline]
     unsafe fn pmic_read(offset: u16) -> u32 {
-        let addr = PWRAP_BASE + offset as usize;
+        let addr = crate::board::PWRAP_BASE + offset as usize;
         // SAFETY: same as pmic_write; volatile read ensures no elision.
         unsafe { core::ptr::read_volatile(addr as *const u32) }
     }
@@ -375,7 +373,7 @@ impl Mt6357Codec {
     }
 }
 
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "qemu")))]
 impl AudioCodecOps for Mt6357Codec {
     fn power_on(&mut self) -> Result<(), AudioError> {
         if self.powered {

--- a/crates/thumos/src/block.rs
+++ b/crates/thumos/src/block.rs
@@ -186,7 +186,7 @@ impl BlockDevice for MemBlockDevice {
 // MsdcBlockDevice — hardware wrapper (non-test only)
 // ---------------------------------------------------------------------------
 
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "qemu")))]
 mod msdc_wrapper {
     use super::{BlockDevice, BlockError, SECTOR_SIZE};
     use crate::emmc::MsdcController;
@@ -331,7 +331,7 @@ mod msdc_wrapper {
     }
 }
 
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "qemu")))]
 pub(crate) use msdc_wrapper::MsdcBlockDevice;
 
 // ---------------------------------------------------------------------------

--- a/crates/thumos/src/bluetooth.rs
+++ b/crates/thumos/src/bluetooth.rs
@@ -10,7 +10,7 @@
 //! ## Hardware path
 //!
 //! The MT6739 Bluetooth hardware is accessed through the WMT combo chip:
-//! - `MT6739_CONSYS = 0x1800_0000` (combo-chip base)
+//! - `board::CONSYS_BASE = 0x1800_0000` (combo-chip base, board::m7 #534)
 //! - Data path goes through WMT STP framing (kelyphos handles the transport)
 //!
 //! ## Integration
@@ -27,13 +27,6 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 use crate::csprng;
-
-// ---------------------------------------------------------------------------
-// MT6739 BT hardware constants
-// ---------------------------------------------------------------------------
-
-/// WMT combo-chip (CONSYS) MMIO base address.
-const MT6739_CONSYS: usize = 0x1800_0000;
 
 /// WMT STP channel identifier for Bluetooth.
 ///
@@ -396,24 +389,25 @@ pub(crate) trait BtHwOps {
 // ---------------------------------------------------------------------------
 
 /// Real BT hardware access via WMT STP on the MT6739 combo chip.
-#[cfg(not(test))]
+/// WHY not(qemu): virt has no combo chip -- the type must not exist there.
+#[cfg(not(any(test, feature = "qemu")))]
 pub(crate) struct BtHw {
     /// WMT combo-chip MMIO base address.
     consys_base: usize,
 }
 
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "qemu")))]
 impl BtHw {
     /// Create a new BT hardware handle.
     #[must_use]
     pub(crate) const fn new() -> Self {
         Self {
-            consys_base: MT6739_CONSYS,
+            consys_base: crate::board::CONSYS_BASE,
         }
     }
 }
 
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "qemu")))]
 impl BtHwOps for BtHw {
     fn send_command(&mut self, _data: &[u8]) -> Result<(), BtError> {
         // TODO(#129)[deliberate-prudent]: implement WMT STP frame TX for BT channel.

--- a/crates/thumos/src/board/m7.rs
+++ b/crates/thumos/src/board/m7.rs
@@ -1,0 +1,230 @@
+//! The AGM M7 field board (MT6739 SoC) — every MT6739-specific fact in the
+//! kernel lives HERE and nowhere else (#534's standing invariant, enforced
+//! by `scripts/check-board-seam.sh`).
+//!
+//! Sources: `docs/PROBE.md`, `docs/DRIVER-INTERFACES.md`, the MT6739 device
+//! tree, and the GPT dump of the AGM M7 eMMC. These are STATIC config
+//! structs by design — two real boards want no device-tree parser (#534
+//! explicitly retires the old "Phase 04+ DT" ambition).
+//!
+//! WHY cfg_attr(not(test)) on some expects (#528 shape): this module
+//! compiles on the host test target, where this file's own tests reference
+//! the consts — a blanket expect(dead_code) would be UNFULFILLED there,
+//! while on armv7a a const with no runtime consumer is genuinely dead.
+
+use crate::device::DeviceRegistry;
+
+/// Board name for the boot banner and docs.
+pub(crate) const BOARD_NAME: &str = "AGM M7 (MT6739)";
+
+// ---------------------------------------------------------------------------
+// Console + interrupt controller
+// ---------------------------------------------------------------------------
+
+/// UART0 (ttyMT0) MMIO base, MTK 8250-style register map.
+pub(crate) const UART0_BASE: usize = 0x1100_2000;
+
+/// UART1 (ttyMT1) MMIO base.
+pub(crate) const UART1_BASE: usize = 0x1100_3000;
+
+/// GIC distributor MMIO base (MT6739 device tree, intc node).
+pub(crate) const GICD_BASE: usize = 0x0C00_0000;
+
+/// GIC CPU interface MMIO base (MT6739).
+pub(crate) const GICC_BASE: usize = 0x0C00_2000;
+
+// ---------------------------------------------------------------------------
+// Storage
+// ---------------------------------------------------------------------------
+
+/// MSDC0 eMMC controller MMIO base.
+pub(crate) const MSDC0_BASE: usize = 0x1123_0000;
+
+/// Start sector of the LFS partition on eMMC.
+/// WHY: the boot, recovery, system, vendor partitions occupy the first
+/// ~2.6 GB. LFS uses the userdata region starting at sector 0x50C000
+/// (~2.6 GB offset). Value from the GPT dump of the MT6739 eMMC
+/// (printgpt: userdata partition).
+pub(crate) const LFS_PARTITION_START: u64 = 0x50C000;
+
+/// Size of the LFS partition in sectors.
+/// WHY: ~3 GB of the 8 GB eMMC is available for user data. Rounded down
+/// from the actual userdata partition length (0x97BFDF sectors) to a clean
+/// segment-aligned boundary.
+pub(crate) const LFS_PARTITION_SIZE: u64 = 0x600000;
+
+// ---------------------------------------------------------------------------
+// USB
+// ---------------------------------------------------------------------------
+
+/// MUSB OTG USB controller MMIO base (device-tree node `usb@11210000`).
+/// NOTE: the pre-#534 device registry carried a stale `0x1120_0000` entry
+/// for `musb-hdrc`; the DT node and the usb.rs driver agree on this value.
+pub(crate) const MUSB_BASE: usize = 0x1121_0000;
+
+// ---------------------------------------------------------------------------
+// Display pipeline
+// ---------------------------------------------------------------------------
+
+/// MMSYS configuration base (display pipeline).
+pub(crate) const MMSYS_BASE: usize = 0x1400_0000;
+
+/// Display mutex controller MMIO base.
+pub(crate) const DISP_MUTEX_BASE: usize = 0x1400_1000;
+
+/// OVL0 (overlay engine) MMIO base.
+pub(crate) const OVL0_BASE: usize = 0x1400_7000;
+
+/// RDMA0 (read DMA engine) MMIO base.
+pub(crate) const RDMA0_BASE: usize = 0x1400_8000;
+
+/// DSI0 controller MMIO base.
+pub(crate) const DSI0_BASE: usize = 0x1400_D000;
+
+/// DSI0 command FIFO register (DSI0 + 0x200), used by the DCS power path.
+pub(crate) const DSI0_CMD_FIFO: usize = DSI0_BASE + 0x200;
+
+/// GC9306 LCM (panel) MMIO base.
+pub(crate) const GC9306_LCM_BASE: usize = 0x1100_A000;
+
+/// Display framebuffer physical base (set by the LK bootloader).
+pub(crate) const FB_BASE: usize = 0x77EE_0000;
+
+// ---------------------------------------------------------------------------
+// Input
+// ---------------------------------------------------------------------------
+
+/// Keypad (KPD) controller MMIO base.
+pub(crate) const KPD_BASE: usize = 0x1001_0000;
+
+/// KPD enable register offset.
+pub(crate) const KPD_EN: usize = 0x00;
+
+/// KPD debounce register offset.
+pub(crate) const KPD_DEBOUNCE: usize = 0x18;
+
+// ---------------------------------------------------------------------------
+// Combo chip (WiFi / BT / GPS / FM over the WMT transport)
+// ---------------------------------------------------------------------------
+
+/// WMT combo-chip (CONSYS) MMIO base.
+pub(crate) const CONSYS_BASE: usize = 0x1800_0000;
+
+/// WiFi (WLAN) MMIO base.
+pub(crate) const WLAN_BASE: usize = 0x180F_0000;
+
+// ---------------------------------------------------------------------------
+// Power + watchdog
+// ---------------------------------------------------------------------------
+
+/// Watchdog (WDT) controller MMIO base.
+pub(crate) const WDT_BASE: usize = 0x1000_7000;
+
+/// ARMPLL control register 1 (DVFS clock source switch).
+pub(crate) const ARMPLL_CON1: usize = 0x1000_C104;
+
+/// MCDI (multi-core deep-idle) controller MMIO base.
+pub(crate) const MCDI_BASE: usize = 0x1000_DC00;
+
+/// MCDI per-core enable register (MCDI + 0x04).
+pub(crate) const MCDI_CORE_EN: usize = MCDI_BASE + 0x04;
+
+/// PMIC wrapper (PWRAP, MT6357 access path) MMIO base.
+pub(crate) const PWRAP_BASE: usize = 0x1000_D000;
+
+// ---------------------------------------------------------------------------
+// Device registry population
+// ---------------------------------------------------------------------------
+
+/// Register every M7 device with a known address (#534: moved here from the
+/// board-neutral registry framework — the device SET is a board fact).
+/// Addresses from `docs/DRIVER-INTERFACES.md` and `docs/PROBE.md`.
+/// IRQs are all 0 today: every driver polls; no IRQ table exists yet.
+pub(crate) fn register_devices(registry: &mut DeviceRegistry) {
+    // Console UARTs
+    registry.register("uart0", UART0_BASE, 0);
+    registry.register("uart1", UART1_BASE, 0);
+
+    // Display
+    registry.register("disp-ovl0", OVL0_BASE, 0);
+    registry.register("disp-rdma0", RDMA0_BASE, 0);
+    registry.register("gc9306-lcm", GC9306_LCM_BASE, 0);
+
+    // Input
+    registry.register("mtk-kpd", KPD_BASE, 0); // Keypad
+    registry.register("mtk-tpd", 0x0, 0); // Touch (I2C, addr TBD from teardown)
+
+    // Modem (ccci-family addresses; the ccci seam owns those drivers)
+    registry.register("ccci-cldma", 0x200F_0000, 0); // CLDMA AP base
+    registry.register("ccci-ccif", 0x2051_0000, 0); // CCIF peer
+
+    // Connectivity
+    registry.register("wmt-consys", CONSYS_BASE, 0); // WMT combo chip
+    registry.register("wlan0", WLAN_BASE, 0); // WiFi
+    registry.register("bt0", 0x0, 0); // BT (via WMT STP)
+    registry.register("gps0", 0x0, 0); // GPS (via WMT STP)
+    registry.register("fm0", 0x0, 0); // FM (via WMT)
+
+    // USB
+    registry.register("musb-hdrc", MUSB_BASE, 0); // USB controller
+
+    // Storage
+    registry.register("msdc0", MSDC0_BASE, 0); // eMMC controller
+
+    // GIC
+    registry.register("gic-dist", GICD_BASE, 0);
+    registry.register("gic-cpu", GICC_BASE, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The registered device set must pin to the module's canonical consts —
+    /// this replaces kinit_plan's pre-#534 address test, which pinned the
+    /// consts the OLD device.rs carried (including the GIC aliases that
+    /// silently resolved to QEMU addresses under --features qemu).
+    #[test]
+    fn register_devices_pins_canonical_addresses() {
+        let mut registry = DeviceRegistry::new();
+        register_devices(&mut registry);
+
+        assert_eq!(registry.list().len(), 18);
+        let cases: &[(&str, usize)] = &[
+            ("uart0", UART0_BASE),
+            ("uart1", UART1_BASE),
+            ("disp-ovl0", OVL0_BASE),
+            ("disp-rdma0", RDMA0_BASE),
+            ("gc9306-lcm", GC9306_LCM_BASE),
+            ("mtk-kpd", KPD_BASE),
+            ("wmt-consys", CONSYS_BASE),
+            ("wlan0", WLAN_BASE),
+            ("musb-hdrc", MUSB_BASE),
+            ("msdc0", MSDC0_BASE),
+            ("gic-dist", GICD_BASE),
+            ("gic-cpu", GICC_BASE),
+        ];
+        for (name, want) in cases {
+            let dev = registry
+                .find(name)
+                .unwrap_or_else(|| panic!("{name} registered"));
+            assert_eq!(&dev.base_addr, want, "{name} base address drifted");
+        }
+        assert_eq!(
+            registry.count_by_status(crate::device::DeviceStatus::Registered),
+            18,
+            "all devices start in the Registered state"
+        );
+    }
+
+    #[test]
+    fn derived_register_addresses_are_self_consistent() {
+        assert_eq!(DSI0_CMD_FIFO, 0x1400_D200);
+        assert_eq!(MCDI_CORE_EN, 0x1000_DC04);
+        assert!(!BOARD_NAME.is_empty());
+    }
+}

--- a/crates/thumos/src/board/mod.rs
+++ b/crates/thumos/src/board/mod.rs
@@ -1,0 +1,85 @@
+//! Board support: the ONE seam between the kernel core and the two machines
+//! thumos boots on (#534).
+//!
+//! thumos is a two-board OS:
+//! - **m7** — the AGM M7 feature phone (MT6739 SoC), the field board;
+//! - **virt** — QEMU `-machine virt` (armv7a), the dev board every CI
+//!   witness boots on (selected by `--features qemu`).
+//!
+//! This module is the single selection point: the board-specific constants
+//! the kernel core needs are re-exported from the selected board's module,
+//! so no per-board `#[cfg]` arm and no `MT6739_*` identifier exists anywhere
+//! else in the kernel core (the standing invariant, enforced by
+//! `scripts/check-board-seam.sh`). Constants that are IDENTICAL on both
+//! boards — the DRAM window, the kernel image layout, the userspace image
+//! base, the display geometry — live directly here, once: they are kernel
+//! design choices (the virt machine is deliberately run with the M7's DRAM
+//! base so the memory map is one truth), not per-board facts.
+//!
+//! OUT OF SCOPE by design (recognition-not-induction, #534): no device-tree
+//! parsing, no runtime board detection, no second SoC port, no mega-HAL —
+//! the per-subsystem `HwOps` traits stay the driver seam; this module is
+//! only the *board* seam.
+
+#[cfg(not(feature = "qemu"))]
+mod m7;
+#[cfg(not(feature = "qemu"))]
+pub(crate) use m7::*;
+
+#[cfg(feature = "qemu")]
+mod virt;
+#[cfg(feature = "qemu")]
+pub(crate) use virt::*;
+
+// ---------------------------------------------------------------------------
+// Shared memory map (identical on both boards, by design)
+// ---------------------------------------------------------------------------
+
+/// RAM start address.
+pub(crate) const RAM_START: usize = 0x4000_0000;
+
+/// RAM end address (1 GB).
+pub(crate) const RAM_END: usize = 0x8000_0000;
+
+/// Kernel load address.
+pub(crate) const KERNEL_LOAD: usize = 0x4000_8000;
+
+/// Kernel reserved size (992 KB).
+/// WHY: kernel image + reserved region spans `0x4000_8000..0x400F_FFFF`
+/// (see the memory map in `memguard.rs`), so KERNEL_END lands on the
+/// 0x4010_0000 page boundary rather than a full 1 MB past KERNEL_LOAD.
+pub(crate) const KERNEL_RESERVED: usize = 0xF_8000;
+
+/// Kernel end address (load + reserved).
+pub(crate) const KERNEL_END: usize = KERNEL_LOAD + KERNEL_RESERVED;
+
+/// Userspace text region base (#474/#482): the top 1 MB of DRAM
+/// (0x7FF0_0000..0x8000_0000), the fixed identity load address for the
+/// image-resident /init. EXCLUDED from the page allocator (kinit passes this
+/// as the allocator's upper bound) so an allocation never collides with the
+/// loaded image. In the KERNEL address space it is plain RAM + execute-never
+/// (W^X #417 — the kernel never executes user code from its own space); a
+/// spawned process runs it user-RX from its OWN page table via `mmu`
+/// per-process mappings (PL0 isolation, #482).
+pub(crate) const USER_TEXT_BASE: usize = 0x7FF0_0000;
+
+/// Display width (the M7's 240x320 panel; the virt synthetic framebuffer
+/// mirrors the same geometry so the UI is pixel-identical across boards).
+pub(crate) const DISPLAY_WIDTH: u32 = 240;
+
+/// Display height.
+pub(crate) const DISPLAY_HEIGHT: u32 = 320;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shared_memory_map_is_self_consistent() {
+        assert_eq!(RAM_END - RAM_START, 1024 * 1024 * 1024);
+        assert_eq!(KERNEL_END, 0x4010_0000);
+        assert_eq!(KERNEL_END, KERNEL_LOAD + KERNEL_RESERVED);
+        assert_eq!(DISPLAY_WIDTH * DISPLAY_HEIGHT * 2, 153_600); // RGB565 framebuffer size
+        assert!(USER_TEXT_BASE < RAM_END);
+    }
+}

--- a/crates/thumos/src/board/virt.rs
+++ b/crates/thumos/src/board/virt.rs
@@ -1,0 +1,29 @@
+//! The QEMU `-machine virt` dev board (armv7a) — the board every CI witness
+//! boots on (#534). Only hardware the virt machine actually HAS is defined
+//! here: a PL011 UART, a GICv2, and DRAM. There is no eMMC, no display
+//! pipeline, no combo chip, no keypad — those consts exist only in
+//! `board::m7`, and code referencing them is selected out of virt builds.
+
+use crate::device::DeviceRegistry;
+
+/// Board name for the boot banner and docs.
+pub(crate) const BOARD_NAME: &str = "QEMU virt (armv7a)";
+
+/// UART0 MMIO base (PL011; the register MAP differs from the M7's MTK 8250,
+/// not just the base — main.rs swaps the driver file under this board).
+pub(crate) const UART0_BASE: usize = 0x0900_0000;
+
+/// GIC distributor MMIO base (virt, GICv2).
+pub(crate) const GICD_BASE: usize = 0x0800_0000;
+
+/// GIC CPU interface MMIO base (virt, GICv2).
+pub(crate) const GICC_BASE: usize = 0x0801_0000;
+
+/// Register the devices the virt machine actually models (#534). Honestly
+/// minimal: the PL011 console UART and the GICv2 — no eMMC, display, combo
+/// chip, keypad, USB, or modem entries, because qemu provides none.
+pub(crate) fn register_devices(registry: &mut DeviceRegistry) {
+    registry.register("uart0", UART0_BASE, 0);
+    registry.register("gic-dist", GICD_BASE, 0);
+    registry.register("gic-cpu", GICC_BASE, 0);
+}

--- a/crates/thumos/src/ccci_logger.rs
+++ b/crates/thumos/src/ccci_logger.rs
@@ -845,9 +845,12 @@ impl fmt::Display for CcciFirewall {
 /// on the modem side cannot prevent or recover from.
 ///
 /// Source: MT6357 PMIC datasheet, VMODEM_CON0 register.
-const PMIC_VMODEM_CON0: usize = 0x1000_D000 + 0x0C00;
+/// Derived from the board's PWRAP base (#534) — one MMIO truth.
+#[cfg(not(feature = "qemu"))]
+const PMIC_VMODEM_CON0: usize = crate::board::PWRAP_BASE + 0x0C00;
 
 /// VMODEM enable bit (bit 0 of VMODEM_CON0).
+#[cfg(not(feature = "qemu"))]
 const VMODEM_EN_BIT: u32 = 1 << 0;
 
 /// Execute a hardware modem power cut via PMIC VMODEM LDO disable.
@@ -866,6 +869,7 @@ const VMODEM_EN_BIT: u32 = 1 << 0;
 /// communication channels are dead.
 ///
 /// In test builds the MMIO write is skipped (no hardware available).
+#[cfg(not(feature = "qemu"))]
 pub unsafe fn modem_power_cut() {
     // SAFETY: PMIC_VMODEM_CON0 is a valid PMIC register on the MT6739.
     // Clearing the enable bit disables the VMODEM LDO.

--- a/crates/thumos/src/device.rs
+++ b/crates/thumos/src/device.rs
@@ -6,153 +6,15 @@
 //!
 //! This is the framework that connects the kernel to UART, display,
 //! keypad, touch, modem, WiFi, BT, GPS, FM, USB, and eMMC.
+//!
+//! The DEVICE SET and every MMIO base address are board facts — they live
+//! in `crate::board` (#534): `board::m7::register_devices` populates the
+//! registry on the field board, `board::virt::register_devices` on the dev
+//! board. This file is the board-neutral framework only.
 
 extern crate alloc;
 use alloc::string::String;
 use alloc::vec::Vec;
-
-use crate::kconfig::{GICC_BASE, GICD_BASE};
-
-// ---------------------------------------------------------------------------
-// MT6739 register base addresses
-// ---------------------------------------------------------------------------
-
-// NOTE: Hardcoded for Phase 03. Device-tree parsing replaces these in Phase 04+.
-// Source: `docs/PROBE.md`, `docs/DRIVER-INTERFACES.md`, MT6739 device tree.
-//
-// WHY: central registry of all hardware base addresses. Individual driver
-// modules have local copies — these are the canonical source of truth for
-// cross-module reference and kinit boot validation.
-//
-// WHY cfg_attr(not(test)) on the expects below (#528): this module compiles
-// on the host test target now, where kinit_plan's address test references the
-// canonical consts -- a blanket expect(dead_code) would be UNFULFILLED there
-// (the const is no longer dead), while on armv7a the consts stay
-// reference-only and the expectation still applies.
-
-/// UART0 (ttyMT0) MMIO base.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "canonical reference; driver uses local const (#463)"
-    )
-)]
-pub(crate) const MT6739_UART0: usize = 0x1100_2000;
-
-/// UART1 (ttyMT1) MMIO base.
-#[expect(
-    dead_code,
-    reason = "canonical reference; driver uses local const (#463)"
-)]
-pub(crate) const MT6739_UART1: usize = 0x1100_3000;
-
-/// MSDC0 eMMC controller MMIO base.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "canonical reference; driver uses local const (#463)"
-    )
-)]
-pub(crate) const MT6739_MSDC0: usize = 0x1123_0000;
-
-/// MUSB OTG USB controller MMIO base.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "canonical reference; driver uses local const (#463)"
-    )
-)]
-pub(crate) const MT6739_MUSB: usize = 0x1121_0000;
-
-/// MMSYS configuration base (display pipeline).
-#[expect(
-    dead_code,
-    reason = "canonical reference; driver uses local const (#463)"
-)]
-pub(crate) const MT6739_MMSYS: usize = 0x1400_0000;
-
-/// OVL0 (overlay engine) MMIO base.
-#[expect(
-    dead_code,
-    reason = "canonical reference; driver uses local const (#463)"
-)]
-pub(crate) const MT6739_OVL0: usize = 0x1400_7000;
-
-/// RDMA0 (read DMA engine) MMIO base.
-#[expect(
-    dead_code,
-    reason = "canonical reference; driver uses local const (#463)"
-)]
-pub(crate) const MT6739_RDMA0: usize = 0x1400_8000;
-
-/// DSI0 controller MMIO base.
-#[expect(
-    dead_code,
-    reason = "canonical reference; driver uses local const (#463)"
-)]
-pub(crate) const MT6739_DSI0: usize = 0x1400_D000;
-
-/// CLDMA AP-side register base (modem DMA).
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "canonical reference; driver uses local const (#463)"
-    )
-)]
-pub(crate) const MT6739_CLDMA_AP: usize = 0x200F_0000;
-
-/// CCIF peer register base (modem mailbox).
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "canonical reference; driver uses local const (#463)"
-    )
-)]
-pub(crate) const MT6739_CCIF: usize = 0x2051_0000;
-
-/// GIC distributor MMIO base.
-pub(crate) const MT6739_GIC_DIST: usize = GICD_BASE;
-
-/// GIC CPU interface MMIO base.
-pub(crate) const MT6739_GIC_CPU: usize = GICC_BASE;
-
-/// Keypad (KPD) controller MMIO base.
-pub(crate) const MT6739_KPD: usize = 0x1001_0000;
-
-/// WMT combo-chip (CONSYS) MMIO base.
-#[expect(
-    dead_code,
-    reason = "canonical reference; driver uses local const (#463)"
-)]
-pub(crate) const MT6739_CONSYS: usize = 0x1800_0000;
-
-/// WiFi MMIO base.
-#[expect(
-    dead_code,
-    reason = "canonical reference; driver uses local const (#463)"
-)]
-pub(crate) const MT6739_WLAN: usize = 0x180F_0000;
-
-/// Framebuffer physical address (set by LK bootloader).
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "canonical reference; kconfig has matching const (#463)"
-    )
-)]
-pub(crate) const MT6739_FB: usize = 0x77EE_0000;
-
-/// KPD enable register offset.
-pub(crate) const KPD_EN: usize = 0x00;
-
-/// KPD debounce register offset.
-pub(crate) const KPD_DEBOUNCE: usize = 0x18;
 
 /// Device status.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -251,44 +113,6 @@ impl DeviceRegistry {
     pub(crate) fn count_by_status(&self, status: DeviceStatus) -> usize {
         self.devices.iter().filter(|d| d.status == status).count()
     }
-
-    /// Register all MT6739 AGM M7 devices with known addresses.
-    /// Addresses from `docs/DRIVER-INTERFACES.md` and `docs/PROBE.md`.
-    pub(crate) fn register_mt6739_devices(&mut self) {
-        // UART
-        self.register("uart0", 0x1100_2000, 0);
-        self.register("uart1", 0x1100_3000, 0);
-
-        // Display
-        self.register("disp-ovl0", 0x1400_7000, 0);
-        self.register("disp-rdma0", 0x1400_8000, 0);
-        self.register("gc9306-lcm", 0x1100_A000, 0);
-
-        // Input
-        self.register("mtk-kpd", 0x1001_0000, 0); // Keypad
-        self.register("mtk-tpd", 0x0, 0); // Touch (I2C, addr TBD from teardown)
-
-        // Modem
-        self.register("ccci-cldma", 0x200F_0000, 0); // CLDMA AP base
-        self.register("ccci-ccif", 0x2051_0000, 0); // CCIF peer
-
-        // Connectivity
-        self.register("wmt-consys", 0x1800_0000, 0); // WMT combo chip
-        self.register("wlan0", 0x180F_0000, 0); // WiFi
-        self.register("bt0", 0x0, 0); // BT (via WMT STP)
-        self.register("gps0", 0x0, 0); // GPS (via WMT STP)
-        self.register("fm0", 0x0, 0); // FM (via WMT)
-
-        // USB
-        self.register("musb-hdrc", 0x1120_0000, 0); // USB controller
-
-        // Storage
-        self.register("msdc0", 0x1123_0000, 0); // eMMC controller
-
-        // GIC
-        self.register("gic-dist", MT6739_GIC_DIST, 0);
-        self.register("gic-cpu", MT6739_GIC_CPU, 0);
-    }
 }
 
 impl Default for DeviceRegistry {
@@ -372,21 +196,5 @@ mod tests {
         assert_eq!(registry.count_by_status(DeviceStatus::Registered), 1);
         assert_eq!(registry.count_by_status(DeviceStatus::Active), 1);
         assert_eq!(registry.count_by_status(DeviceStatus::PoweredOff), 0);
-    }
-
-    #[test]
-    fn register_mt6739_devices_populates_expected_device_set() {
-        let mut registry = DeviceRegistry::new();
-        registry.register_mt6739_devices();
-
-        assert_eq!(registry.list().len(), 18);
-        assert!(registry.find("uart0").is_some());
-        assert!(registry.find("ccci-cldma").is_some());
-        assert!(registry.find("gic-cpu").is_some());
-        assert_eq!(
-            registry.count_by_status(DeviceStatus::Registered),
-            18,
-            "all devices start in the Registered state"
-        );
     }
 }

--- a/crates/thumos/src/display.rs
+++ b/crates/thumos/src/display.rs
@@ -18,21 +18,6 @@ use crate::timer;
 // Constants: base addresses
 // ---------------------------------------------------------------------------
 
-/// MMSYS configuration base (MT6739 device tree).
-const MMSYS_CONFIG_BASE: usize = 0x1400_0000;
-
-/// OVL0 engine base.
-const OVL0_BASE: usize = 0x1400_7000;
-
-/// RDMA0 engine base.
-const RDMA0_BASE: usize = 0x1400_8000;
-
-/// DSI0 controller base.
-const DSI0_BASE: usize = 0x1400_D000;
-
-/// Display mutex base.
-const DISP_MUTEX_BASE: usize = 0x1400_1000;
-
 /// AGM M7 display width in pixels.
 const DISPLAY_WIDTH: u16 = 240;
 
@@ -51,26 +36,25 @@ const FB_ADDR_ALIGN: usize = 16;
 
 /// MMSYS register block.
 mod mmsys {
-    use super::MMSYS_CONFIG_BASE;
 
     /// Clock gate status 0.
-    pub(crate) const CG_CON0: usize = MMSYS_CONFIG_BASE + 0x100;
+    pub(crate) const CG_CON0: usize = crate::board::MMSYS_BASE + 0x100;
     /// Clock gate SET 0 (write 1 = disable clock).
-    pub(crate) const CG_SET0: usize = MMSYS_CONFIG_BASE + 0x104;
+    pub(crate) const CG_SET0: usize = crate::board::MMSYS_BASE + 0x104;
     /// Clock gate clear 0 (write 1 = enable clock).
-    pub(crate) const CG_CLR0: usize = MMSYS_CONFIG_BASE + 0x108;
+    pub(crate) const CG_CLR0: usize = crate::board::MMSYS_BASE + 0x108;
     /// Clock gate status 1.
-    pub(crate) const CG_CON1: usize = MMSYS_CONFIG_BASE + 0x110;
+    pub(crate) const CG_CON1: usize = crate::board::MMSYS_BASE + 0x110;
     /// Clock gate SET 1 (write 1 = disable clock).
-    pub(crate) const CG_SET1: usize = MMSYS_CONFIG_BASE + 0x114;
+    pub(crate) const CG_SET1: usize = crate::board::MMSYS_BASE + 0x114;
     /// Clock gate clear 1 (write 1 = enable clock).
-    pub(crate) const CG_CLR1: usize = MMSYS_CONFIG_BASE + 0x118;
+    pub(crate) const CG_CLR1: usize = crate::board::MMSYS_BASE + 0x118;
     /// Software reset 0 (active low  -  write 1 to release).
-    pub(crate) const SW0_RST_B: usize = MMSYS_CONFIG_BASE + 0x140;
+    pub(crate) const SW0_RST_B: usize = crate::board::MMSYS_BASE + 0x140;
     /// Software reset 1 (active low  -  write 1 to release).
-    pub(crate) const SW1_RST_B: usize = MMSYS_CONFIG_BASE + 0x144;
+    pub(crate) const SW1_RST_B: usize = crate::board::MMSYS_BASE + 0x144;
     /// LCM reset control (active low  -  write 1 to release).
-    pub(crate) const LCM_RST_B: usize = MMSYS_CONFIG_BASE + 0x150;
+    pub(crate) const LCM_RST_B: usize = crate::board::MMSYS_BASE + 0x150;
 
     // WHY: clock gate bits for display pipeline modules in CG_CLR0/CG_CLR1.
     // These enable the clocks for each module when written to the CLR register.
@@ -99,30 +83,29 @@ mod mmsys {
 
 /// OVL0 register block.
 mod ovl {
-    use super::OVL0_BASE;
 
     /// Status; bit 0 = running.
-    pub(crate) const STA: usize = OVL0_BASE;
+    pub(crate) const STA: usize = crate::board::OVL0_BASE;
     /// Interrupt enable.
-    pub(crate) const INTEN: usize = OVL0_BASE + 0x004;
+    pub(crate) const INTEN: usize = crate::board::OVL0_BASE + 0x004;
     /// Interrupt status.
-    pub(crate) const INTSTA: usize = OVL0_BASE + 0x008;
+    pub(crate) const INTSTA: usize = crate::board::OVL0_BASE + 0x008;
     /// Enable; bit 0 = OVL_EN, bit 8 = CK_ON.
-    pub(crate) const EN: usize = OVL0_BASE + 0x00C;
+    pub(crate) const EN: usize = crate::board::OVL0_BASE + 0x00C;
     /// Trigger; bit 0 = SW_TRIG.
-    pub(crate) const TRIG: usize = OVL0_BASE + 0x010;
+    pub(crate) const TRIG: usize = crate::board::OVL0_BASE + 0x010;
     /// Reset.
-    pub(crate) const RST: usize = OVL0_BASE + 0x014;
+    pub(crate) const RST: usize = crate::board::OVL0_BASE + 0x014;
     /// Region of interest size; bits [12:0] = W, bits [28:16] = H.
-    pub(crate) const ROI_SIZE: usize = OVL0_BASE + 0x020;
+    pub(crate) const ROI_SIZE: usize = crate::board::OVL0_BASE + 0x020;
     /// Datapath config.
-    pub(crate) const DATAPATH_CON: usize = OVL0_BASE + 0x024;
+    pub(crate) const DATAPATH_CON: usize = crate::board::OVL0_BASE + 0x024;
     /// Background colour RGBA.
-    pub(crate) const ROI_BGCLR: usize = OVL0_BASE + 0x028;
+    pub(crate) const ROI_BGCLR: usize = crate::board::OVL0_BASE + 0x028;
     /// Source enable; bits 0–3 = layer 0–3 enable.
-    pub(crate) const SRC_CON: usize = OVL0_BASE + 0x02C;
+    pub(crate) const SRC_CON: usize = crate::board::OVL0_BASE + 0x02C;
     /// Layer 0 control (alpha, flip, format).
-    pub(crate) const L0_CON: usize = OVL0_BASE + 0x030;
+    pub(crate) const L0_CON: usize = crate::board::OVL0_BASE + 0x030;
 
     /// OVL_EN bit.
     pub(crate) const EN_BIT: u32 = 1 << 0;
@@ -149,20 +132,19 @@ mod ovl {
 
 /// RDMA0 register block.
 mod rdma {
-    use super::RDMA0_BASE;
 
     /// Global control; bit 0 = ENGINE_EN, bit 1 = MODE_SEL (1=memory).
-    pub(crate) const GLOBAL_CON: usize = RDMA0_BASE;
+    pub(crate) const GLOBAL_CON: usize = crate::board::RDMA0_BASE;
     /// Output frame width.
-    pub(crate) const SIZE_CON_0: usize = RDMA0_BASE + 0x014;
+    pub(crate) const SIZE_CON_0: usize = crate::board::RDMA0_BASE + 0x014;
     /// Output frame height.
-    pub(crate) const SIZE_CON_1: usize = RDMA0_BASE + 0x018;
+    pub(crate) const SIZE_CON_1: usize = crate::board::RDMA0_BASE + 0x018;
     /// Memory mode control (format selection).
-    pub(crate) const MEM_CON: usize = RDMA0_BASE + 0x024;
+    pub(crate) const MEM_CON: usize = crate::board::RDMA0_BASE + 0x024;
     /// Memory source pitch (stride in bytes).
-    pub(crate) const MEM_SRC_PITCH: usize = RDMA0_BASE + 0x02C;
+    pub(crate) const MEM_SRC_PITCH: usize = crate::board::RDMA0_BASE + 0x02C;
     /// Framebuffer start address (physical).
-    pub(crate) const MEM_START_ADDR: usize = RDMA0_BASE + 0x0F0;
+    pub(crate) const MEM_START_ADDR: usize = crate::board::RDMA0_BASE + 0x0F0;
 
     /// ENGINE_EN bit.
     pub(crate) const ENGINE_EN: u32 = 1 << 0;
@@ -179,49 +161,48 @@ mod rdma {
 
 /// DSI0 register block.
 mod dsi {
-    use super::DSI0_BASE;
 
     /// DSI start control.
-    pub(crate) const START: usize = DSI0_BASE;
+    pub(crate) const START: usize = crate::board::DSI0_BASE;
     /// Interrupt enable.
-    pub(crate) const INTEN: usize = DSI0_BASE + 0x008;
+    pub(crate) const INTEN: usize = crate::board::DSI0_BASE + 0x008;
     /// Interrupt status.
-    pub(crate) const INTSTA: usize = DSI0_BASE + 0x00C;
+    pub(crate) const INTSTA: usize = crate::board::DSI0_BASE + 0x00C;
     /// Connection control.
-    pub(crate) const CON_CTRL: usize = DSI0_BASE + 0x010;
+    pub(crate) const CON_CTRL: usize = crate::board::DSI0_BASE + 0x010;
     /// Mode control (CMD vs VDO).
-    pub(crate) const MODE_CTRL: usize = DSI0_BASE + 0x014;
+    pub(crate) const MODE_CTRL: usize = crate::board::DSI0_BASE + 0x014;
     /// TX/RX control (lane count).
-    pub(crate) const TXRX_CTRL: usize = DSI0_BASE + 0x018;
+    pub(crate) const TXRX_CTRL: usize = crate::board::DSI0_BASE + 0x018;
     /// Packet size control.
-    pub(crate) const PSCTRL: usize = DSI0_BASE + 0x01C;
+    pub(crate) const PSCTRL: usize = crate::board::DSI0_BASE + 0x01C;
     /// Vertical sync active lines.
-    pub(crate) const VSA_NL: usize = DSI0_BASE + 0x020;
+    pub(crate) const VSA_NL: usize = crate::board::DSI0_BASE + 0x020;
     /// Vertical back porch lines.
-    pub(crate) const VBP_NL: usize = DSI0_BASE + 0x024;
+    pub(crate) const VBP_NL: usize = crate::board::DSI0_BASE + 0x024;
     /// Vertical front porch lines.
-    pub(crate) const VFP_NL: usize = DSI0_BASE + 0x028;
+    pub(crate) const VFP_NL: usize = crate::board::DSI0_BASE + 0x028;
     /// Vertical active lines.
-    pub(crate) const VACT_NL: usize = DSI0_BASE + 0x02C;
+    pub(crate) const VACT_NL: usize = crate::board::DSI0_BASE + 0x02C;
     /// Horizontal sync active word count.
-    pub(crate) const HSA_WC: usize = DSI0_BASE + 0x050;
+    pub(crate) const HSA_WC: usize = crate::board::DSI0_BASE + 0x050;
     /// Horizontal back porch word count.
-    pub(crate) const HBP_WC: usize = DSI0_BASE + 0x054;
+    pub(crate) const HBP_WC: usize = crate::board::DSI0_BASE + 0x054;
     /// Horizontal front porch word count.
-    pub(crate) const HFP_WC: usize = DSI0_BASE + 0x058;
+    pub(crate) const HFP_WC: usize = crate::board::DSI0_BASE + 0x058;
     /// PHY LC (clock lane) control.
-    pub(crate) const PHY_LCCON: usize = DSI0_BASE + 0x104;
+    pub(crate) const PHY_LCCON: usize = crate::board::DSI0_BASE + 0x104;
     /// PHY LD0 (data lane 0) control.
-    pub(crate) const PHY_LD0CON: usize = DSI0_BASE + 0x108;
+    pub(crate) const PHY_LD0CON: usize = crate::board::DSI0_BASE + 0x108;
 
     /// Command queue size register (number of entries).
-    pub(crate) const CMDQ_SIZE: usize = DSI0_BASE + 0x060;
+    pub(crate) const CMDQ_SIZE: usize = crate::board::DSI0_BASE + 0x060;
     /// Command queue data register 0 (first slot in the 128-entry queue).
     ///
     /// Each slot is 4 bytes. Slot N is at `CMDQ_DATA + N * 4`.
-    pub(crate) const CMDQ_DATA: usize = DSI0_BASE + 0x200;
+    pub(crate) const CMDQ_DATA: usize = crate::board::DSI0_BASE + 0x200;
     /// Rack (read-ack) register — write 1 to acknowledge completed command.
-    pub(crate) const RACK: usize = DSI0_BASE + 0x084;
+    pub(crate) const RACK: usize = crate::board::DSI0_BASE + 0x084;
 
     /// DSI_START bit.
     pub(crate) const START_BIT: u32 = 1;
@@ -262,14 +243,13 @@ mod dsi {
 
 /// Display mutex register block.
 mod disp_mutex {
-    use super::DISP_MUTEX_BASE;
 
     /// Mutex 0 enable.
-    pub(crate) const EN: usize = DISP_MUTEX_BASE + 0x020;
+    pub(crate) const EN: usize = crate::board::DISP_MUTEX_BASE + 0x020;
     /// Mutex 0 module membership.
-    pub(crate) const MOD: usize = DISP_MUTEX_BASE + 0x02C;
+    pub(crate) const MOD: usize = crate::board::DISP_MUTEX_BASE + 0x02C;
     /// Mutex 0 SOF source.
-    pub(crate) const SOF: usize = DISP_MUTEX_BASE + 0x030;
+    pub(crate) const SOF: usize = crate::board::DISP_MUTEX_BASE + 0x030;
 
     /// Mutex enable bit.
     pub(crate) const EN_BIT: u32 = 1;
@@ -1321,7 +1301,7 @@ mod tests {
     fn dsi_cmdq_data_at_expected_offset() {
         assert_eq!(
             dsi::CMDQ_DATA,
-            DSI0_BASE + 0x200,
+            crate::board::DSI0_BASE + 0x200,
             "CMDQ_DATA must be at DSI0 + 0x200"
         );
     }
@@ -1330,7 +1310,7 @@ mod tests {
     fn dsi_cmdq_size_at_expected_offset() {
         assert_eq!(
             dsi::CMDQ_SIZE,
-            DSI0_BASE + 0x060,
+            crate::board::DSI0_BASE + 0x060,
             "CMDQ_SIZE must be at DSI0 + 0x060"
         );
     }

--- a/crates/thumos/src/elf.rs
+++ b/crates/thumos/src/elf.rs
@@ -771,7 +771,7 @@ mod tests {
 
         // Elf32Phdr at offset 52: p_type = PT_LOAD (1).
         buf[52..56].copy_from_slice(&1u32.to_le_bytes());
-        // p_vaddr (offset 60): kconfig::KERNEL_END, inside the allowed load
+        // p_vaddr (offset 60): board::KERNEL_END, inside the allowed load
         // region so #318's check does not fire first.
         buf[60..64].copy_from_slice(&0x4010_0000u32.to_le_bytes());
         // p_memsz (offset 72): 32 MB, comfortably inside RAM but four times
@@ -937,7 +937,7 @@ mod tests {
     fn load_does_not_leak_pages_on_success() {
         // WHY function-local `static mut`: load() writes segment bytes
         // directly to the ELF's p_vaddr. This binary's PIE image (hence any
-        // `static`) loads inside [kconfig::KERNEL_END, kconfig::RAM_END) on
+        // `static`) loads inside [board::KERNEL_END, board::RAM_END) on
         // this host toolchain, so its address passes validate_user_buffer
         // and is safe to dereference — unlike a fabricated physical address
         // or a stack array (glibc places thread stacks above RAM_END).

--- a/crates/thumos/src/emmc.rs
+++ b/crates/thumos/src/emmc.rs
@@ -24,8 +24,6 @@ use crate::mmio;
 
 /// MSDC0 base address on the MT6739.
 // NOTE: FROM device registry, `crates/thumos/src/device.rs:127`
-const MSDC0_BASE: usize = 0x1123_0000;
-
 /// Sector size in bytes (eMMC standard).
 const SECTOR_SIZE: usize = 512;
 
@@ -520,7 +518,7 @@ impl MsdcController {
     /// Create a new controller handle at the default MSDC0 base address.
     pub(crate) fn new() -> Self {
         Self {
-            base: MSDC0_BASE,
+            base: crate::board::MSDC0_BASE,
             initialized: false,
         }
     }
@@ -1437,26 +1435,30 @@ mod tests {
             !ctrl.is_initialized(),
             "new controller must not be initialized"
         );
-        assert_eq!(ctrl.base, MSDC0_BASE, "default base address");
+        assert_eq!(ctrl.base, crate::board::MSDC0_BASE, "default base address");
     }
 
     #[test]
     fn controller_reg_computes_absolute_address() {
         let ctrl = MsdcController::new();
-        assert_eq!(ctrl.reg(REG_MSDC_CFG), MSDC0_BASE, "CFG at base + 0x00");
+        assert_eq!(
+            ctrl.reg(REG_MSDC_CFG),
+            crate::board::MSDC0_BASE,
+            "CFG at base + 0x00"
+        );
         assert_eq!(
             ctrl.reg(REG_MSDC_INT),
-            MSDC0_BASE + 0x0C,
+            crate::board::MSDC0_BASE + 0x0C,
             "INT at base + 0x0C"
         );
         assert_eq!(
             ctrl.reg(REG_SDC_CMD),
-            MSDC0_BASE + 0x34,
+            crate::board::MSDC0_BASE + 0x34,
             "CMD at base + 0x34"
         );
         assert_eq!(
             ctrl.reg(REG_MSDC_DMA_SA),
-            MSDC0_BASE + 0x90,
+            crate::board::MSDC0_BASE + 0x90,
             "DMA_SA at base + 0x90"
         );
     }

--- a/crates/thumos/src/fd.rs
+++ b/crates/thumos/src/fd.rs
@@ -1952,7 +1952,7 @@ mod tests {
         // WHY function-local `static mut`: sys_read now validates buf_ptr via
         // validate_user_buffer before dereferencing it. This binary's PIE
         // image (hence any `static`) loads inside
-        // [kconfig::KERNEL_END, kconfig::RAM_END) on this host toolchain;
+        // [board::KERNEL_END, board::RAM_END) on this host toolchain;
         // a stack array does not (verified: glibc places the per-test-thread
         // stack near the top of the 32-bit address space, above RAM_END).
         static mut BUF: [u8; 64] = [0u8; 64];
@@ -2806,35 +2806,35 @@ mod tests {
 
     #[test]
     fn sys_open_rejects_kernel_range_path_ptr() {
-        let kernel_ptr = crate::kconfig::KERNEL_LOAD as u32;
+        let kernel_ptr = crate::board::KERNEL_LOAD as u32;
         let result = sys_open(kernel_ptr, 4, 0);
         assert_eq!(result, EFAULT, "kernel-range path_ptr must return EFAULT");
     }
 
     #[test]
     fn sys_read_rejects_kernel_range_buf_ptr() {
-        let kernel_ptr = crate::kconfig::KERNEL_LOAD as u32;
+        let kernel_ptr = crate::board::KERNEL_LOAD as u32;
         let result = sys_read(99, kernel_ptr, 4);
         assert_eq!(result, EFAULT, "kernel-range buf_ptr must return EFAULT");
     }
 
     #[test]
     fn sys_write_rejects_kernel_range_buf_ptr() {
-        let kernel_ptr = crate::kconfig::KERNEL_LOAD as u32;
+        let kernel_ptr = crate::board::KERNEL_LOAD as u32;
         let result = sys_write(99, kernel_ptr, 4);
         assert_eq!(result, EFAULT, "kernel-range buf_ptr must return EFAULT");
     }
 
     #[test]
     fn sys_stat_rejects_kernel_range_path_ptr() {
-        let kernel_ptr = crate::kconfig::KERNEL_LOAD as u32;
+        let kernel_ptr = crate::board::KERNEL_LOAD as u32;
         let result = sys_stat(kernel_ptr, 4, IN_RANGE_UNBACKED_PTR);
         assert_eq!(result, EFAULT, "kernel-range path_ptr must return EFAULT");
     }
 
     #[test]
     fn sys_stat_rejects_kernel_range_stat_buf_ptr() {
-        let kernel_ptr = crate::kconfig::KERNEL_LOAD as u32;
+        let kernel_ptr = crate::board::KERNEL_LOAD as u32;
         let result = sys_stat(IN_RANGE_UNBACKED_PTR, 4, kernel_ptr);
         assert_eq!(
             result, EFAULT,
@@ -2851,7 +2851,7 @@ mod tests {
         }
         let fd = install_test_fd(FileDescriptor::from_vfs(0, 1, 0));
 
-        let kernel_ptr = crate::kconfig::KERNEL_LOAD as u32;
+        let kernel_ptr = crate::board::KERNEL_LOAD as u32;
         let result = sys_fstat(fd, kernel_ptr);
         assert_eq!(
             result, EFAULT,
@@ -2861,28 +2861,28 @@ mod tests {
 
     #[test]
     fn sys_getcwd_rejects_kernel_range_buf_ptr() {
-        let kernel_ptr = crate::kconfig::KERNEL_LOAD as u32;
+        let kernel_ptr = crate::board::KERNEL_LOAD as u32;
         let result = sys_getcwd(kernel_ptr, 32);
         assert_eq!(result, EFAULT, "kernel-range buf_ptr must return EFAULT");
     }
 
     #[test]
     fn sys_mkdir_rejects_kernel_range_path_ptr() {
-        let kernel_ptr = crate::kconfig::KERNEL_LOAD as u32;
+        let kernel_ptr = crate::board::KERNEL_LOAD as u32;
         let result = sys_mkdir(kernel_ptr, 4);
         assert_eq!(result, EFAULT, "kernel-range path_ptr must return EFAULT");
     }
 
     #[test]
     fn sys_unlink_rejects_kernel_range_path_ptr() {
-        let kernel_ptr = crate::kconfig::KERNEL_LOAD as u32;
+        let kernel_ptr = crate::board::KERNEL_LOAD as u32;
         let result = sys_unlink(kernel_ptr, 4);
         assert_eq!(result, EFAULT, "kernel-range path_ptr must return EFAULT");
     }
 
     #[test]
     fn sys_chdir_rejects_kernel_range_path_ptr() {
-        let kernel_ptr = crate::kconfig::KERNEL_LOAD as u32;
+        let kernel_ptr = crate::board::KERNEL_LOAD as u32;
         let result = sys_chdir(kernel_ptr, 4);
         assert_eq!(result, EFAULT, "kernel-range path_ptr must return EFAULT");
     }

--- a/crates/thumos/src/fm_radio.rs
+++ b/crates/thumos/src/fm_radio.rs
@@ -8,7 +8,7 @@
 //! ## Hardware path
 //!
 //! FM radio is accessed through the WMT STP transport on the combo chip:
-//! - `MT6739_CONSYS = 0x1800_0000` (combo-chip base)
+//! - `board::CONSYS_BASE = 0x1800_0000` (combo-chip base, board::m7 #534)
 //! - WMT channel 0x04 for FM radio commands
 //! - FM register block at offset `0x6000` within the combo chip
 //!
@@ -37,9 +37,6 @@ extern crate alloc;
 // ---------------------------------------------------------------------------
 // FM hardware constants
 // ---------------------------------------------------------------------------
-
-/// WMT combo-chip MMIO base address.
-const MT6739_CONSYS: usize = 0x1800_0000;
 
 /// WMT STP channel identifier for FM radio.
 const WMT_FM_CHANNEL: u8 = 0x04;
@@ -208,7 +205,7 @@ pub(crate) trait FmHwOps {
 // ---------------------------------------------------------------------------
 
 /// Real FM hardware access via WMT STP on the MT6739 combo chip.
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "qemu")))]
 pub(crate) struct FmHw {
     /// WMT combo-chip MMIO base address.
     consys_base: usize,
@@ -216,19 +213,19 @@ pub(crate) struct FmHw {
     current_freq: u32,
 }
 
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "qemu")))]
 impl FmHw {
     /// Create a new FM hardware handle.
     #[must_use]
     pub(crate) const fn new() -> Self {
         Self {
-            consys_base: MT6739_CONSYS,
+            consys_base: crate::board::CONSYS_BASE,
             current_freq: FM_DEFAULT_FREQ_KHZ,
         }
     }
 }
 
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "qemu")))]
 impl FmHwOps for FmHw {
     fn power_on(&mut self) -> Result<(), FmError> {
         // TODO(#129)[deliberate-prudent]: send WMT power-on command for FM subsystem.

--- a/crates/thumos/src/futex.rs
+++ b/crates/thumos/src/futex.rs
@@ -278,7 +278,7 @@ mod tests {
         // WHY function-local `static mut`: sys_futex_wait now validates
         // `addr` via validate_user_buffer before dereferencing it. A stack
         // address (e.g. `&word`) falls outside
-        // [kconfig::KERNEL_END, kconfig::RAM_END) on this host binary and
+        // [board::KERNEL_END, board::RAM_END) on this host binary and
         // would be rejected before the mismatch check is ever reached; a
         // function-local static lands inside that window (see fd.rs tests
         // for the same pattern).
@@ -299,7 +299,7 @@ mod tests {
         // A kernel-range addr must be rejected by validate_user_buffer
         // before any read_volatile — verified by never reaching the mismatch
         // path (which would return EAGAIN, not EINVAL).
-        let result = sys_futex_wait(crate::kconfig::KERNEL_LOAD as u32, 0);
+        let result = sys_futex_wait(crate::board::KERNEL_LOAD as u32, 0);
         assert_eq!(
             result, EINVAL,
             "kernel-range addr must return EINVAL without a load"

--- a/crates/thumos/src/gic.rs
+++ b/crates/thumos/src/gic.rs
@@ -10,7 +10,7 @@
 // NOTE: GIC base addresses live in kconfig (single source of truth); the
 // qemu feature remaps them to the virt board's GICv2. The register-level
 // driver below is plain architectural GICv2 and works unchanged on both.
-use crate::kconfig::{GICC_BASE, GICD_BASE};
+use crate::board::{GICC_BASE, GICD_BASE};
 
 // Distributor registers
 mod gicd {

--- a/crates/thumos/src/gps.rs
+++ b/crates/thumos/src/gps.rs
@@ -10,7 +10,7 @@
 //! ## Hardware path
 //!
 //! The MT6739 GPS hardware is accessed through the WMT combo chip:
-//! - `MT6739_CONSYS = 0x1800_0000` (combo-chip base)
+//! - `board::CONSYS_BASE = 0x1800_0000` (combo-chip base, board::m7 #534)
 //! - Data path goes through WMT STP framing (kelyphos handles the transport)
 //!
 //! ## Design
@@ -35,9 +35,6 @@ use alloc::vec::Vec;
 // ---------------------------------------------------------------------------
 // MT6739 GPS hardware constants
 // ---------------------------------------------------------------------------
-
-/// WMT combo-chip (CONSYS) MMIO base address.
-const MT6739_CONSYS: usize = 0x1800_0000;
 
 /// WMT STP channel identifier for GPS.
 const WMT_GPS_CHANNEL: u8 = 0x02;
@@ -650,21 +647,24 @@ pub(crate) trait GpsHwOps {
 // ---------------------------------------------------------------------------
 
 /// Real GPS hardware access via WMT STP on the MT6739 combo chip.
+#[cfg(not(feature = "qemu"))]
 pub(crate) struct GpsHw {
     /// WMT combo-chip MMIO base address.
     consys_base: usize,
 }
 
+#[cfg(not(feature = "qemu"))]
 impl GpsHw {
     /// Create a new GPS hardware handle.
     #[must_use]
     pub(crate) const fn new() -> Self {
         Self {
-            consys_base: MT6739_CONSYS,
+            consys_base: crate::board::CONSYS_BASE,
         }
     }
 }
 
+#[cfg(not(feature = "qemu"))]
 impl GpsHwOps for GpsHw {
     fn read_data(&mut self, _buf: &mut [u8]) -> usize {
         // TODO(#129)[deliberate-prudent]: implement WMT STP frame RX for GPS channel.

--- a/crates/thumos/src/kardia.rs
+++ b/crates/thumos/src/kardia.rs
@@ -787,8 +787,8 @@ fn restart_supervised(path: &'static str) -> Option<crate::process::Pid> {
     let loaded = unsafe {
         crate::elf::load_confined(
             elf_data,
-            crate::kconfig::USER_TEXT_BASE,
-            crate::kconfig::RAM_END,
+            crate::board::USER_TEXT_BASE,
+            crate::board::RAM_END,
         )
     }
     .ok()?;

--- a/crates/thumos/src/kconfig.rs
+++ b/crates/thumos/src/kconfig.rs
@@ -3,6 +3,10 @@
 //! Runtime-configurable parameters for kernel behavior. These can be
 //! set from the boot command line, the debug console, or from userspace
 //! via syscall. All parameters have defaults suitable for the MT6739.
+//!
+//! Board and memory-map CONSTANTS (UART/GIC bases, RAM window, kernel
+//! layout, framebuffer, partition table, display geometry) are NOT here —
+//! they live under `crate::board` (#534: one seam, one selection point).
 
 /// Scheduler tick interval in milliseconds.
 pub(crate) static mut TICK_MS: u32 = 10;
@@ -33,85 +37,10 @@ pub(crate) static mut DEBUG_CONSOLE: bool = false;
 /// Panic behavior: 0 = halt, N = reboot after N seconds.
 pub(crate) static mut PANIC_TIMEOUT: u32 = 0;
 
-/// RAM start address.
-pub(crate) const RAM_START: usize = 0x4000_0000;
-
-/// RAM end address (1 GB).
-pub(crate) const RAM_END: usize = 0x8000_0000;
-
-/// Kernel load address.
-pub(crate) const KERNEL_LOAD: usize = 0x4000_8000;
-
-/// Kernel reserved size (992 KB).
-/// WHY: kernel image + reserved region spans `0x4000_8000..0x400F_FFFF`
-/// (see the memory map in `memguard.rs`), so KERNEL_END lands on the
-/// 0x4010_0000 page boundary rather than a full 1 MB past KERNEL_LOAD.
-pub(crate) const KERNEL_RESERVED: usize = 0xF_8000;
-
-/// Kernel end address (load + reserved).
-pub(crate) const KERNEL_END: usize = KERNEL_LOAD + KERNEL_RESERVED;
-
-/// Userspace text region base (#474/#482): the top 1 MB of DRAM
-/// (0x7FF0_0000..0x8000_0000), the fixed identity load address for the
-/// image-resident /init. EXCLUDED from the page allocator (kinit passes this as
-/// the allocator's upper bound) so an allocation never collides with the loaded
-/// image. In the KERNEL address space it is plain RAM + execute-never (W^X
-/// #417 -- the kernel never executes user code from its own space); a spawned
-/// process runs it user-RX from its OWN page table via `mmu` per-process
-/// mappings (PL0 isolation, #482).
-pub(crate) const USER_TEXT_BASE: usize = 0x7FF0_0000;
-
-/// UART0 base address (MT6739 ttyMT0, MTK 8250-style register map).
-#[cfg(not(feature = "qemu"))]
-pub(crate) const UART0_BASE: usize = 0x1100_2000;
-
-/// UART0 base address (PL011 on QEMU `-machine virt`).
-/// NOTE: consumed by uart_pl011.rs, which main.rs swaps in under the qemu
-/// feature -- the register map differs, not just the base.
-#[cfg(feature = "qemu")]
-pub(crate) const UART0_BASE: usize = 0x0900_0000;
-
-/// GIC distributor base address (MT6739 device tree, intc node).
-#[cfg(not(feature = "qemu"))]
-pub(crate) const GICD_BASE: usize = 0x0C00_0000;
-
-/// GIC distributor base address (QEMU `-machine virt`, GICv2).
-#[cfg(feature = "qemu")]
-pub(crate) const GICD_BASE: usize = 0x0800_0000;
-
-/// GIC CPU interface base address (MT6739).
-#[cfg(not(feature = "qemu"))]
-pub(crate) const GICC_BASE: usize = 0x0C00_2000;
-
-/// GIC CPU interface base address (QEMU `-machine virt`, GICv2).
-#[cfg(feature = "qemu")]
-pub(crate) const GICC_BASE: usize = 0x0801_0000;
-
-/// Display framebuffer base (set by LK bootloader).
-pub(crate) const FB_BASE: usize = 0x77EE_0000;
-
-/// Start sector of the LFS partition on eMMC.
-/// WHY: the boot, recovery, system, vendor partitions occupy the first ~2.6 GB.
-/// LFS uses the userdata region starting at sector 0x50C000 (~2.6 GB offset).
-/// Value from GPT dump of the MT6739 eMMC (printgpt: userdata partition).
-pub(crate) const LFS_PARTITION_START: u64 = 0x50C000;
-
-/// Size of the LFS partition in sectors.
-/// WHY: ~3 GB of the 8 GB eMMC is available for user data.
-/// Rounded down from the actual userdata partition length (0x97BFDF sectors)
-/// to a clean segment-aligned boundary.
-pub(crate) const LFS_PARTITION_SIZE: u64 = 0x600000;
-
 /// Number of blocks in the block cache.
 /// WHY: 256 entries x 4 KiB = 1 MiB of cached data. Balances memory usage
 /// against hit rate for typical file access patterns.
 pub(crate) const BLOCK_CACHE_BLOCKS: usize = 256;
-
-/// Display width.
-pub(crate) const DISPLAY_WIDTH: u32 = 240;
-
-/// Display height.
-pub(crate) const DISPLAY_HEIGHT: u32 = 320;
 
 /// Parse a boot command line parameter.
 /// Format: "key=value" pairs separated by spaces.
@@ -157,13 +86,6 @@ pub(crate) fn parse_cmdline(cmdline: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn constants_are_correct() {
-        assert_eq!(RAM_END - RAM_START, 1024 * 1024 * 1024);
-        assert_eq!(KERNEL_END, 0x4010_0000);
-        assert_eq!(DISPLAY_WIDTH * DISPLAY_HEIGHT * 2, 153_600); // RGB565 framebuffer size
-    }
 
     #[test]
     fn parse_cmdline_sets_tick_rate_and_security_flags() {

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -20,15 +20,13 @@ use core::sync::atomic::AtomicBool;
 #[cfg(not(feature = "qemu"))]
 use core::sync::atomic::Ordering;
 
+use crate::board;
 #[cfg(not(feature = "qemu"))]
 use crate::ccci::CcciDriver;
 #[cfg(feature = "debug-console")]
 use crate::console::Console;
 use crate::csprng;
-#[cfg(feature = "qemu")]
 use crate::device::DeviceRegistry;
-#[cfg(not(feature = "qemu"))]
-use crate::device::{self, DeviceRegistry};
 #[cfg(not(feature = "qemu"))]
 use crate::dhcp::{DhcpClient, DhcpEvent};
 #[cfg(not(feature = "qemu"))]
@@ -39,16 +37,21 @@ use crate::elf;
 use crate::exceptions;
 use crate::gic;
 use crate::heap;
+// Gated: only the debug-console gate reads kconfig::DEBUG_CONSOLE.
+#[cfg(feature = "debug-console")]
 use crate::kconfig;
 #[cfg(not(feature = "qemu"))]
 use crate::kinit_plan::MODEM_BOOT_TIMEOUT_MS;
-use crate::kinit_plan::{
-    BootState, PANIC_RED_RGB565, UserspaceSpawnPlan, plan_userspace_spawn_from_vfs,
-};
+use crate::kinit_plan::{BootState, UserspaceSpawnPlan, plan_userspace_spawn_from_vfs};
+// M7-only: the panic-red fill exists only where a hardware framebuffer does.
+#[cfg(not(feature = "qemu"))]
+use crate::kinit_plan::PANIC_RED_RGB565;
 #[cfg(not(feature = "qemu"))]
 use crate::mmio;
 use crate::mmu;
-use crate::net::{self, NetworkReadiness, WifiDevice};
+use crate::net;
+#[cfg(not(feature = "qemu"))]
+use crate::net::{NetworkReadiness, WifiDevice};
 // #403: the net stack is built on both targets (loop-persistent), so these are
 // no longer qemu-gated. DhcpClient/DnsResolver stay gated -- used only in the
 // non-qemu DHCP/DNS self-test below.
@@ -133,16 +136,21 @@ pub(crate) unsafe fn fill_framebuffer(fb_addr: usize, width: u32, height: u32, c
 /// WHY(qemu): exit code 6 (distinct from 0=ok / 1=panic / 5=loop-stall) so
 /// a runner sees a secure-boot halt as its own diagnostic; unreachable
 /// today because qemu presents no boot medium.
+#[cfg_attr(feature = "qemu", allow(unused_variables))]
 fn halt_boot(serial: &mut Uart, display_ok: bool) -> ! {
+    // WHY not(qemu): virt has no hardware framebuffer (its render target is
+    // a synthetic heap buffer) and display_ok can only be set on the M7 --
+    // the fill is M7 bring-up, so it is selected out, not emulated.
+    #[cfg(not(feature = "qemu"))]
     if display_ok {
         // SAFETY: display_ok is only true after display.init() succeeded,
-        // so FB_BASE is a valid, mapped framebuffer of at least
+        // so board::FB_BASE is a valid, mapped framebuffer of at least
         // DISPLAY_WIDTH * DISPLAY_HEIGHT * 2 bytes (RGB565).
         unsafe {
             fill_framebuffer(
-                kconfig::FB_BASE,
-                kconfig::DISPLAY_WIDTH,
-                kconfig::DISPLAY_HEIGHT,
+                board::FB_BASE,
+                board::DISPLAY_WIDTH,
+                board::DISPLAY_HEIGHT,
                 PANIC_RED_RGB565,
             );
         }
@@ -242,7 +250,9 @@ pub unsafe fn run() -> ! {
     serial.log("\r\n");
     serial.log("================================\r\n");
     serial.log(" THUMOS v0.1.0\r\n");
-    serial.log(" Rust OS for the AGM M7 (MT6739)\r\n");
+    serial.log(" Rust OS for the ");
+    serial.log(board::BOARD_NAME);
+    serial.log("\r\n");
     // WHY (#233): every boot names its trust anchor -- a dev-keyed image can
     // never be mistaken for a production-trusted one, on the serial log or
     // via `strings` on the flashed binary (the stamp lives in rodata).
@@ -280,11 +290,7 @@ pub unsafe fn run() -> ! {
     // executable userspace text region (#474), reserved for spawned ELFs and
     // kept out of the allocator so kernel pages never collide with userspace.
     unsafe {
-        page::init(
-            kconfig::RAM_START,
-            kconfig::USER_TEXT_BASE,
-            kconfig::KERNEL_END,
-        );
+        page::init(board::RAM_START, board::USER_TEXT_BASE, board::KERNEL_END);
     }
     boot_log!(
         serial,
@@ -423,7 +429,7 @@ pub unsafe fn run() -> ! {
     // -----------------------------------------------------------------------
     serial.log("[init] Device registry\r\n");
     let mut devices = DeviceRegistry::new();
-    devices.register_mt6739_devices();
+    board::register_devices(&mut devices);
     boot_log!(serial, " {} devices registered\r\n", devices.list().len());
 
     // -----------------------------------------------------------------------
@@ -469,11 +475,11 @@ pub unsafe fn run() -> ! {
         // SAFETY: FB_BASE is a framebuffer physical address provided by the LK
         // bootloader and identity-mapped as device memory in the MMU init.
         unsafe {
-            display.init(kconfig::FB_BASE);
+            display.init(board::FB_BASE);
         }
         if display.state() != crate::display::DisplayState::Uninitialized {
             serial.log(" Display pipeline active\r\n");
-            boot_log!(serial, " Framebuffer @ {:#010x}\r\n", kconfig::FB_BASE);
+            boot_log!(serial, " Framebuffer @ {:#010x}\r\n", board::FB_BASE);
             devices.activate("gc9306-lcm");
             devices.activate("disp-ovl0");
             devices.activate("disp-rdma0");
@@ -506,16 +512,16 @@ pub unsafe fn run() -> ! {
     {
         // NOTE: Full keypad driver is in crates/haphe. Here we enable the
         // KPD hardware so interrupt-driven scanning can start.
-        let kpd_base = device::MT6739_KPD;
+        let kpd_base = board::KPD_BASE;
         // SAFETY: KPD_EN and KPD_DEBOUNCE are device MMIO registers at known
-        // offsets from the MT6739_KPD base address (0x1001_0000), which is
+        // offsets from the KPD base address (0x1001_0000), which is
         // identity-mapped as device memory. Writing these registers enables the
         // hardware keypad scanner with 16 ms debounce.
         unsafe {
             // Enable KPD module (bit 0 of KPD_EN).
-            mmio::write32(kpd_base + device::KPD_EN, 1);
+            mmio::write32(kpd_base + board::KPD_EN, 1);
             // Set debounce to 16 ms (hardware units).
-            mmio::write32(kpd_base + device::KPD_DEBOUNCE, 16);
+            mmio::write32(kpd_base + board::KPD_DEBOUNCE, 16);
         }
         devices.activate("mtk-kpd");
         state.input_ok = true;
@@ -577,19 +583,25 @@ pub unsafe fn run() -> ! {
     // Captures the mounted LFS so it can back the VFS root below instead
     // of a fresh, volatile ramfs (#343). Stays `None` on any path that
     // does not end with a durably mounted filesystem.
+    #[cfg_attr(feature = "qemu", allow(unused_mut))]
     let mut lfs_root: Option<alloc::boxed::Box<dyn crate::vfs::Filesystem>> = None;
     // WHY (#217): persistent storage mounts ONLY on a verified boot --
     // secure_boot.rs's contract is that the filesystem mounts AFTER the
     // trust gate so a tampered kernel cannot reach encrypted data. A
     // verification FAILURE has already halted above; this gate covers the
     // no-boot-medium degrade, where nothing persistent may be touched.
+    // WHY not(qemu): the mount path is eMMC + LFS-partition bring-up, which
+    // exists only on the M7 (#534) -- virt models no block medium, so
+    // `lfs_root` stays None there exactly as the runtime gate already
+    // produced, and the VFS root falls back to ramfs.
+    #[cfg(not(feature = "qemu"))]
     if state.emmc_ok && state.secure_boot_ok {
         use crate::block::MsdcBlockDevice;
         use crate::lfs;
         use crate::lfs_imap::LfsError;
 
         // Compute device size in sectors from the partition constants.
-        let sector_count = kconfig::LFS_PARTITION_SIZE;
+        let sector_count = board::LFS_PARTITION_SIZE;
 
         // Create a block device wrapping the eMMC controller at the LFS partition.
         let mut blk_dev = MsdcBlockDevice::new(sector_count);
@@ -875,6 +887,7 @@ pub unsafe fn run() -> ! {
     // Step 13: Network configuration (WiFi readiness + DHCP/DNS smoke)
     // -----------------------------------------------------------------------
     serial.log("[init] Network WiFi readiness\r\n");
+    #[cfg(not(feature = "qemu"))]
     {
         let wifi_device = WifiDevice::new(crate::wifi::WifiHw::new());
         let readiness =
@@ -893,6 +906,12 @@ pub unsafe fn run() -> ! {
             }
         }
     }
+    // WHY(virt): no combo chip exists on this board; the old path probed the
+    // M7's CONSYS address and relied on qemu's RAZ/WI to fail the probe.
+    // BootState's default is already HardwareUnavailable(Wifi), so the skip
+    // leaves the boot record identical -- but the board truth is now named.
+    #[cfg(feature = "qemu")]
+    serial.log(" WiFi skipped (virt: no combo chip)\r\n");
 
     serial.log("[init] Network loopback smoke (DHCP + DNS)\r\n");
     // #403: the net stack is now LOOP-PERSISTENT -- built here on BOTH targets
@@ -1000,6 +1019,7 @@ pub unsafe fn run() -> ! {
     // Step 13b: Bluetooth adapter
     // -----------------------------------------------------------------------
     serial.log("[init] Bluetooth (BT HCI via WMT)\r\n");
+    #[cfg(not(feature = "qemu"))]
     {
         let bt_hw = crate::bluetooth::BtHw::new();
         let mut bt = crate::bluetooth::BtAdapter::new(bt_hw);
@@ -1027,11 +1047,14 @@ pub unsafe fn run() -> ! {
             }
         }
     }
+    #[cfg(feature = "qemu")]
+    serial.log(" BT skipped (virt: no combo chip)\r\n");
 
     // -----------------------------------------------------------------------
     // Step 13c: GPS receiver
     // -----------------------------------------------------------------------
     serial.log("[init] GPS (via WMT)\r\n");
+    #[cfg(not(feature = "qemu"))]
     {
         let gps_hw = crate::gps::GpsHw::new();
         let mut gps = crate::gps::GpsReceiver::new(gps_hw);
@@ -1047,6 +1070,8 @@ pub unsafe fn run() -> ! {
             }
         }
     }
+    #[cfg(feature = "qemu")]
+    serial.log(" GPS skipped (virt: no combo chip)\r\n");
 
     // -----------------------------------------------------------------------
     // Boot status summary
@@ -1122,9 +1147,8 @@ pub unsafe fn run() -> ! {
                 // SAFETY (#502): kinit runs under the kernel L1 (proc0's table,
                 // scheduling disabled), satisfying load_confined's TTBR0
                 // precondition -- the image write lands in identity DRAM.
-                match unsafe {
-                    elf::load_confined(elf_data, kconfig::USER_TEXT_BASE, kconfig::RAM_END)
-                } {
+                match unsafe { elf::load_confined(elf_data, board::USER_TEXT_BASE, board::RAM_END) }
+                {
                     Ok(loaded) => {
                         // WHY(#482): spawn_user runs /init UNPRIVILEGED (PL0, User
                         // mode 0x10) in its own address space -- the ELF mapped
@@ -1156,9 +1180,8 @@ pub unsafe fn run() -> ! {
                 // SAFETY (#502): kinit runs under the kernel L1 (proc0's table,
                 // scheduling disabled), satisfying load_confined's TTBR0
                 // precondition -- the image write lands in identity DRAM.
-                match unsafe {
-                    elf::load_confined(elf_data, kconfig::USER_TEXT_BASE, kconfig::RAM_END)
-                } {
+                match unsafe { elf::load_confined(elf_data, board::USER_TEXT_BASE, board::RAM_END) }
+                {
                     Ok(loaded) => {
                         // WHY(#482): /shell runs PL0 in its own isolated space too.
                         if let Some(pid) = process::spawn_user(&loaded) {
@@ -1197,8 +1220,7 @@ pub unsafe fn run() -> ! {
         if let UserspaceSpawnPlan::Elf(elf_data) = plan_userspace_spawn_from_vfs("/crasher") {
             // SAFETY (#502): kinit runs under the kernel L1 (proc0's table,
             // scheduling disabled), satisfying load_confined's TTBR0 precondition.
-            match unsafe { elf::load_confined(elf_data, kconfig::USER_TEXT_BASE, kconfig::RAM_END) }
-            {
+            match unsafe { elf::load_confined(elf_data, board::USER_TEXT_BASE, board::RAM_END) } {
                 Ok(loaded) => {
                     if let Some(pid) = process::spawn_user(&loaded) {
                         boot_log!(serial, " /crasher spawned PL0 (PID {})\r\n", pid);
@@ -1293,7 +1315,7 @@ pub unsafe fn run() -> ! {
         // SAFETY: display_ok is set only after display.init(FB_BASE) mapped
         // FB_BASE as a writable RGB565 framebuffer of FRAMEBUFFER_PIXELS pixels.
         Some(unsafe {
-            core::slice::from_raw_parts_mut(kconfig::FB_BASE as *mut u16, FRAMEBUFFER_PIXELS)
+            core::slice::from_raw_parts_mut(board::FB_BASE as *mut u16, FRAMEBUFFER_PIXELS)
         })
     } else {
         None

--- a/crates/thumos/src/kinit_plan.rs
+++ b/crates/thumos/src/kinit_plan.rs
@@ -644,28 +644,10 @@ mod tests {
     }
 
     // -- Register address constants --
-
-    #[test]
-    fn mt6739_addresses_match_device_registry() {
-        // WHY: central constants must match what register_mt6739_devices uses
-        assert_eq!(device::MT6739_UART0, 0x1100_2000, "UART0 base address");
-        assert_eq!(device::MT6739_MSDC0, 0x1123_0000, "MSDC0 base address");
-        assert_eq!(device::MT6739_MUSB, 0x1121_0000, "MUSB base address");
-        assert_eq!(
-            device::MT6739_CLDMA_AP,
-            0x200F_0000,
-            "CLDMA AP base address"
-        );
-        assert_eq!(device::MT6739_CCIF, 0x2051_0000, "CCIF base address");
-        assert_eq!(device::MT6739_KPD, 0x1001_0000, "KPD base address");
-        assert_eq!(device::MT6739_GIC_DIST, 0x0C00_0000, "GIC distributor base");
-        assert_eq!(
-            device::MT6739_GIC_CPU,
-            0x0C00_2000,
-            "GIC CPU interface base"
-        );
-        assert_eq!(device::MT6739_FB, 0x77EE_0000, "framebuffer address");
-    }
+    // NOTE (#534): the canonical address test moved with the constants — see
+    // board/m7.rs's `register_devices_pins_canonical_addresses`, which pins
+    // the registry against board::m7's consts directly (and cannot alias to
+    // QEMU addresses, the pre-#534 trap this test fell into).
 
     // -- Modem timeout constant --
 

--- a/crates/thumos/src/main.rs
+++ b/crates/thumos/src/main.rs
@@ -31,6 +31,7 @@ mod battery;
 mod bfu_timer;
 mod block;
 mod bluetooth;
+mod board;
 mod briar;
 mod bt_audio;
 mod cache;
@@ -90,16 +91,18 @@ mod csprng;
 mod devfs;
 // WHY (#528): un-gated from cfg(not(test)) -- the registry is pure data
 // (alloc String/Vec, no MMIO at compile time), and the gate left its own 7
-// unit tests dead source under every build (the kinit trap). kinit_plan's
-// address test also reads the canonical MT6739_* consts from host tests now.
+// unit tests dead source under every build (the kinit trap). The device SET
+// and addresses moved to board:: (#534); this is the board-neutral
+// framework.
 mod device;
 mod dhcp;
+#[cfg(not(feature = "qemu"))]
 mod display;
 mod dns;
 mod dns_tls;
 mod ekphrasis;
 mod elf;
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "qemu")))]
 mod emmc;
 mod encryption;
 #[cfg(not(test))]
@@ -227,7 +230,7 @@ mod timer;
 mod timer;
 #[cfg(all(not(test), not(feature = "qemu")))]
 mod uart;
-// WHY(qemu): virt has a PL011 at kconfig::UART0_BASE, not the MTK 8250-style
+// WHY(qemu): virt has a PL011 at board::UART0_BASE, not the MTK 8250-style
 // UART; same module surface, different register map (see uart_pl011.rs).
 #[cfg(all(not(test), feature = "qemu"))]
 #[path = "uart_pl011.rs"]
@@ -239,6 +242,7 @@ mod ui;
 #[cfg(test)]
 #[path = "uart_stub.rs"]
 mod uart;
+#[cfg(not(feature = "qemu"))]
 mod usb;
 mod vfs;
 #[cfg(all(not(test), not(feature = "qemu")))]
@@ -319,15 +323,19 @@ pub extern "C" fn kernel_main() -> ! {
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     // Attempt visual panic indicator on display (if available).
+    // WHY not(qemu): as halt_boot -- DISPLAY_AVAILABLE is M7-only, and the
+    // framebuffer address exists only on that board (#534).
+    #[cfg(not(feature = "qemu"))]
     if kinit::DISPLAY_AVAILABLE.load(core::sync::atomic::Ordering::Acquire) {
         // SAFETY: DISPLAY_AVAILABLE is only set to true after display.init()
-        // succeeds, guaranteeing FB_BASE is a valid, mapped framebuffer of at
-        // least DISPLAY_WIDTH * DISPLAY_HEIGHT * 2 bytes (RGB565).
+        // succeeds, guaranteeing board::FB_BASE is a valid, mapped
+        // framebuffer of at least DISPLAY_WIDTH * DISPLAY_HEIGHT * 2 bytes
+        // (RGB565).
         unsafe {
             kinit::fill_framebuffer(
-                kconfig::FB_BASE,
-                kconfig::DISPLAY_WIDTH,
-                kconfig::DISPLAY_HEIGHT,
+                board::FB_BASE,
+                board::DISPLAY_WIDTH,
+                board::DISPLAY_HEIGHT,
                 0xF800, // NOTE: RGB565 pure red
             );
         }

--- a/crates/thumos/src/memguard.rs
+++ b/crates/thumos/src/memguard.rs
@@ -7,7 +7,7 @@
 //! subsystems (`pipe`, `fd`, `socket`, `time`, ...) can call it and — crucially
 //! — so the guard has runnable host unit tests.
 
-use crate::kconfig;
+use crate::board;
 
 /// Validate that a user-supplied buffer `[ptr, ptr+len)` lies entirely
 /// within user-accessible DRAM and does not overlap kernel-reserved memory.
@@ -38,7 +38,7 @@ pub(crate) fn validate_user_buffer(ptr: usize, len: usize) -> bool {
     // Entire range must be within user DRAM: [KERNEL_END, RAM_END)
     // WHY: KERNEL_END is the first byte after kernel-reserved memory;
     // RAM_END is one past the last byte of physical DRAM.
-    ptr >= kconfig::KERNEL_END && end <= kconfig::RAM_END
+    ptr >= board::KERNEL_END && end <= board::RAM_END
 }
 
 /// True if `addr` is a page-aligned address inside the user-allocatable DRAM
@@ -47,7 +47,7 @@ pub(crate) fn validate_user_buffer(ptr: usize, len: usize) -> bool {
 /// address, device MMIO, or a misaligned value) before it reaches the physical
 /// page allocator, where an out-of-range address would corrupt the bitmap.
 pub(crate) fn is_freeable_user_page(addr: usize) -> bool {
-    addr % crate::page::PAGE_SIZE == 0 && addr >= kconfig::KERNEL_END && addr < kconfig::RAM_END
+    addr % crate::page::PAGE_SIZE == 0 && addr >= board::KERNEL_END && addr < board::RAM_END
 }
 
 #[cfg(test)]
@@ -61,8 +61,8 @@ mod tests {
 
     #[test]
     fn entire_user_range_passes() {
-        let start = kconfig::KERNEL_END;
-        let len = kconfig::RAM_END - kconfig::KERNEL_END;
+        let start = board::KERNEL_END;
+        let len = board::RAM_END - board::KERNEL_END;
         assert!(validate_user_buffer(start, len));
     }
 
@@ -79,8 +79,8 @@ mod tests {
 
     #[test]
     fn kernel_space_fails() {
-        assert!(!validate_user_buffer(kconfig::KERNEL_LOAD, 4096));
-        assert!(!validate_user_buffer(kconfig::KERNEL_LOAD + 0x1000, 256));
+        assert!(!validate_user_buffer(board::KERNEL_LOAD, 4096));
+        assert!(!validate_user_buffer(board::KERNEL_LOAD + 0x1000, 256));
     }
 
     #[test]
@@ -91,7 +91,7 @@ mod tests {
 
     #[test]
     fn above_ram_fails() {
-        assert!(!validate_user_buffer(kconfig::RAM_END, 1));
+        assert!(!validate_user_buffer(board::RAM_END, 1));
         assert!(!validate_user_buffer(0xC000_0000, 4096));
     }
 
@@ -104,37 +104,37 @@ mod tests {
     #[test]
     fn buffer_spanning_into_kernel_fails() {
         // Starts one byte below KERNEL_END, so the range dips into kernel space.
-        assert!(!validate_user_buffer(kconfig::KERNEL_END - 1, 2));
+        assert!(!validate_user_buffer(board::KERNEL_END - 1, 2));
     }
 
     #[test]
     fn buffer_spanning_past_ram_end_fails() {
-        assert!(!validate_user_buffer(kconfig::RAM_END - 10, 20));
+        assert!(!validate_user_buffer(board::RAM_END - 10, 20));
     }
 
     #[test]
     fn boundary_exact_edges() {
         // Exactly at KERNEL_END is valid; one byte below is not.
-        assert!(validate_user_buffer(kconfig::KERNEL_END, 1));
-        assert!(!validate_user_buffer(kconfig::KERNEL_END - 1, 1));
+        assert!(validate_user_buffer(board::KERNEL_END, 1));
+        assert!(!validate_user_buffer(board::KERNEL_END - 1, 1));
         // Last valid byte of DRAM.
-        assert!(validate_user_buffer(kconfig::RAM_END - 1, 1));
+        assert!(validate_user_buffer(board::RAM_END - 1, 1));
     }
 
     #[test]
     fn freeable_page_accepts_aligned_user_pages() {
-        assert!(is_freeable_user_page(kconfig::KERNEL_END));
+        assert!(is_freeable_user_page(board::KERNEL_END));
         assert!(is_freeable_user_page(
-            kconfig::RAM_END - crate::page::PAGE_SIZE
+            board::RAM_END - crate::page::PAGE_SIZE
         ));
     }
 
     #[test]
     fn freeable_page_rejects_forged_addresses() {
         assert!(!is_freeable_user_page(0)); // null
-        assert!(!is_freeable_user_page(kconfig::KERNEL_LOAD)); // kernel image
+        assert!(!is_freeable_user_page(board::KERNEL_LOAD)); // kernel image
         assert!(!is_freeable_user_page(0x1100_2000)); // UART MMIO
-        assert!(!is_freeable_user_page(kconfig::RAM_END)); // above RAM
-        assert!(!is_freeable_user_page(kconfig::KERNEL_END + 1)); // misaligned
+        assert!(!is_freeable_user_page(board::RAM_END)); // above RAM
+        assert!(!is_freeable_user_page(board::KERNEL_END + 1)); // misaligned
     }
 }

--- a/crates/thumos/src/pipe.rs
+++ b/crates/thumos/src/pipe.rs
@@ -583,7 +583,7 @@ mod tests {
             assert_eq!(buf.write(b"data"), 4);
         }
         // A pointer inside the kernel image must be rejected before any deref.
-        let kernel_ptr = crate::kconfig::KERNEL_LOAD as u32;
+        let kernel_ptr = crate::board::KERNEL_LOAD as u32;
         let result = sys_pipe_read(pipe_idx, kernel_ptr, 4);
         assert_eq!(result, EFAULT, "kernel-range buf_ptr must return EFAULT");
     }
@@ -593,7 +593,7 @@ mod tests {
         reset_pool();
         let pipe_idx = alloc_pipe_slot(0).expect("alloc pipe");
         // Buffer empty and both ends open, so the write reaches validation.
-        let kernel_ptr = crate::kconfig::KERNEL_LOAD as u32;
+        let kernel_ptr = crate::board::KERNEL_LOAD as u32;
         let result = sys_pipe_write(pipe_idx, kernel_ptr, 4, 0);
         assert_eq!(result, EFAULT, "kernel-range buf_ptr must return EFAULT");
     }

--- a/crates/thumos/src/power.rs
+++ b/crates/thumos/src/power.rs
@@ -26,26 +26,6 @@
 // MT6739 governor registers
 // ---------------------------------------------------------------------------
 
-/// ARMPLL_CON1: CPU PLL control register.
-/// Bits [21:0] = PCW (integer + fractional divider).
-/// The four values below are approximate; production firmware reads them
-/// from the efuse-calibrated OPP table.
-#[cfg_attr(
-    feature = "qemu",
-    expect(
-        dead_code,
-        reason = "the ARMPLL write is qemu-gated; virt models no MT6739 CMU (#463)"
-    )
-)]
-const ARMPLL_CON1: usize = 0x1000_C104;
-
-/// MCDI (Multi-Core Deep Idle) base address.
-const MCDI_BASE: usize = 0x1000_DC00;
-
-/// MCDI_CORE_EN: per-core power-down enable register.
-/// Bit N = 1 → core N is powered down.
-const MCDI_CORE_EN: usize = MCDI_BASE + 0x04;
-
 // ---------------------------------------------------------------------------
 // CPU frequency steps
 // ---------------------------------------------------------------------------
@@ -214,11 +194,11 @@ pub(crate) fn evaluate_dvfs(load_percent: u8) {
         // WHY(qemu): virt models no MT6739 CMU; the ARMPLL write would
         // data-abort inside the timer IRQ. Governor state still updates.
         #[cfg(not(feature = "qemu"))]
-        // SAFETY: ARMPLL_CON1 is a valid MMIO register on the MT6739 CMU
-        // block at 0x1000_C104.  Volatile write is required for hardware
+        // SAFETY: board::ARMPLL_CON1 is a valid MMIO register on the MT6739
+        // CMU block at 0x1000_C104.  Volatile write is required for hardware
         // registers.  Called with IRQs disabled so no torn write.
         unsafe {
-            crate::mmio::write32(ARMPLL_CON1, new_freq as u32);
+            crate::mmio::write32(crate::board::ARMPLL_CON1, new_freq as u32);
         }
     }
 }
@@ -257,7 +237,7 @@ pub(crate) fn evaluate_core_parking(runnable_count: usize) {
         // which is not yet wired.
         #[cfg(not(feature = "qemu"))]
         unsafe {
-            crate::mmio::write32(MCDI_CORE_EN, park_mask);
+            crate::mmio::write32(crate::board::MCDI_CORE_EN, park_mask);
         }
     }
 }
@@ -365,9 +345,9 @@ unsafe fn dcs_cmd0(cmd: u8) {
     {
         // SAFETY: DSI0_CMD_FIFO is a valid MMIO register within the DSI0
         // address space at 0x1400_D000.  Volatile access required for hardware.
-        const DSI0_CMD_FIFO: usize = 0x1400_D200;
+
         unsafe {
-            crate::mmio::write32(DSI0_CMD_FIFO, u32::from(cmd) | 0x100);
+            crate::mmio::write32(crate::board::DSI0_CMD_FIFO, u32::from(cmd) | 0x100);
         }
     }
 }
@@ -569,7 +549,11 @@ impl PowerManager {
                 *s = PowerState::PmicKilled;
             }
         }
+        // WHY not(qemu): virt has no PMIC; the kill write would be a
+        // fictitious MMIO touch. The PmicKilled bookkeeping above is
+        // board-neutral and still records the kill.
         // SAFETY: caller guarantees PMIC registers are mapped.
+        #[cfg(not(feature = "qemu"))]
         unsafe {
             crate::ccci_logger::modem_power_cut();
         }

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -662,7 +662,7 @@ unsafe fn fork_copy_phase(parent_pt: usize, child_pt: usize) -> bool {
             // Fail closed: only DRAM-backed user pages are copyable. A
             // device-mapped user page has no copy semantics -- refuse the whole
             // fork rather than share or skip it.
-            if !(crate::kconfig::RAM_START..crate::kconfig::RAM_END).contains(&parent_phys) {
+            if !(crate::board::RAM_START..crate::board::RAM_END).contains(&parent_phys) {
                 return false;
             }
             let Some(child_page) = page::alloc_page() else {
@@ -1836,8 +1836,8 @@ pub unsafe fn exec_replace_context(
         //    ran in sys_execve before this call).
         {
             // The image window is exactly one 1 MB section (256 4 KB pages).
-            let image_end = crate::kconfig::USER_TEXT_BASE + 0x10_0000;
-            let mut va = crate::kconfig::USER_TEXT_BASE;
+            let image_end = crate::board::USER_TEXT_BASE + 0x10_0000;
+            let mut va = crate::board::USER_TEXT_BASE;
             while va < image_end {
                 if let Some(entry) = mmu::read_l2_entry(pt, va)
                     && mmu::l2_entry_is_user(entry)
@@ -1854,7 +1854,7 @@ pub unsafe fn exec_replace_context(
         //    stale PL0 image window survives and map_user_image re-maps into the
         //    SAME L2 (no fresh alloc -> infallible). A live PL0 caller always has
         //    a shattered image MB, so false here is an invariant break.
-        let image_was_mapped = mmu::reset_shattered_section(pt, crate::kconfig::USER_TEXT_BASE);
+        let image_was_mapped = mmu::reset_shattered_section(pt, crate::board::USER_TEXT_BASE);
         debug_assert!(
             image_was_mapped,
             "exec: caller's image MB must be shattered"
@@ -3319,7 +3319,7 @@ mod tests {
             let img_phys = page::alloc_page().unwrap();
             assert!(mmu::map_page(
                 pt,
-                crate::kconfig::USER_TEXT_BASE,
+                crate::board::USER_TEXT_BASE,
                 img_phys,
                 l2_attrs
             ));

--- a/crates/thumos/src/signal.rs
+++ b/crates/thumos/src/signal.rs
@@ -56,7 +56,7 @@ pub(crate) const SIGNAL_FRAME_SIZE: usize = SIGNAL_FRAME_REGS * 4;
 /// trampoline survives exec; and fork's copy-all-user-pages replicates it
 /// for the child automatically.
 pub(crate) const SIGNAL_TRAMPOLINE_VA: usize =
-    crate::kconfig::USER_TEXT_BASE - crate::page::PAGE_SIZE;
+    crate::board::USER_TEXT_BASE - crate::page::PAGE_SIZE;
 
 /// ARM `mov r7, #81` — loads the Sigreturn syscall number into r7.
 /// Encoding: E3A07051 (MOV r7, #0x51 where 0x51 = 81).
@@ -615,7 +615,7 @@ mod tests {
     fn signal_trampoline_va_is_the_reserved_slot() {
         assert_eq!(
             SIGNAL_TRAMPOLINE_VA,
-            crate::kconfig::USER_TEXT_BASE - crate::page::PAGE_SIZE,
+            crate::board::USER_TEXT_BASE - crate::page::PAGE_SIZE,
             "trampoline page sits directly below USER_TEXT_BASE"
         );
         assert_eq!(
@@ -625,7 +625,7 @@ mod tests {
         );
         // Outside the USER_TEXT 1 MB section exec revokes + rebuilds.
         assert!(
-            SIGNAL_TRAMPOLINE_VA < crate::kconfig::USER_TEXT_BASE,
+            SIGNAL_TRAMPOLINE_VA < crate::board::USER_TEXT_BASE,
             "trampoline must not share the exec-rebuilt section"
         );
     }

--- a/crates/thumos/src/socket.rs
+++ b/crates/thumos/src/socket.rs
@@ -1265,7 +1265,7 @@ mod tests {
     ///
     /// WHY function-local `static mut`: sys_bind now validates addr_ptr via
     /// validate_user_buffer before dereferencing it. A stack address (e.g.
-    /// `&addr`) falls outside [kconfig::KERNEL_END, kconfig::RAM_END) on
+    /// `&addr`) falls outside [board::KERNEL_END, board::RAM_END) on
     /// this host binary and would be rejected before bind logic runs; a
     /// function-local static lands inside that window (see fd.rs tests for
     /// the same pattern).
@@ -1348,7 +1348,7 @@ mod tests {
     fn bind_rejects_kernel_range_addr_ptr() {
         // No socket setup needed: validate_user_buffer runs before the
         // FD_TABLE is-a-socket check, so fd=0 (< MAX_FDS) is sufficient.
-        let kernel_ptr = crate::kconfig::KERNEL_LOAD as u32;
+        let kernel_ptr = crate::board::KERNEL_LOAD as u32;
         let result = sys_bind(0, kernel_ptr, core::mem::size_of::<SockaddrIn>() as u32);
         assert_eq!(
             result,
@@ -1390,7 +1390,7 @@ mod tests {
 
     #[test]
     fn connect_rejects_kernel_range_addr_ptr() {
-        let kernel_ptr = crate::kconfig::KERNEL_LOAD as u32;
+        let kernel_ptr = crate::board::KERNEL_LOAD as u32;
         let result = sys_connect(0, kernel_ptr, core::mem::size_of::<SockaddrIn>() as u32);
         assert_eq!(
             result,
@@ -1417,7 +1417,7 @@ mod tests {
         // WHY function-local `static mut`: sys_bind/sys_connect now validate
         // addr_ptr via validate_user_buffer (issue #291) before
         // dereferencing it. A stack address falls outside
-        // [kconfig::KERNEL_END, kconfig::RAM_END) on this host binary and
+        // [board::KERNEL_END, board::RAM_END) on this host binary and
         // would be rejected before bind/connect logic runs.
         static mut BIND_ADDR: SockaddrIn = SockaddrIn {
             sin_family: 0,

--- a/crates/thumos/src/syscall.rs
+++ b/crates/thumos/src/syscall.rs
@@ -23,12 +23,12 @@
 
 use core::fmt::Write;
 
+#[cfg(test)]
+use crate::board;
 use crate::capability;
 use crate::fd;
 use crate::futex;
 use crate::ipc;
-#[cfg(test)]
-use crate::kconfig;
 use crate::memguard::validate_user_buffer;
 use crate::mmu;
 use crate::page;
@@ -849,8 +849,8 @@ fn sys_execve(path_ptr: u32, argv_ptr: u32, _envp_ptr: u32) -> u32 {
     let loaded = match unsafe {
         crate::elf::load_confined(
             elf_data,
-            crate::kconfig::USER_TEXT_BASE,
-            crate::kconfig::RAM_END,
+            crate::board::USER_TEXT_BASE,
+            crate::board::RAM_END,
         )
     } {
         Ok(l) => l,
@@ -1824,8 +1824,8 @@ mod tests {
 
     #[test]
     fn validate_user_buffer_entire_user_range() {
-        let start = kconfig::KERNEL_END;
-        let len = kconfig::RAM_END - kconfig::KERNEL_END;
+        let start = board::KERNEL_END;
+        let len = board::RAM_END - board::KERNEL_END;
         assert!(
             validate_user_buffer(start, len),
             "full user DRAM range must be valid"
@@ -1859,11 +1859,11 @@ mod tests {
     #[test]
     fn validate_user_buffer_kernel_space() {
         assert!(
-            !validate_user_buffer(kconfig::KERNEL_LOAD, 4096),
+            !validate_user_buffer(board::KERNEL_LOAD, 4096),
             "kernel load address must fail validation"
         );
         assert!(
-            !validate_user_buffer(kconfig::KERNEL_LOAD + 0x1000, 256),
+            !validate_user_buffer(board::KERNEL_LOAD + 0x1000, 256),
             "pointer within kernel image must fail validation"
         );
     }
@@ -1907,7 +1907,7 @@ mod tests {
     #[test]
     fn validate_user_buffer_spans_into_kernel() {
         assert!(
-            !validate_user_buffer(kconfig::KERNEL_END - 1, 2),
+            !validate_user_buffer(board::KERNEL_END - 1, 2),
             "buffer spanning into kernel region must fail"
         );
     }
@@ -1915,7 +1915,7 @@ mod tests {
     #[test]
     fn validate_user_buffer_spans_past_ram_end() {
         assert!(
-            !validate_user_buffer(kconfig::RAM_END - 10, 20),
+            !validate_user_buffer(board::RAM_END - 10, 20),
             "buffer extending past RAM_END must fail"
         );
     }
@@ -1923,15 +1923,15 @@ mod tests {
     #[test]
     fn validate_user_buffer_boundary_exact() {
         assert!(
-            validate_user_buffer(kconfig::KERNEL_END, 1),
+            validate_user_buffer(board::KERNEL_END, 1),
             "first byte of user DRAM must be valid"
         );
         assert!(
-            !validate_user_buffer(kconfig::KERNEL_END - 1, 1),
+            !validate_user_buffer(board::KERNEL_END - 1, 1),
             "last byte of kernel region must fail"
         );
         assert!(
-            validate_user_buffer(kconfig::RAM_END - 1, 1),
+            validate_user_buffer(board::RAM_END - 1, 1),
             "last byte of DRAM must be valid"
         );
     }
@@ -2297,7 +2297,7 @@ mod tests {
 
         // Kernel-space pointer must also fail (below KERNEL_END).
         assert!(
-            !validate_user_buffer(kconfig::KERNEL_LOAD, 1),
+            !validate_user_buffer(board::KERNEL_LOAD, 1),
             "kernel-load address must fail validate_user_buffer"
         );
 
@@ -2309,7 +2309,7 @@ mod tests {
 
         // A valid user-DRAM pointer must pass (sanity: the positive case).
         assert!(
-            validate_user_buffer(kconfig::KERNEL_END + 0x1000, 1),
+            validate_user_buffer(board::KERNEL_END + 0x1000, 1),
             "pointer just above KERNEL_END must pass validate_user_buffer"
         );
 
@@ -2325,7 +2325,7 @@ mod tests {
     /// RAM_END into unmapped/device memory.
     #[test]
     fn execve_rejects_path_pointer_near_ram_end() {
-        let result = sys_execve((kconfig::RAM_END - 1) as u32, 0, 0);
+        let result = sys_execve((board::RAM_END - 1) as u32, 0, 0);
         assert_eq!(
             result, EFAULT,
             "execve must reject a path pointer within MAX_PATH bytes of RAM_END instead of scanning past it"
@@ -2573,7 +2573,7 @@ mod tests {
         // Sample 33 evenly-spaced addresses across the kernel image and
         // reserved region [0x4000_0000, KERNEL_END).
         let kernel_range_start: usize = 0x4000_0000;
-        let kernel_range_end: usize = kconfig::KERNEL_END;
+        let kernel_range_end: usize = board::KERNEL_END;
         let span = kernel_range_end - kernel_range_start;
         let step = span / 32;
 
@@ -2591,7 +2591,7 @@ mod tests {
         }
 
         // Exact boundary: one byte before user DRAM must fail.
-        let boundary = kconfig::KERNEL_END - 1;
+        let boundary = board::KERNEL_END - 1;
         assert!(
             !validate_user_buffer(boundary, 1),
             "last byte of kernel region 0x{boundary:08x} must be rejected"
@@ -2649,10 +2649,10 @@ mod tests {
     fn zero_length_accepted() {
         // Representative valid user addresses spanning the user DRAM range.
         let addrs: &[usize] = &[
-            kconfig::KERNEL_END,
-            kconfig::KERNEL_END + 0x1000,
+            board::KERNEL_END,
+            board::KERNEL_END + 0x1000,
             0x5000_0000,
-            kconfig::RAM_END - 1,
+            board::RAM_END - 1,
         ];
         for &addr in addrs {
             assert!(

--- a/crates/thumos/src/uart.rs
+++ b/crates/thumos/src/uart.rs
@@ -16,8 +16,6 @@
 use core::fmt;
 
 /// Base address of UART0 on MT6739.
-const UART0_BASE: usize = 0x1100_2000;
-
 /// Transmit holding register OFFSET.
 const THR: usize = 0x00;
 
@@ -44,6 +42,33 @@ const LSR_DR: u32 = 1 << 0;
 /// the kernel.
 const UART_TX_TIMEOUT_SPINS: u32 = 1_000_000;
 
+/// Run `f` with IRQs masked, restoring the caller's previous mask state.
+///
+/// WHY: kernel thread-mode prints (the kinit handoff, the kardia service
+/// loop) run with IRQs live — a timer IRQ mid-print preempts into userspace,
+/// whose own writes (already atomic: SVC entry sets CPSR.I) then split the
+/// kernel's line. The 2026-08-05 boot witness caught exactly that:
+/// `kardia: modem ready state=` and its value landed on different lines.
+/// Masking for the byte loop keeps a kernel print contiguous without
+/// changing userspace (SVC/IRQ paths are atomic by hardware already).
+/// Nested calls are safe: the prior I-bit is restored, never force-enabled.
+#[inline(always)]
+fn irqs_masked<R>(f: impl FnOnce() -> R) -> R {
+    let saved: u32;
+    // SAFETY: privileged CPSR read; always available at PL1 on armv7a.
+    unsafe {
+        core::arch::asm!("mrs {}, cpsr", out(reg) saved, options(nomem, nostack, preserves_flags))
+    };
+    // SAFETY: mask IRQs for the critical section.
+    unsafe { core::arch::asm!("cpsid i", options(nomem, nostack, preserves_flags)) };
+    let r = f();
+    if saved & 0x80 == 0 {
+        // SAFETY: the caller had IRQs enabled; restore that state.
+        unsafe { core::arch::asm!("cpsie i", options(nomem, nostack, preserves_flags)) };
+    }
+    r
+}
+
 /// UART driver for MT6739.
 pub(crate) struct Uart {
     base: usize,
@@ -53,7 +78,9 @@ impl Uart {
     /// Create a UART driver for the debug console.
     /// LK has already configured baud rate and pin mux.
     pub(crate) fn new() -> Self {
-        Self { base: UART0_BASE }
+        Self {
+            base: crate::board::UART0_BASE,
+        }
     }
 
     /// Write a single byte, waiting (bounded) for the TX buffer to be ready.
@@ -95,9 +122,11 @@ impl Uart {
 
     /// Write a string to the UART.
     pub(crate) fn write_str_raw(&self, s: &str) {
-        for byte in s.bytes() {
-            self.putc(byte);
-        }
+        irqs_masked(|| {
+            for byte in s.bytes() {
+                self.putc(byte);
+            }
+        });
     }
 
     /// Write a string to the console as a boot log line.

--- a/crates/thumos/src/uart_pl011.rs
+++ b/crates/thumos/src/uart_pl011.rs
@@ -8,7 +8,7 @@
 
 use core::fmt;
 
-use crate::kconfig::UART0_BASE;
+use crate::board::UART0_BASE;
 
 /// Data register OFFSET.
 const DR: usize = 0x00;
@@ -30,6 +30,33 @@ const UART_TX_TIMEOUT_SPINS: u32 = 1_000_000;
 /// UART driver for the QEMU virt PL011 console.
 pub(crate) struct Uart {
     base: usize,
+}
+
+/// Run `f` with IRQs masked, restoring the caller's previous mask state.
+///
+/// WHY: kernel thread-mode prints (the kinit handoff, the kardia service
+/// loop) run with IRQs live — a timer IRQ mid-print preempts into userspace,
+/// whose own writes (already atomic: SVC entry sets CPSR.I) then split the
+/// kernel's line. The 2026-08-05 boot witness caught exactly that:
+/// `kardia: modem ready state=` and its value landed on different lines.
+/// Masking for the byte loop keeps a kernel print contiguous without
+/// changing userspace (SVC/IRQ paths are atomic by hardware already).
+/// Nested calls are safe: the prior I-bit is restored, never force-enabled.
+#[inline(always)]
+fn irqs_masked<R>(f: impl FnOnce() -> R) -> R {
+    let saved: u32;
+    // SAFETY: privileged CPSR read; always available at PL1 on armv7a.
+    unsafe {
+        core::arch::asm!("mrs {}, cpsr", out(reg) saved, options(nomem, nostack, preserves_flags))
+    };
+    // SAFETY: mask IRQs for the critical section.
+    unsafe { core::arch::asm!("cpsid i", options(nomem, nostack, preserves_flags)) };
+    let r = f();
+    if saved & 0x80 == 0 {
+        // SAFETY: the caller had IRQs enabled; restore that state.
+        unsafe { core::arch::asm!("cpsie i", options(nomem, nostack, preserves_flags)) };
+    }
+    r
 }
 
 impl Uart {
@@ -64,9 +91,11 @@ impl Uart {
 
     /// Write a string to the UART.
     pub(crate) fn write_str_raw(&self, s: &str) {
-        for byte in s.bytes() {
-            self.putc(byte);
-        }
+        irqs_masked(|| {
+            for byte in s.bytes() {
+                self.putc(byte);
+            }
+        });
     }
 
     /// Non-blocking receive: returns the next byte if the RX FIFO has one

--- a/crates/thumos/src/ui.rs
+++ b/crates/thumos/src/ui.rs
@@ -13,7 +13,7 @@
 //!
 //! RGB565, 16-bit per pixel, matching the kernel's display driver and the eidolon
 //! crate's `Framebuffer`. The kernel renders into a flat `[u16]` buffer that maps
-//! directly to the hardware framebuffer at `kconfig::FB_BASE`.
+//! directly to the hardware framebuffer at `board::FB_BASE`.
 //!
 //! ## Font
 //!

--- a/crates/thumos/src/usb.rs
+++ b/crates/thumos/src/usb.rs
@@ -25,7 +25,6 @@ use crate::irq;
 
 /// MUSB OTG controller base address on MT6739.
 /// Source: MT6739 device tree `usb0: usb@11210000`.
-const MUSB_BASE: usize = 0x1121_0000;
 
 // ---------------------------------------------------------------------------
 // Common register offsets (relative to MUSB_BASE)
@@ -838,7 +837,7 @@ impl UsbController {
     /// [`init`]: UsbController::init
     pub(crate) const fn new() -> Self {
         Self {
-            base: MUSB_BASE,
+            base: crate::board::MUSB_BASE,
             ep0_state: Ep0State::Idle,
             pending_address: 0,
             ep0_buf: [0u8; EP0_BUF_LEN],

--- a/crates/thumos/src/watchdog.rs
+++ b/crates/thumos/src/watchdog.rs
@@ -34,16 +34,14 @@ use crate::mmio;
 /// WHY: 0x1000_7000 is the documented WDT base in the MT6739 BSP and matches
 /// the typical MTK layout for this SoC family. Verify against your specific
 /// BSP header (wdt.h or mach/mt_wdt.h) if porting to a different MT variant.
-const WDT_BASE: usize = 0x1000_7000;
-
 /// WDT_MODE: enable/disable and mode control.
-const WDT_MODE: usize = WDT_BASE + 0x00;
+const WDT_MODE: usize = crate::board::WDT_BASE + 0x00;
 
 /// WDT_LENGTH: timeout value register.
-const WDT_LENGTH: usize = WDT_BASE + 0x04;
+const WDT_LENGTH: usize = crate::board::WDT_BASE + 0x04;
 
 /// WDT_RESTART: write 0x1971 here to pet the watchdog.
-const WDT_RESTART: usize = WDT_BASE + 0x08;
+const WDT_RESTART: usize = crate::board::WDT_BASE + 0x08;
 
 /// Magic value required to pet (restart) the watchdog countdown.
 const WDT_RESTART_KEY: u32 = 0x1971;

--- a/crates/thumos/src/wifi.rs
+++ b/crates/thumos/src/wifi.rs
@@ -9,8 +9,8 @@
 //! ## Hardware path
 //!
 //! The MT6739 WiFi hardware is accessed through the WMT combo chip:
-//! - `MT6739_CONSYS = 0x1800_0000` (combo-chip base)
-//! - `MT6739_WLAN  = 0x180F_0000` (WiFi MMIO region)
+//! - `board::CONSYS_BASE = 0x1800_0000` (combo-chip base, board::m7 #534)
+//! - `board::WLAN_BASE  = 0x180F_0000` (WiFi MMIO region, board::m7 #534)
 //!
 //! Data path goes through WMT STP framing (kelyphos handles the transport).
 //! The `WifiHw` struct provides `#[cfg(not(test))]` MMIO access with a
@@ -38,12 +38,6 @@ use crate::security::{hmac_sha1, pbkdf2_hmac_sha1, prf_384};
 // ---------------------------------------------------------------------------
 // MT6739 WiFi hardware constants
 // ---------------------------------------------------------------------------
-
-/// WMT combo-chip (CONSYS) MMIO base address.
-const MT6739_CONSYS: usize = 0x1800_0000;
-
-/// WiFi MMIO base address within the combo-chip region.
-const MT6739_WLAN: usize = 0x180F_0000;
 
 // ---------------------------------------------------------------------------
 // Error types
@@ -1074,6 +1068,7 @@ pub(crate) trait WifiHwOps {
 ///
 /// Provides MMIO-based access to the WiFi hardware on the real target,
 /// and a mock-friendly scan result buffer for testing.
+#[cfg(not(any(test, feature = "qemu")))]
 pub(crate) struct WifiHw {
     /// WLAN MMIO base address.
     wlan_base: usize,
@@ -1083,18 +1078,20 @@ pub(crate) struct WifiHw {
     scan_buf: Vec<ScanResult>,
 }
 
+#[cfg(not(any(test, feature = "qemu")))]
 impl WifiHw {
     /// Construct a new WiFi hardware driver.
     #[must_use]
     pub(crate) const fn new() -> Self {
         Self {
-            wlan_base: MT6739_WLAN,
-            consys_base: MT6739_CONSYS,
+            wlan_base: crate::board::WLAN_BASE,
+            consys_base: crate::board::CONSYS_BASE,
             scan_buf: Vec::new(),
         }
     }
 }
 
+#[cfg(not(any(test, feature = "qemu")))]
 impl WifiHwOps for WifiHw {
     fn data_path_ready(&self) -> bool {
         false

--- a/docs/capability-inventory.toml
+++ b/docs/capability-inventory.toml
@@ -12,7 +12,7 @@
 
 [[capability]]
 id = "kernel-core"
-modules = ["kinit", "kinit_plan", "kardia", "exceptions", "irq", "gic", "mmu", "slab", "page", "heap", "process", "fd", "signal", "elf", "futex", "ipc", "pipe", "socket", "supervisor", "syscall", "reflex", "mmio", "memguard"]
+modules = ["kinit", "kinit_plan", "kardia", "exceptions", "irq", "gic", "mmu", "slab", "page", "heap", "process", "fd", "signal", "elf", "futex", "ipc", "pipe", "socket", "supervisor", "syscall", "reflex", "mmio", "memguard", "board"]
 tier = "emulated-mock-proven"
 witness = ["THUMOS-QEMU: boot-complete", "THUMOS-QEMU: service-loop ticks=", "/init spawned", "shell: hello from userspace", "USERFAULT:"]
 notes = "PL0 isolation, graceful kill, fork/exec/brk/guard witnesses live in the per-probe scripts (kfault/sleep/fork/exec/forkexec/guard/brk/crashloop)."

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -120,8 +120,26 @@ tests = 27
 mechanism = "host"
 
 [[module]]
+name = "board"
+tests = 1
+mechanism = "host"
+fidelity = "shared memory-map tables pinned host-side; MMIO interaction is the m7 boot path (hardware-gated)"
+
+[[module]]
+name = "board/m7"
+tests = 2
+mechanism = "host"
+fidelity = "address tables + registry population pinned host-side; MMIO interaction is the m7 boot path (hardware-gated)"
+
+[[module]]
+name = "board/virt"
+tests = 0
+mechanism = "host"
+fidelity = "virt consts compile only under --features qemu (the armv7a witness builds); the boot witness exercises the virt registry"
+
+[[module]]
 name = "device"
-tests = 7
+tests = 6
 mechanism = "host"
 
 [[module]]
@@ -278,7 +296,7 @@ witness = "boot.sh+crashloop.sh"
 
 [[module]]
 name = "kconfig"
-tests = 4
+tests = 3
 mechanism = "host"
 fidelity = "constant table only — nothing target-executed to diverge"
 
@@ -296,7 +314,7 @@ witness = "boot.sh"
 
 [[module]]
 name = "kinit_plan"
-tests = 22
+tests = 21
 mechanism = "host"
 
 [[module]]

--- a/scripts/check-board-seam.sh
+++ b/scripts/check-board-seam.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# check-board-seam.sh — the #534 standing invariant, enforced as source
+# structure rather than prose. Fails when:
+#   (a) an `MT6739_*` identifier appears anywhere in the kernel crate outside
+#       board/m7.rs (the whole point of the seam; the ccci family is exempt —
+#       its seam is klesis-protocol-vs-kernel-transport, not the board);
+#   (b) a canonical board-MMIO hex value is re-DECLARED as a const outside
+#       board/ (the pre-#534 duplication class: five CONSYS copies, three
+#       UART0 copies). Literal appearances in comments and host-test fault
+#       fixtures (arbitrary-MMIIO-address probes) are not declarations and
+#       are allowed.
+# Board constants live only under board::*; board selection happens once, in
+# board/mod.rs.
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+SRC="$REPO_ROOT/crates/thumos/src"
+
+rc=0
+
+# (a) No MT6739_* identifier outside board/m7.rs and the ccci family.
+# The `+` (not `*`) keeps the prose glob "MT6739_*" from self-matching.
+hits=$(grep -rn 'MT6739_[A-Z0-9_]\+' "$SRC" --include='*.rs' \
+    | grep -v '/board/m7.rs:' \
+    | grep -v '/ccci.rs:' | grep -v '/ccci_logger.rs:' || true)
+if [ -n "$hits" ]; then
+    echo "SEAM DRIFT: MT6739_* identifier outside board::m7 (kernel core must name the board seam, not the SoC):" >&2
+    echo "$hits" >&2
+    rc=1
+fi
+
+# (b) No re-declared board-MMIO const outside board/. Values are the
+# canonical set absorbed by board/m7.rs (#534).
+for hex in 0x1800_0000 0x180F_0000 0x1123_0000 0x1121_0000 0x1400_0000 \
+           0x1400_7000 0x1400_8000 0x1400_D000 0x1400_1000 0x1001_0000 \
+           0x1000_7000 0x1000_D000 0x1000_C104 0x1000_DC00 0x1100_A000 \
+           0x1100_3000 0x77EE_0000 0x1100_2000 0x0C00_0000 0x0C00_2000; do
+    hits=$(grep -rn "const [A-Z0-9_]*: usize = $hex" "$SRC" --include='*.rs' \
+        | grep -v '/board/' || true)
+    if [ -n "$hits" ]; then
+        echo "SEAM DRIFT: board MMIO value $hex re-declared as a const outside board/:" >&2
+        echo "$hits" >&2
+        rc=1
+    fi
+done
+
+[ "$rc" -eq 0 ] && echo "board seam: no MT6739_* outside board::m7, no re-declared board consts"
+exit "$rc"

--- a/scripts/check-target-test-ledger.sh
+++ b/scripts/check-target-test-ledger.sh
@@ -43,8 +43,9 @@ TARGET_PAT = re.compile(r'asm!|core::arch|global_asm|0x[0-9A-Fa-f]{6,}|read_vola
 
 witness_files = {os.path.basename(f) for f in glob.glob(os.path.join(wit_dir, "*.sh"))}
 
-for f in sorted(glob.glob(os.path.join(src_dir, "*.rs"))):
-    m = os.path.basename(f)[:-3]
+for f in sorted(glob.glob(os.path.join(src_dir, "**", "*.rs"), recursive=True)):
+    rel = os.path.relpath(f, src_dir)[:-3]
+    m = rel[:-4] if rel.endswith("/mod") else rel  # board/mod.rs -> "board"
     text = open(f, errors="ignore").read()
     tests = len(re.findall(r'#\[test\]', text))
     sensitive = bool(TARGET_PAT.search(text))
@@ -66,7 +67,8 @@ for f in sorted(glob.glob(os.path.join(src_dir, "*.rs"))):
         fail(f"module '{m}' is host-only with target-sensitive patterns but carries no fidelity note")
 
 for m in by_name:
-    if not os.path.exists(os.path.join(src_dir, m + ".rs")):
+    if not (os.path.exists(os.path.join(src_dir, m + ".rs"))
+            or os.path.exists(os.path.join(src_dir, m, "mod.rs"))):
         fail(f"ledger row '{m}' has no source file")
 
 if rc == 0:


### PR DESCRIPTION
## Summary

thumos already boots one kernel on two boards — qemu-virt (dev, behind `#[cfg(feature = "qemu")]`) and the AGM M7 / MT6739 (field) — but that two-board reality was neither named nor consolidated: board-MMIO constants were duplicated across driver files (five `CONSYS` copies, three `UART0` copies), the `device.rs` registry carried 16 mostly-dead `MT6739_*` constants, and kinit mixed board bring-up with generic init (WiFi/BT/GPS steps probing M7 addresses on virt and relying on qemu's RAZ/WI to fail). This is recognition, not induction: the seam names what already exists.

**The seam** (`crates/thumos/src/board/`):

- `board/mod.rs` — the single selection point (`m7` vs `virt` on the existing `qemu` feature) plus the memory-map constants that are identical on both boards by design (DRAM window, kernel layout, `USER_TEXT_BASE`, display geometry).
- `board/m7.rs` — every MT6739 fact: UART/GIC/eMMC/USB/display/KPD/CONSYS/WLAN/WDT/PMIC/CMU bases, the framebuffer, the LFS partition, and `register_devices` (the 18-entry device set, absorbed from `device.rs`; the stale `musb-hdrc` entry is corrected to the DT node `usb@11210000` = `0x1121_0000`, which `usb.rs` already used).
- `board/virt.rs` — only what the virt machine has: PL011 UART, GICv2, and an honestly-minimal 3-entry registry.

**Standing invariant, enforced as structure** (`scripts/check-board-seam.sh`, wired into ci.yml + `.kanon-ci.toml` like the #551 ledger checker): no `MT6739_*` identifier outside `board::m7` (the ccci modem family stays its own seam), and no board-MMIO value re-declared as a `const` outside `board/`.

**Bring-up honesty**: kinit's WiFi/BT/GPS steps and the LFS mount are now selected out of virt builds (`BootState` defaults already match the old RAZ-probe outcomes, so the boot record is unchanged — the board truth is just named). The real `BtHw`/`FmHw`/`GpsHw`/`WifiHw`/`Mt6357Codec` types no longer compile on virt at all; `emmc`, `usb`, `display` modules and `block::MsdcBlockDevice` are M7-only; the PMIC modem-kill write is M7-only (its bookkeeping stays board-neutral). `device.rs` is the board-neutral registry framework again (the old "Phase 04+ DT" ambition is retired — two static boards want static config). `ARCHITECTURE.md`/`README.md` now state the two-board reality (`vision.md` does not exist; the restatement lands where the project actually frames itself).

Per-subsystem `HwOps` traits are untouched — no mega-HAL, no device-tree parser, no runtime board detection.

**Latent bug exposed and fixed (serial interleave):** the banner/arm timing changes shifted a pre-existing race into the open — kernel thread-mode prints (kinit handoff, kardia loop) run with IRQs live, so a timer IRQ mid-print preempts into userspace whose (already-atomic) writes split the kernel line: the boot witness caught `kardia: modem ready state=` and `Registered` on different lines. SVC/IRQ paths are atomic by hardware (exception entry sets CPSR.I); thread-mode prints now get the same mask — `write_str_raw` in both `uart.rs` and `uart_pl011.rs` runs its byte loop under an IRQ-mask/restore helper. No userspace or timing-contract change (elapsed_ms derives from free-running CNTPCT).

## Verification

- `cargo check` (armv7a, m7 default): clean, zero warnings (`-D warnings` gate).
- `cargo check --features qemu` (armv7a, virt): clean, zero warnings.
- `scripts/kernel-host-tests.sh` (i686 + debug-console pass): **2293/2293 pass** (incl. new `board` + `board/m7` tests).
- `scripts/witness-run-all.sh`: **ALL KERNEL QEMU WITNESSES: PASS** (boot, kfault, sleep, fork, exec, forkexec, guard, brk, crashloop) — boot log evidence: `Rust OS for the QEMU virt (armv7a)`, `3 devices registered`, `WiFi/BT/GPS skipped (virt: no combo chip)`, `kardia: modem ready state=Registered` contiguous.
- `scripts/check-board-seam.sh`: no `MT6739_*` outside `board::m7`, no re-declared board consts.
- `scripts/check-target-test-ledger.sh`: no drift (extended to recurse `src/**/*.rs` for the new `board/` submodule; rows added for `board`, `board/m7`, `board/virt`).
- `scripts/check-wiring-inventory.sh --no-log`: 115 modules classified (`board` in kernel-core).
- `cargo fmt --manifest-path crates/thumos/Cargo.toml --check`: clean.

Closes #534
