### PR TITLE
sema: calibration honesty + deterministic eval harness for threat scores (#555)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,6 +1049,7 @@ dependencies = [
  "postcard",
  "serde",
  "snafu",
+ "toml",
 ]
 
 [[package]]
@@ -1098,6 +1099,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1268,6 +1278,47 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "topos"
@@ -1464,6 +1515,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/crates/sema/Cargo.toml
+++ b/crates/sema/Cargo.toml
@@ -14,6 +14,9 @@ log = { workspace = true }
 serde = { workspace = true }
 postcard = { workspace = true }
 
+[dev-dependencies]
+toml = "0.8"
+
 [lints]
 workspace = true
 

--- a/crates/sema/corpus/benign-stationary-01.toml
+++ b/crates/sema/corpus/benign-stationary-01.toml
@@ -1,0 +1,11 @@
+schema_version = 1
+id = "benign-stationary-01"
+kind = "benign_stationary"
+provenance = "synthetic (#555); hand-built, NOT field-measured"
+target_level = "Low"
+
+# Stationary device on stable home macro coverage: at most incidental
+# reselections, all to announced neighbours (no alert kinds fire).
+[[alerts]]
+kind = "rapid_reselection"
+count = 2

--- a/crates/sema/corpus/controlled-attack-01.toml
+++ b/crates/sema/corpus/controlled-attack-01.toml
@@ -1,0 +1,18 @@
+schema_version = 1
+id = "controlled-attack-01"
+kind = "controlled_attack"
+provenance = "synthetic (#555); hand-built, NOT field-measured"
+target_level = "High"
+
+# Controlled IMSI-catcher emulation: cipher downgrade, coerced handover to
+# an unannounced tower, and an implausibly strong new cell together.
+[[alerts]]
+kind = "cipher_downgrade"
+algorithm = "A5_1"
+
+[[alerts]]
+kind = "sudden_tower_change"
+
+[[alerts]]
+kind = "unusually_strong_new_tower"
+signal_dbm = -30

--- a/crates/sema/corpus/dense-urban-01.toml
+++ b/crates/sema/corpus/dense-urban-01.toml
@@ -1,0 +1,29 @@
+schema_version = 1
+id = "dense-urban-01"
+kind = "dense_urban"
+provenance = "synthetic (#555); hand-built, NOT field-measured"
+target_level = "Low"
+
+# Dense-urban RF churn: many strong neighbour cells come and go. The
+# documented residual false-positive class at the provisional weights (#555
+# and the phase plan): the harmonic model bounds it at Medium, calibration
+# must close it to Low.
+[[alerts]]
+kind = "unusually_strong_new_tower"
+signal_dbm = -40
+
+[[alerts]]
+kind = "unusually_strong_new_tower"
+signal_dbm = -42
+
+[[alerts]]
+kind = "unusually_strong_new_tower"
+signal_dbm = -38
+
+[[alerts]]
+kind = "unusually_strong_new_tower"
+signal_dbm = -45
+
+[[alerts]]
+kind = "unusually_strong_new_tower"
+signal_dbm = -41

--- a/crates/sema/corpus/driving-01.toml
+++ b/crates/sema/corpus/driving-01.toml
@@ -1,0 +1,15 @@
+schema_version = 1
+id = "driving-01"
+kind = "driving"
+provenance = "synthetic (#555); hand-built, NOT field-measured"
+target_level = "Low"
+
+# Ordinary mobility: handovers to announced towers plus routine reselection
+# churn spread across the trip.
+[[alerts]]
+kind = "rapid_reselection"
+count = 3
+
+[[alerts]]
+kind = "rapid_reselection"
+count = 2

--- a/crates/sema/corpus/femtocell-01.toml
+++ b/crates/sema/corpus/femtocell-01.toml
@@ -1,0 +1,10 @@
+schema_version = 1
+id = "femtocell-01"
+kind = "femtocell"
+provenance = "synthetic (#555); hand-built, NOT field-measured"
+target_level = "Low"
+
+# A carrier femtocell appears nearby: one strong new cell, nothing else.
+[[alerts]]
+kind = "unusually_strong_new_tower"
+signal_dbm = -48

--- a/crates/sema/corpus/outage-01.toml
+++ b/crates/sema/corpus/outage-01.toml
@@ -1,0 +1,10 @@
+schema_version = 1
+id = "outage-01"
+kind = "outage"
+provenance = "synthetic (#555); hand-built, NOT field-measured"
+target_level = "Low"
+
+# Serving-cell outage and recovery to announced coverage.
+[[alerts]]
+kind = "rapid_reselection"
+count = 2

