### PR TITLE
pteron: spec-conformant RPA — ah() per Appendix D + zeroized Irk (#455 stages 1-2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,9 +903,11 @@ dependencies = [
 name = "pteron"
 version = "0.1.16"
 dependencies = [
+ "aes",
  "jiff",
  "log",
  "snafu",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/pteron/Cargo.toml
+++ b/crates/pteron/Cargo.toml
@@ -8,6 +8,8 @@ publish.workspace = true
 repository.workspace = true
 
 [dependencies]
+aes = "0.8"
+zeroize = "1"
 jiff = { workspace = true }
 snafu = { workspace = true }
 log = { workspace = true }

--- a/crates/pteron/src/lib.rs
+++ b/crates/pteron/src/lib.rs
@@ -15,4 +15,5 @@ pub mod ble;
 pub mod config;
 pub mod device;
 pub mod hci;
+pub mod smp;
 pub mod transport;

--- a/crates/pteron/src/smp.rs
+++ b/crates/pteron/src/smp.rs
@@ -1,0 +1,151 @@
+//! SMP cryptographic toolbox subset (#455): the `ah()` random-address hash
+//! function (BT Core Spec Vol 3, Part H §2.2.2) and the Identity Resolving
+//! Key type.
+//!
+//! # Byte-order convention
+//!
+//! Everything in this module is **big-endian display order**, the same
+//! convention `transport.rs` uses for `BdAddr` (index 0 = display MSB) and
+//! the convention the spec's Appendix D test vectors are written in. That
+//! makes `ah()` byte-for-byte the spec's definition — `r' = padding || r`
+//! and `ah(k, r) = e(k, r') mod 2^24` — with NO byte reversal anywhere.
+//! (The LE-over-air swap dance Linux's `smp_ah` performs exists only
+//! because Linux stores keys/addresses little-endian; this crate's HCI
+//! layer already converts at the packet boundary, `build_le_*_cmd`.)
+//!
+//! Verified against Core Spec Vol 3, Part H, Appendix D.7 (v5.4 p1644):
+//! IRK `ec0234a357c8ad05341010a60a397d9b`, prand `708194`,
+//! AES `159d5fb7 2ebe2311 a48c1bdc c40dfbaa`, ah `0dfbaa` — see the tests.
+
+use aes::Aes128;
+use aes::cipher::{BlockEncrypt, KeyInit, generic_array::GenericArray};
+use zeroize::Zeroize;
+
+/// The `ah()` random-address hash function (Vol 3, Part H §2.2.2):
+/// `ah(k, r) = e(k, r') mod 2^24`, AES-128-ECB single block.
+///
+/// - `irk` — the Identity Resolving Key, 16 bytes big-endian display order.
+/// - `prand` — the 22-bit random, 3 bytes big-endian display order (its top
+///   two bits carry the RPA type field; they are input bits, not masked here).
+///
+/// Returns the 24-bit hash, 3 bytes big-endian display order.
+pub(crate) fn ah(irk: &[u8; 16], prand: &[u8; 3]) -> [u8; 3] {
+    // r' = padding(104 bits) || r(24 bits): thirteen zero bytes, then prand.
+    let mut m = [0u8; 16];
+    m[13..].copy_from_slice(prand);
+    // Aes128::new takes the 16-byte key by reference — no fallible slice
+    // conversion, so no unwrap/expect anywhere in the primitive.
+    let cipher = Aes128::new(GenericArray::from_slice(irk));
+    let mut block = *GenericArray::from_slice(&m);
+    cipher.encrypt_block(&mut block);
+    // mod 2^24: the least significant 24 bits of the big-endian output —
+    // the last three octets of the ciphertext block.
+    [block[13], block[14], block[15]]
+}
+
+/// An Identity Resolving Key (#455 stage 2): 16 bytes, zeroized on drop,
+/// redacted in Debug.
+///
+/// # Persistence seam (deliberate boundary)
+///
+/// An IRK must survive our own address rotations and reboots to be useful,
+/// but it is a SECRET: in cleartext on disk it defeats the unlinkability it
+/// exists to provide (a device in hand would resolve every past RPA). The
+/// designed home is slot kind 2 of the kernel's on-disk secrets preamble
+/// (#449) — a slot SEALED under the passphrase-derived primary key once the
+/// boot input loop (kinit Step 8d) exists to derive it. An unsealed
+/// on-disk write is rejected for the same reason a device-id-derived
+/// sealing key is rejected (attacker-readable from a device in hand). So
+/// today the IRK lives in RAM only: generated at boot/pairing, zeroized on
+/// drop. The sealed persistence lands with 8d, not before.
+pub(crate) struct Irk([u8; 16]);
+
+impl Irk {
+    /// Generate a fresh random IRK (`getrandom` in production, an injected
+    /// stream in tests).
+    pub(crate) fn generate(random: impl FnOnce(&mut [u8; 16])) -> Self {
+        let mut bytes = [0u8; 16];
+        random(&mut bytes);
+        Self(bytes)
+    }
+
+    /// Wrap existing bytes (restore from the sealed store, test vectors).
+    pub(crate) const fn from_bytes(bytes: [u8; 16]) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the key bytes (big-endian display order).
+    pub(crate) const fn as_bytes(&self) -> &[u8; 16] {
+        &self.0
+    }
+}
+
+impl Drop for Irk {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+impl core::fmt::Debug for Irk {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("Irk([REDACTED])")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Core Spec v5.4 Vol 3 Part H Appendix `D.7` (p1644): the canonical `ah()`
+    /// vector, big-endian display order throughout.
+    const APPENDIX_D_IRK: [u8; 16] = [
+        0xec, 0x02, 0x34, 0xa3, 0x57, 0xc8, 0xad, 0x05, 0x34, 0x10, 0x10, 0xa6, 0x0a, 0x39, 0x7d,
+        0x9b,
+    ];
+
+    #[test]
+    fn ah_matches_appendix_d_7() {
+        let prand = [0x70, 0x81, 0x94];
+        let hash = ah(&APPENDIX_D_IRK, &prand);
+        assert_eq!(
+            hash,
+            [0x0d, 0xfb, 0xaa],
+            "ah(IRK, 708194) must equal the spec's 0dfbaa (AES 159d5fb7..0dfbaa)"
+        );
+    }
+
+    #[test]
+    fn ah_is_deterministic_and_prand_sensitive() {
+        let prand = [0x70, 0x81, 0x94];
+        assert_eq!(ah(&APPENDIX_D_IRK, &prand), ah(&APPENDIX_D_IRK, &prand));
+        let other = [0x70, 0x81, 0x95];
+        assert_ne!(
+            ah(&APPENDIX_D_IRK, &prand),
+            ah(&APPENDIX_D_IRK, &other),
+            "a one-bit prand change must change the hash (it is an AES block)"
+        );
+    }
+
+    #[test]
+    fn irk_debug_is_redacted() {
+        let irk = Irk::from_bytes([0xAA; 16]);
+        let dbg = format!("{irk:?}");
+        assert_eq!(dbg, "Irk([REDACTED])");
+        assert!(!dbg.contains("aa"), "IRK bytes must never appear in Debug");
+    }
+
+    #[test]
+    fn irk_generate_uses_the_injected_stream() {
+        let irk = Irk::generate(|buf: &mut [u8; 16]| {
+            for (i, b) in buf.iter_mut().enumerate() {
+                *b = i as u8;
+            }
+        });
+        assert_eq!(irk.as_bytes()[0], 0);
+        assert_eq!(irk.as_bytes()[15], 15);
+    }
+}

--- a/crates/pteron/src/transport.rs
+++ b/crates/pteron/src/transport.rs
@@ -436,35 +436,24 @@ pub(crate) const fn generate_nrpa(entropy: &[u8; 6]) -> BdAddr {
     BdAddr::from_bytes([b0, b1, b2, b3, b4, b5])
 }
 
-/// Generate an address with RPA type bits SET (two MSBs = 0b01).
+/// Generate a Resolvable Private Address per BT Core Spec Vol 6, Part B
+/// §1.3.2.2 (#455): `[prand(22b) | 0b01(2b MSB)] : [ah(IRK, prand)(24b)]`.
 ///
-/// SECURITY GAP (too large for a mechanical fix; tracked separately): this
-/// does NOT compute a spec-conformant Resolvable Private Address. Per BT
-/// Core Spec Vol 6, Part B §1.3.2.2, an RPA's lower 24 bits MUST equal
-/// `ah(IRK, prand)` — an AES-128 hash of the upper 22-bit prand under the
-/// bonded peer's Identity Resolving Key — so a bonded peer can resolve the
-/// address back to our identity. This function fills BOTH the prand region
-/// AND the hash region FROM raw `entropy`, with no relation to any IRK. The
-/// result:
-/// - is NOT resolvable by any bonded peer (defeats reconnection, bonded
-///   auto-connect, and directed-advertising use cases that rely on RPA
-///   resolution), and
-/// - is NOT a valid RPA per spec, while still asserting via the type bits
-///   that it is one — worse than an NRPA for any caller that branches on
-///   the address-type bits and assumes resolvability.
+/// - `irk` — the Identity Resolving Key, 16 bytes big-endian display order
+///   (see `smp.rs`; ours while unbonded, the bonded peer's once SMP lands).
+/// - `prand` — 3 bytes big-endian display order, drawn independently by the
+///   caller for each rotation; only the low 22 bits are used, the top two
+///   are forced to the RPA type field 0b01.
 ///
-/// A conformant implementation needs an `ah()` AES-128 primitive (this
-/// crate has no AES dependency and no raw-ECB usage pattern anywhere), an
-/// IRK generation/storage seam (zeroized, persistent across our own address
-/// rotations), and an SMP (Security Manager Protocol) bonding flow to
-/// exchange IRKs with peers (this crate has no L2CAP/SMP layer at all —
-/// HCI/STP transport only). None of those seams exist yet; do not treat
-/// this function's output as a real RPA.
-pub(crate) const fn generate_rpa(entropy: &[u8; 6]) -> BdAddr {
-    let [mut b0, b1, b2, b3, b4, b5] = *entropy;
+/// The lower 24 bits are `ah(IRK, prand)` (spec AES-128 hash), so a bonded
+/// peer can resolve the address back to our identity — the property the
+/// pre-#455 raw-entropy fill did not have.
+pub(crate) fn generate_rpa(irk: &[u8; 16], prand: &[u8; 3]) -> BdAddr {
+    let [p0, p1, p2] = *prand;
     // Force two MSBs to 0b01 in the most-significant byte (index 0 = display MSB)
-    b0 = (b0 & !RANDOM_ADDR_MSB_MASK) | RPA_MSB_BITS;
-    BdAddr::from_bytes([b0, b1, b2, b3, b4, b5])
+    let b0 = (p0 & !RANDOM_ADDR_MSB_MASK) | RPA_MSB_BITS;
+    let hash = crate::smp::ah(irk, prand);
+    BdAddr::from_bytes([b0, p1, p2, hash[0], hash[1], hash[2]])
 }
 
 /// Build the `HCI_LE_Set_Random_Address` command packet (OGF=0x08, OCF=0x0005).
@@ -1075,10 +1064,16 @@ mod tests {
         );
     }
 
+    /// The Appendix `D.7` IRK, shared with smp.rs's `ah()` vector tests.
+    const APPENDIX_D_IRK: [u8; 16] = [
+        0xec, 0x02, 0x34, 0xa3, 0x57, 0xc8, 0xad, 0x05, 0x34, 0x10, 0x10, 0xa6, 0x0a, 0x39, 0x7d,
+        0x9b,
+    ];
+
     #[test]
     fn rpa_two_msbs_are_01() {
-        let entropy = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
-        let addr = generate_rpa(&entropy);
+        let prand = [0x00, 0x00, 0x00];
+        let addr = generate_rpa(&APPENDIX_D_IRK, &prand);
         let msb = addr.as_bytes()[0];
         assert_eq!(
             msb & RANDOM_ADDR_MSB_MASK,
@@ -1088,18 +1083,39 @@ mod tests {
     }
 
     #[test]
-    fn rpa_lower_bits_preserved() {
-        let entropy = [0x7F, 0x11, 0x22, 0x33, 0x44, 0x55];
-        let addr = generate_rpa(&entropy);
+    fn rpa_layout_is_prand_then_ah_hash() {
+        // The spec RPA: [prand(22b) | 0b01(2b)] : [ah(IRK, prand)(24b)].
+        // Appendix D.7: prand 708194 -> hash 0dfbaa.
+        let prand = [0x70, 0x81, 0x94];
+        let addr = generate_rpa(&APPENDIX_D_IRK, &prand);
+        let bytes = addr.as_bytes();
         assert_eq!(
-            addr.as_bytes()[0] & !RANDOM_ADDR_MSB_MASK,
-            entropy.first().copied().unwrap_or_default() & !RANDOM_ADDR_MSB_MASK,
-            "lower bits of MSB byte must be preserved FROM entropy"
+            bytes[0],
+            0x70 & !RANDOM_ADDR_MSB_MASK | RPA_MSB_BITS,
+            "MSB carries prand's low 22 bits plus the 0b01 type field"
         );
+        assert_eq!(bytes[1], 0x81, "prand byte 1 preserved");
+        assert_eq!(bytes[2], 0x94, "prand byte 2 preserved");
         assert_eq!(
-            &addr.as_bytes()[1..],
-            &entropy[1..],
-            "bytes 1-5 of RPA must be copied FROM entropy unchanged"
+            &bytes[3..],
+            &[0x0d, 0xfb, 0xaa],
+            "the hash field is ah(IRK, prand) — resolvable by a bonded peer (#455)"
+        );
+    }
+
+    #[test]
+    fn rpa_resolution_round_trip() {
+        // A bonded peer resolves an RPA by recomputing ah(IRK, prand) and
+        // comparing the hash field — the contract #455 exists to provide.
+        let prand = [0x21, 0x43, 0x65];
+        let addr = generate_rpa(&APPENDIX_D_IRK, &prand);
+        let bytes = addr.as_bytes();
+        let recovered_prand = [bytes[0] & !RANDOM_ADDR_MSB_MASK, bytes[1], bytes[2]];
+        let recomputed = crate::smp::ah(&APPENDIX_D_IRK, &recovered_prand);
+        assert_eq!(
+            &bytes[3..],
+            &recomputed,
+            "the hash field must resolve against the embedded prand"
         );
     }
 


### PR DESCRIPTION
## Summary

`pteron::transport::generate_rpa` set the RPA type bits (two MSBs = 0b01) but filled the lower 24 bits with raw entropy — not a resolvable, or even valid, Resolvable Private Address. Worse than an NRPA for any peer that branches on the type bits and assumes resolvability.

**Stage 1 — `ah()`**: new `pteron::smp` module implements `ah(k, r) = e(k, r') mod 2^24` (Vol 3 Part H §2.2.2) as a single AES-128-ECB block, **verified against the spec's own Appendix D.7 vector** (Core Spec v5.4 p1644: IRK `ec0234a357c8ad05341010a60a397d9b`, prand `708194`, AES `159d5fb7 2ebe2311 a48c1bdc c40dfbaa`, ah `0dfbaa`). The LSB/MSB gotcha the issue warns about dissolves into the crate's existing big-endian display convention (`BdAddr` index 0 = display MSB): `r' = padding || r` and the 24-bit truncation are exactly the spec's layout — no swap dance. `generate_rpa(irk, prand)` now produces `[prand(22b)|0b01] : [ah(IRK, prand)(24b)]`, with a resolution round-trip test pinning the bonded-peer contract. The byte ordering was triangulated against three sources: the spec vector, Linux's `smp_ah` pipeline, and an independent openssl reproduction (all in the module docs/tests).

**Stage 2 — the IRK seam**: `Irk` — 16 bytes, `zeroize`-on-drop, redacted Debug, generated from an injected random stream. Persistence is deliberately bounded: an IRK in cleartext on disk defeats the unlinkability it exists to provide, so the designed home is slot kind 2 of the kernel's secrets preamble (#449) **sealed** under the passphrase-derived key once the 8d boot input loop exists. An unsealed write is rejected for the same reason a device-id-derived sealing key is (attacker-readable from a device in hand). RAM-only until then — this is a no-compromise boundary, not a stub.

**Stage 3** (SMP/L2CAP bonding flow, the largest gap) is explicitly hardware-ledger work: this crate has no L2CAP/SMP layer at all.

## Verification

- `cargo test -p pteron`: **74/74 pass** — new tests: Appendix D.7 vector, determinism + prand sensitivity, RPA layout (`[prand|0b01]:[ah]`), resolution round-trip, IRK redaction, injected-stream generation.
- `cargo clippy -p pteron --all-targets -- -D warnings`: clean.
- `cargo fmt`: clean.

Refs #455