### PR TITLE
metaxu: versioned bounded envelope + typed STT events + golden vectors (#553)

### DIFF
--- a/crates/metaxu/src/envelope.rs
+++ b/crates/metaxu/src/envelope.rs
@@ -167,7 +167,6 @@ pub enum EnvelopeError {
     },
 }
 
-
 /// A parsed envelope header (validated; the payload is checked separately).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct EnvelopeHeader {
@@ -206,7 +205,11 @@ impl EnvelopeHeader {
                 present: bytes.len(),
             });
         }
-        let magic = u32::from_le_bytes(bytes[0..4].try_into().map_err(|_| EnvelopeError::BadMagic)?);
+        let magic = u32::from_le_bytes(
+            bytes[0..4]
+                .try_into()
+                .map_err(|_| EnvelopeError::BadMagic)?,
+        );
         if magic != MAGIC {
             return Err(EnvelopeError::BadMagic);
         }
@@ -231,7 +234,8 @@ impl EnvelopeHeader {
                 .try_into()
                 .map_err(|_| EnvelopeError::UnknownKind { kind: 0 })?,
         );
-        let kind = MessageKind::from_u16(kind_raw).ok_or(EnvelopeError::UnknownKind { kind: kind_raw })?;
+        let kind =
+            MessageKind::from_u16(kind_raw).ok_or(EnvelopeError::UnknownKind { kind: kind_raw })?;
         let correlation_id = u64::from_le_bytes(
             bytes[10..18]
                 .try_into()
@@ -280,11 +284,12 @@ impl Envelope {
         correlation_id: u64,
         payload: Vec<u8>,
     ) -> Result<Self, EnvelopeError> {
-        let payload_len = u32::try_from(payload.len()).map_err(|_| EnvelopeError::FrameTooLarge {
-            kind,
-            declared: u32::MAX,
-            ceiling: kind.payload_ceiling(),
-        })?;
+        let payload_len =
+            u32::try_from(payload.len()).map_err(|_| EnvelopeError::FrameTooLarge {
+                kind,
+                declared: u32::MAX,
+                ceiling: kind.payload_ceiling(),
+            })?;
         let ceiling = kind.payload_ceiling();
         if payload_len > ceiling {
             return Err(EnvelopeError::FrameTooLarge {
@@ -445,8 +450,16 @@ mod tests {
         assert_eq!(bytes[6], MAJOR, "major at [6]");
         assert_eq!(bytes[7], MINOR, "minor at [7]");
         assert_eq!(&bytes[8..10], &1u16.to_le_bytes(), "kind at [8..10)");
-        assert_eq!(&bytes[10..18], &7u64.to_le_bytes(), "correlation at [10..18)");
-        assert_eq!(&bytes[18..22], &3u32.to_le_bytes(), "payload_len at [18..22)");
+        assert_eq!(
+            &bytes[10..18],
+            &7u64.to_le_bytes(),
+            "correlation at [10..18)"
+        );
+        assert_eq!(
+            &bytes[18..22],
+            &3u32.to_le_bytes(),
+            "payload_len at [18..22)"
+        );
         assert_eq!(&bytes[22..], &[1, 2, 3], "payload follows");
     }
 

--- a/crates/metaxu/src/envelope.rs
+++ b/crates/metaxu/src/envelope.rs
@@ -1,0 +1,575 @@
+//! The versioned wire envelope: the ONE shared Aletheia-facing contract
+//! (#553).
+//!
+//! Every Aletheia-facing frame — task request, task response, STT event —
+//! travels inside this envelope. It exists so two repositories (thumos and
+//! aletheia) never ship separate assumptions: magic + schema identity,
+//! major/minor version, message kind, correlation ID, and declared length
+//! are checked BEFORE any allocation or payload decode, and decoding is
+//! exact (a frame is the header plus exactly `payload_len` bytes, no more,
+//! no less).
+//!
+//! # Layout (22-byte fixed header, little-endian)
+//!
+//! ```text
+//! [0..4)   magic: u32 = MAGIC ("MTX1" bytes 4D 54 58 31)
+//! [4..6)   schema: u16 = SCHEMA_ID (1)
+//! [6]      major: u8   = MAJOR (1)
+//! [7]      minor: u8   = MINOR (0)
+//! [8..10)  kind: u16   = MessageKind
+//! [10..18) correlation_id: u64 (request/response/event correlation)
+//! [18..22) payload_len: u32 (declared; ceiling-checked BEFORE allocation)
+//! [22..)   payload (postcard bytes for the kind's payload type)
+//! ```
+//!
+//! # Compatibility rules
+//!
+//! - Wrong magic or schema: reject (`BadMagic` / `UnsupportedSchema`) —
+//!   never a silent misdecode.
+//! - `major` mismatch: reject (`IncompatibleVersion`). A major bump is
+//!   never negotiated silently.
+//! - `minor` NEWER than ours: accepted ONLY if `kind` is known and the
+//!   payload decodes exactly — minor bumps may ADD kinds or optional
+//!   fields within a kind, never change an existing kind's payload shape.
+//!   An unknown kind always rejects (`UnknownKind`).
+//! - `minor` older than ours: accepted (symmetric rule).
+//! - `payload_len` above the kind's ceiling: reject (`FrameTooLarge`)
+//!   BEFORE allocating — a 1 GB device never allocates on a peer's say-so.
+//! - Actual bytes != 22 + `payload_len`: reject (`TruncatedFrame` /
+//!   `TrailingBytes`) — exact decoding, always.
+//!
+//! Golden vectors live in `vectors.rs`; both repositories must decode them
+//! identically (#544 proves both endpoints against them).
+
+use compact_str::CompactString;
+use serde::{Deserialize, Serialize};
+use snafu::Snafu;
+
+/// Envelope magic bytes: "MTX1" as a u32 LE (4D 54 58 31 on the wire).
+pub(crate) const MAGIC: u32 = 0x3158_544D;
+
+/// Schema family identifier (bump only for a new envelope family).
+pub(crate) const SCHEMA_ID: u16 = 1;
+
+/// Major version: incompatible changes only.
+pub(crate) const MAJOR: u8 = 1;
+
+/// Minor version: additive changes within [`MAJOR`].
+pub(crate) const MINOR: u8 = 0;
+
+/// Fixed header length in bytes.
+pub(crate) const HEADER_LEN: usize = 22;
+
+/// Per-kind payload ceilings (v1). Derived from content classes:
+/// - STT text is one utterance: 4 KiB.
+/// - Task requests/responses carry summaries, drafts, small batches: 32 KiB.
+pub(crate) const MAX_STT_PAYLOAD: u32 = 4 * 1024;
+/// Task request payload ceiling.
+pub(crate) const MAX_TASK_REQUEST_PAYLOAD: u32 = 32 * 1024;
+/// Task response payload ceiling.
+pub(crate) const MAX_TASK_RESPONSE_PAYLOAD: u32 = 32 * 1024;
+
+/// The message kinds this envelope version knows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[must_use]
+#[non_exhaustive]
+#[repr(u16)]
+pub enum MessageKind {
+    /// A task request (device action proposal).
+    TaskRequest = 1,
+    /// A task response (accepted/rejected).
+    TaskResponse = 2,
+    /// An STT event (partial/final/error).
+    SttEvent = 3,
+}
+
+impl MessageKind {
+    /// Parse a wire kind value.
+    const fn from_u16(v: u16) -> Option<Self> {
+        match v {
+            1 => Some(Self::TaskRequest),
+            2 => Some(Self::TaskResponse),
+            3 => Some(Self::SttEvent),
+            _ => None,
+        }
+    }
+
+    /// This kind's payload ceiling.
+    const fn payload_ceiling(self) -> u32 {
+        match self {
+            Self::TaskRequest => MAX_TASK_REQUEST_PAYLOAD,
+            Self::TaskResponse => MAX_TASK_RESPONSE_PAYLOAD,
+            Self::SttEvent => MAX_STT_PAYLOAD,
+        }
+    }
+}
+
+/// Envelope errors: every reject is explicit and named (#553).
+#[derive(Debug, Clone, PartialEq, Eq, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[must_use]
+#[non_exhaustive]
+pub enum EnvelopeError {
+    /// Magic bytes did not match.
+    #[snafu(display("bad envelope magic"))]
+    BadMagic,
+    /// Schema family is not supported.
+    #[snafu(display("unsupported schema {schema}"))]
+    UnsupportedSchema {
+        /// The frame's schema ID.
+        schema: u16,
+    },
+    /// Major version mismatch — never silently negotiated.
+    #[snafu(display("incompatible major version (ours {ours}, theirs {theirs})"))]
+    IncompatibleVersion {
+        /// Our major.
+        ours: u8,
+        /// The frame's major.
+        theirs: u8,
+    },
+    /// The kind value is not known at this version.
+    #[snafu(display("unknown message kind {kind}"))]
+    UnknownKind {
+        /// The frame's kind field.
+        kind: u16,
+    },
+    /// A decoder was handed a frame of a different kind than it expects.
+    #[snafu(display("unexpected kind: expected {expected:?}, got {got:?}"))]
+    UnexpectedKind {
+        /// The kind the caller asked for.
+        expected: MessageKind,
+        /// The kind the frame carries.
+        got: MessageKind,
+    },
+    /// Declared payload length exceeds the kind's ceiling.
+    #[snafu(display("frame too large for {kind:?}: declared {declared} > ceiling {ceiling}"))]
+    FrameTooLarge {
+        /// The kind.
+        kind: MessageKind,
+        /// The declared length.
+        declared: u32,
+        /// The ceiling.
+        ceiling: u32,
+    },
+    /// Fewer bytes than 22 + `payload_len` arrived.
+    #[snafu(display("truncated frame: expected {expected} bytes, have {present}"))]
+    TruncatedFrame {
+        /// Bytes expected.
+        expected: usize,
+        /// Bytes present.
+        present: usize,
+    },
+    /// More bytes than 22 + `payload_len` arrived (exact decoding).
+    #[snafu(display("{extra} trailing bytes after frame"))]
+    TrailingBytes {
+        /// Extra byte count.
+        extra: usize,
+    },
+}
+
+
+/// A parsed envelope header (validated; the payload is checked separately).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct EnvelopeHeader {
+    /// Message kind.
+    pub(crate) kind: MessageKind,
+    /// Correlation ID.
+    pub(crate) correlation_id: u64,
+    /// Declared payload length (ceiling-checked already).
+    pub(crate) payload_len: u32,
+    /// The frame's minor version.
+    pub(crate) minor: u8,
+}
+
+impl EnvelopeHeader {
+    /// Encode the header bytes for an outgoing frame.
+    fn encode(&self) -> [u8; HEADER_LEN] {
+        let mut out = [0u8; HEADER_LEN];
+        out[0..4].copy_from_slice(&MAGIC.to_le_bytes());
+        out[4..6].copy_from_slice(&SCHEMA_ID.to_le_bytes());
+        out[6] = MAJOR;
+        out[7] = MINOR;
+        out[8..10].copy_from_slice(&(self.kind as u16).to_le_bytes());
+        out[10..18].copy_from_slice(&self.correlation_id.to_le_bytes());
+        out[18..22].copy_from_slice(&self.payload_len.to_le_bytes());
+        out
+    }
+
+    /// Parse + validate a header from the front of `bytes`.
+    ///
+    /// Checks magic, schema, major compat, kind, and the payload ceiling —
+    /// everything BEFORE the caller allocates for a payload (#553).
+    fn parse(bytes: &[u8]) -> Result<Self, EnvelopeError> {
+        if bytes.len() < HEADER_LEN {
+            return Err(EnvelopeError::TruncatedFrame {
+                expected: HEADER_LEN,
+                present: bytes.len(),
+            });
+        }
+        let magic = u32::from_le_bytes(bytes[0..4].try_into().map_err(|_| EnvelopeError::BadMagic)?);
+        if magic != MAGIC {
+            return Err(EnvelopeError::BadMagic);
+        }
+        let schema = u16::from_le_bytes(
+            bytes[4..6]
+                .try_into()
+                .map_err(|_| EnvelopeError::UnsupportedSchema { schema: 0 })?,
+        );
+        if schema != SCHEMA_ID {
+            return Err(EnvelopeError::UnsupportedSchema { schema });
+        }
+        let major = bytes[6];
+        if major != MAJOR {
+            return Err(EnvelopeError::IncompatibleVersion {
+                ours: MAJOR,
+                theirs: major,
+            });
+        }
+        let minor = bytes[7];
+        let kind_raw = u16::from_le_bytes(
+            bytes[8..10]
+                .try_into()
+                .map_err(|_| EnvelopeError::UnknownKind { kind: 0 })?,
+        );
+        let kind = MessageKind::from_u16(kind_raw).ok_or(EnvelopeError::UnknownKind { kind: kind_raw })?;
+        let correlation_id = u64::from_le_bytes(
+            bytes[10..18]
+                .try_into()
+                .map_err(|_| EnvelopeError::BadMagic)?,
+        );
+        let payload_len = u32::from_le_bytes(
+            bytes[18..22]
+                .try_into()
+                .map_err(|_| EnvelopeError::BadMagic)?,
+        );
+        let ceiling = kind.payload_ceiling();
+        if payload_len > ceiling {
+            return Err(EnvelopeError::FrameTooLarge {
+                kind,
+                declared: payload_len,
+                ceiling,
+            });
+        }
+        Ok(Self {
+            kind,
+            correlation_id,
+            payload_len,
+            minor,
+        })
+    }
+}
+
+/// An owned, fully-validated frame (header + exact payload).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Envelope {
+    /// The validated header.
+    pub(crate) header: EnvelopeHeader,
+    /// The payload bytes (exactly `header.payload_len` long).
+    pub(crate) payload: Vec<u8>,
+}
+
+impl Envelope {
+    /// Build an outgoing frame from kind/correlation/payload.
+    ///
+    /// # Errors
+    ///
+    /// [`EnvelopeError::FrameTooLarge`] if the payload exceeds the kind's
+    /// ceiling (outgoing frames obey the same bound as incoming).
+    pub(crate) fn build(
+        kind: MessageKind,
+        correlation_id: u64,
+        payload: Vec<u8>,
+    ) -> Result<Self, EnvelopeError> {
+        let payload_len = u32::try_from(payload.len()).map_err(|_| EnvelopeError::FrameTooLarge {
+            kind,
+            declared: u32::MAX,
+            ceiling: kind.payload_ceiling(),
+        })?;
+        let ceiling = kind.payload_ceiling();
+        if payload_len > ceiling {
+            return Err(EnvelopeError::FrameTooLarge {
+                kind,
+                declared: payload_len,
+                ceiling,
+            });
+        }
+        Ok(Self {
+            header: EnvelopeHeader {
+                kind,
+                correlation_id,
+                payload_len,
+                minor: MINOR,
+            },
+            payload,
+        })
+    }
+
+    /// Serialize the frame (header + payload).
+    pub(crate) fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(HEADER_LEN + self.payload.len());
+        out.extend_from_slice(&self.header.encode());
+        out.extend_from_slice(&self.payload);
+        out
+    }
+
+    /// Parse a frame, enforcing exact decoding: the input must be EXACTLY
+    /// one frame (no truncation, no trailing bytes), and the payload length
+    /// is ceiling-checked BEFORE the payload is copied (#553).
+    pub(crate) fn decode(bytes: &[u8]) -> Result<Self, EnvelopeError> {
+        let header = EnvelopeHeader::parse(bytes)?;
+        let expected = HEADER_LEN + header.payload_len as usize;
+        if bytes.len() < expected {
+            return Err(EnvelopeError::TruncatedFrame {
+                expected,
+                present: bytes.len(),
+            });
+        }
+        if bytes.len() > expected {
+            return Err(EnvelopeError::TrailingBytes {
+                extra: bytes.len() - expected,
+            });
+        }
+        Ok(Self {
+            header,
+            payload: bytes[HEADER_LEN..expected].to_vec(),
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Typed STT events (#553): partial/final/error with sequence + provenance
+// ---------------------------------------------------------------------------
+
+/// A typed STT event — the payload of a [`MessageKind::SttEvent`] frame.
+///
+/// Replaces the ad hoc `{"text", "final"}` convention: every event carries
+/// a session-correlated sequence number and, for finals, provenance
+/// (language, model, audio duration) so a transcript is auditable.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[must_use]
+#[non_exhaustive]
+pub enum SttEvent {
+    /// An in-progress partial result (seq is monotonic within a session).
+    Partial {
+        /// Sequence number within the session (monotonic).
+        seq: u32,
+        /// Partial transcript text (bounded by the frame ceiling).
+        text: CompactString,
+        /// Recognizer confidence, per-mille when known (0 = unknown).
+        confidence_milli: u16,
+    },
+    /// The session's final transcript, with provenance.
+    Final {
+        /// Sequence number (greater than every partial's).
+        seq: u32,
+        /// Final transcript text.
+        text: CompactString,
+        /// BCP-47 language tag actually recognized.
+        language: CompactString,
+        /// Model identifier that produced the transcript.
+        model: CompactString,
+        /// Audio duration processed, milliseconds.
+        duration_ms: u32,
+    },
+    /// A terminal error event.
+    Error {
+        /// Sequence number.
+        seq: u32,
+        /// Typed error code.
+        code: SttErrorCode,
+    },
+}
+
+/// Typed STT error codes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[must_use]
+#[non_exhaustive]
+pub enum SttErrorCode {
+    /// The recognizer is overloaded/unavailable.
+    ModelOverloaded,
+    /// The audio stream was malformed or unsupported.
+    BadAudio,
+    /// The session was cancelled by the service.
+    Cancelled,
+}
+
+impl SttEvent {
+    /// The event's sequence number.
+    pub const fn seq(&self) -> u32 {
+        match self {
+            Self::Partial { seq, .. } | Self::Final { seq, .. } | Self::Error { seq, .. } => *seq,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_payload(kind: MessageKind) -> Vec<u8> {
+        match kind {
+            MessageKind::TaskRequest => b"task-payload".to_vec(),
+            MessageKind::TaskResponse => b"response-payload".to_vec(),
+            MessageKind::SttEvent => b"stt".to_vec(),
+        }
+    }
+
+    #[test]
+    fn round_trip_preserves_frame() {
+        for kind in [
+            MessageKind::TaskRequest,
+            MessageKind::TaskResponse,
+            MessageKind::SttEvent,
+        ] {
+            let frame = Envelope::build(kind, 0xA5A5_1234, sample_payload(kind)).ok();
+            assert!(frame.is_some());
+            let frame = frame.unwrap_or_else(|| unreachable!());
+            let bytes = frame.encode();
+            let back = Envelope::decode(&bytes);
+            assert_eq!(back, Ok(frame), "{kind:?} must round-trip exactly");
+        }
+    }
+
+    #[test]
+    fn header_layout_is_exact() {
+        let frame = Envelope::build(MessageKind::TaskRequest, 7, vec![1, 2, 3])
+            .unwrap_or_else(|_| unreachable!());
+        let bytes = frame.encode();
+        assert_eq!(bytes.len(), HEADER_LEN + 3);
+        assert_eq!(&bytes[0..4], &MAGIC.to_le_bytes(), "magic at [0..4)");
+        assert_eq!(&bytes[4..6], &SCHEMA_ID.to_le_bytes(), "schema at [4..6)");
+        assert_eq!(bytes[6], MAJOR, "major at [6]");
+        assert_eq!(bytes[7], MINOR, "minor at [7]");
+        assert_eq!(&bytes[8..10], &1u16.to_le_bytes(), "kind at [8..10)");
+        assert_eq!(&bytes[10..18], &7u64.to_le_bytes(), "correlation at [10..18)");
+        assert_eq!(&bytes[18..22], &3u32.to_le_bytes(), "payload_len at [18..22)");
+        assert_eq!(&bytes[22..], &[1, 2, 3], "payload follows");
+    }
+
+    #[test]
+    fn bad_magic_rejects() {
+        let mut bytes = Envelope::build(MessageKind::TaskRequest, 1, vec![0])
+            .unwrap_or_else(|_| unreachable!())
+            .encode();
+        bytes[0] ^= 0xFF;
+        assert_eq!(Envelope::decode(&bytes), Err(EnvelopeError::BadMagic));
+    }
+
+    #[test]
+    fn major_mismatch_rejects_explicitly() {
+        let mut bytes = Envelope::build(MessageKind::TaskRequest, 1, vec![0])
+            .unwrap_or_else(|_| unreachable!())
+            .encode();
+        bytes[6] = MAJOR + 1;
+        assert_eq!(
+            Envelope::decode(&bytes),
+            Err(EnvelopeError::IncompatibleVersion {
+                ours: MAJOR,
+                theirs: MAJOR + 1,
+            }),
+            "a major bump is an explicit error, never a silent downgrade"
+        );
+    }
+
+    #[test]
+    fn unknown_kind_rejects() {
+        let mut bytes = Envelope::build(MessageKind::TaskRequest, 1, vec![0])
+            .unwrap_or_else(|_| unreachable!())
+            .encode();
+        bytes[8..10].copy_from_slice(&99u16.to_le_bytes());
+        assert_eq!(
+            Envelope::decode(&bytes),
+            Err(EnvelopeError::UnknownKind { kind: 99 })
+        );
+    }
+
+    #[test]
+    fn oversized_payload_rejects_before_allocation() {
+        let mut bytes = Envelope::build(MessageKind::SttEvent, 1, vec![0])
+            .unwrap_or_else(|_| unreachable!())
+            .encode();
+        // Declare a payload one byte over the STT ceiling.
+        bytes[18..22].copy_from_slice(&(MAX_STT_PAYLOAD + 1).to_le_bytes());
+        assert_eq!(
+            Envelope::decode(&bytes),
+            Err(EnvelopeError::FrameTooLarge {
+                kind: MessageKind::SttEvent,
+                declared: MAX_STT_PAYLOAD + 1,
+                ceiling: MAX_STT_PAYLOAD,
+            }),
+            "the ceiling check fires on the DECLARED length, before any payload copy"
+        );
+    }
+
+    #[test]
+    fn truncated_and_trailing_reject() {
+        let frame = Envelope::build(MessageKind::TaskRequest, 1, b"abc".to_vec())
+            .unwrap_or_else(|_| unreachable!());
+        let bytes = frame.encode();
+        let truncated = &bytes[..bytes.len() - 1];
+        assert!(matches!(
+            Envelope::decode(truncated),
+            Err(EnvelopeError::TruncatedFrame { .. })
+        ));
+        let mut trailing = bytes.clone();
+        trailing.push(0);
+        assert_eq!(
+            Envelope::decode(&trailing),
+            Err(EnvelopeError::TrailingBytes { extra: 1 }),
+            "exact decoding: extra bytes are a protocol error"
+        );
+    }
+
+    #[test]
+    fn newer_minor_with_known_kind_accepted() {
+        // Compat rule: a newer minor is accepted when kind is known and the
+        // payload decodes exactly (minor bumps are additive only).
+        let mut bytes = Envelope::build(MessageKind::TaskRequest, 1, vec![0])
+            .unwrap_or_else(|_| unreachable!())
+            .encode();
+        bytes[7] = MINOR + 1;
+        let back = Envelope::decode(&bytes);
+        assert!(back.is_ok(), "newer minor + known kind must accept");
+        assert_eq!(
+            back.ok().map(|f| f.header.minor),
+            Some(MINOR + 1),
+            "the frame's minor is preserved for the caller's semantics"
+        );
+    }
+
+    #[test]
+    fn build_rejects_over_ceiling_payload() {
+        let too_big = vec![0u8; MAX_STT_PAYLOAD as usize + 1];
+        assert!(matches!(
+            Envelope::build(MessageKind::SttEvent, 1, too_big),
+            Err(EnvelopeError::FrameTooLarge { .. })
+        ));
+    }
+
+    #[test]
+    fn stt_event_seq_accessor() {
+        let p = SttEvent::Partial {
+            seq: 3,
+            text: "hello".into(),
+            confidence_milli: 800,
+        };
+        assert_eq!(p.seq(), 3);
+        let f = SttEvent::Final {
+            seq: 7,
+            text: "hello world".into(),
+            language: "en".into(),
+            model: "whisper-small".into(),
+            duration_ms: 1200,
+        };
+        assert_eq!(f.seq(), 7);
+        let e = SttEvent::Error {
+            seq: 8,
+            code: SttErrorCode::Cancelled,
+        };
+        assert_eq!(e.seq(), 8);
+    }
+}

--- a/crates/metaxu/src/error.rs
+++ b/crates/metaxu/src/error.rs
@@ -45,6 +45,17 @@ where
         location: Location,
     },
 
+    /// The wire envelope rejected a frame (bad magic, version, kind,
+    /// size, or shape) before any payload decode (#553).
+    #[snafu(display("envelope rejected frame at {location}: {source}"))]
+    Envelope {
+        /// The envelope-level rejection.
+        source: crate::envelope::EnvelopeError,
+        /// Source location where the error was attached.
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     /// A request was missing the capability grant required by its task.
     #[snafu(display(
         "request {request_id} is missing required capability grant {capability:?} at {location}"
@@ -126,6 +137,7 @@ impl Error<core::convert::Infallible> {
                 capability,
                 location,
             },
+            Self::Envelope { source, location } => Error::Envelope { source, location },
             Self::ResponseRequestMismatch {
                 request_id,
                 response_id,

--- a/crates/metaxu/src/lib.rs
+++ b/crates/metaxu/src/lib.rs
@@ -10,17 +10,16 @@
 mod client;
 mod envelope;
 mod error;
-#[cfg(test)]
-mod vectors;
 mod protocol;
 mod transport;
-
+#[cfg(test)]
+mod vectors;
 
 use snafu::{OptionExt as _, ResultExt as _};
 
 pub use client::BridgeClient; // kanon:ignore RUST/pub-visibility -- public API
-pub use error::{Error, Result};
 pub use envelope::{EnvelopeError, MessageKind, SttErrorCode, SttEvent}; // kanon:ignore RUST/pub-visibility -- public API
+pub use error::{Error, Result};
 pub use protocol::{
     AudioMode, Capability, CapabilityGrant, ContactSummary, DeviceAction, DeviceIdentityRef,
     IdentityKind, TaskRequest, TaskResponse, TaskStatus,
@@ -159,8 +158,8 @@ mod tests {
     }
 
     #[test]
-    fn decode_request_rejects_malformed_payload(
-    ) -> core::result::Result<(), crate::envelope::EnvelopeError> {
+    fn decode_request_rejects_malformed_payload()
+    -> core::result::Result<(), crate::envelope::EnvelopeError> {
         // A well-formed envelope whose payload is not a valid TaskRequest:
         // the envelope passes, the postcard layer rejects.
         let frame = crate::envelope::Envelope::build(

--- a/crates/metaxu/src/lib.rs
+++ b/crates/metaxu/src/lib.rs
@@ -8,14 +8,19 @@
 //! authenticate grants, or require live Menos connectivity.
 
 mod client;
+mod envelope;
 mod error;
+#[cfg(test)]
+mod vectors;
 mod protocol;
 mod transport;
+
 
 use snafu::{OptionExt as _, ResultExt as _};
 
 pub use client::BridgeClient; // kanon:ignore RUST/pub-visibility -- public API
 pub use error::{Error, Result};
+pub use envelope::{EnvelopeError, MessageKind, SttErrorCode, SttEvent}; // kanon:ignore RUST/pub-visibility -- public API
 pub use protocol::{
     AudioMode, Capability, CapabilityGrant, ContactSummary, DeviceAction, DeviceIdentityRef,
     IdentityKind, TaskRequest, TaskResponse, TaskStatus,
@@ -148,13 +153,30 @@ mod tests {
     fn decode_request_rejects_malformed_bytes() {
         let result = decode_request(&[]);
 
+        // #553: the envelope layer rejects first (truncated header), so a
+        // malformed frame can never reach the postcard decoder.
+        assert!(matches!(result, Err(Error::Envelope { .. })));
+    }
+
+    #[test]
+    fn decode_request_rejects_malformed_payload(
+    ) -> core::result::Result<(), crate::envelope::EnvelopeError> {
+        // A well-formed envelope whose payload is not a valid TaskRequest:
+        // the envelope passes, the postcard layer rejects.
+        let frame = crate::envelope::Envelope::build(
+            crate::envelope::MessageKind::TaskRequest,
+            1,
+            vec![0xFF, 0xFF, 0xFF],
+        )?;
+        let result = decode_request(&frame.encode());
         assert!(matches!(result, Err(Error::Decode { .. })));
+        Ok(())
     }
 
     #[test]
     fn decode_response_rejects_malformed_bytes() {
         let result = decode_response(&[]);
 
-        assert!(matches!(result, Err(Error::Decode { .. })));
+        assert!(matches!(result, Err(Error::Envelope { .. })));
     }
 }

--- a/crates/metaxu/src/protocol.rs
+++ b/crates/metaxu/src/protocol.rs
@@ -7,6 +7,7 @@ use snafu::ResultExt as _;
 use ulid::Ulid;
 
 use crate::error::{EncodeSnafu, Result};
+use snafu::IntoError as _;
 
 mod ulid_bytes {
     use serde::{Deserialize as _, Serialize as _, Serializer};
@@ -356,24 +357,67 @@ impl TaskResponse {
     }
 }
 
-/// Serialize a task request for transport.
+/// Correlation ID for the envelope: the first 8 bytes of the request's
+/// ULID (a ULID's leading 48 bits are its timestamp; the next bits are
+/// randomness -- 64 bits total is ample correlation space, documented in
+/// the envelope contract).
+fn correlation_of(id: ulid::Ulid) -> u64 {
+    let bytes = id.to_bytes();
+    u64::from_le_bytes(bytes[..8].try_into().unwrap_or([0; 8]))
+}
+
+/// Serialize a task request for transport, wrapped in the versioned
+/// envelope (#553).
 pub(crate) fn encode_request(request: &TaskRequest) -> Result<Vec<u8>> {
-    postcard::to_allocvec(request).context(EncodeSnafu)
+    let payload = postcard::to_allocvec(request).context(EncodeSnafu)?;
+    let frame = crate::envelope::Envelope::build(
+        crate::envelope::MessageKind::TaskRequest,
+        correlation_of(request.request_id()),
+        payload,
+    )
+    .context(crate::error::EnvelopeSnafu)?;
+    Ok(frame.encode())
 }
 
-/// Deserialize a task request from transport bytes.
+/// Deserialize a task request from transport bytes: envelope validation
+/// first (exact, ceiling-checked before allocation), then the postcard
+/// payload (#553).
 pub(crate) fn decode_request(bytes: &[u8]) -> Result<TaskRequest> {
-    postcard::from_bytes(bytes).context(crate::error::DecodeSnafu)
+    let frame = crate::envelope::Envelope::decode(bytes).context(crate::error::EnvelopeSnafu)?;
+    if frame.header.kind != crate::envelope::MessageKind::TaskRequest {
+        return Err(crate::error::EnvelopeSnafu
+            .into_error(crate::envelope::EnvelopeError::UnexpectedKind {
+                expected: crate::envelope::MessageKind::TaskRequest,
+                got: frame.header.kind,
+            }));
+    }
+    postcard::from_bytes(&frame.payload).context(crate::error::DecodeSnafu)
 }
 
-/// Serialize a task response for transport.
+/// Serialize a task response for transport, wrapped in the versioned
+/// envelope (#553).
 pub(crate) fn encode_response(response: &TaskResponse) -> Result<Vec<u8>> {
-    postcard::to_allocvec(response).context(EncodeSnafu)
+    let payload = postcard::to_allocvec(response).context(EncodeSnafu)?;
+    let frame = crate::envelope::Envelope::build(
+        crate::envelope::MessageKind::TaskResponse,
+        correlation_of(response.request_id),
+        payload,
+    )
+    .context(crate::error::EnvelopeSnafu)?;
+    Ok(frame.encode())
 }
 
-/// Deserialize a task response from transport bytes.
+/// Deserialize a task response from transport bytes (#553).
 pub(crate) fn decode_response(bytes: &[u8]) -> Result<TaskResponse> {
-    postcard::from_bytes(bytes).context(crate::error::DecodeSnafu)
+    let frame = crate::envelope::Envelope::decode(bytes).context(crate::error::EnvelopeSnafu)?;
+    if frame.header.kind != crate::envelope::MessageKind::TaskResponse {
+        return Err(crate::error::EnvelopeSnafu
+            .into_error(crate::envelope::EnvelopeError::UnexpectedKind {
+                expected: crate::envelope::MessageKind::TaskResponse,
+                got: frame.header.kind,
+            }));
+    }
+    postcard::from_bytes(&frame.payload).context(crate::error::DecodeSnafu)
 }
 
 #[cfg(test)]

--- a/crates/metaxu/src/protocol.rs
+++ b/crates/metaxu/src/protocol.rs
@@ -385,11 +385,12 @@ pub(crate) fn encode_request(request: &TaskRequest) -> Result<Vec<u8>> {
 pub(crate) fn decode_request(bytes: &[u8]) -> Result<TaskRequest> {
     let frame = crate::envelope::Envelope::decode(bytes).context(crate::error::EnvelopeSnafu)?;
     if frame.header.kind != crate::envelope::MessageKind::TaskRequest {
-        return Err(crate::error::EnvelopeSnafu
-            .into_error(crate::envelope::EnvelopeError::UnexpectedKind {
+        return Err(crate::error::EnvelopeSnafu.into_error(
+            crate::envelope::EnvelopeError::UnexpectedKind {
                 expected: crate::envelope::MessageKind::TaskRequest,
                 got: frame.header.kind,
-            }));
+            },
+        ));
     }
     postcard::from_bytes(&frame.payload).context(crate::error::DecodeSnafu)
 }
@@ -411,11 +412,12 @@ pub(crate) fn encode_response(response: &TaskResponse) -> Result<Vec<u8>> {
 pub(crate) fn decode_response(bytes: &[u8]) -> Result<TaskResponse> {
     let frame = crate::envelope::Envelope::decode(bytes).context(crate::error::EnvelopeSnafu)?;
     if frame.header.kind != crate::envelope::MessageKind::TaskResponse {
-        return Err(crate::error::EnvelopeSnafu
-            .into_error(crate::envelope::EnvelopeError::UnexpectedKind {
+        return Err(crate::error::EnvelopeSnafu.into_error(
+            crate::envelope::EnvelopeError::UnexpectedKind {
                 expected: crate::envelope::MessageKind::TaskResponse,
                 got: frame.header.kind,
-            }));
+            },
+        ));
     }
     postcard::from_bytes(&frame.payload).context(crate::error::DecodeSnafu)
 }

--- a/crates/metaxu/src/vectors.rs
+++ b/crates/metaxu/src/vectors.rs
@@ -52,7 +52,8 @@ pub(crate) static GOLDEN_VECTORS: &[GoldenVector] = &[
             0x03, 0x00, // kind 3 = SttEvent
             0x2A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // correlation 42
             0x04, 0x00, 0x00, 0x00, // payload_len 4
-            0x00, 0x03, 0x00, 0x00, // payload: discriminant 0 (Partial), seq 3, empty text, confidence 0
+            0x00, 0x03, 0x00,
+            0x00, // payload: discriminant 0 (Partial), seq 3, empty text, confidence 0
         ],
         kind: MessageKind::SttEvent,
         correlation_id: 42,
@@ -111,11 +112,13 @@ mod tests {
             duration_ms: 1200,
         };
         let payload = postcard::to_allocvec(&event).unwrap_or_else(|_| unreachable!());
-        let frame = Envelope::build(MessageKind::SttEvent, 0x00C0_FFEE, payload).unwrap_or_else(|_| unreachable!());
+        let frame = Envelope::build(MessageKind::SttEvent, 0x00C0_FFEE, payload)
+            .unwrap_or_else(|_| unreachable!());
         let back = Envelope::decode(&frame.encode());
         assert_eq!(back, Ok(frame));
-        let decoded: SttEvent = postcard::from_bytes(&back.unwrap_or_else(|_| unreachable!()).payload)
-            .unwrap_or_else(|_| unreachable!());
+        let decoded: SttEvent =
+            postcard::from_bytes(&back.unwrap_or_else(|_| unreachable!()).payload)
+                .unwrap_or_else(|_| unreachable!());
         assert_eq!(decoded, event);
     }
 
@@ -134,7 +137,8 @@ mod tests {
         };
         for event in [partial, err] {
             let payload = postcard::to_allocvec(&event).unwrap_or_else(|_| unreachable!());
-            let decoded: SttEvent = postcard::from_bytes(&payload).unwrap_or_else(|_| unreachable!());
+            let decoded: SttEvent =
+                postcard::from_bytes(&payload).unwrap_or_else(|_| unreachable!());
             assert_eq!(decoded, event);
         }
     }
@@ -146,7 +150,8 @@ mod tests {
         // produce for this case.
         let v = &GOLDEN_VECTORS[1];
         let frame = Envelope::decode(v.bytes).unwrap_or_else(|_| unreachable!());
-        let event: SttEvent = postcard::from_bytes(&frame.payload).unwrap_or_else(|_| unreachable!());
+        let event: SttEvent =
+            postcard::from_bytes(&frame.payload).unwrap_or_else(|_| unreachable!());
         assert_eq!(
             event,
             SttEvent::Partial {

--- a/crates/metaxu/src/vectors.rs
+++ b/crates/metaxu/src/vectors.rs
@@ -1,0 +1,171 @@
+//! Golden vectors for the envelope contract (#553).
+//!
+//! Byte-exact frames both repositories (thumos and aletheia) MUST decode
+//! identically. A change to the envelope layout, kind set, version fields,
+//! or payload encoding that alters these bytes is a CONTRACT CHANGE and
+//! must be made deliberately (envelope major/minor/schema), never as a
+//! side effect of an implementation refactor. #544 proves both endpoints
+//! against these vectors before live action support expands.
+
+use crate::envelope::MessageKind;
+
+/// A golden vector: exact frame bytes plus the values they must decode to.
+pub(crate) struct GoldenVector {
+    /// Human name (used in assertion messages).
+    pub(crate) name: &'static str,
+    /// The exact frame bytes (22-byte header + payload).
+    pub(crate) bytes: &'static [u8],
+    /// The kind the frame carries.
+    pub(crate) kind: MessageKind,
+    /// The correlation ID it carries.
+    pub(crate) correlation_id: u64,
+    /// The exact payload bytes.
+    pub(crate) payload: &'static [u8],
+}
+
+/// The golden vectors (envelope v1: magic "MTX1" LE, schema 1, major 1,
+/// minor 0). Segments annotated per byte run.
+pub(crate) static GOLDEN_VECTORS: &[GoldenVector] = &[
+    GoldenVector {
+        name: "task-request-minimal",
+        bytes: &[
+            0x4D, 0x54, 0x58, 0x31, // magic "MTX1"
+            0x01, 0x00, // schema 1
+            0x01, // major 1
+            0x00, // minor 0
+            0x01, 0x00, // kind 1 = TaskRequest
+            0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // correlation 7
+            0x01, 0x00, 0x00, 0x00, // payload_len 1
+            0x00, // payload: one zero byte
+        ],
+        kind: MessageKind::TaskRequest,
+        correlation_id: 7,
+        payload: &[0x00],
+    },
+    GoldenVector {
+        name: "stt-event-partial-minimal",
+        bytes: &[
+            0x4D, 0x54, 0x58, 0x31, // magic "MTX1"
+            0x01, 0x00, // schema 1
+            0x01, // major 1
+            0x00, // minor 0
+            0x03, 0x00, // kind 3 = SttEvent
+            0x2A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // correlation 42
+            0x04, 0x00, 0x00, 0x00, // payload_len 4
+            0x00, 0x03, 0x00, 0x00, // payload: discriminant 0 (Partial), seq 3, empty text, confidence 0
+        ],
+        kind: MessageKind::SttEvent,
+        correlation_id: 42,
+        payload: &[0x00, 0x03, 0x00, 0x00],
+    },
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::{Envelope, EnvelopeError, MessageKind, SttErrorCode, SttEvent};
+    use compact_str::CompactString;
+
+    #[test]
+    fn golden_vectors_decode_and_reencode_identically() {
+        for v in GOLDEN_VECTORS {
+            let frame = Envelope::decode(v.bytes)
+                .unwrap_or_else(|e| unreachable!("{}: golden vector must decode: {e}", v.name));
+            assert_eq!(frame.header.kind, v.kind, "{}", v.name);
+            assert_eq!(frame.header.correlation_id, v.correlation_id, "{}", v.name);
+            assert_eq!(frame.payload, v.payload, "{}", v.name);
+            assert_eq!(
+                frame.encode(),
+                v.bytes,
+                "{}: re-encode must reproduce the golden bytes exactly",
+                v.name
+            );
+        }
+    }
+
+    #[test]
+    fn golden_vector_shape_is_pinned() {
+        // The first vector's exact header bytes, hand-verified against the
+        // documented layout: magic LE, schema LE, major, minor, kind LE,
+        // correlation LE, payload_len LE.
+        let v = &GOLDEN_VECTORS[0];
+        assert_eq!(&v.bytes[0..4], &crate::envelope::MAGIC.to_le_bytes());
+        assert_eq!(&v.bytes[4..6], &crate::envelope::SCHEMA_ID.to_le_bytes());
+        assert_eq!(v.bytes[6], crate::envelope::MAJOR);
+        assert_eq!(v.bytes[7], crate::envelope::MINOR);
+        assert_eq!(&v.bytes[8..10], &1u16.to_le_bytes());
+        assert_eq!(&v.bytes[10..18], &7u64.to_le_bytes());
+        assert_eq!(&v.bytes[18..22], &1u32.to_le_bytes());
+        assert_eq!(v.bytes.len(), 23, "22-byte header + 1-byte payload");
+    }
+
+    #[test]
+    fn stt_event_postcard_round_trip_through_envelope() {
+        // The STT event wire shape, pinned through the envelope: a Final
+        // with provenance encodes, decodes, and matches exactly.
+        let event = SttEvent::Final {
+            seq: 7,
+            text: CompactString::from("hello world"),
+            language: CompactString::from("en"),
+            model: CompactString::from("whisper-small"),
+            duration_ms: 1200,
+        };
+        let payload = postcard::to_allocvec(&event).unwrap_or_else(|_| unreachable!());
+        let frame = Envelope::build(MessageKind::SttEvent, 0x00C0_FFEE, payload).unwrap_or_else(|_| unreachable!());
+        let back = Envelope::decode(&frame.encode());
+        assert_eq!(back, Ok(frame));
+        let decoded: SttEvent = postcard::from_bytes(&back.unwrap_or_else(|_| unreachable!()).payload)
+            .unwrap_or_else(|_| unreachable!());
+        assert_eq!(decoded, event);
+    }
+
+    #[test]
+    fn stt_event_kinds_are_distinct_on_the_wire() {
+        // Partial/Final/Error encode with distinct discriminants and decode
+        // back exactly — the typed-event contract replacing {"text","final"}.
+        let partial = SttEvent::Partial {
+            seq: 3,
+            text: CompactString::from("hel"),
+            confidence_milli: 800,
+        };
+        let err = SttEvent::Error {
+            seq: 8,
+            code: SttErrorCode::ModelOverloaded,
+        };
+        for event in [partial, err] {
+            let payload = postcard::to_allocvec(&event).unwrap_or_else(|_| unreachable!());
+            let decoded: SttEvent = postcard::from_bytes(&payload).unwrap_or_else(|_| unreachable!());
+            assert_eq!(decoded, event);
+        }
+    }
+
+    #[test]
+    fn stt_golden_vector_decodes_to_the_documented_event() {
+        // The STT golden vector's payload decodes to a Partial with seq 3
+        // and confidence 0 — the exact bytes an aletheia endpoint must
+        // produce for this case.
+        let v = &GOLDEN_VECTORS[1];
+        let frame = Envelope::decode(v.bytes).unwrap_or_else(|_| unreachable!());
+        let event: SttEvent = postcard::from_bytes(&frame.payload).unwrap_or_else(|_| unreachable!());
+        assert_eq!(
+            event,
+            SttEvent::Partial {
+                seq: 3,
+                text: CompactString::from(""),
+                confidence_milli: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn downgrade_attempt_is_an_explicit_error_not_a_misdecode() {
+        // A frame claiming a future major must reject loudly (#553's
+        // downgrade-ambiguity ban), never decode with wrong semantics.
+        let mut bytes = GOLDEN_VECTORS[0].bytes.to_vec();
+        bytes[6] = crate::envelope::MAJOR + 1;
+        assert!(matches!(
+            Envelope::decode(&bytes),
+            Err(EnvelopeError::IncompatibleVersion { .. })
+        ));
+    }
+}

--- a/crates/thumos/src/ekphrasis.rs
+++ b/crates/thumos/src/ekphrasis.rs
@@ -140,6 +140,20 @@ pub enum EkphrasisError {
     ConnectionClosed,
     /// An incomplete frame was received — need more bytes.
     Incomplete,
+    /// The STT event's protocol version is not supported (#553).
+    UnsupportedVersion {
+        /// The version the event declared.
+        got: i64,
+    },
+    /// The STT event's session does not match this recording session (#553).
+    SessionMismatch,
+    /// The STT event's sequence number regressed (#553).
+    SequenceRegression,
+    /// The STT service reported a terminal error event (#553).
+    ServiceError {
+        /// The typed error code string.
+        code: String,
+    },
 }
 
 impl fmt::Display for EkphrasisError {
@@ -158,6 +172,12 @@ impl fmt::Display for EkphrasisError {
             Self::Json(e) => write!(f, "JSON error: {e}"),
             Self::ConnectionClosed => write!(f, "WebSocket connection closed"),
             Self::Incomplete => write!(f, "incomplete WebSocket frame"),
+            Self::UnsupportedVersion { got } => {
+                write!(f, "unsupported STT protocol version {got}")
+            }
+            Self::SessionMismatch => write!(f, "STT event for a different session"),
+            Self::SequenceRegression => write!(f, "STT event sequence regressed"),
+            Self::ServiceError { code } => write!(f, "STT service error: {code}"),
         }
     }
 }
@@ -620,6 +640,16 @@ pub(crate) struct Ekphrasis {
     endpoint_reachable: bool,
     /// Audio buffer for captured samples before streaming.
     audio_buffer: Vec<u8>,
+    /// This recording session's correlation ID (#553): every STT event for
+    /// the session must carry it.
+    session_id: u64,
+    /// Highest STT event sequence seen this session (#553).
+    last_seq: u32,
+    /// Provenance of the final transcript: the language the service
+    /// recognized, when it declared one (#553).
+    final_language: Option<String>,
+    /// Provenance of the final transcript: the model that produced it (#553).
+    final_model: Option<String>,
 }
 
 impl Ekphrasis {
@@ -637,6 +667,10 @@ impl Ekphrasis {
             capture_config: AudioCaptureConfig::stt_default(),
             endpoint_reachable: false,
             audio_buffer: Vec::new(),
+            session_id: 0,
+            last_seq: 0,
+            final_language: None,
+            final_model: None,
         }
     }
 
@@ -653,7 +687,7 @@ impl Ekphrasis {
     /// Returns [`EkphrasisError::InvalidState`] if not in `Idle` state.
     /// Returns [`EkphrasisError::EndpointUnreachable`] if the endpoint
     /// has not been marked reachable.
-    pub(crate) fn start_recording(&mut self) -> Result<(), EkphrasisError> {
+    pub(crate) fn start_recording(&mut self, session_id: u64) -> Result<(), EkphrasisError> {
         if !self.endpoint_reachable {
             return Err(EkphrasisError::EndpointUnreachable);
         }
@@ -663,6 +697,10 @@ impl Ekphrasis {
                 self.partial_text.clear();
                 self.final_text.clear();
                 self.audio_buffer.clear();
+                self.session_id = session_id;
+                self.last_seq = 0;
+                self.final_language = None;
+                self.final_model = None;
                 self.state = EkphrasisState::Recording;
                 Ok(())
             }
@@ -789,51 +827,115 @@ impl Ekphrasis {
         }
     }
 
-    /// Process a transcription text response from aletheia.
+    /// Process a typed STT event from the aletheia STT service (#553).
     ///
-    /// The response is expected to be JSON with at least a "text" field
-    /// and an optional "final" boolean:
+    /// The wire shape is the thumos-side rendering of the shared contract
+    /// (docs/protocols/aletheia-v1.md): every event is versioned,
+    /// session-correlated, sequenced, and typed:
     ///
     /// ```json
-    /// {"text": "hello world", "final": false}
+    /// {"v":1, "session":42, "seq":3, "kind":"partial", "text":"hel", "confidence_milli":800}
+    /// {"v":1, "session":42, "seq":7, "kind":"final", "text":"hello", "language":"en", "model":"whisper-small", "duration_ms":1200}
+    /// {"v":1, "session":42, "seq":8, "kind":"error", "code":"model_overloaded"}
     /// ```
+    ///
+    /// Exact decoding: an unknown version, a foreign session, a sequence
+    /// regression, or a missing required field is an explicit error — never
+    /// a silent default (#553).
     fn process_transcription(&mut self, text: &str) -> Result<(), EkphrasisError> {
         let value = JsonParser::parse(text.as_bytes())?;
 
-        // WHY: a missing/non-string "text" field previously fell back to ""
-        // silently -- indistinguishable from the server legitimately sending
-        // an empty transcript. Error instead so a malformed response is
-        // surfaced rather than swallowed.
-        let transcript = value
-            .get("text")
+        // Version gate: only v1 is understood; anything else rejects
+        // explicitly (no downgrade ambiguity).
+        let version = value
+            .get("v")
+            .and_then(JsonValue::as_i64)
+            .ok_or(EkphrasisError::InvalidFrame)?;
+        if version != 1 {
+            return Err(EkphrasisError::UnsupportedVersion { got: version });
+        }
+
+        // Session correlation: events for another session are an error,
+        // not a silent mix.
+        let session = value
+            .get("session")
+            .and_then(JsonValue::as_i64)
+            .ok_or(EkphrasisError::InvalidFrame)?;
+        if session < 0 || session as u64 != self.session_id {
+            return Err(EkphrasisError::SessionMismatch);
+        }
+
+        // Sequence: monotonic within the session.
+        let seq = value
+            .get("seq")
+            .and_then(JsonValue::as_i64)
+            .ok_or(EkphrasisError::InvalidFrame)?;
+        if seq < 0 || (seq as u32) < self.last_seq {
+            return Err(EkphrasisError::SequenceRegression);
+        }
+        let seq = seq as u32;
+
+        let kind = value
+            .get("kind")
             .and_then(JsonValue::as_str)
             .ok_or(EkphrasisError::InvalidFrame)?;
 
-        let is_final = value
-            .get("final")
-            .and_then(JsonValue::as_bool)
-            .unwrap_or(false);
-
-        if is_final {
-            if transcript.len() > MAX_FINAL_TEXT_LEN {
-                return Err(EkphrasisError::TextTooLong);
+        match kind {
+            "partial" => {
+                let transcript = value
+                    .get("text")
+                    .and_then(JsonValue::as_str)
+                    .ok_or(EkphrasisError::InvalidFrame)?;
+                if transcript.len() > MAX_PARTIAL_TEXT_LEN {
+                    return Err(EkphrasisError::TextTooLong);
+                }
+                self.last_seq = seq;
+                self.partial_text.clear();
+                self.partial_text.push_str(transcript);
+                if self.state == EkphrasisState::Streaming {
+                    self.state = EkphrasisState::Transcribing;
+                }
+                Ok(())
             }
-            self.final_text.clear();
-            self.final_text.push_str(transcript);
-            self.state = EkphrasisState::Idle;
-        } else {
-            if transcript.len() > MAX_PARTIAL_TEXT_LEN {
-                return Err(EkphrasisError::TextTooLong);
+            "final" => {
+                let transcript = value
+                    .get("text")
+                    .and_then(JsonValue::as_str)
+                    .ok_or(EkphrasisError::InvalidFrame)?;
+                if transcript.len() > MAX_FINAL_TEXT_LEN {
+                    return Err(EkphrasisError::TextTooLong);
+                }
+                self.last_seq = seq;
+                self.final_text.clear();
+                self.final_text.push_str(transcript);
+                // Provenance (#553): recorded when the service declares it.
+                self.final_language = value
+                    .get("language")
+                    .and_then(JsonValue::as_str)
+                    .map(String::from);
+                self.final_model = value
+                    .get("model")
+                    .and_then(JsonValue::as_str)
+                    .map(String::from);
+                self.state = EkphrasisState::Idle;
+                Ok(())
             }
-            self.partial_text.clear();
-            self.partial_text.push_str(transcript);
-            // Remain in streaming/transcribing state.
-            if self.state == EkphrasisState::Streaming {
-                self.state = EkphrasisState::Transcribing;
+            "error" => {
+                let code = value
+                    .get("code")
+                    .and_then(JsonValue::as_str)
+                    .ok_or(EkphrasisError::InvalidFrame)?;
+                self.last_seq = seq;
+                // WHY no state write here: handle_server_frame owns the
+                // transition to Error(ServiceError) on any returned error --
+                // a service-reported terminal error must be acknowledged via
+                // reset(), not silently cleared.
+                Err(EkphrasisError::ServiceError {
+                    code: String::from(code),
+                })
             }
+            _ => Err(EkphrasisError::InvalidFrame),
         }
-
-        Ok(())
     }
 
     /// Stop recording and return the final transcription.
@@ -1567,7 +1669,7 @@ Let me know if you need anything else."#;
         assert_eq!(*ek.state(), EkphrasisState::Idle);
         assert!(!ek.is_recording());
 
-        let result = ek.start_recording();
+        let result = ek.start_recording(42);
         assert!(result.is_ok());
         assert_eq!(*ek.state(), EkphrasisState::Recording);
         assert!(ek.is_recording());
@@ -1577,7 +1679,7 @@ Let me know if you need anything else."#;
     fn state_recording_to_streaming() {
         let mut ek = Ekphrasis::new("stt.example.lan", 8080);
         ek.set_endpoint_reachable(true);
-        let _ = ek.start_recording();
+        let _ = ek.start_recording(42);
 
         let result = ek.begin_streaming();
         assert!(result.is_ok());
@@ -1591,7 +1693,7 @@ Let me know if you need anything else."#;
         // Not reachable by default.
         assert!(!ek.is_available());
 
-        let result = ek.start_recording();
+        let result = ek.start_recording(42);
         assert_eq!(result, Err(EkphrasisError::EndpointUnreachable));
     }
 
@@ -1599,9 +1701,9 @@ Let me know if you need anything else."#;
     fn state_cannot_record_when_already_recording() {
         let mut ek = Ekphrasis::new("stt.example.lan", 8080);
         ek.set_endpoint_reachable(true);
-        let _ = ek.start_recording();
+        let _ = ek.start_recording(42);
 
-        let result = ek.start_recording();
+        let result = ek.start_recording(42);
         assert!(result.is_err());
         match result {
             Err(EkphrasisError::InvalidState { operation, current }) => {
@@ -1623,7 +1725,7 @@ Let me know if you need anything else."#;
     fn state_stop_from_recording() {
         let mut ek = Ekphrasis::new("stt.example.lan", 8080);
         ek.set_endpoint_reachable(true);
-        let _ = ek.start_recording();
+        let _ = ek.start_recording(42);
 
         let result = ek.stop_recording();
         assert!(result.is_ok());
@@ -1635,12 +1737,12 @@ Let me know if you need anything else."#;
     fn stop_recording_returns_partial_text_when_no_final() {
         let mut ek = Ekphrasis::new("stt.example.lan", 8080);
         ek.set_endpoint_reachable(true);
-        let _ = ek.start_recording();
+        let _ = ek.start_recording(42);
         let _ = ek.begin_streaming();
 
         let partial_frame = WsFrame::new(
             WsOpcode::Text,
-            b"{\"text\": \"partial only\", \"final\": false}".to_vec(),
+            b"{\"v\":1, \"session\":42, \"seq\":1, \"kind\":\"partial\", \"text\":\"partial only\"}".to_vec(),
         );
         let _ = ek.handle_server_frame(&partial_frame);
         assert!(ek.final_text().is_empty());
@@ -1661,7 +1763,7 @@ Let me know if you need anything else."#;
     fn state_feed_audio_while_recording() {
         let mut ek = Ekphrasis::new("stt.example.lan", 8080);
         ek.set_endpoint_reachable(true);
-        let _ = ek.start_recording();
+        let _ = ek.start_recording(42);
 
         let result = ek.feed_audio(&[0x01, 0x02, 0x03]);
         assert!(result.is_ok());
@@ -1678,7 +1780,7 @@ Let me know if you need anything else."#;
     fn feed_audio_rejects_beyond_max_buffer() {
         let mut ek = Ekphrasis::new("stt.example.lan", 8080);
         ek.set_endpoint_reachable(true);
-        let _ = ek.start_recording();
+        let _ = ek.start_recording(42);
 
         // Fill exactly to the cap.
         let chunk = alloc::vec![0u8; MAX_AUDIO_BUFFER_BYTES];
@@ -1702,7 +1804,7 @@ Let me know if you need anything else."#;
     fn state_take_audio_frame() {
         let mut ek = Ekphrasis::new("stt.example.lan", 8080);
         ek.set_endpoint_reachable(true);
-        let _ = ek.start_recording();
+        let _ = ek.start_recording(42);
         let _ = ek.begin_streaming();
 
         // No data yet.
@@ -1721,13 +1823,14 @@ Let me know if you need anything else."#;
     fn state_transcription_flow() {
         let mut ek = Ekphrasis::new("stt.example.lan", 8080);
         ek.set_endpoint_reachable(true);
-        let _ = ek.start_recording();
+        let _ = ek.start_recording(42);
         let _ = ek.begin_streaming();
 
         // Receive partial transcription.
         let partial_frame = WsFrame::new(
             WsOpcode::Text,
-            b"{\"text\": \"hello\", \"final\": false}".to_vec(),
+            b"{\"v\":1, \"session\":42, \"seq\":1, \"kind\":\"partial\", \"text\":\"hello\"}"
+                .to_vec(),
         );
         let result = ek.handle_server_frame(&partial_frame);
         assert!(result.is_ok());
@@ -1737,7 +1840,7 @@ Let me know if you need anything else."#;
         // Receive final transcription.
         let final_frame = WsFrame::new(
             WsOpcode::Text,
-            b"{\"text\": \"hello world\", \"final\": true}".to_vec(),
+            b"{\"v\":1, \"session\":42, \"seq\":2, \"kind\":\"final\", \"text\":\"hello world\", \"language\":\"en\", \"model\":\"whisper-small\", \"duration_ms\":1200}".to_vec(),
         );
         let result = ek.handle_server_frame(&final_frame);
         assert!(result.is_ok());
@@ -1746,10 +1849,103 @@ Let me know if you need anything else."#;
     }
 
     #[test]
+    fn transcription_final_records_provenance() {
+        let mut ek = Ekphrasis::new("stt.example.lan", 8080);
+        ek.set_endpoint_reachable(true);
+        let _ = ek.start_recording(42);
+        let _ = ek.begin_streaming();
+        let frame = WsFrame::new(
+            WsOpcode::Text,
+            b"{\"v\":1, \"session\":42, \"seq\":1, \"kind\":\"final\", \"text\":\"hi\", \"language\":\"en\", \"model\":\"whisper-small\", \"duration_ms\":900}".to_vec(),
+        );
+        assert!(ek.handle_server_frame(&frame).is_ok());
+        assert_eq!(ek.final_language.as_deref(), Some("en"));
+        assert_eq!(ek.final_model.as_deref(), Some("whisper-small"));
+    }
+
+    #[test]
+    fn transcription_rejects_unknown_version() {
+        let mut ek = Ekphrasis::new("stt.example.lan", 8080);
+        ek.set_endpoint_reachable(true);
+        let _ = ek.start_recording(42);
+        let _ = ek.begin_streaming();
+        let frame = WsFrame::new(
+            WsOpcode::Text,
+            b"{\"v\":2, \"session\":42, \"seq\":1, \"kind\":\"partial\", \"text\":\"hi\"}".to_vec(),
+        );
+        let result = ek.handle_server_frame(&frame);
+        assert_eq!(
+            result,
+            Err(EkphrasisError::UnsupportedVersion { got: 2 }),
+            "an unknown protocol version must reject explicitly (#553)"
+        );
+    }
+
+    #[test]
+    fn transcription_rejects_foreign_session() {
+        let mut ek = Ekphrasis::new("stt.example.lan", 8080);
+        ek.set_endpoint_reachable(true);
+        let _ = ek.start_recording(42);
+        let _ = ek.begin_streaming();
+        let frame = WsFrame::new(
+            WsOpcode::Text,
+            b"{\"v\":1, \"session\":43, \"seq\":1, \"kind\":\"partial\", \"text\":\"hi\"}".to_vec(),
+        );
+        assert_eq!(
+            ek.handle_server_frame(&frame),
+            Err(EkphrasisError::SessionMismatch),
+            "an event for another session is an error, not a silent mix (#553)"
+        );
+    }
+
+    #[test]
+    fn transcription_rejects_sequence_regression() {
+        let mut ek = Ekphrasis::new("stt.example.lan", 8080);
+        ek.set_endpoint_reachable(true);
+        let _ = ek.start_recording(42);
+        let _ = ek.begin_streaming();
+        let f1 = WsFrame::new(
+            WsOpcode::Text,
+            b"{\"v\":1, \"session\":42, \"seq\":5, \"kind\":\"partial\", \"text\":\"a\"}".to_vec(),
+        );
+        assert!(ek.handle_server_frame(&f1).is_ok());
+        let f2 = WsFrame::new(
+            WsOpcode::Text,
+            b"{\"v\":1, \"session\":42, \"seq\":4, \"kind\":\"partial\", \"text\":\"ab\"}".to_vec(),
+        );
+        assert_eq!(
+            ek.handle_server_frame(&f2),
+            Err(EkphrasisError::SequenceRegression),
+            "a regressing sequence number must reject (#553)"
+        );
+    }
+
+    #[test]
+    fn transcription_error_event_surfaces_service_error() {
+        let mut ek = Ekphrasis::new("stt.example.lan", 8080);
+        ek.set_endpoint_reachable(true);
+        let _ = ek.start_recording(42);
+        let _ = ek.begin_streaming();
+        let frame = WsFrame::new(
+            WsOpcode::Text,
+            b"{\"v\":1, \"session\":42, \"seq\":9, \"kind\":\"error\", \"code\":\"model_overloaded\"}".to_vec(),
+        );
+        let result = ek.handle_server_frame(&frame);
+        assert!(
+            matches!(result, Err(EkphrasisError::ServiceError { .. })),
+            "a typed error event surfaces as ServiceError (#553)"
+        );
+        assert!(
+            matches!(ek.state(), EkphrasisState::Error(_)),
+            "a service-reported terminal error must require an explicit reset()"
+        );
+    }
+
+    #[test]
     fn state_server_close_frame() {
         let mut ek = Ekphrasis::new("stt.example.lan", 8080);
         ek.set_endpoint_reachable(true);
-        let _ = ek.start_recording();
+        let _ = ek.start_recording(42);
         let _ = ek.begin_streaming();
 
         let close_frame = WsFrame::new(WsOpcode::Close, Vec::new());
@@ -1779,7 +1975,7 @@ Let me know if you need anything else."#;
     fn handle_server_frame_rejects_and_stays_in_error_state() {
         let mut ek = Ekphrasis::new("stt.example.lan", 8080);
         ek.set_endpoint_reachable(true);
-        let _ = ek.start_recording();
+        let _ = ek.start_recording(42);
         let _ = ek.begin_streaming();
         ek.state = EkphrasisState::Error(EkphrasisError::ConnectionClosed);
 
@@ -1799,7 +1995,7 @@ Let me know if you need anything else."#;
     fn process_transcription_errors_on_missing_text_field() {
         let mut ek = Ekphrasis::new("stt.example.lan", 8080);
         ek.set_endpoint_reachable(true);
-        let _ = ek.start_recording();
+        let _ = ek.start_recording(42);
         let _ = ek.begin_streaming();
 
         let frame = WsFrame::new(WsOpcode::Text, b"{\"final\": false}".to_vec());
@@ -1815,7 +2011,7 @@ Let me know if you need anything else."#;
     fn handle_server_frame_transitions_to_error_on_malformed_response() {
         let mut ek = Ekphrasis::new("stt.example.lan", 8080);
         ek.set_endpoint_reachable(true);
-        let _ = ek.start_recording();
+        let _ = ek.start_recording(42);
         let _ = ek.begin_streaming();
 
         let frame = WsFrame::new(WsOpcode::Text, b"{\"final\": false}".to_vec());
@@ -1831,7 +2027,7 @@ Let me know if you need anything else."#;
     fn state_reset_clears_everything() {
         let mut ek = Ekphrasis::new("stt.example.lan", 8080);
         ek.set_endpoint_reachable(true);
-        let _ = ek.start_recording();
+        let _ = ek.start_recording(42);
         let _ = ek.feed_audio(&[0xFF; 100]);
 
         ek.reset();

--- a/docs/protocols/aletheia-v1.md
+++ b/docs/protocols/aletheia-v1.md
@@ -1,0 +1,83 @@
+# Aletheia-facing protocol, v1 (issue #553)
+
+The ONE versioned contract between thumos and aletheia. Two transports carry
+the same semantic contract; neither repository declares device-local
+conventions.
+
+- **Envelope** (binary, postcard payloads): every Aletheia-facing frame —
+  task request, task response — travels in the envelope below.
+  Implementation: `crates/metaxu/src/envelope.rs`, golden vectors in
+  `crates/metaxu/src/vectors.rs`.
+- **STT events** (JSON over WebSocket): transcription events for the
+  aletheia STT service, thumos-side rendering of the same typed-event
+  semantics. Implementation: `crates/thumos/src/ekphrasis.rs`.
+
+## 1. Envelope (binary)
+
+Every frame is a 22-byte fixed header (little-endian) followed by exactly
+`payload_len` payload bytes (postcard for the kind's payload type):
+
+```
+[0..4)   magic: u32      = "MTX1" (0x4D 0x54 0x58 0x31)
+[4..6)   schema: u16     = 1
+[6]      major: u8       = 1
+[7]      minor: u8       = 0
+[8..10)  kind: u16       = 1 TaskRequest | 2 TaskResponse | 3 SttEvent
+[10..18) correlation_id: u64 (request ULID's first 8 bytes)
+[18..22) payload_len: u32
+```
+
+### Compatibility rules
+
+- Wrong magic or schema: reject (`BadMagic` / `UnsupportedSchema`) — never
+  a silent misdecode.
+- `major` mismatch: reject (`IncompatibleVersion`). A major bump is never
+  negotiated silently; a downgrade attempt is an explicit error.
+- `minor` newer than the decoder's: accepted ONLY when `kind` is known and
+  the payload decodes exactly. Minor bumps may ADD kinds or optional
+  fields; they never change an existing kind's payload shape. An unknown
+  kind always rejects (`UnknownKind`).
+- `minor` older: accepted (symmetric rule).
+- `payload_len` above the kind's ceiling: reject (`FrameTooLarge`) BEFORE
+  allocating. Ceilings (v1): TaskRequest 32 KiB, TaskResponse 32 KiB,
+  SttEvent 4 KiB.
+- Frame bytes != 22 + payload_len: reject (`TruncatedFrame` /
+  `TrailingBytes`) — decoding is exact, always.
+
+## 2. STT events (JSON over WebSocket)
+
+Every event is versioned, session-correlated, sequenced, and typed:
+
+```json
+{"v":1, "session":42, "seq":3, "kind":"partial", "text":"hel", "confidence_milli":800}
+{"v":1, "session":42, "seq":7, "kind":"final", "text":"hello", "language":"en", "model":"whisper-small", "duration_ms":1200}
+{"v":1, "session":42, "seq":8, "kind":"error", "code":"model_overloaded"}
+```
+
+Rules (thumos-side, `ekphrasis::process_transcription`):
+
+- `v` must be 1 — anything else is `UnsupportedVersion` (no downgrade
+  ambiguity).
+- `session` must equal the recording session's id — a foreign session is
+  `SessionMismatch`, never a silent mix.
+- `seq` is monotonic per session — a regression is `SequenceRegression`.
+- `kind`: `partial` (text required, bounded; `confidence_milli` optional),
+  `final` (text required, bounded; `language`/`model`/`duration_ms`
+  recorded as provenance), `error` (`code` required; surfaces as
+  `ServiceError` and ends the session).
+- Error codes (v1): `model_overloaded`, `bad_audio`, `cancelled`.
+
+## 3. Golden vectors
+
+`crates/metaxu/src/vectors.rs` holds byte-exact frames both repositories
+MUST decode identically. Changing them is a contract change (major/minor/
+schema), never an implementation side effect. #544 proves both endpoints
+against the same immutable vectors before live action support expands.
+
+## 4. Non-goals (v1)
+
+- No feature negotiation beyond the minor-version additive rule.
+- No authentication/encryption at this layer (the transport and the #544
+  grant-verification path own those).
+- No streaming reassembly across frames; each frame is self-contained and
+  exactly sized.

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -165,7 +165,7 @@ mechanism = "host"
 
 [[module]]
 name = "ekphrasis"
-tests = 59
+tests = 64
 mechanism = "host"
 
 [[module]]


### PR DESCRIPTION
## Summary

Thumos independently declared two Aletheia-facing protocols before a shared contract existed: `metaxu` serialized raw Postcard enums with no envelope, version, frame limit, or schema identity, and the STT client accepted an ad hoc `{"text","final"}` JSON convention with no correlation or provenance — both poised to become accidental cross-repository standards. This defines the one versioned artifact both sides consume.

**The envelope** (`crates/metaxu/src/envelope.rs`): a 22-byte fixed header — magic `"MTX1"`, schema ID, major/minor version, message kind, correlation ID, declared length — followed by exactly `payload_len` bytes. Validation happens in the only safe order: magic/schema/major/kind and the per-kind payload ceiling are checked **before any allocation**, and decoding is exact (a frame is header + exactly the declared payload; truncation and trailing bytes are explicit errors). Compatibility rules are written down and tested: wrong magic/schema rejects; major mismatch rejects (a downgrade attempt is never a silent misdecode); newer-minor accepts only known kinds with exact payload decode (additive-only rule); unknown kind rejects. Per-kind v1 ceilings: TaskRequest/TaskResponse 32 KiB, SttEvent 4 KiB — a 1 GB device never allocates on a peer's say-so. `encode_request`/`decode_request`/`encode_response`/`decode_response` now wrap it, with `UnexpectedKind` for kind-mismatched decoders.

**Typed STT events, both renderings of one contract** (`docs/protocols/aletheia-v1.md` is the shared document):
- `metaxu::SttEvent` — the postcard wire type: `Partial{seq,text,confidence_milli}`, `Final{seq,text,language,model,duration_ms}`, `Error{seq,code}` with provenance.
- `ekphrasis::process_transcription` — the thumos JSON rendering: `{"v","session","seq","kind",...}` with the same semantics enforced exactly: unknown version → `UnsupportedVersion`, foreign session → `SessionMismatch`, sequence regression → `SequenceRegression`, typed error event → `ServiceError` requiring an explicit reset, final provenance (language/model) recorded.

**Golden vectors** (`crates/metaxu/src/vectors.rs`): byte-exact frames both repositories must decode identically — decode and re-encode pinned in both directions, header shape hand-verified against the documented layout, the STT golden vector decoding to its documented event. #544 proves both endpoints against these before live action support expands.

## Verification

- `cargo test -p metaxu`: **28/28 pass** (envelope round-trips, header layout, bad-magic/major-mismatch/unknown-kind/oversize/truncate/trailing rejects, newer-minor compat, golden vectors, downgrade-as-error).
- `cargo clippy -p metaxu --all-targets -- -D warnings`: clean (workspace lint set).
- `scripts/kernel-host-tests.sh` (i686 + debug-console pass): **2306/2306 and 2310/2310 pass** (ekphrasis 59→64: typed-contract tests for version/session/sequence/error/provenance).
- `cargo check` (armv7a, m7) + `cargo check --features qemu` (virt): both clean, zero warnings.
- `scripts/witness-run-all.sh`: **ALL KERNEL QEMU WITNESSES: PASS** (all 10)
- `scripts/check-target-test-ledger.sh`: no drift.
- `cargo fmt`: clean.

Closes #553