--- a/crates/sema/corpus/roaming-01.toml
+++ b/crates/sema/corpus/roaming-01.toml
@@ -1,0 +1,11 @@
+schema_version = 1
+id = "roaming-01"
+kind = "roaming"
+provenance = "synthetic (#555); hand-built, NOT field-measured"
+target_level = "Low"
+
+# Roaming onto a foreign network: foreign towers are never announced
+# neighbours, so handovers read as "sudden tower change" — a second
+# documented residual false-positive class (#555).
+[[alerts]]
+kind = "sudden_tower_change"

--- a/crates/sema/src/cell.rs
+++ b/crates/sema/src/cell.rs
@@ -162,20 +162,65 @@ impl core::fmt::Display for CipherAlgorithm {
 
 // ── Threat scoring ──────────────────────────────────────────────────────────
 
+/// Calibration provenance of a [`ThreatScore`] (#555).
+///
+/// The detector's weights and thresholds ship as **provisional defaults**
+/// with no retained calibration corpus or evaluation behind them. Until the
+/// evaluation harness (`crate::eval`) reports an operating point over a
+/// versioned trace corpus, every score must be presented as UNCALIBRATED —
+/// never as validated operational severity. This marker is how the type
+/// system carries that honesty: a score cannot exist without stating its
+/// provenance, and any future automatic response must match on
+/// `Calibrated` before it may act.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[must_use]
+#[non_exhaustive]
+pub(crate) enum Calibration {
+    /// Weights/thresholds are the provisional hand-maintained defaults; no
+    /// corpus-backed evaluation has established an operating point.
+    Uncalibrated,
+    /// Weights/thresholds were derived from the named corpus version at the
+    /// recorded operating point, satisfying the recorded error budget.
+    Calibrated {
+        /// Version identifier of the trace corpus the evaluation ran over.
+        corpus: String,
+        /// The operating point (weight set + thresholds) the evaluation
+        /// selected, in `Config`-serializable form.
+        operating_point: String,
+        /// The measured error rates at that operating point
+        /// (false-positive and false-negative rates, per mille).
+        error_budget_per_mille: (u32, u32),
+    },
+}
+
+impl core::fmt::Display for Calibration {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Uncalibrated => f.write_str("UNCALIBRATED"),
+            Self::Calibrated { corpus, .. } => write!(f, "calibrated({corpus})"),
+        }
+    }
+}
+
 /// Threat level derived from the cumulative [`ThreatScore`].
 ///
 /// Thresholds: `<30` Low, `30–59` Medium, `60–79` High, `≥80` Critical.
+/// These boundaries are protocol invariants (changing them is a semver
+/// break), but their MEANING is provisional until the score behind them is
+/// `Calibration::Calibrated` (#555): the bands name score ranges, not yet
+/// validated detection confidence.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[must_use]
 #[non_exhaustive]
 pub(crate) enum ThreatLevel {
-    /// Score below 30. Normal operating conditions.
+    /// Score below 30. Normal operating conditions (provisional band).
     Low,
-    /// Score 30–59. Suspicious activity detected.
+    /// Score 30–59. Suspicious activity band (provisional).
     Medium,
-    /// Score 60–79. Likely IMSI catcher or active attack.
+    /// Score 60–79. High band — labeled "likely IMSI catcher" only after
+    /// calibration establishes what the band actually separates (#555).
     High,
-    /// Score 80+. Multiple strong indicators of an active attack.
+    /// Score 80+. Critical band (provisional; see High).
     Critical,
 }
 
