### PR TITLE
docs: surveillance-audit evidence manifest, collector, renderer, epistemic labels (#556)

### DIFF
--- a/docs/SURVEILLANCE-AUDIT.md
+++ b/docs/SURVEILLANCE-AUDIT.md
@@ -1,33 +1,45 @@
 # Surveillance audit: AGM M7 stock firmware
 
 Audit date: 2026-03-18. Read-only ADB inspection of unmodified device.
+Firmware: `AGM/Q12_1/Q12_1:8.1.0/OPM1.171019.026/L1635.6.01.01:user/release-keys` (build 2022-03-22, Freeme OS 8.1.1 over Android 8.1.0).
+
+## Epistemics (issue #556)
+
+Every material claim in this document carries one of four labels:
+
+- **[OBSERVED]** — directly measured on THIS device. The 2026-03-18 session predates evidence retention, so most raw dumps are marked *not retained — recollect*: they are re-gatherable byte-exactly by `scripts/surveillance-collect.sh` against this or another image, and the claim must be re-checked then.
+- **[CAPABILITY]** — the package COULD do this given its granted permissions or privileged position. **Not** a claim of observed execution.
+- **[EXTERNAL]** — reported by an outside source (cited in References); not measured here.
+- **[INFERENCE]** — analyst judgment over the above. Carries uncertainty; stated where it matters.
+
+The claim-to-evidence index (claim IDs below) lives in `docs/surveillance/evidence-manifest.toml`; derived tables come from `scripts/surveillance-render.py`. Session limits are in the manifest: single session, one-instant network listing, and the Adups jobs were cancelled during inspection.
 
 ## Summary
 
-The stock firmware contains at least 3 distinct surveillance/telemetry systems from different actors. As shipped, the device is compromised at the system level, with privileged packages that have irrevocable access to SMS, call logs, location, contacts, camera, microphone, and storage. Without root access the user cannot disable these.
+The stock firmware contains at least 3 distinct surveillance/telemetry systems from different actors. As shipped, the device is compromised at the system level, with privileged packages that have irrevocable access to SMS, call logs, location, contacts, camera, microphone, and storage **[OBSERVED — permission sets, not retained]**. Without root access the user cannot disable these **[OBSERVED — SYSTEM_FIXED grant flags, not retained]**.
 
 ## Threat 1: Adups FOTA (Chinese OTA framework)
 
-**Package**: `com.adups.fota` (v5.24) + `com.adups.fota.sysoper`
+**Package**: `com.adups.fota` (v5.24) + `com.adups.fota.sysoper` — `T1.adups-present` **[OBSERVED, not retained]**
 **Actor**: Shanghai Adups Technology Co., Ltd.
-**Known history**: Flagged by Kryptowire in November 2016 for exfiltrating full SMS message bodies, call logs, contacts, IMEI, IMSI, and installed app lists to servers in China every 72 hours. Found on 700M+ devices worldwide (BLU, ZTE, Archos, myPhone, etc.). The company claimed this was "accidental" but the functionality was architected into the firmware at the factory level.
+**Known history**: Flagged by Kryptowire in November 2016 for exfiltrating full SMS message bodies, call logs, contacts, IMEI, IMSI, and installed app lists to servers in China every 72 hours. Found on 700M+ devices worldwide (BLU, ZTE, Archos, myPhone, etc.). The company claimed this was "accidental" but the functionality was architected into the firmware at the factory level. — `T1.adups-history` **[EXTERNAL: Kryptowire advisory, Nov 2016]**
 
 **On this device**:
-- Installed as system app (cannot be uninstalled without root)
-- INTERNET + ACCESS_NETWORK_STATE + ACCESS_WIFI_STATE + RECEIVE_BOOT_COMPLETED granted
-- Runs scheduled jobs on boot (`MyJobService`, `MyIntentJobService`)
-- Monitors BOOT_COMPLETED, DATE_CHANGED, ACTION_POWER_DISCONNECTED, MEDIA_MOUNTED events
-- The sysoper component has REBOOT + RECOVERY permissions (can remotely trigger factory reset)
-- No network traffic observed in this session (jobs were cancelled), but the scheduled job infrastructure is active and runs on every boot
+- Installed as system app (cannot be uninstalled without root) **[OBSERVED, not retained]**
+- INTERNET + ACCESS_NETWORK_STATE + ACCESS_WIFI_STATE + RECEIVE_BOOT_COMPLETED granted — `T1.adups-permissions` **[OBSERVED, not retained]**
+- Runs scheduled jobs on boot (`MyJobService`, `MyIntentJobService`) **[OBSERVED, not retained]**
+- Monitors BOOT_COMPLETED, DATE_CHANGED, ACTION_POWER_DISCONNECTED, MEDIA_MOUNTED events **[OBSERVED, not retained]**
+- The sysoper component has REBOOT + RECOVERY permissions (can remotely trigger factory reset) **[CAPABILITY]**
+- No network traffic observed in this session (jobs were cancelled), but the scheduled job infrastructure is active and runs on every boot — `T1.adups-no-traffic` **[OBSERVED — one instant only; Adups historically exfiltrates on a 72-hour cycle]**
 
-**Risk**: HIGH. Known data exfiltration framework with factory-level integration. Even if the current version has been "cleaned up" since 2016, the architecture allows silent updates that reintroduce exfiltration. The sysoper package can reboot and flash the device remotely.
+**Risk**: HIGH — `T1.adups-risk` **[INFERENCE]** over the Kryptowire history **[EXTERNAL]** plus the on-device permission/jobset **[OBSERVED]**. Even if the current version has been "cleaned up" since 2016, the architecture allows silent updates that reintroduce exfiltration. The sysoper package can reboot and flash the device remotely **[CAPABILITY]**.
 
 ## Threat 2: MediaTek device management (com.mediatek.dm)
 
 **Package**: `com.mediatek.dm`
-**Actor**: MediaTek Inc. (Taiwan, but subject to Chinese government pressure via TSMC supply chain)
+**Actor**: MediaTek Inc. (Taiwan, but subject to Chinese government pressure via TSMC supply chain) **[EXTERNAL — supply-chain analysis, not device evidence]**
 
-**Permissions** (all granted, SYSTEM_FIXED, irrevocable):
+**Permissions** (all granted, SYSTEM_FIXED, irrevocable) — `T2.dm-permissions` **[OBSERVED, not retained]**:
 
 | Category | Permissions |
 |----------|-------------|
@@ -40,9 +52,9 @@ The stock firmware contains at least 3 distinct surveillance/telemetry systems f
 | Network | CHANGE_NETWORK_STATE, CHANGE_WIFI_STATE, CONNECTIVITY_INTERNAL, MANAGE_NETWORK_POLICY |
 | System | INJECT_EVENTS, DUMP, FORCE_STOP_PACKAGES, STOP_APP_SWITCHES, INTERACT_ACROSS_USERS_FULL |
 
-This single package has total device access: it can read every SMS, record audio, access the camera, track location, make calls, wipe the device, and inject input events (simulate touches/keystrokes). All permissions are SYSTEM_FIXED, meaning they cannot be revoked through Android's permission manager.
+This single package has total device access: it can read every SMS, record audio, access the camera, track location, make calls, wipe the device, and inject input events (simulate touches/keystrokes). All permissions are SYSTEM_FIXED, meaning they cannot be revoked through Android's permission manager. — `T2.dm-total-access` **[CAPABILITY]**
 
-**Risk**: CRITICAL. This is an OMA-DM (Open Mobile Alliance Device Management) client that carriers and the OEM can use for remote device provisioning. But the permission set far exceeds what OMA-DM requires. The INJECT_EVENTS + CAMERA + RECORD_AUDIO combination is indistinguishable from a remote access trojan.
+**Risk**: CRITICAL — `T2.dm-risk` **[INFERENCE]**. This is an OMA-DM (Open Mobile Alliance Device Management) client that carriers and the OEM can use for remote device provisioning. But the permission set far exceeds what OMA-DM requires **[INFERENCE — what OMA-DM functionally requires is itself an analyst judgment]**. The INJECT_EVENTS + CAMERA + RECORD_AUDIO combination is indistinguishable from a remote access trojan — `T2.dm-rat-equivalence` **[INFERENCE: a statement about the permission profile, not about observed use]**.
 
 ## Threat 3: MediaTek location services
 
@@ -52,11 +64,11 @@ This single package has total device access: it can read every SMS, record audio
 - `com.mediatek.location.mtknlp` (MediaTek network location provider, actively running)
 - `com.mediatek.nlpservice` (NLP service, actively running)
 
-Three location services are running continuously in the background. LPPe (Location Protocol Profile extensions) is a carrier-grade positioning protocol that combines GPS, cell tower, WiFi, and sensor data for enhanced location accuracy. This data is shared with the carrier and potentially MediaTek's location services.
+Three location services are running continuously in the background. — `T3.location-services-running` **[OBSERVED, not retained]**. LPPe (Location Protocol Profile extensions) is a carrier-grade positioning protocol that combines GPS, cell tower, WiFi, and sensor data for enhanced location accuracy **[EXTERNAL — protocol role]**. This data is shared with the carrier and potentially MediaTek's location services — `T3.location-data-shared` **[INFERENCE: the sharing path is architectural; no traffic capture exists for these services]**.
 
-`com.mediatek.gpslocationupdate` has the same massive permission set as `com.mediatek.dm`, including MASTER_CLEAR, CRYPT_KEEPER, DELETE_PACKAGES, MANAGE_PROFILE_AND_DEVICE_OWNERS, and OEM_UNLOCK_STATE. This is not a location service. It's a full device management agent disguised as a location service.
+`com.mediatek.gpslocationupdate` has the same massive permission set as `com.mediatek.dm`, including MASTER_CLEAR, CRYPT_KEEPER, DELETE_PACKAGES, MANAGE_PROFILE_AND_DEVICE_OWNERS, and OEM_UNLOCK_STATE. This is not a location service. It's a full device management agent disguised as a location service. — `T3.gpslocationupdate-agent` **[OBSERVED for the permission set, not retained; the "what it is" framing is CAPABILITY/INFERENCE]**
 
-**Risk**: HIGH. Continuous location tracking with carrier-grade precision, combined with full device management capabilities.
+**Risk**: HIGH — `T3.risk` **[INFERENCE]**. Continuous location tracking with carrier-grade precision **[OBSERVED: services running]**, combined with full device management capabilities **[CAPABILITY]**.
 
 ## Threat 4: MediaTek logging and diagnostics
 
@@ -65,38 +77,40 @@ Three location services are running continuously in the background. LPPe (Locati
 - `com.mediatek.mtklogger.proxy` (vendor partition, mediates log access)
 - `com.mediatek.engineermode` (hardware diagnostics, IMEI access, radio control)
 
-MTKLogger can read all system logs (including other apps' log output), capture screen contents (READ_FRAME_BUFFER), and runs on boot. Combined with INTERNET access, this is a complete device surveillance capability.
+MTKLogger can read all system logs (including other apps' log output), capture screen contents (READ_FRAME_BUFFER), and runs on boot. Combined with INTERNET access, this is a complete device surveillance capability. — `T4.mtklogger-capability` **[CAPABILITY]**
 
-EngineerMode provides direct hardware access including baseband AT commands, radio parameters, and device identifiers. While primarily a diagnostic tool, it's an attack surface: any app that can launch EngineerMode activities can access radio hardware directly.
+EngineerMode provides direct hardware access including baseband AT commands, radio parameters, and device identifiers. While primarily a diagnostic tool, it's an attack surface: any app that can launch EngineerMode activities can access radio hardware directly. — `T4.engineermode-surface` **[CAPABILITY]**
 
-**Risk**: MEDIUM. Primarily diagnostic tools, but the permission set enables surveillance if the packages are compromised or remotely updated.
+**Risk**: MEDIUM — `T4.risk` **[INFERENCE]**. Primarily diagnostic tools, but the permission set enables surveillance if the packages are compromised or remotely updated **[CAPABILITY]**.
 
 ## Threat 5: OMA Client Provisioning (com.mediatek.omacp)
 
 **Package**: `com.mediatek.omacp`
-**Purpose**: Allows carriers to remotely configure APN settings, bookmarks, email accounts, and WiFi networks via specially formatted SMS messages (WAP Push).
+**Purpose**: Allows carriers to remotely configure APN settings, bookmarks, email accounts, and WiFi networks via specially formatted SMS messages (WAP Push) **[EXTERNAL — protocol purpose]**.
 
-**Permissions**: RECEIVE_WAP_PUSH, RECEIVE_SMS, CALL_PHONE, BLUETOOTH_ADMIN, CHANGE_NETWORK_STATE, INSTALL_DRM
+**Permissions**: RECEIVE_WAP_PUSH, RECEIVE_SMS, CALL_PHONE, BLUETOOTH_ADMIN, CHANGE_NETWORK_STATE, INSTALL_DRM — `T5.omacp-permissions` **[OBSERVED, not retained]**
 
-**Risk**: MEDIUM. OMA-CP is a known attack vector: a crafted SMS can reconfigure the device's APN to route all traffic through an attacker's proxy. The device will apply the configuration silently. This is a documented technique used by nation-states for targeted surveillance (see Checkpoint Research, 2019).
+**Risk**: MEDIUM — `T5.risk` **[INFERENCE]**. OMA-CP is a known attack vector: a crafted SMS can reconfigure the device's APN to route all traffic through an attacker's proxy. The device will apply the configuration silently. This is a documented technique used by nation-states for targeted surveillance — `T5.omacp-vector` **[EXTERNAL: Check Point Research, 2019]**.
 
 ## Threat 6: Pre-installed social media
 
-**Packages**: `com.zhiliaoapp.musically` (TikTok), `com.whatsapp` (WhatsApp), `com.loudtalks` (Zello)
+**Packages**: `com.zhiliaoapp.musically` (TikTok), `com.whatsapp` (WhatsApp), `com.loudtalks` (Zello) — `T6.preinstalled-social` **[OBSERVED, not retained]**
 
-TikTok is pre-installed as a system app. ByteDance (TikTok's parent) is subject to Chinese national security law requiring cooperation with intelligence services. WhatsApp shares metadata with Meta. Both have full internet access and broad permissions.
+TikTok is pre-installed as a system app. ByteDance (TikTok's parent) is subject to Chinese national security law requiring cooperation with intelligence services — `T6.bytedance-law` **[EXTERNAL: PRC National Intelligence Law, 2017, Art. 7]**. WhatsApp shares metadata with Meta **[EXTERNAL — Meta policy]**. Both have full internet access and broad permissions **[OBSERVED, not retained]**.
 
-**Risk**: MEDIUM. These can be disabled or uninstalled (they're not in /system/priv-app, just /system/app), but their presence as factory defaults indicates the OEM's relationship with these platforms.
+**Risk**: MEDIUM **[INFERENCE]**. These can be disabled or uninstalled (they're not in /system/priv-app, just /system/app) **[OBSERVED, not retained]**, but their presence as factory defaults indicates the OEM's relationship with these platforms — `T6.oem-relationship` **[INFERENCE]**.
 
 ## Threat 7: Freeme OS framework
 
 **Packages**: `freeme` (framework), `com.freeme.provider.badge`, `com.freeme.factory`
 
-Freeme OS is a Chinese Android customization framework (similar to MIUI, ColorOS). It's the UI layer provided by TYD Technology. The `freeme` framework package runs at the framework level, meaning it has access to all Android framework internals. Badge provider and factory test are lower-risk utility apps.
+Freeme OS is a Chinese Android customization framework (similar to MIUI, ColorOS). It's the UI layer provided by TYD Technology. The `freeme` framework package runs at the framework level, meaning it has access to all Android framework internals. — `T7.freeme-framework` **[OBSERVED, not retained]**. Badge provider and factory test are lower-risk utility apps **[INFERENCE]**.
 
-**Risk**: LOW-MEDIUM. The framework package runs with system privileges. Without decompiling the APK, its exact behavior is unknown. Freeme OS has no public security audit history.
+**Risk**: LOW-MEDIUM **[INFERENCE]**. The framework package runs with system privileges. Without decompiling the APK, its exact behavior is unknown. Freeme OS has no public security audit history. — `T7.freeme-unknown` **[EXTERNAL: an absence-of-publications claim; no decompilation was performed for this audit]**.
 
 ## Active services at time of probe
+
+`S.services-table` **[OBSERVED, not retained — one session's listing]**
 
 | Service | Package | Status |
 |---------|---------|--------|
@@ -107,20 +121,38 @@ Freeme OS is a Chinese Android customization framework (similar to MIUI, ColorOS
 
 ## Network connections at time of probe
 
+`N.connections-table` **[OBSERVED, not retained — one instant, not a capture window]**
+
 | Local | Remote | Proto | Purpose |
 |-------|--------|-------|---------|
 | 21.28.129.209:42318 | 10.166.154.5:5060 | TCP | Carrier IMS/SIP (VoLTE) |
-| 21.28.129.209:50001 | 10.166.154.5:65529 | TCP | Carrier IMS control |
+| 21.28.129.209:50001 | 10.166.154.5:65529 | TCP | IMS control |
 
-Only carrier IMS traffic observed. WiFi was connected but no outbound connections to surveillance infrastructure during the probe window. This does not mean no exfiltration occurs  -  Adups typically exfiltrates on a 72-hour cycle, and the device may have been recently powered on.
+Only carrier IMS traffic observed. WiFi was connected but no outbound connections to surveillance infrastructure during the probe window — `N.no-surveillance-traffic` **[OBSERVED — does not establish absence of exfiltration across a 72-hour cycle]**. Adups typically exfiltrates on a 72-hour cycle **[EXTERNAL]**, and the device may have been recently powered on.
 
 ## Conclusion
 
-The stock AGM M7 firmware contains at minimum:
-- A known Chinese data exfiltration framework (Adups) with boot persistence and remote reboot capability
-- A device management agent (MediaTek DM) with permissions equivalent to a remote access trojan
-- Continuous background location tracking via 3 separate services
-- A carrier remote provisioning system vulnerable to SMS-based APN hijacking
-- Pre-installed Chinese social media (TikTok) subject to national security cooperation requirements
+`C.device-conclusions` **[INFERENCE]** over the claims above:
 
-None of these can be disabled by the user without root access. All are SYSTEM_FIXED. This is the baseline threat that thumos exists to eliminate.
+The stock AGM M7 firmware contains at minimum:
+- A known Chinese data exfiltration framework (Adups) **[EXTERNAL]** with boot persistence and remote reboot capability **[OBSERVED + CAPABILITY]**
+- A device management agent (MediaTek DM) with permissions equivalent to a remote access trojan **[OBSERVED the set; CAPABILITY the equivalence]**
+- Continuous background location tracking via 3 separate services **[OBSERVED]**
+- A carrier remote provisioning system vulnerable to SMS-based APN hijacking **[CAPABILITY + EXTERNAL]**
+- Pre-installed Chinese social media (TikTok) subject to national security cooperation requirements **[OBSERVED + EXTERNAL]**
+
+None of these can be disabled by the user without root access. All are SYSTEM_FIXED **[OBSERVED, not retained]**. This is the baseline threat that thumos exists to eliminate **[INFERENCE — project mission framing]**.
+
+## References
+
+- Kryptowire / Adups FOTA disclosure, November 2016 (public reporting; see e.g. contemporaneous coverage of the BLU device findings).
+- Check Point Research, "Advanced SMS Phishing — OMA CP Provisioning Messages", 2019.
+- PRC National Intelligence Law, 2017 (Article 7).
+- LPPe / OMA Location Protocol — public protocol documentation.
+
+## Reproduction
+
+- Evidence manifest + claim index: `docs/surveillance/evidence-manifest.toml`
+- Recollect every non-retained artifact (read-only): `scripts/surveillance-collect.sh`
+- Derive the evidence report: `scripts/surveillance-render.py <evidence-dir>`
+- Retained artifacts (SHA-256 in the manifest): `docs/full-props.txt`, `docs/kernel-config-stock`

--- a/docs/surveillance/evidence-manifest.toml
+++ b/docs/surveillance/evidence-manifest.toml
@@ -1,0 +1,282 @@
+# Surveillance-audit evidence manifest (issue #556)
+#
+# The machine-checkable companion to docs/SURVEILLANCE-AUDIT.md: firmware
+# identity, retained artifacts with hashes, non-retained evidence (with the
+# recollection path), and the claim-to-evidence index. Every material claim
+# in the audit narrative carries one of four epistemic labels:
+#
+#   observed    — directly measured on THIS device (a dump, listing, or
+#                 capture the audit retained or can recollect byte-exactly)
+#   capability  — a package COULD do this given its granted permissions /
+#                 privileged position; NOT a claim of observed execution
+#   external    — reported by an outside source (cited); not measured here
+#   inference   — analyst judgment over the above; carries uncertainty
+#
+# The renderer (scripts/surveillance-render.py) derives the audit's tables
+# from this manifest + the collected evidence; the collector
+# (scripts/surveillance-collect.sh) re-gathers every non-retained artifact
+# read-only against this or another firmware image.
+
+[audit]
+date = "2026-03-18"
+method = "read-only ADB inspection of unmodified device"
+collector = "interactive ADB session (predates scripts/surveillance-collect.sh)"
+limits = [
+  "single session; no longitudinal network capture",
+  "no network tap beyond an on-device connection listing at one instant",
+  "jobscheduler state was altered during inspection (the adups jobs were cancelled), so the scheduled-jobs listing is the pre-cancellation state as recalled, not a retained dump",
+]
+
+[firmware]
+fingerprint = "AGM/Q12_1/Q12_1:8.1.0/OPM1.171019.026/L1635.6.01.01:user/release-keys"
+display_id = "PQ1181WAA39A.AGM.O1.QV.KFS39SST.220323.V3.07"
+build_date_utc = 1647949016 # 2022-03-22 19:36:56 CST
+android = "8.1.0"
+freemeos = "8.1.1"
+build_type = "user"
+build_tags = "release-keys"
+model = "AGM M7"
+
+[tools]
+# The 2026-03-18 session did not capture tool versions — recorded as unknown
+# rather than reconstructed. The collector captures them on every rerun.
+adb_version = "unknown (not captured)"
+device_side = "stock user build, no root"
+
+# ---------------------------------------------------------------------------
+# Retained artifacts (hashed)
+# ---------------------------------------------------------------------------
+
+[[artifact]]
+path = "docs/full-props.txt"
+sha256 = "11b27ca9f0683142841c768232b42ef8e065419798109d2cf440087b47c1e680"
+kind = "getprop dump (full)"
+retained = true
+
+[[artifact]]
+path = "docs/kernel-config-stock"
+sha256 = "580dfaa3b3a1f2f403b0f93ae6d492d2bcf6ae97b0cd4b0babd3b9faaf1303f5"
+kind = "stock kernel build config"
+retained = true
+
+# ---------------------------------------------------------------------------
+# Non-retained evidence (recollect via scripts/surveillance-collect.sh)
+# ---------------------------------------------------------------------------
+
+[[artifact]]
+kind = "package manifests + permission dumps (dumpsys package) for every package named in the audit"
+packages = [
+  "com.adups.fota", "com.adups.fota.sysoper",
+  "com.mediatek.dm",
+  "com.mediatek.gpslocationupdate", "com.mediatek.location.lppe.main",
+  "com.mediatek.location.mtknlp", "com.mediatek.nlpservice",
+  "com.mediatek.mtklogger", "com.mediatek.mtklogger.proxy",
+  "com.mediatek.engineermode", "com.mediatek.omacp",
+  "com.zhiliaoapp.musically", "com.whatsapp", "com.loudtalks",
+  "freeme", "com.freeme.provider.badge", "com.freeme.factory",
+]
+retained = false
+recollect = "scripts/surveillance-collect.sh"
+
+[[artifact]]
+kind = "APK SHA-256 hashes for the same package set"
+retained = false
+recollect = "scripts/surveillance-collect.sh"
+
+[[artifact]]
+kind = "service/process listings (dumpsys activity services, ps) at probe time"
+retained = false
+recollect = "scripts/surveillance-collect.sh"
+
+[[artifact]]
+kind = "network connection listing (ss/netstat) at probe time"
+retained = false
+recollect = "scripts/surveillance-collect.sh"
+
+[[artifact]]
+kind = "jobscheduler dump showing Adups scheduled jobs"
+retained = false
+recollect = "scripts/surveillance-collect.sh"
+
+# ---------------------------------------------------------------------------
+# Claim-to-evidence index
+# ---------------------------------------------------------------------------
+
+[[claim]]
+id = "T1.adups-present"
+text = "com.adups.fota (v5.24) + com.adups.fota.sysoper are installed as system apps"
+label = "observed"
+evidence = ["dumpsys package com.adups.fota (not retained — recollect)"]
+
+[[claim]]
+id = "T1.adups-history"
+text = "Adups was flagged in Nov 2016 for exfiltrating SMS bodies, call logs, contacts, IMEI/IMSI, and app lists to servers in China on a 72-hour cycle, on 700M+ devices"
+label = "external"
+evidence = ["Kryptowire advisory, reported 2016-11 (see SURVEILLANCE-AUDIT.md references)"]
+
+[[claim]]
+id = "T1.adups-permissions"
+text = "INTERNET, ACCESS_NETWORK_STATE, ACCESS_WIFI_STATE, RECEIVE_BOOT_COMPLETED granted; sysoper holds REBOOT + RECOVERY"
+label = "observed"
+evidence = ["dumpsys package (not retained — recollect)"]
+
+[[claim]]
+id = "T1.adups-jobs"
+text = "MyJobService/MyIntentJobService are scheduled on boot and monitor BOOT_COMPLETED, DATE_CHANGED, power, and media events"
+label = "observed"
+evidence = ["dumpsys jobscheduler (not retained — recollect); session note: jobs were cancelled during inspection"]
+
+[[claim]]
+id = "T1.adups-no-traffic"
+text = "No Adups network traffic was observed during the session"
+label = "observed"
+evidence = ["session connection listing (not retained — recollect)"]
+limits = "one instant only; Adups historically exfiltrates on a 72-hour cycle"
+
+[[claim]]
+id = "T1.adups-risk"
+text = "HIGH risk: known exfiltration framework with factory integration and remote reflash capability"
+label = "inference"
+evidence = ["T1.adups-history", "T1.adups-permissions", "T1.adups-jobs"]
+
+[[claim]]
+id = "T2.dm-permissions"
+text = "com.mediatek.dm holds the listed SYSTEM_FIXED permission set (SMS, call log, location, contacts, storage, camera, mic, MASTER_CLEAR, REBOOT, INJECT_EVENTS, network control)"
+label = "observed"
+evidence = ["dumpsys package com.mediatek.dm (not retained — recollect)"]
+
+[[claim]]
+id = "T2.dm-total-access"
+text = "That set grants total device access (read every SMS, record audio, camera, location, calls, wipe, inject input)"
+label = "capability"
+evidence = ["T2.dm-permissions"]
+
+[[claim]]
+id = "T2.dm-rat-equivalence"
+text = "The INJECT_EVENTS + CAMERA + RECORD_AUDIO combination is indistinguishable from a remote access trojan"
+label = "inference"
+evidence = ["T2.dm-total-access"]
+uncertainty = "a statement about the permission profile, not about observed use"
+
+[[claim]]
+id = "T2.dm-risk"
+text = "CRITICAL risk"
+label = "inference"
+evidence = ["T2.dm-permissions", "T2.dm-total-access"]
+
+[[claim]]
+id = "T3.location-services-running"
+text = "NlpLocationService, LPPeServiceWrapper, and NlpService were running continuously in the background at probe time"
+label = "observed"
+evidence = ["service listing (not retained — recollect)"]
+
+[[claim]]
+id = "T3.location-data-shared"
+text = "LPPe positioning data is shared with the carrier and potentially MediaTek location services"
+label = "inference"
+evidence = ["T3.location-services-running", "LPPe protocol role (carrier-grade positioning, external documentation)"]
+uncertainty = "no traffic capture exists for these services; the sharing path is architectural, not observed"
+
+[[claim]]
+id = "T3.gpslocationupdate-agent"
+text = "com.mediatek.gpslocationupdate holds a device-management-grade permission set (MASTER_CLEAR, CRYPT_KEEPER, DELETE_PACKAGES, device-owner management) — a full device agent in a location package"
+label = "capability"
+evidence = ["dumpsys package com.mediatek.gpslocationupdate (not retained — recollect)"]
+
+[[claim]]
+id = "T3.risk"
+text = "HIGH risk: continuous carrier-grade location tracking plus device-management capability"
+label = "inference"
+evidence = ["T3.location-services-running", "T3.gpslocationupdate-agent"]
+
+[[claim]]
+id = "T4.mtklogger-capability"
+text = "MTKLogger can read all system logs and capture screen contents (READ_LOGS, READ_FRAME_BUFFER, DUMP), on boot, with INTERNET"
+label = "capability"
+evidence = ["dumpsys package com.mediatek.mtklogger (not retained — recollect)"]
+
+[[claim]]
+id = "T4.engineermode-surface"
+text = "EngineerMode exposes baseband AT commands, radio parameters, and device identifiers to anything that can launch its activities"
+label = "capability"
+evidence = ["dumpsys package com.mediatek.engineermode (not retained — recollect)"]
+
+[[claim]]
+id = "T4.risk"
+text = "MEDIUM risk"
+label = "inference"
+evidence = ["T4.mtklogger-capability", "T4.engineermode-surface"]
+
+[[claim]]
+id = "T5.omacp-permissions"
+text = "com.mediatek.omacp holds RECEIVE_WAP_PUSH, RECEIVE_SMS, CALL_PHONE, BLUETOOTH_ADMIN, CHANGE_NETWORK_STATE, INSTALL_DRM"
+label = "observed"
+evidence = ["dumpsys package com.mediatek.omacp (not retained — recollect)"]
+
+[[claim]]
+id = "T5.omacp-vector"
+text = "OMA-CP provisioning messages can silently reconfigure APN/proxy settings; the technique is documented in targeted-surveillance reporting"
+label = "external"
+evidence = ["Check Point Research, OMA CP provisioning phishing (2019; see references)"]
+
+[[claim]]
+id = "T5.risk"
+text = "MEDIUM risk"
+label = "inference"
+evidence = ["T5.omacp-permissions", "T5.omacp-vector"]
+
+[[claim]]
+id = "T6.preinstalled-social"
+text = "TikTok, WhatsApp, and Zello are pre-installed (in /system/app, not priv-app)"
+label = "observed"
+evidence = ["package listing (not retained — recollect)"]
+
+[[claim]]
+id = "T6.bytedance-law"
+text = "ByteDance is subject to Chinese national security law requiring cooperation with intelligence services"
+label = "external"
+evidence = ["PRC National Intelligence Law (2017), Article 7 — public statute"]
+
+[[claim]]
+id = "T6.oem-relationship"
+text = "Their factory-default presence indicates an OEM-platform relationship"
+label = "inference"
+evidence = ["T6.preinstalled-social"]
+
+[[claim]]
+id = "T7.freeme-framework"
+text = "The freeme framework package runs at the Android framework level with system privileges"
+label = "observed"
+evidence = ["package listing + uid (not retained — recollect)"]
+
+[[claim]]
+id = "T7.freeme-unknown"
+text = "Freeme OS has no public security audit history; without decompilation its behavior is unknown"
+label = "external"
+evidence = ["absence-of-publications claim; no decompilation performed for this audit"]
+
+[[claim]]
+id = "S.services-table"
+text = "The four services in the audit table were active at probe time (three location services running; Adups jobs scheduled)"
+label = "observed"
+evidence = ["service/jobscheduler listing (not retained — recollect)"]
+
+[[claim]]
+id = "N.connections-table"
+text = "The only connections at probe time were the two carrier IMS/SIP sessions listed"
+label = "observed"
+evidence = ["connection listing (not retained — recollect)"]
+limits = "one instant; not a capture window"
+
+[[claim]]
+id = "N.no-surveillance-traffic"
+text = "No outbound connections to surveillance infrastructure were observed during the probe window"
+label = "observed"
+evidence = ["connection listing (not retained — recollect)"]
+limits = "does not establish absence of exfiltration across a 72-hour cycle"
+
+[[claim]]
+id = "C.device-conclusions"
+text = "The conclusion list (exfiltration framework, RAT-equivalent agent, continuous location tracking, APN-hijack surface, pre-installed social media, none user-disableable)"
+label = "inference"
+evidence = ["all T1..T7 claims above; SYSTEM_FIXED grant flags from the package dumps (not retained — recollect)"]

--- a/scripts/surveillance-collect.sh
+++ b/scripts/surveillance-collect.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# surveillance-collect.sh — read-only surveillance-audit evidence collection (#556).
+set -euo pipefail
+# Re-gathers every artifact docs/surveillance/evidence-manifest.toml marks
+# non-retained, against the connected device or any firmware image.
+#
+# READ-ONLY INVARIANT: this script NEVER mutates the device. No
+# install/uninstall/disable, no `settings put`, no `input`, no `am`/`pm`
+# verbs other than list/dump, no root, no file pushes, no writes outside
+# /sdcard-avoiding dumpsys/getprop/cat queries. Every command below is a
+# query (getprop, dumpsys, pm list, cat, sha256sum of READ-ONLY APK paths,
+# ss/netstat, ps, date). If you add a command, it must keep that invariant.
+#
+# Usage: scripts/surveillance-collect.sh [outdir]
+#   outdir defaults to docs/surveillance/evidence/<build-fingerprint-sanitized>/
+# Requires: adb in PATH, a device connected and authorized.
+
+say() { printf '%s\n' "$*"; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+have adb || { echo "FAIL: adb not in PATH" >&2; exit 1; }
+adb get-state 1>/dev/null 2>&1 || { echo "FAIL: no authorized device (adb get-state)" >&2; exit 1; }
+
+FINGERPRINT=$(adb shell getprop ro.build.fingerprint | tr -d '\r')
+SAFE=$(printf '%s' "$FINGERPRINT" | tr '/: ' '___')
+OUT="${1:-docs/surveillance/evidence/$SAFE}"
+mkdir -p "$OUT"
+printf 'collecting into %s (fingerprint: %s)\n' "$OUT" "$FINGERPRINT"
+
+# -- Session metadata (tool versions + timestamps, the gap from the 2026-03-18 session)
+{
+    echo "collection_utc: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    echo "adb_version: $(adb version | head -1)"
+    echo "host_uname: $(uname -a)"
+    echo "device_date: $(adb shell date | tr -d '\r')"
+    echo "device_uptime: $(adb shell uptime | tr -d '\r')"
+} > "$OUT/session.txt"
+
+# -- Firmware identity
+adb shell getprop > "$OUT/getprop.txt"
+grep -E 'ro.build.fingerprint|ro.build.display.id|ro.build.date.utc|ro.build.version.incremental|ro.product.model' \
+    "$OUT/getprop.txt" > "$OUT/firmware-identity.txt" || true # a missing prop line must not abort the whole collection
+
+# -- Partition/block state
+adb shell cat /proc/partitions > "$OUT/proc-partitions.txt"
+adb shell cat /proc/mounts > "$OUT/proc-mounts.txt"
+
+# -- Package inventory + APK hashes (read-only)
+adb shell pm list packages -f -i -U > "$OUT/packages-full.txt"
+# SHA-256 every APK path the package manager reports (paths are read by
+# hash; nothing is pulled or written).
+adb shell 'for p in $(pm list packages -f | sed "s/package://;s/=.*//"); do sha256sum "$p" 2>/dev/null; done' \
+    > "$OUT/apk-sha256.txt"
+
+# -- The surveillance-relevant package set from the manifest
+PACKAGES=(
+com.adups.fota
+com.adups.fota.sysoper
+com.mediatek.dm
+com.mediatek.gpslocationupdate
+com.mediatek.location.lppe.main
+com.mediatek.location.mtknlp
+com.mediatek.nlpservice
+com.mediatek.mtklogger
+com.mediatek.mtklogger.proxy
+com.mediatek.engineermode
+com.mediatek.omacp
+com.zhiliaoapp.musically
+com.whatsapp
+com.loudtalks
+freeme
+com.freeme.provider.badge
+com.freeme.factory
+)
+mkdir -p "$OUT/packages"
+for pkg in "${PACKAGES[@]}"; do
+    adb shell dumpsys package "$pkg" > "$OUT/packages/$pkg.txt" 2>&1 || true # an absent package must not abort the set; the empty dump records its absence as evidence
+done
+
+# -- Runtime state
+adb shell dumpsys activity services > "$OUT/activity-services.txt"
+adb shell dumpsys jobscheduler > "$OUT/jobscheduler.txt"
+adb shell ps -A > "$OUT/ps.txt" 2>/dev/null || adb shell ps > "$OUT/ps.txt"
+if adb shell ss -tup > "$OUT/connections.txt" 2>/dev/null; then
+    :
+else
+    adb shell netstat -tup > "$OUT/connections.txt" 2>/dev/null || \
+        { echo "NOTE: neither ss nor netstat available" > "$OUT/connections.txt"; }
+fi
+
+# -- Hashes of everything collected (deterministic integrity record)
+( cd "$OUT" && find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS )
+
+printf 'done: %s artifacts, hashed in %s\n' "$(find "$OUT" -type f | wc -l)" "$OUT/SHA256SUMS"
+printf 'next: scripts/surveillance-render.py %s\n' "$OUT"

--- a/scripts/surveillance-render.py
+++ b/scripts/surveillance-render.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""surveillance-render.py — deterministic evidence renderer (issue #556).
+
+Reads an evidence directory produced by scripts/surveillance-collect.sh plus
+docs/surveillance/evidence-manifest.toml, and emits SURVEILLANCE-EVIDENCE.md:
+derived tables (per-package granted permissions, running services, network
+connections, APK hashes) and the claim-coverage report (which manifest
+claims are backed by retained/collected evidence and which still need
+recollection).
+
+Deterministic: sorted output, no wall clock, no host identity. The audit
+narrative stays hand-written; every TABLE in it must trace to this output.
+"""
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+MANIFEST = REPO / "docs" / "surveillance" / "evidence-manifest.toml"
+
+# Permissions the audit narrative cares about (its table rows), sorted.
+TRACKED_PERMS = sorted({
+    "android.permission.READ_SMS", "android.permission.RECEIVE_SMS",
+    "android.permission.SEND_SMS", "android.permission.READ_CALL_LOG",
+    "android.permission.WRITE_CALL_LOG", "android.permission.CALL_PHONE",
+    "android.permission.PROCESS_OUTGOING_CALLS", "android.permission.USE_SIP",
+    "android.permission.ACCESS_FINE_LOCATION", "android.permission.ACCESS_COARSE_LOCATION",
+    "android.permission.READ_CONTACTS", "android.permission.WRITE_CONTACTS",
+    "android.permission.GET_ACCOUNTS",
+    "android.permission.READ_EXTERNAL_STORAGE", "android.permission.WRITE_EXTERNAL_STORAGE",
+    "android.permission.CAMERA", "android.permission.RECORD_AUDIO",
+    "android.permission.MASTER_CLEAR", "android.permission.REBOOT",
+    "android.permission.MODIFY_PHONE_STATE", "android.permission.WRITE_SECURE_SETTINGS",
+    "android.permission.INTERNET", "android.permission.CHANGE_NETWORK_STATE",
+    "android.permission.CHANGE_WIFI_STATE", "android.permission.CONNECTIVITY_INTERNAL",
+    "android.permission.MANAGE_NETWORK_POLICY", "android.permission.INJECT_EVENTS",
+    "android.permission.DUMP", "android.permission.FORCE_STOP_PACKAGES",
+    "android.permission.STOP_APP_SWITCHES", "android.permission.INTERACT_ACROSS_USERS_FULL",
+    "android.permission.RECEIVE_BOOT_COMPLETED", "android.permission.ACCESS_NETWORK_STATE",
+    "android.permission.ACCESS_WIFI_STATE", "android.permission.RECEIVE_WAP_PUSH",
+    "android.permission.BLUETOOTH_ADMIN", "android.permission.INSTALL_DRM",
+    "android.permission.READ_LOGS", "android.permission.READ_FRAME_BUFFER",
+    "android.permission.CRYPT_KEEPER", "android.permission.DELETE_PACKAGES",
+    "android.permission.MANAGE_PROFILE_AND_DEVICE_OWNERS", "android.permission.OEM_UNLOCK_STATE",
+})
+
+
+def granted_permissions(dump: str) -> list[str]:
+    """Granted permissions from a `dumpsys package` text, filtered to the
+    tracked set, sorted. Matches both '...: granted=true' and the older
+    flat listed style."""
+    out = set()
+    for m in re.finditer(r"(android\.permission\.[A-Z_]+)(?::\s*granted=(true|false))?", dump):
+        name, granted = m.group(1), m.group(2)
+        if granted == "false":
+            continue
+        if name in TRACKED_PERMS:
+            out.add(name)
+    return sorted(out)
+
+
+def main() -> int:
+    evdir = Path(sys.argv[1]) if len(sys.argv) > 1 else None
+    if evdir is None or not evdir.is_dir():
+        print("usage: surveillance-render.py <evidence-dir>\n"
+              "(produce one with scripts/surveillance-collect.sh)", file=sys.stderr)
+        return 2
+
+    manifest = tomllib.loads(MANIFEST.read_text())
+    lines: list[str] = []
+    a = lines.append
+
+    a("# Surveillance evidence report (derived — do not hand-edit)")
+    a("")
+    a(f"Firmware fingerprint: `{manifest['firmware']['fingerprint']}`")
+    a(f"Evidence directory: `{evdir}`")
+    a("")
+
+    # -- Firmware identity
+    ident = evdir / "firmware-identity.txt"
+    if ident.exists():
+        a("## Firmware identity")
+        a("")
+        a("```")
+        a(ident.read_text().strip())
+        a("```")
+        a("")
+
+    # -- Per-package granted permissions
+    pkgdir = evdir / "packages"
+    if pkgdir.is_dir():
+        a("## Granted permissions (tracked set, from dumpsys package)")
+        a("")
+        for dump_path in sorted(pkgdir.glob("*.txt")):
+            perms = granted_permissions(dump_path.read_text(errors="ignore"))
+            a(f"### `{dump_path.stem}`")
+            if perms:
+                for p in perms:
+                    short = p.removeprefix("android.permission.")
+                    a(f"- {short}")
+            else:
+                a("- (none of the tracked permissions found — check the dump)")
+            a("")
+
+    # -- Running services (lines mentioning the audit's packages)
+    svc = evdir / "activity-services.txt"
+    if svc.exists():
+        names = [c["id"] for c in manifest.get("claim", []) if c["id"] == "S.services-table"]
+        a("## Service listing excerpt (audit-relevant packages)")
+        a("")
+        a("```")
+        hits = [
+            ln for ln in svc.read_text(errors="ignore").splitlines()
+            if any(k in ln for k in ("mediatek", "adups", "freeme", "ServiceRecord"))
+        ]
+        a("\n".join(hits) if hits else "(no audit-relevant services in the listing)")
+        a("```")
+        a("")
+        del names
+
+    # -- Connections
+    conn = evdir / "connections.txt"
+    if conn.exists():
+        a("## Network connections at collection time")
+        a("")
+        a("```")
+        a(conn.read_text(errors="ignore").strip())
+        a("```")
+        a("")
+
+    # -- APK hashes
+    hashes = evdir / "apk-sha256.txt"
+    if hashes.exists():
+        a("## APK SHA-256")
+        a("")
+        a("```")
+        a(hashes.read_text(errors="ignore").strip())
+        a("```")
+        a("")
+
+    # -- Claim coverage
+    a("## Claim coverage (from evidence-manifest.toml)")
+    a("")
+    a("| claim | label | evidence status |")
+    a("|---|---|---|")
+    for c in manifest.get("claim", []):
+        missing = any("not retained" in e for e in c.get("evidence", []))
+        status = "recollectable (collector output present)" if missing and pkgdir.is_dir() else (
+            "needs recollection" if missing else "retained"
+        )
+        a(f"| {c['id']} | {c['label']} | {status} |")
+    a("")
+
+    out = evdir / "SURVEILLANCE-EVIDENCE.md"
+    out.write_text("\n".join(lines))
+    print(f"wrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

The stock-firmware surveillance audit drew high/critical conclusions from a one-time ADB session but retained none of the evidence needed to reproduce it — and repeatedly moved from a package's *capability* to claims about *observed behavior* without labeling the inference. This makes the audit reproducible and its evidence classes explicit, without changing its substance.

- **`docs/surveillance/evidence-manifest.toml`** — the privacy-reviewed evidence manifest: firmware identity (`AGM/Q12_1/Q12_1:8.1.0/OPM1.171019.026/L1635.6.01.01:user/release-keys`, build 2022-03-22), session limits, tool-version record (the 2026-03-18 session's gap is recorded as unknown, not reconstructed), retained artifacts with SHA-256 (`full-props.txt`, `kernel-config-stock`), non-retained artifacts with the recollection path, and a **claim-to-evidence index** — every material claim labeled **observed / capability / external / inference** with uncertainty stated.
- **`scripts/surveillance-collect.sh`** — read-only ADB collection (getprop, partitions, `dumpsys package` for the 17 audit-relevant packages, service/jobscheduler/process listings, connections, APK SHA-256, tool versions, timestamps) under an explicit no-mutation invariant, rerunnable against this or another firmware image.
- **`scripts/surveillance-render.py`** — deterministic renderer (sorted output, no wall clock, no host identity) deriving the evidence report and the claim-coverage table from collected artifacts + the manifest.
- **`docs/SURVEILLANCE-AUDIT.md` rewritten** — every material claim carries its label inline with claim IDs tying to the manifest. The capability-vs-observed-use boundary is explicit (e.g. the RAT-equivalence line is labeled inference over the permission profile, *not* observed use; the LPPe data-sharing line is labeled inference with its no-traffic-capture uncertainty). References added for the external claims (Kryptowire 2016, Check Point 2019, PRC NIL Art. 7).

The narrative is unchanged in substance — the labels make its evidence class visible, and the collector closes the reproducibility gap on the next device session (operator-run, hardware-gated).

## Verification

- `scripts/surveillance-render.py` run end-to-end on a synthetic evidence dir: derived permission table, connections, APK hashes, and the claim-coverage matrix all render as designed (transcript in the commit history).
- `bash -n` on the collector; `python3 -m ast` parse of the renderer.
- `kanon lint`: zero violations on the new files (the repo's pre-existing baseline entries untouched).
- Manifest hashes recomputed against the retained artifacts (`sha256sum docs/full-props.txt docs/kernel-config-stock`).

Closes #556