### PR TITLE
block: partition-addressed LFS — PartitionBlockDevice view (#603)

### DIFF
--- a/crates/thumos/src/block.rs
+++ b/crates/thumos/src/block.rs
@@ -97,6 +97,86 @@ pub(crate) trait BlockDevice {
 }
 
 // ---------------------------------------------------------------------------
+// PartitionBlockDevice — partition view over a physical device (#603)
+// ---------------------------------------------------------------------------
+
+/// A partition view over a physical [`BlockDevice`]: view LBAs `[0, len)`
+/// map onto `base_lba + lba` of the inner device, and every access is
+/// bounds-checked against the partition length — never the whole device.
+///
+/// WHY (#603): `MsdcBlockDevice` addressed the eMMC from physical sector 0,
+/// so the LFS mount path would have written the GPT/boot region instead of
+/// the userdata partition (`LFS_PARTITION_START` had no consumer). The view
+/// makes partition addressing explicit and host-testable: a
+/// `MemBlockDevice` stands in as the physical device, the view as the
+/// partition. The #449 secrets preamble is a second view onto the same
+/// userdata partition's head sectors.
+///
+/// WHY the gate: the only production consumer today is the eMMC/LFS mount
+/// path, which is M7-only (#534) — on virt the view would be dead surface.
+#[cfg(not(feature = "qemu"))]
+pub(crate) struct PartitionBlockDevice<D: BlockDevice> {
+    /// The physical device this view carves from.
+    inner: D,
+    /// First physical sector of the partition.
+    base_lba: u64,
+    /// Partition length in sectors.
+    sector_count: u64,
+}
+
+#[cfg(not(feature = "qemu"))]
+impl<D: BlockDevice> PartitionBlockDevice<D> {
+    /// Create a partition view `[base_lba, base_lba + sector_count)` of
+    /// `inner`. `base_lba` must be within the inner device's bounds; every
+    /// I/O revalidates the range against the partition length.
+    pub(crate) const fn new(inner: D, base_lba: u64, sector_count: u64) -> Self {
+        Self {
+            inner,
+            base_lba,
+            sector_count,
+        }
+    }
+
+    /// Consume the view and return the physical device.
+    #[cfg(test)]
+    pub(crate) fn into_inner(self) -> D {
+        self.inner
+    }
+
+    /// Translate a view `[lba, lba+count)` to its physical base LBA,
+    /// bounds-checked against the partition length (and u64 overflow).
+    fn translate(&self, lba: u64, count: u32) -> Result<u64, BlockError> {
+        let end = lba
+            .checked_add(u64::from(count))
+            .ok_or(BlockError::OutOfBounds)?;
+        if end > self.sector_count {
+            return Err(BlockError::OutOfBounds);
+        }
+        self.base_lba
+            .checked_add(lba)
+            .ok_or(BlockError::OutOfBounds)
+    }
+}
+
+#[cfg(not(feature = "qemu"))]
+impl<D: BlockDevice> BlockDevice for PartitionBlockDevice<D> {
+    fn read_sectors(&self, lba: u64, count: u32, buf: &mut [u8]) -> Result<(), BlockError> {
+        let phys = self.translate(lba, count)?;
+        self.inner.read_sectors(phys, count, buf)
+    }
+
+    fn write_sectors(&mut self, lba: u64, count: u32, buf: &[u8]) -> Result<(), BlockError> {
+        let phys = self.translate(lba, count)?;
+        self.inner.write_sectors(phys, count, buf)
+    }
+
+    /// The PARTITION length in sectors — never the physical device's.
+    fn sector_count(&self) -> u64 {
+        self.sector_count
+    }
+}
+
+// ---------------------------------------------------------------------------
 // MemBlockDevice — in-memory mock
 // ---------------------------------------------------------------------------
 
@@ -385,6 +465,81 @@ pub(crate) mod tests {
     use alloc::vec;
 
     use super::*;
+
+    // -- PartitionBlockDevice (#603): partition addressing is real ---------
+
+    /// A sector-sized pattern buffer for view tests.
+    fn pattern(fill: u8) -> alloc::vec::Vec<u8> {
+        vec![fill; SECTOR_SIZE]
+    }
+
+    #[test]
+    fn partition_view_translates_view_lba_to_physical() {
+        let mut phys = MemBlockDevice::new(32).expect("phys device");
+        let mut view = PartitionBlockDevice::new(phys, 10, 5);
+
+        // Write two sectors at view lba 1; they must land at physical 11.
+        let mut two = pattern(0xA5);
+        two.extend_from_within(..);
+        view.write_sectors(1, 2, &two).expect("view write");
+
+        // Read back through the view.
+        let mut got = vec![0u8; 2 * SECTOR_SIZE];
+        view.read_sectors(1, 2, &mut got).expect("view read");
+        assert_eq!(got, two, "view read must return what the view wrote");
+    }
+
+    #[test]
+    fn partition_view_never_touches_below_base() {
+        let mut phys = MemBlockDevice::new(32).expect("phys device");
+        // Pre-fill the whole physical device with a marker.
+        let marker = pattern(0x11);
+        for lba in 0..32 {
+            phys.write_sectors(lba, 1, &marker).expect("pre-fill");
+        }
+        let mut view = PartitionBlockDevice::new(phys, 10, 5);
+        view.write_sectors(0, 1, &pattern(0xFF))
+            .expect("view write");
+
+        // The inner device is moved into the view; verify via the view that
+        // the write went to view lba 0 (physical 10) only — and that a view
+        // of the region BELOW the partition is untouched (physical 0..10).
+        let mut got = vec![0u8; SECTOR_SIZE];
+        view.read_sectors(0, 1, &mut got).expect("read back");
+        assert_eq!(got, pattern(0xFF));
+
+        let below = PartitionBlockDevice::new(view.into_inner(), 0, 10);
+        let mut below_buf = vec![0u8; SECTOR_SIZE];
+        below
+            .read_sectors(9, 1, &mut below_buf)
+            .expect("read below base");
+        assert_eq!(
+            below_buf,
+            pattern(0x11),
+            "physical sectors below the partition base must be untouched"
+        );
+    }
+
+    #[test]
+    fn partition_view_bounds_check_uses_partition_length() {
+        let phys = MemBlockDevice::new(32).expect("phys device");
+        let mut view = PartitionBlockDevice::new(phys, 10, 5);
+
+        // lba 4 is the last in-partition sector; lba 5 is out even though
+        // the physical device has plenty of room past it.
+        assert!(view.write_sectors(4, 1, &pattern(0x77)).is_ok());
+        assert_eq!(
+            view.write_sectors(5, 1, &pattern(0x77)).err(),
+            Some(BlockError::OutOfBounds),
+            "past-partition write must fail even with physical space left"
+        );
+        let mut buf = vec![0u8; 2 * SECTOR_SIZE];
+        assert_eq!(
+            view.read_sectors(4, 2, &mut buf).err(),
+            Some(BlockError::OutOfBounds),
+            "a range crossing the partition end must fail"
+        );
+    }
 
     #[test]
     fn create_mem_device_with_correct_size() {

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -603,13 +603,22 @@ pub unsafe fn run() -> ! {
         // Compute device size in sectors from the partition constants.
         let sector_count = board::LFS_PARTITION_SIZE;
 
-        // Create a block device wrapping the eMMC controller at the LFS partition.
-        let mut blk_dev = MsdcBlockDevice::new(sector_count);
+        // #603: the eMMC block device addresses the PHYSICAL medium (its LBA
+        // 0 is the eMMC's sector 0 -- the GPT/boot region), so its bound is
+        // the partition's END; the LFS mount then runs inside the userdata
+        // partition VIEW carved at LFS_PARTITION_START. Before the view, LFS
+        // would have formatted over the boot/vendor partitions.
+        let mut phys_dev = MsdcBlockDevice::new(board::LFS_PARTITION_START + sector_count);
 
         // SAFETY: eMMC controller was initialized successfully in Step 7.
         // MsdcBlockDevice::init() is called once here; the controller is ready.
-        match unsafe { blk_dev.init() } {
+        match unsafe { phys_dev.init() } {
             Ok(()) => {
+                let blk_dev = crate::block::PartitionBlockDevice::new(
+                    phys_dev,
+                    board::LFS_PARTITION_START,
+                    sector_count,
+                );
                 // Try to mount existing LFS.
                 match lfs::mount(alloc::boxed::Box::new(blk_dev)) {
                     Ok(fs) => {
@@ -624,44 +633,60 @@ pub unsafe fn run() -> ! {
                     // transient I/O fault (#360).
                     Err(LfsError::InvalidSuperblock) => {
                         serial.log(" LFS mount failed (no superblock), formatting\r\n");
-                        let mut fmt_dev = MsdcBlockDevice::new(sector_count);
+                        let mut fmt_phys =
+                            MsdcBlockDevice::new(board::LFS_PARTITION_START + sector_count);
                         // SAFETY: eMMC controller was initialized successfully in
-                        // Step 7; fmt_dev.init() is called once here on a
+                        // Step 7; fmt_phys.init() is called once here on a
                         // freshly constructed MsdcBlockDevice.
-                        if unsafe { fmt_dev.init() }.is_ok() && lfs::format(&mut fmt_dev).is_ok() {
-                            serial.log(" LFS formatted OK\r\n");
-                            // Remount the freshly formatted device so the
-                            // VFS root is backed by durable storage from
-                            // this boot onward, not just after the NEXT
-                            // reboot (#343).
-                            let mut remount_dev = MsdcBlockDevice::new(sector_count);
-                            // SAFETY: eMMC controller was initialized successfully
-                            // in Step 7; remount_dev.init() is called once here on
-                            // a freshly constructed MsdcBlockDevice.
-                            match unsafe { remount_dev.init() } {
-                                Ok(()) => match lfs::mount(alloc::boxed::Box::new(remount_dev)) {
-                                    Ok(fs) => {
-                                        serial.log(" LFS remounted OK\r\n");
-                                        lfs_root = Some(alloc::boxed::Box::new(fs));
+                        if unsafe { fmt_phys.init() }.is_ok() {
+                            let mut fmt_dev = crate::block::PartitionBlockDevice::new(
+                                fmt_phys,
+                                board::LFS_PARTITION_START,
+                                sector_count,
+                            );
+                            if lfs::format(&mut fmt_dev).is_ok() {
+                                serial.log(" LFS formatted OK\r\n");
+                                // Remount the freshly formatted device so the
+                                // VFS root is backed by durable storage from
+                                // this boot onward, not just after the NEXT
+                                // reboot (#343).
+                                let mut remount_phys =
+                                    MsdcBlockDevice::new(board::LFS_PARTITION_START + sector_count);
+                                // SAFETY: eMMC controller was initialized successfully
+                                // in Step 7; remount_phys.init() is called once here on
+                                // a freshly constructed MsdcBlockDevice.
+                                match unsafe { remount_phys.init() } {
+                                    Ok(()) => {
+                                        let remount_dev = crate::block::PartitionBlockDevice::new(
+                                            remount_phys,
+                                            board::LFS_PARTITION_START,
+                                            sector_count,
+                                        );
+                                        match lfs::mount(alloc::boxed::Box::new(remount_dev)) {
+                                            Ok(fs) => {
+                                                serial.log(" LFS remounted OK\r\n");
+                                                lfs_root = Some(alloc::boxed::Box::new(fs));
+                                            }
+                                            Err(e) => {
+                                                boot_log!(
+                                                    serial,
+                                                    " WARN LFS remount after format failed: {:?}\r\n",
+                                                    e
+                                                );
+                                            }
+                                        }
                                     }
                                     Err(e) => {
                                         boot_log!(
                                             serial,
-                                            " WARN LFS remount after format failed: {:?}\r\n",
+                                            " WARN Block device re-init for remount failed: {:?}\r\n",
                                             e
                                         );
                                     }
-                                },
-                                Err(e) => {
-                                    boot_log!(
-                                        serial,
-                                        " WARN Block device re-init for remount failed: {:?}\r\n",
-                                        e
-                                    );
                                 }
+                            } else {
+                                serial.log(" WARN LFS format failed\r\n");
                             }
-                        } else {
-                            serial.log(" WARN LFS format failed\r\n");
                         }
                     }
                     Err(e) => {

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -50,7 +50,7 @@ mechanism = "host"
 
 [[module]]
 name = "block"
-tests = 11
+tests = 14
 mechanism = "host"
 
 [[module]]


### PR DESCRIPTION
## Summary

`MsdcBlockDevice` addressed the eMMC from **physical sector 0**: its LBA 0 is the medium's first sector (the GPT/boot region), and `LFS_PARTITION_START` (the userdata offset from the GPT dump) had zero consumers. kinit's Step 8c comment claimed "a block device wrapping the eMMC controller at the LFS partition", but no partition offset was ever applied — the first hardware boot to reach 8c would have formatted or mounted LFS over the boot/vendor partitions. Host tests were structurally blind to this (the RAM-backed double honestly starts at 0).

**Fix**: a host-testable `PartitionBlockDevice<D>` view — view LBAs `[0, len)` map onto `base_lba + lba` of the inner device, bounds-checked against the partition length (never the physical device). kinit 8c now constructs the physical `MsdcBlockDevice` with the partition's END as its bound and mounts/formats/remounts LFS inside the userdata view at `board::LFS_PARTITION_START` / `board::LFS_PARTITION_SIZE`. The view is M7-only in production (the mount path is #534-gated); its tests run host-side against the `MemBlockDevice` double.

This is the partition-addressing fix the #449 secrets preamble also builds on (the preamble is a second view onto the userdata partition's head sectors).

## Verification

- `scripts/kernel-host-tests.sh` (i686 + debug-console pass): **2300/2300 pass** — 3 new view tests prove view→physical translation, below-base immunity, and partition-length bounds (not device-length).
- `cargo check` (armv7a, m7) + `cargo check --features qemu` (virt): both clean, zero warnings (the view is `not(qemu)`-gated; `into_inner` is test-only).
- `scripts/witness-run-all.sh`: **ALL KERNEL QEMU WITNESSES: PASS** (all 10, incl. signal)
- `cargo fmt --manifest-path crates/thumos/Cargo.toml`: clean.

Closes #603