@@ -223,14 +268,18 @@ pub(crate) struct ThreatScore {
     pub(crate) level: ThreatLevel,
     /// Individual contributing factors.
     pub(crate) factors: Vec<ThreatFactor>,
+    /// Calibration provenance (#555). Every score states it; presentation
+    /// and any future automatic response must honor it.
+    pub(crate) calibration: Calibration,
 }
 
 impl core::fmt::Display for ThreatScore {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
-            "threat score {}: {} ({} factor{})",
+            "threat score {} [{}]: {} ({} factor{})",
             self.total,
+            self.calibration,
             self.level,
             self.factors.len(),
             if self.factors.len() == 1 { "" } else { "s" },
@@ -261,12 +310,27 @@ pub(crate) fn score_threat(alerts: &[ImsiCatcherAlert]) -> ThreatScore {
 /// Supplying a non-default `config` observably changes the per-alert weights
 /// in the result and can move the overall [`ThreatLevel`] boundary. This is
 /// the primary entry point for agents tuning detection policy.
+///
+/// # Correlation model (#555)
+///
+/// Repeated alerts of the SAME kind are correlated observations — one
+/// underlying event re-reported — not independent evidence. Summing them at
+/// full weight let a single benign burst (e.g. dense-urban reselection
+/// churn) accumulate into a Critical score. The contribution of the *n*-th
+/// alert of a kind is therefore `weight / n` (harmonic discount: first
+/// alert full weight, second half, third a third, …). The harmonic series
+/// is parameter-free — it models diminishing independent information per
+/// repeat without minting another hand-maintained constant. Distinct kinds
+/// still sum fully (a cipher downgrade AND a sudden tower change ARE
+/// independent signals).
 pub(crate) fn score_threat_with_config(
     alerts: &[ImsiCatcherAlert],
     config: &Config,
 ) -> ThreatScore {
     let mut total: u32 = 0;
     let mut factors = Vec::new();
+    // Per-kind occurrence index for the harmonic correlation discount (#555).
+    let mut kind_counts = [0u32; 5];
 
     let w_cipher = config.weight_cipher_downgrade();
     let w_lac_cid = config.weight_unusual_lac_cid();
@@ -274,18 +338,21 @@ pub(crate) fn score_threat_with_config(
     let w_rapid = config.weight_rapid_reselection();
 
     for alert in alerts {
-        let (name, weight, description) = match alert {
+        let (kind_idx, name, base_weight, description) = match alert {
             ImsiCatcherAlert::TechnologyDowngrade { from, to } => (
+                0,
                 "tech_downgrade",
                 w_cipher,
                 format!("technology downgrade: {from} → {to}"),
             ),
             ImsiCatcherAlert::CipherDowngrade { algorithm } => (
+                1,
                 "cipher_downgrade",
                 w_cipher,
                 format!("weak cipher negotiated: {algorithm}"),
             ),
             ImsiCatcherAlert::SuddenTowerChange { previous, current } => (
+                2,
                 "unusual_lac_cid",
                 w_lac_cid,
                 format!(
@@ -294,6 +361,7 @@ pub(crate) fn score_threat_with_config(
                 ),
             ),
             ImsiCatcherAlert::UnusuallyStrongNewTower { tower } => (
+                3,
                 "abnormal_signal",
                 w_abnormal,
                 format!(
@@ -302,12 +370,18 @@ pub(crate) fn score_threat_with_config(
                 ),
             ),
             ImsiCatcherAlert::RapidReselection { count } => (
+                4,
                 "rapid_reselection",
                 w_rapid,
                 format!("{count} cell reselections in observation window"), // kanon:ignore STORAGE/sql-string-concat -- false positive: "reselections" contains "SELECT" substring; this is a human-readable alert string, not SQL. kanon:ignore RUST/format-sql -- same rationale
             ),
         };
 
+        // Harmonic correlation discount: the n-th alert of this kind
+        // contributes base_weight/n (#555; doc on the function).
+        kind_counts[kind_idx] += 1;
+        let n = kind_counts[kind_idx];
+        let weight = base_weight / n;
         total = total.saturating_add(weight);
         factors.push(ThreatFactor {
             name,
@@ -321,6 +395,9 @@ pub(crate) fn score_threat_with_config(
         total,
         level,
         factors,
+        // Every score ships uncalibrated until the eval harness + a versioned
+        // corpus establish an operating point (#555).
+        calibration: Calibration::Uncalibrated,
     }
 }
 
@@ -1113,6 +1190,66 @@ mod tests {
     }
 
     #[test]
+    fn score_threat_repeated_kind_gets_harmonic_discount() {
+        // #555 correlation model: three RapidReselection alerts are
+        // correlated observations of churn, not three independent events.
+        // Contributions: 10/1 + 10/2 + 10/3 = 10 + 5 + 3 = 18, NOT 30.
+        let alerts = [
+            ImsiCatcherAlert::RapidReselection { count: 3 },
+            ImsiCatcherAlert::RapidReselection { count: 4 },
+            ImsiCatcherAlert::RapidReselection { count: 5 },
+        ];
+        let score = score_threat(&alerts);
+        assert_eq!(
+            score.total, 18,
+            "repeated kind must score harmonically (10 + 5 + 3), not independently (30)"
+        );
+        assert_eq!(score.level, ThreatLevel::Low);
+        let weights: Vec<u32> = score.factors.iter().map(|f| f.weight).collect();
+        assert_eq!(weights, [10, 5, 3], "factor weights must be w, w/2, w/3");
+    }
+
+    #[test]
+    fn score_threat_repeated_strong_towers_do_not_stack_to_critical() {
+        // #555: the pre-model failure mode — five benign-but-strong tower
+        // sightings (dense-urban RF churn) stacking to 100 = Critical.
+        // Harmonic: 20 + 10 + 6 + 5 + 4 = 45 (Medium), still provisional
+        // but no longer a fabricated Critical from correlated noise.
+        let alerts: Vec<ImsiCatcherAlert> = (1..=5)
+            .map(|cid| ImsiCatcherAlert::UnusuallyStrongNewTower {
+                tower: tower(cid, -40, CellTechnology::Lte),
+            })
+            .collect();
+        let score = score_threat(&alerts);
+        assert_eq!(score.total, 45, "harmonic sum 20+10+6+5+4 = 45");
+        assert_eq!(score.level, ThreatLevel::Medium);
+    }
+
+    #[test]
+    fn score_threat_distinct_kinds_still_sum_fully() {
+        // The discount applies WITHIN a kind; distinct kinds are
+        // independent observations and sum at full weight.
+        let alerts = [
+            ImsiCatcherAlert::RapidReselection { count: 3 },
+            ImsiCatcherAlert::RapidReselection { count: 4 },
+            ImsiCatcherAlert::UnusuallyStrongNewTower {
+                tower: tower(9, -40, CellTechnology::Lte),
+            },
+        ];
+        let score = score_threat(&alerts);
+        assert_eq!(score.total, 35, "10 + 5 (harmonic) + 20 (full) = 35");
+    }
+
+    #[test]
+    fn score_threat_ships_uncalibrated() {
+        // #555: no score may exist without stating its provenance.
+        let alerts = [ImsiCatcherAlert::RapidReselection { count: 3 }];
+        let score = score_threat(&alerts);
+        assert_eq!(score.calibration, Calibration::Uncalibrated);
+        assert!(format!("{score}").contains("UNCALIBRATED"));
+    }
+
+    #[test]
     fn score_threat_combined_high() {
         // Cipher downgrade (40) + sudden tower (30) = 70 → High.
         let alerts = [
@@ -1243,6 +1380,7 @@ mod tests {
                     description: "second".to_owned(),
                 },
             ],
+            calibration: Calibration::Uncalibrated,
         };
         let display = format!("{score}");
         assert!(display.contains("70"), "display must contain total score");
@@ -1253,6 +1391,10 @@ mod tests {
         assert!(
             display.contains("2 factors"),
             "display must contain factor count"
+        );
+        assert!(
+            display.contains("UNCALIBRATED"),
+            "display must carry the calibration marker (#555) so no score reads as validated severity"
         );
     }
 

--- a/crates/sema/src/config.rs
+++ b/crates/sema/src/config.rs
@@ -2,9 +2,27 @@
 //!
 //! The IMSI-catcher detector combines five heuristic signals. Each signal has
 //! a weight that feeds a cumulative threat score and some signals carry a
-//! threshold that gates firing at all. Those values are tunable per deployment
-//! profile (daily vs. sentinel vs. panic) and should be adjustable by agents
-//! reviewing detection-vs-false-positive telemetry — not baked into the binary.
+//! threshold that gates firing at all.
+//!
+//! # Calibration status (#555): PROVISIONAL
+//!
+//! Every constant in this file is a **provisional default** — held from the
+//! detector's first implementation, with no retained calibration corpus or
+//! evaluation behind it. They are NOT validated. Two consequences:
+//!
+//! 1. Every [`crate::cell::ThreatScore`] ships marked
+//!    [`crate::cell::Calibration::Uncalibrated`]; no presentation or
+//!    automatic response may treat the resulting level as validated
+//!    operational severity.
+//! 2. The ONLY legitimate path to changing a value here is a measured
+//!    derivation: [`crate::eval`] over the versioned corpus in
+//!    `crates/sema/corpus/` (benign stationary, driving, dense-urban,
+//!    femtocell, roaming, outage, controlled attack), which reports
+//!    per-scenario outcomes and corpus-level false-positive / false-negative
+//!    / precision / recall. A calibrated config records its corpus version,
+//!    operating point, and measured error budget in
+//!    [`crate::cell::Calibration::Calibrated`]. Hand-tuning a constant
+//!    without that artifact is exactly the practice #555 prohibits.
 //!
 //! Protocol invariants (cipher algorithm IDs, threat-level boundaries at
 //! 30/60/80) remain as [`crate::cell`] compile-time values; the level
@@ -17,9 +35,10 @@ use serde::{Deserialize, Serialize};
 
 /// Default signal threshold above which a previously-unseen tower is flagged.
 ///
-/// Source: IMSI catchers typically outpower legitimate cells to force
-/// reselection; -50 dBm indicates a transmitter within ~10 m line-of-sight,
-/// which is implausible for a licensed cell site in typical deployment.
+/// PROVISIONAL (#555): rationale — IMSI catchers typically outpower
+/// legitimate cells to force reselection; -50 dBm indicates a transmitter
+/// within ~10 m line-of-sight, implausible for a licensed cell site in
+/// typical deployment. Not corpus-derived; see the module header.
 pub(crate) const DEFAULT_UNUSUALLY_STRONG_SIGNAL_DBM: i32 = -50;
 
 /// Minimum sensible signal threshold (never flag).
@@ -81,9 +100,9 @@ pub(crate) const MAX_RAPID_RESELECTION_WINDOW_SECS: u64 = 3600;
 
 /// Default weight for a cipher-downgrade alert (A5/0, A5/1, A5/2).
 ///
-/// Source: cipher downgrade is the strongest single indicator of active
-/// interception; the historical value of 40 lifts a lone alert to Medium
-/// level on its own.
+/// PROVISIONAL (#555): rationale — cipher downgrade is the strongest
+/// single indicator of active interception; 40 lifts a lone alert to
+/// Medium on its own. Not corpus-derived; see the module header.
 pub(crate) const DEFAULT_WEIGHT_CIPHER_DOWNGRADE: u32 = 40;
 
 /// Default weight for an unannounced handover (sudden-tower-change).

--- a/crates/sema/src/eval.rs
+++ b/crates/sema/src/eval.rs
@@ -1,0 +1,415 @@
+//! Deterministic replay/evaluation harness for the IMSI-catcher detector
+//! (#555).
+//!
+//! The detector's weights and thresholds are provisional constants. The only
+//! honest path to calibrated ones is evaluation over a versioned,
+//! privacy-safe trace corpus (`crates/sema/corpus/*.toml`): each scenario
+//! carries its provenance (synthetic vs field-measured) and a labeled
+//! target level; [`evaluate`] replays the alerts through
+//! [`score_threat_with_config`] and reports per-scenario outcomes plus the
+//! corpus-level false-positive / false-negative sets. Deterministic: no
+//! wall clock, no randomness, no I/O beyond the corpus files the tests load.
+//!
+//! What this harness deliberately does NOT do: learn weights. An optimizer
+//! over this report is the calibration work that follows; until a corpus
+//! version + operating point + measured error budget are recorded in
+//! [`Calibration::Calibrated`], every score stays `Uncalibrated` (#555).
+
+use serde::{Deserialize, Serialize};
+
+use crate::cell::{
+    CellTechnology, CellTower, CipherAlgorithm, ImsiCatcherAlert, ThreatLevel,
+    score_threat_with_config,
+};
+use crate::config::Config;
+
+/// Scenario kinds the corpus must eventually cover with field data (#555).
+/// Today every entry is synthetic; the kind is what future field traces map
+/// onto, not a claim about current provenance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ScenarioKind {
+    /// Device stationary, ordinary home macro coverage.
+    BenignStationary,
+    /// Ordinary mobility at driving speed.
+    Driving,
+    /// Dense-urban RF churn (many strong neighbor cells).
+    DenseUrban,
+    /// A carrier femtocell / small cell appears nearby.
+    Femtocell,
+    /// Roaming onto a foreign network.
+    Roaming,
+    /// Serving-cell outage and recovery.
+    Outage,
+    /// A controlled attack emulation (red-team / faraday-cage IMSI catcher).
+    ControlledAttack,
+}
+
+/// A corpus scenario: a replayable alert sequence plus the labeled truth.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Scenario {
+    /// Corpus schema version (1).
+    pub(crate) schema_version: u32,
+    /// Unique scenario identifier.
+    pub(crate) id: String,
+    /// Scenario kind (drives the positive/negative classification).
+    pub(crate) kind: ScenarioKind,
+    /// Where this trace came from — "synthetic" entries say so loudly;
+    /// field traces must name the collection session and privacy review.
+    pub(crate) provenance: String,
+    /// The labeled target: the level a calibrated scorer SHOULD produce.
+    pub(crate) target_level: ThreatLevel,
+    /// The alert sequence to replay (already privacy-minimized).
+    #[serde(default)]
+    pub(crate) alerts: Vec<AlertSpec>,
+}
+
+/// A TOML-friendly alert description. Towers are synthetic placeholders —
+/// scoring reads the alert KIND and its parameters, never real cell IDs
+/// (privacy: no real LAC/CID/measurements in the corpus).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case", tag = "kind")]
+pub(crate) enum AlertSpec {
+    /// Cipher downgrade to the named algorithm.
+    CipherDowngrade {
+        /// A5 algorithm negotiated.
+        algorithm: CipherAlgorithm,
+    },
+    /// Radio-technology downgrade (e.g. LTE → GSM).
+    TechnologyDowngrade,
+    /// Handover to an unannounced tower.
+    SuddenTowerChange,
+    /// Unknown tower at an unusually strong signal.
+    UnusuallyStrongNewTower {
+        /// Advertised signal strength, dBm.
+        signal_dbm: i32,
+    },
+    /// Coerced-reselection burst.
+    RapidReselection {
+        /// Reselections in the observation window.
+        count: u32,
+    },
+}
+
+impl AlertSpec {
+    /// Realize the spec as a scored alert (synthetic tower fields).
+    const fn to_alert(&self) -> ImsiCatcherAlert {
+        match self {
+            Self::CipherDowngrade { algorithm } => ImsiCatcherAlert::CipherDowngrade {
+                algorithm: *algorithm,
+            },
+            Self::TechnologyDowngrade => ImsiCatcherAlert::TechnologyDowngrade {
+                from: CellTechnology::Lte,
+                to: CellTechnology::Gsm,
+            },
+            Self::SuddenTowerChange => ImsiCatcherAlert::SuddenTowerChange {
+                previous: CellTower::new(
+                    0,
+                    0,
+                    0,
+                    0,
+                    -70,
+                    CellTechnology::Lte,
+                    jiff::Timestamp::UNIX_EPOCH,
+                ),
+                current: CellTower::new(
+                    0,
+                    0,
+                    0,
+                    0,
+                    -70,
+                    CellTechnology::Lte,
+                    jiff::Timestamp::UNIX_EPOCH,
+                ),
+            },
+            Self::UnusuallyStrongNewTower { signal_dbm } => {
+                ImsiCatcherAlert::UnusuallyStrongNewTower {
+                    tower: CellTower::new(
+                        0,
+                        0,
+                        0,
+                        0,
+                        *signal_dbm,
+                        CellTechnology::Lte,
+                        jiff::Timestamp::UNIX_EPOCH,
+                    ),
+                }
+            }
+            Self::RapidReselection { count } => {
+                ImsiCatcherAlert::RapidReselection { count: *count }
+            }
+        }
+    }
+}
+
+/// One scenario's evaluated outcome.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ScenarioOutcome {
+    /// Scenario id.
+    pub(crate) id: String,
+    /// Scenario kind.
+    pub(crate) kind: ScenarioKind,
+    /// Score the current weights produce.
+    pub(crate) total: u32,
+    /// Level the current thresholds produce.
+    pub(crate) level: ThreatLevel,
+    /// The labeled target level.
+    pub(crate) target: ThreatLevel,
+    /// Whether the produced level meets the target's expectation class:
+    /// benign kinds must score AT or BELOW target, attack kinds AT or ABOVE.
+    pub(crate) pass: bool,
+}
+
+/// The corpus-level evaluation report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EvalReport {
+    /// Per-scenario outcomes, corpus order.
+    pub(crate) outcomes: Vec<ScenarioOutcome>,
+    /// Benign scenarios whose level exceeded the target (false positives).
+    pub(crate) false_positives: Vec<String>,
+    /// Attack scenarios whose level fell below the target (false negatives).
+    pub(crate) false_negatives: Vec<String>,
+}
+
+impl EvalReport {
+    /// Precision at the corpus level: detected-as-attack scenarios that are
+    /// attack scenarios. `None` when nothing was detected as attack.
+    pub(crate) fn precision_milli(&self) -> Option<u32> {
+        let detected: Vec<&ScenarioOutcome> = self
+            .outcomes
+            .iter()
+            .filter(|o| o.level >= ThreatLevel::Medium)
+            .collect();
+        if detected.is_empty() {
+            return None;
+        }
+        let true_pos = detected
+            .iter()
+            .filter(|o| o.kind == ScenarioKind::ControlledAttack)
+            .count();
+        Some((true_pos * 1000 / detected.len()) as u32)
+    }
+
+    /// Recall at the corpus level: attack scenarios detected as attack.
+    /// `None` when the corpus has no attack scenarios.
+    pub(crate) fn recall_milli(&self) -> Option<u32> {
+        let attacks: Vec<&ScenarioOutcome> = self
+            .outcomes
+            .iter()
+            .filter(|o| o.kind == ScenarioKind::ControlledAttack)
+            .collect();
+        if attacks.is_empty() {
+            return None;
+        }
+        let found = attacks
+            .iter()
+            .filter(|o| o.level >= ThreatLevel::Medium)
+            .count();
+        Some((found * 1000 / attacks.len()) as u32)
+    }
+}
+
+/// Replay every scenario through the scorer at `config` and report outcomes.
+pub(crate) fn evaluate(scenarios: &[Scenario], config: &Config) -> EvalReport {
+    let mut outcomes = Vec::new();
+    let mut false_positives = Vec::new();
+    let mut false_negatives = Vec::new();
+
+    for scenario in scenarios {
+        let alerts: Vec<ImsiCatcherAlert> =
+            scenario.alerts.iter().map(AlertSpec::to_alert).collect();
+        let score = score_threat_with_config(&alerts, config);
+        let is_attack = scenario.kind == ScenarioKind::ControlledAttack;
+        let pass = if is_attack {
+            score.level >= scenario.target_level
+        } else {
+            score.level <= scenario.target_level
+        };
+        if !pass && is_attack {
+            false_negatives.push(scenario.id.clone());
+        } else if !pass {
+            false_positives.push(scenario.id.clone());
+        }
+        outcomes.push(ScenarioOutcome {
+            id: scenario.id.clone(),
+            kind: scenario.kind,
+            total: score.total,
+            level: score.level,
+            target: scenario.target_level,
+            pass,
+        });
+    }
+
+    EvalReport {
+        outcomes,
+        false_positives,
+        false_negatives,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn corpus_dir() -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("corpus")
+    }
+
+    /// Load every corpus entry from a directory of TOML files, sorted by
+    /// file name for determinism. Unreadable/unparseable entries are
+    /// skipped; the corpus tests assert the exact expected count, so a
+    /// broken file fails loudly there (the workspace lint set forbids
+    /// panic!/expect anywhere, tests included).
+    fn load_corpus(dir: &std::path::Path) -> Vec<Scenario> {
+        let mut files: Vec<_> = std::fs::read_dir(dir)
+            .map(|rd| {
+                rd.filter_map(std::result::Result::ok)
+                    .map(|e| e.path())
+                    .collect()
+            })
+            .unwrap_or_default();
+        files.sort();
+        files
+            .iter()
+            .filter(|p| p.extension().is_some_and(|x| x == "toml"))
+            .filter_map(|p| std::fs::read_to_string(p).ok())
+            .filter_map(|text| toml::from_str::<Scenario>(&text).ok())
+            .collect()
+    }
+
+    #[test]
+    fn corpus_parses_and_covers_required_kinds() {
+        let scenarios = load_corpus(&corpus_dir());
+        assert_eq!(
+            scenarios.len(),
+            7,
+            "every corpus file must load (a parse/IO failure shows here): {scenarios:?}"
+        );
+        for kind in [
+            ScenarioKind::BenignStationary,
+            ScenarioKind::Driving,
+            ScenarioKind::DenseUrban,
+            ScenarioKind::Femtocell,
+            ScenarioKind::Roaming,
+            ScenarioKind::Outage,
+            ScenarioKind::ControlledAttack,
+        ] {
+            assert!(
+                scenarios.iter().any(|s| s.kind == kind),
+                "corpus must contain a {kind:?} scenario"
+            );
+        }
+        for s in &scenarios {
+            assert_eq!(s.schema_version, 1, "{}: schema version", s.id);
+            assert!(
+                s.provenance.contains("synthetic"),
+                "{}: provenance must declare its class (field traces must name their session)",
+                s.id
+            );
+        }
+    }
+
+    #[test]
+    fn corpus_evaluation_is_deterministic() {
+        let scenarios = load_corpus(&corpus_dir());
+        let a = evaluate(&scenarios, &Config::default());
+        let b = evaluate(&scenarios, &Config::default());
+        assert_eq!(a, b, "the harness must be deterministic");
+    }
+
+    #[test]
+    fn benign_core_scenarios_stay_low_at_current_weights() {
+        // Ordinary benign traces must not fabricate attack detections.
+        // The documented RESIDUAL false positives (dense-urban, roaming —
+        // see corpus_evaluates_residual_fps) are excluded here on purpose.
+        let scenarios = load_corpus(&corpus_dir());
+        let report = evaluate(&scenarios, &Config::default());
+        for outcome in &report.outcomes {
+            if matches!(
+                outcome.kind,
+                ScenarioKind::BenignStationary
+                    | ScenarioKind::Driving
+                    | ScenarioKind::Femtocell
+                    | ScenarioKind::Outage
+            ) {
+                assert!(
+                    outcome.level <= ThreatLevel::Low,
+                    "benign scenario {} must not score above Low (got {:?} at {})",
+                    outcome.id,
+                    outcome.level,
+                    outcome.total
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn corpus_evaluates_residual_fps_honestly() {
+        // Dense-urban and roaming are the documented residual false-positive
+        // classes at the provisional weights (the harmonic model BOUNDS
+        // dense-urban at Medium instead of the old fabricated Critical;
+        // closing both to Low is calibration work, tracked by this report).
+        let scenarios = load_corpus(&corpus_dir());
+        let report = evaluate(&scenarios, &Config::default());
+        assert!(
+            report
+                .false_positives
+                .iter()
+                .any(|id| id == "dense-urban-01"),
+            "dense-urban must be counted as a residual FP: {:?}",
+            report.false_positives
+        );
+        assert!(
+            report.false_positives.iter().any(|id| id == "roaming-01"),
+            "roaming must be counted as a residual FP: {:?}",
+            report.false_positives
+        );
+        assert_eq!(
+            report.false_positives.len(),
+            2,
+            "exactly the two documented residual FPs"
+        );
+        // The harness reports the degraded precision these FPs cause:
+        // 1 attack detected out of 3 attack-band scenarios.
+        assert_eq!(report.precision_milli(), Some(333));
+    }
+
+    #[test]
+    fn controlled_attack_is_detected_at_current_weights() {
+        let scenarios = load_corpus(&corpus_dir());
+        let report = evaluate(&scenarios, &Config::default());
+        assert!(
+            report.false_negatives.is_empty(),
+            "the controlled attack must be detected: {:?}",
+            report.false_negatives
+        );
+        assert_eq!(report.recall_milli(), Some(1000), "recall on the corpus");
+    }
+
+    #[test]
+    fn harmonic_model_bounds_dense_urban_fp() {
+        // The pre-#555 independent-sum model stacked five strong-tower
+        // sightings to Critical (100). The harmonic model bounds the same
+        // trace at Medium — still above the Low target (an honest residual
+        // FP the calibration work must close), but no longer a fabricated
+        // Critical. This test pins the MODEL's effect, not the constants.
+        let scenario = Scenario {
+            schema_version: 1,
+            id: "dense-urban-model-check".to_owned(),
+            kind: ScenarioKind::DenseUrban,
+            provenance: "synthetic (#555)".to_owned(),
+            target_level: ThreatLevel::Low,
+            alerts: (0..5)
+                .map(|_| AlertSpec::UnusuallyStrongNewTower { signal_dbm: -40 })
+                .collect(),
+        };
+        let report = evaluate(&[scenario], &Config::default());
+        assert_eq!(report.outcomes[0].total, 45, "20+10+6+5+4 harmonic bound");
+        assert_eq!(report.outcomes[0].level, ThreatLevel::Medium);
+    }
+}

--- a/crates/sema/src/lib.rs
+++ b/crates/sema/src/lib.rs
@@ -8,5 +8,6 @@
 
 pub mod cell;
 pub mod config;
+pub mod eval;
 pub mod wifi;
 pub mod wifi_analysis;


### PR DESCRIPTION
## Summary

The IMSI-catcher detector assigned exact weights and Low/Medium/High/Critical labels with no retained calibration corpus, cited derivation, or evaluation harness — tests merely reproduced the constants. And it summed every repeated alert as if independent, so correlated benign churn (dense-urban RF, roaming) could accumulate into a fabricated "Critical" that an actuator would one day trust.

**Calibration honesty (structural, not prose):** every `ThreatScore` now carries a `Calibration` marker — `Uncalibrated` today; `Calibrated` requires a corpus version, operating point, and measured error budget — rendered in `Display` (`threat score 45 [UNCALIBRATED]: MEDIUM ...`). No score can exist without stating its provenance; any future automatic response must match on `Calibrated` before acting. `ThreatLevel` docs stop claiming "likely IMSI catcher"; the 30/60/80 boundaries stay protocol invariants with *provisional* meaning.

**Correlation modeled:** the n-th alert of a kind contributes `weight / n` (harmonic discount — parameter-free diminishing independent evidence; distinct kinds still sum fully). The pre-model failure mode (five strong-tower sightings stacking to 100 = Critical) now bounds at 45, pinned by tests.

**The harness** (`crates/sema/src/eval.rs`): deterministic replay/evaluation over a versioned TOML corpus — per-scenario outcomes, corpus false positives/negatives, precision/recall (`milli`). No wall clock, no randomness, no I/O beyond the corpus.

**The corpus** (`crates/sema/corpus/`, schema v1): 7 synthetic scenarios covering every kind the issue names (benign stationary, driving, dense-urban, femtocell, roaming, outage, controlled attack), each declaring its provenance class. The harness **honestly counts the two residual false-positive classes the phase plan predicts** — dense-urban (harmonic-bounded at Medium) and roaming — yielding corpus precision 333/1000 with recall 1000. Closing them is calibration work that must show up in this report, not in prose.

`config.rs` now marks every constant PROVISIONAL and names the harness as the only legitimate derivation path.

## Verification

- `cargo test -p sema`: **83/83 pass** — harmonic discount arithmetic, repeated-tower bound, distinct-kind full sum, UNCALIBRATED marker in display, corpus parse + exact-count load, deterministic eval, benign-core scenarios stay Low, residual FPs counted (dense-urban, roaming; precision 333), attack detected (recall 1000).
- `cargo clippy -p sema --all-targets -- -D warnings`: clean (workspace lint set: no unwrap/expect/panic anywhere, tests included — `load_corpus` is total with count assertions).
- `cargo fmt`: clean.

Closes #555