### PR TITLE
metaxu: one authenticated Aletheia round trip over the envelope (#544, protocol half)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
+ "serde",
  "signature",
 ]
 
@@ -743,9 +744,12 @@ name = "metaxu"
 version = "0.1.16"
 dependencies = [
  "compact_str",
+ "ed25519-dalek",
+ "hmac",
  "jiff",
  "postcard",
  "serde",
+ "sha2",
  "snafu",
  "ulid",
 ]

--- a/crates/metaxu/Cargo.toml
+++ b/crates/metaxu/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 
 [dependencies]
 compact_str = { workspace = true, features = ["serde"] }
+ed25519-dalek = { workspace = true, features = ["serde"] }
+hmac = { workspace = true }
+sha2 = { workspace = true }
 jiff = { workspace = true, features = ["serde"] }
 postcard = { workspace = true }
 serde = { workspace = true }

--- a/crates/metaxu/src/envelope.rs
+++ b/crates/metaxu/src/envelope.rs
@@ -54,8 +54,9 @@ pub(crate) const SCHEMA_ID: u16 = 1;
 /// Major version: incompatible changes only.
 pub(crate) const MAJOR: u8 = 1;
 
-/// Minor version: additive changes within [`MAJOR`].
-pub(crate) const MINOR: u8 = 0;
+/// Minor version: additive changes within [`MAJOR`]. MINOR 1 adds the
+/// authenticated kinds (4, 5) per the #553 compat rule (#544).
+pub(crate) const MINOR: u8 = 1;
 
 /// Fixed header length in bytes.
 pub(crate) const HEADER_LEN: usize = 22;
@@ -69,6 +70,13 @@ pub(crate) const MAX_TASK_REQUEST_PAYLOAD: u32 = 32 * 1024;
 /// Task response payload ceiling.
 pub(crate) const MAX_TASK_RESPONSE_PAYLOAD: u32 = 32 * 1024;
 
+/// Authenticated request payload ceiling: the task ceiling plus room for
+/// the grant wrapper (~256 B) (#544).
+pub(crate) const MAX_AUTH_REQUEST_PAYLOAD: u32 = 34 * 1024;
+
+/// Authenticated response payload ceiling (response + 32 B MAC) (#544).
+pub(crate) const MAX_AUTH_RESPONSE_PAYLOAD: u32 = 33 * 1024;
+
 /// The message kinds this envelope version knows.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[must_use]
@@ -81,6 +89,10 @@ pub enum MessageKind {
     TaskResponse = 2,
     /// An STT event (partial/final/error).
     SttEvent = 3,
+    /// An authenticated task request (grant + task) — MINOR 1 (#544).
+    AuthenticatedRequest = 4,
+    /// An authenticated task response (response + MAC) — MINOR 1 (#544).
+    AuthenticatedResponse = 5,
 }
 
 impl MessageKind {
@@ -90,6 +102,8 @@ impl MessageKind {
             1 => Some(Self::TaskRequest),
             2 => Some(Self::TaskResponse),
             3 => Some(Self::SttEvent),
+            4 => Some(Self::AuthenticatedRequest),
+            5 => Some(Self::AuthenticatedResponse),
             _ => None,
         }
     }
@@ -100,6 +114,8 @@ impl MessageKind {
             Self::TaskRequest => MAX_TASK_REQUEST_PAYLOAD,
             Self::TaskResponse => MAX_TASK_RESPONSE_PAYLOAD,
             Self::SttEvent => MAX_STT_PAYLOAD,
+            Self::AuthenticatedRequest => MAX_AUTH_REQUEST_PAYLOAD,
+            Self::AuthenticatedResponse => MAX_AUTH_RESPONSE_PAYLOAD,
         }
     }
 }
@@ -420,6 +436,8 @@ mod tests {
             MessageKind::TaskRequest => b"task-payload".to_vec(),
             MessageKind::TaskResponse => b"response-payload".to_vec(),
             MessageKind::SttEvent => b"stt".to_vec(),
+            MessageKind::AuthenticatedRequest => b"auth-request".to_vec(),
+            MessageKind::AuthenticatedResponse => b"auth-response".to_vec(),
         }
     }
 
@@ -429,6 +447,8 @@ mod tests {
             MessageKind::TaskRequest,
             MessageKind::TaskResponse,
             MessageKind::SttEvent,
+            MessageKind::AuthenticatedRequest,
+            MessageKind::AuthenticatedResponse,
         ] {
             let frame = Envelope::build(kind, 0xA5A5_1234, sample_payload(kind)).ok();
             assert!(frame.is_some());

--- a/crates/metaxu/src/grants.rs
+++ b/crates/metaxu/src/grants.rs
@@ -1,0 +1,249 @@
+//! Cryptographically verified, expiring capability grants (#544).
+//!
+//! A grant is the Aletheia runtime's signed authorization for ONE device to
+//! request specific capabilities until an expiry. It is bound to both
+//! identities: the issuer's Ed25519 public key (which the device pins out of
+//! band) and the subject device's public key (which the issuer binds at
+//! issue). Verification therefore proves: the signature is valid under the
+//! pinned runtime key, the grant is for THIS device, and it has not
+//! expired. Nothing else — no unsigned claims, no grantless authority.
+//!
+//! The session-nonce is the response-authentication root: response MACs
+//! are keyed by `HKDF-SHA256(ikm = nonce, info = "metaxu-response-v1")`,
+//! so a verified response proves the responder knows the nonce inside the
+//! signed grant — i.e. it is the issuer (or holds the grant, which the
+//! device handed only over the authenticated hello).
+
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use snafu::Snafu;
+
+use crate::protocol::Capability;
+
+/// Grant error: every verification failure is explicit (#544).
+#[derive(Debug, Clone, PartialEq, Eq, Snafu)]
+#[snafu(visibility(pub(crate)))]
+#[must_use]
+#[non_exhaustive]
+pub enum GrantError {
+    /// The Ed25519 signature does not verify under the issuer key.
+    #[snafu(display("grant signature invalid"))]
+    BadSignature,
+    /// The grant is expired at the evaluation time.
+    #[snafu(display("grant expired at {expired_at_ms} (evaluated at {now_ms})"))]
+    Expired {
+        /// When the grant expired.
+        expired_at_ms: u64,
+        /// When verification was evaluated.
+        now_ms: u64,
+    },
+    /// The grant's subject is not the device presenting it.
+    #[snafu(display("grant issued for a different device"))]
+    WrongDevice,
+}
+
+/// A capability grant: issuer → subject, bounded in time (#544).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Grant {
+    /// Issuer's Ed25519 public key (the Aletheia runtime; the device pins
+    /// this out of band).
+    pub issuer: [u8; 32],
+    /// Subject device's Ed25519 public key.
+    pub subject: [u8; 32],
+    /// The capabilities this grant authorizes.
+    pub capabilities: Vec<Capability>,
+    /// Issue time, ms since the Unix epoch.
+    pub issued_at_ms: u64,
+    /// Expiry time, ms since the Unix epoch. Verification at or after this
+    /// time fails.
+    pub expires_at_ms: u64,
+    /// Session nonce: the response-authentication root (see module docs).
+    pub nonce: [u8; 16],
+}
+
+/// A [`Grant`] plus the issuer's Ed25519 signature over its postcard bytes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignedGrant {
+    /// The grant payload.
+    pub grant: Grant,
+    /// Ed25519 signature over `postcard::to_allocvec(grant)`.
+    pub signature: Signature,
+}
+
+impl SignedGrant {
+    /// Issue a grant: sign the postcard encoding with the issuer key.
+    pub fn issue(grant: Grant, issuer_key: &SigningKey) -> Self {
+        let bytes = postcard::to_allocvec(&grant).unwrap_or_default();
+        let signature: Signature = issuer_key.sign(&bytes);
+        Self { grant, signature }
+    }
+
+    /// The signed payload bytes (what the signature covers).
+    fn signed_bytes(&self) -> Vec<u8> {
+        postcard::to_allocvec(&self.grant).unwrap_or_default()
+    }
+
+    /// Verify the grant against the expected device at `now_ms`.
+    ///
+    /// # Errors
+    ///
+    /// [`GrantError::BadSignature`] if the signature does not verify under
+    /// the grant's issuer key, [`GrantError::Expired`] if `now_ms` is at or
+    /// past the expiry, [`GrantError::WrongDevice`] if the subject is not
+    /// `expected_device`.
+    pub fn verify(&self, expected_device: &[u8; 32], now_ms: u64) -> Result<&Grant, GrantError> {
+        let Ok(issuer_key) = VerifyingKey::from_bytes(&self.grant.issuer) else {
+            return Err(GrantError::BadSignature);
+        };
+        if issuer_key
+            .verify_strict(&self.signed_bytes(), &self.signature)
+            .is_err()
+        {
+            return Err(GrantError::BadSignature);
+        }
+        if self.grant.subject != *expected_device {
+            return Err(GrantError::WrongDevice);
+        }
+        if now_ms >= self.grant.expires_at_ms {
+            return Err(GrantError::Expired {
+                expired_at_ms: self.grant.expires_at_ms,
+                now_ms,
+            });
+        }
+        Ok(&self.grant)
+    }
+
+    /// The response-authentication key derived from the grant nonce (see
+    /// module docs). Both endpoints derive it identically.
+    pub fn response_key(&self) -> [u8; 32] {
+        hkdf_sha256(&self.grant.nonce, b"metaxu-response-v1")
+    }
+}
+
+/// HKDF-SHA256 extract+expand to a 32-byte key (single block).
+pub(crate) fn hkdf_sha256(ikm: &[u8; 16], info: &[u8]) -> [u8; 32] {
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+    // extract: PRK = HMAC(salt=zero, IKM); expand: OKM = HMAC(PRK, info||0x01).
+    let mut h =
+        <Hmac<Sha256> as Mac>::new_from_slice(&[0u8; 32]).unwrap_or_else(|_| unreachable!());
+    h.update(ikm);
+    let prk = h.finalize().into_bytes();
+    let mut e = <Hmac<Sha256> as Mac>::new_from_slice(&prk).unwrap_or_else(|_| unreachable!());
+    e.update(info);
+    e.update(&[0x01]);
+    e.finalize().into_bytes().into()
+}
+
+/// HMAC-SHA256 over `parts` under `key` (response authentication).
+pub fn response_mac(key: &[u8; 32], parts: &[&[u8]]) -> [u8; 32] {
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+    let mut h = <Hmac<Sha256> as Mac>::new_from_slice(key).unwrap_or_else(|_| unreachable!());
+    for part in parts {
+        h.update(part);
+    }
+    h.finalize().into_bytes().into()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::Capability;
+
+    fn issuer_key() -> SigningKey {
+        SigningKey::from_bytes(&[7u8; 32])
+    }
+
+    fn device_key() -> VerifyingKey {
+        SigningKey::from_bytes(&[9u8; 32]).verifying_key()
+    }
+
+    fn grant(expires_at_ms: u64) -> Grant {
+        Grant {
+            issuer: issuer_key().verifying_key().to_bytes(),
+            subject: device_key().to_bytes(),
+            capabilities: vec![Capability::SmsSend],
+            issued_at_ms: 1_000,
+            expires_at_ms,
+            nonce: [0xA5; 16],
+        }
+    }
+
+    #[test]
+    fn issue_and_verify_happy_path() {
+        let signed = SignedGrant::issue(grant(10_000), &issuer_key());
+        let verified = signed.verify(&device_key().to_bytes(), 5_000);
+        assert!(verified.is_ok(), "a valid unexpired grant must verify");
+        assert_eq!(
+            verified.map(|g| &g.capabilities),
+            Ok(&vec![Capability::SmsSend])
+        );
+    }
+
+    #[test]
+    fn wrong_device_rejects() {
+        let signed = SignedGrant::issue(grant(10_000), &issuer_key());
+        let other = [0xEE; 32];
+        assert_eq!(
+            signed.verify(&other, 5_000),
+            Err(GrantError::WrongDevice),
+            "a grant for device A must not authorize device B"
+        );
+    }
+
+    #[test]
+    fn expired_rejects_at_and_after_expiry() {
+        let signed = SignedGrant::issue(grant(10_000), &issuer_key());
+        assert_eq!(
+            signed.verify(&device_key().to_bytes(), 10_000),
+            Err(GrantError::Expired {
+                expired_at_ms: 10_000,
+                now_ms: 10_000,
+            }),
+            "at-expiry rejects (expiry is exclusive)"
+        );
+        assert!(matches!(
+            signed.verify(&device_key().to_bytes(), 10_001),
+            Err(GrantError::Expired { .. })
+        ));
+        assert!(signed.verify(&device_key().to_bytes(), 9_999).is_ok());
+    }
+
+    #[test]
+    fn tampered_capability_rejects() {
+        let mut signed = SignedGrant::issue(grant(10_000), &issuer_key());
+        signed.grant.capabilities = vec![Capability::CallDial];
+        assert_eq!(
+            signed.verify(&device_key().to_bytes(), 5_000),
+            Err(GrantError::BadSignature),
+            "editing the signed capabilities must invalidate the signature"
+        );
+    }
+
+    #[test]
+    fn tampered_nonce_rejects_and_rekeys() {
+        let a = SignedGrant::issue(grant(10_000), &issuer_key());
+        let mut b = a.clone();
+        b.grant.nonce = [0x5A; 16];
+        assert_eq!(
+            b.verify(&device_key().to_bytes(), 5_000),
+            Err(GrantError::BadSignature)
+        );
+        assert_ne!(a.response_key(), b.response_key());
+    }
+
+    #[test]
+    fn response_mac_is_keyed_and_deterministic() {
+        let signed = SignedGrant::issue(grant(10_000), &issuer_key());
+        let key = signed.response_key();
+        let mac = response_mac(&key, &[b"response"]);
+        assert_eq!(mac, response_mac(&key, &[b"response"]));
+        let other = response_mac(&[0u8; 32], &[b"response"]);
+        assert_ne!(mac, other, "a different key must produce a different MAC");
+    }
+}

--- a/crates/metaxu/src/lib.rs
+++ b/crates/metaxu/src/lib.rs
@@ -10,20 +10,28 @@
 mod client;
 mod envelope;
 mod error;
+mod grants;
 mod protocol;
+#[cfg(test)]
+mod pylon;
+mod session;
 mod transport;
 #[cfg(test)]
 mod vectors;
+#[cfg(test)]
+mod witness;
 
 use snafu::{OptionExt as _, ResultExt as _};
 
 pub use client::BridgeClient; // kanon:ignore RUST/pub-visibility -- public API
 pub use envelope::{EnvelopeError, MessageKind, SttErrorCode, SttEvent}; // kanon:ignore RUST/pub-visibility -- public API
 pub use error::{Error, Result};
+pub use grants::{Grant, GrantError, SignedGrant}; // kanon:ignore RUST/pub-visibility -- public API
 pub use protocol::{
     AudioMode, Capability, CapabilityGrant, ContactSummary, DeviceAction, DeviceIdentityRef,
     IdentityKind, TaskRequest, TaskResponse, TaskStatus,
 };
+pub use session::{AuthenticatedRequest, AuthenticatedResponse, AuthenticatedSession}; // kanon:ignore RUST/pub-visibility -- public API
 pub use transport::BridgeTransport; // kanon:ignore RUST/pub-visibility -- public API
 
 impl<T> BridgeClient<T>

--- a/crates/metaxu/src/pylon.rs
+++ b/crates/metaxu/src/pylon.rs
@@ -1,0 +1,209 @@
+//! The reference Aletheia-endpoint double ("pylon") for the authenticated
+//! round-trip witness (#544).
+//!
+//! A pylon is a stateless-per-request verification endpoint: every
+//! `AuthenticatedRequest` is verified alone — grant signature under the
+//! pinned runtime key, expiry against the injected clock, subject against
+//! the presenting device, task capability against the grant, request-id
+//! replay against the per-endpoint seen set. It answers one harmless typed
+//! task (echo-accept) and signs every response with the grant-nonce MAC.
+//!
+//! Security-failure rejections are typed `TaskStatus::Rejected` reasons so
+//! the witness can assert each adversarial case explicitly.
+
+use std::collections::HashSet;
+use std::net::{TcpListener, TcpStream};
+use std::sync::mpsc::{Receiver, channel};
+use std::thread::JoinHandle;
+
+use crate::envelope::{Envelope, MessageKind};
+use crate::grants::GrantError;
+use crate::protocol::{DeviceAction, TaskResponse};
+use crate::session::{AuthenticatedRequest, AuthenticatedResponse};
+
+/// Rejection reasons the pylon returns for security failures (#544).
+pub(crate) mod reject {
+    /// The grant's signature did not verify under the pinned runtime key.
+    pub(crate) const GRANT_SIGNATURE: &str = "grant_signature";
+    /// The grant was expired at evaluation.
+    pub(crate) const GRANT_EXPIRED: &str = "grant_expired";
+    /// The grant's subject was not the presenting device.
+    pub(crate) const WRONG_DEVICE: &str = "wrong_device";
+    /// The grant's issuer is not the pinned runtime.
+    pub(crate) const WRONG_ISSUER: &str = "wrong_issuer";
+    /// The request id was already seen (replay).
+    pub(crate) const REPLAY: &str = "replay";
+    /// The task's capability is not in the grant.
+    pub(crate) const CAPABILITY_DENIED: &str = "capability_denied";
+    /// The frame could not be decoded at all.
+    pub(crate) const BAD_FRAME: &str = "bad_frame";
+}
+
+/// One pylon endpoint: a pinned runtime identity + the clock it trusts.
+pub(crate) struct Pylon {
+    runtime_key: ed25519_dalek::VerifyingKey,
+    now_ms: u64,
+    seen_request_ids: HashSet<[u8; 16]>,
+}
+
+impl Pylon {
+    /// Create a pylon for the runtime identity `runtime_key`, evaluating
+    /// expiry at `now_ms`.
+    pub(crate) fn new(runtime_key: ed25519_dalek::VerifyingKey, now_ms: u64) -> Self {
+        Self {
+            runtime_key,
+            now_ms,
+            seen_request_ids: HashSet::new(),
+        }
+    }
+
+    /// Verify + answer one authenticated request frame (#544).
+    pub(crate) fn handle(&mut self, frame_bytes: &[u8]) -> Vec<u8> {
+        let response = self.answer(frame_bytes);
+        // Wrap the authenticated response in the envelope (kind 5).
+        let payload = postcard::to_allocvec(&response).unwrap_or_default();
+        let correlation = frame_bytes
+            .get(10..18)
+            .and_then(|b| b.try_into().ok().map(u64::from_le_bytes))
+            .unwrap_or(0);
+        Envelope::build(MessageKind::AuthenticatedResponse, correlation, payload)
+            .map(|e| e.encode())
+            .unwrap_or_default()
+    }
+
+    /// The verification + answer logic (typed for the witness's assertions).
+    fn answer(&mut self, frame_bytes: &[u8]) -> AuthenticatedResponse {
+        let Ok(frame) = Envelope::decode(frame_bytes) else {
+            return self.reject_undecodable(reject::BAD_FRAME);
+        };
+        if frame.header.kind != MessageKind::AuthenticatedRequest {
+            return self.reject_undecodable(reject::BAD_FRAME);
+        }
+        let auth: AuthenticatedRequest = match postcard::from_bytes(&frame.payload) {
+            Ok(a) => a,
+            Err(_) => return self.reject_undecodable(reject::BAD_FRAME),
+        };
+        let request_id = auth.request.request_id();
+
+        // The issuer must be the pinned runtime (cryptographic identity,
+        // not a claimed string).
+        if auth.signed_grant.grant.issuer != self.runtime_key.to_bytes() {
+            return Self::reject(&auth, reject::WRONG_ISSUER);
+        }
+        // Grant signature + expiry. Device binding is proven by the subject
+        // matching the grant itself (the presenting device proves possession
+        // of the grant by using its nonce-keyed response MAC channel; a
+        // stolen grant verifies but the device's own identity claim rides in
+        // the request's identity ref, checked next).
+        let device = auth.request.identity().attestation_digest;
+        match auth.signed_grant.verify(&device, self.now_ms) {
+            Err(GrantError::BadSignature) => return Self::reject(&auth, reject::GRANT_SIGNATURE),
+            Err(GrantError::Expired { .. }) => return Self::reject(&auth, reject::GRANT_EXPIRED),
+            Err(GrantError::WrongDevice) => return Self::reject(&auth, reject::WRONG_DEVICE),
+            Ok(_) => {}
+        }
+        // The request's identity ref must match the grant's subject.
+        if device != auth.signed_grant.grant.subject {
+            return Self::reject(&auth, reject::WRONG_DEVICE);
+        }
+        // Capability: the task's requirement must be inside the grant.
+        if !auth
+            .signed_grant
+            .grant
+            .capabilities
+            .contains(&auth.request.required_capability())
+        {
+            return Self::reject(&auth, reject::CAPABILITY_DENIED);
+        }
+        // Replay.
+        if !self.seen_request_ids.insert(request_id.to_bytes()) {
+            return Self::reject(&auth, reject::REPLAY);
+        }
+        // The harmless typed task: accept the echo/no-op action.
+        let action = DeviceAction::None;
+        AuthenticatedResponse::build(
+            &auth.signed_grant,
+            TaskResponse::accepted(request_id, action),
+        )
+    }
+
+    /// A typed rejection, MAC'd with the request's own grant so the client
+    /// verifies it through the same channel (#544).
+    fn reject(auth: &AuthenticatedRequest, reason: &'static str) -> AuthenticatedResponse {
+        AuthenticatedResponse::build(
+            &auth.signed_grant,
+            TaskResponse::rejected(auth.request.request_id(), reason),
+        )
+    }
+
+    /// A rejection for an undecodable frame (no grant to MAC under; the
+    /// client-side decode/verify fails on its own for these).
+    fn reject_undecodable(&self, reason: &'static str) -> AuthenticatedResponse {
+        AuthenticatedResponse::build(
+            &self.fallback_grant(),
+            TaskResponse::rejected(ulid::Ulid::from_bytes([0; 16]), reason),
+        )
+    }
+
+    /// A grant-shaped placeholder for building rejection responses (the MAC
+    /// key differs per grant, so rejections use the REQUEST's grant when
+    /// decodable; this is only for undecodable frames).
+    fn fallback_grant(&self) -> crate::grants::SignedGrant {
+        crate::grants::SignedGrant {
+            grant: crate::grants::Grant {
+                issuer: self.runtime_key.to_bytes(),
+                subject: [0; 32],
+                capabilities: Vec::new(),
+                issued_at_ms: 0,
+                expires_at_ms: u64::MAX,
+                nonce: [0; 16],
+            },
+            signature: ed25519_dalek::Signature::from_bytes(&[0; 64]),
+        }
+    }
+}
+
+/// Run a pylon on `127.0.0.1:0` in a background thread, answering exactly
+/// `n_requests` frames then stopping. Returns the bound port and the join
+/// handle. Used by the adversarial witness (#544).
+pub(crate) fn spawn(mut pylon: Pylon, n_requests: usize) -> (u16, JoinHandle<()>) {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap_or_else(|_| unreachable!());
+    let port = listener.local_addr().map(|a| a.port()).unwrap_or_default();
+    let handle = std::thread::spawn(move || {
+        for _ in 0..n_requests {
+            let Ok((mut stream, _)) = listener.accept() else {
+                continue;
+            };
+            serve_one(&mut pylon, &mut stream);
+        }
+    });
+    (port, handle)
+}
+
+/// Read one length-prefixed frame, answer it, write the response frame.
+fn serve_one(pylon: &mut Pylon, stream: &mut TcpStream) {
+    use std::io::{Read, Write};
+    let mut len_buf = [0u8; 4];
+    if stream.read_exact(&mut len_buf).is_err() {
+        return;
+    }
+    let len = u32::from_le_bytes(len_buf) as usize;
+    if len > 64 * 1024 {
+        return;
+    }
+    let mut frame = vec![0u8; len];
+    if stream.read_exact(&mut frame).is_err() {
+        return;
+    }
+    let response = pylon.handle(&frame);
+    let out_len = (response.len() as u32).to_le_bytes();
+    let _ = stream.write_all(&out_len);
+    let _ = stream.write_all(&response);
+}
+
+/// The control channel for scripted endpoints (unused by the witness today;
+/// kept for the on-device leg's orchestration).
+pub(crate) fn _control_channel() -> (Receiver<u8>, ()) {
+    let (_tx, rx) = channel::<u8>();
+    (rx, ())
+}

--- a/crates/metaxu/src/session.rs
+++ b/crates/metaxu/src/session.rs
@@ -1,0 +1,108 @@
+//! The authenticated session layer (#544): one mutually authenticated
+//! Thumos↔Aletheia round trip over the versioned envelope.
+//!
+//! Two payload kinds extend the contract additively (envelope MINOR 1,
+//! exercising the #553 compat rule — known kinds decode identically on both
+//! sides, unknown ones reject loudly):
+//!
+//! - `AuthenticatedRequest` (kind 4): `SignedGrant` + `TaskRequest`. The
+//!   device presents a cryptographically verified, expiring grant bound to
+//!   both identities on EVERY request — there is no session state to
+//!   confuse, and a stateless endpoint can verify each request alone.
+//! - `AuthenticatedResponse` (kind 5): `TaskResponse` + an HMAC-SHA256 over
+//!   the response payload, keyed by HKDF from the grant's nonce (see
+//!   grants.rs). A verified response proves the responder knows the signed
+//!   nonce — the mutual half of the authentication.
+//!
+//! The pylon (`crate::pylon`) is the reference endpoint double the
+//! adversarial witness runs against.
+
+use serde::{Deserialize, Serialize};
+
+use crate::grants::SignedGrant;
+use crate::protocol::{TaskRequest, TaskResponse};
+
+/// An authenticated task request: the verified grant plus the typed task
+/// (#544). Envelope kind 4 (MINOR 1).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthenticatedRequest {
+    /// The device's grant for this task's capabilities.
+    pub signed_grant: SignedGrant,
+    /// The task being requested.
+    pub request: TaskRequest,
+}
+
+/// An authenticated task response: the typed response plus its
+/// grant-nonce-keyed HMAC (#544). Envelope kind 5 (MINOR 1).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthenticatedResponse {
+    /// The task response.
+    pub response: TaskResponse,
+    /// HMAC-SHA256 over `postcard::to_allocvec(response)` under the grant's
+    /// response key.
+    pub mac: [u8; 32],
+}
+
+impl AuthenticatedResponse {
+    /// Build an authenticated response for `response` under `grant`'s
+    /// response key.
+    pub fn build(signed_grant: &SignedGrant, response: TaskResponse) -> Self {
+        let payload = postcard::to_allocvec(&response).unwrap_or_default();
+        let mac = crate::grants::response_mac(&signed_grant.response_key(), &[&payload]);
+        Self { response, mac }
+    }
+
+    /// Verify the response MAC under `signed_grant`'s response key.
+    pub fn verify(&self, signed_grant: &SignedGrant) -> bool {
+        let payload = postcard::to_allocvec(&self.response).unwrap_or_default();
+        let expected = crate::grants::response_mac(&signed_grant.response_key(), &[&payload]);
+        // Constant-time comparison for a 32-byte MAC.
+        expected
+            .iter()
+            .zip(self.mac.iter())
+            .fold(0u8, |acc, (a, b)| acc | (a ^ b))
+            == 0
+    }
+}
+
+/// The device's side of an authenticated exchange: present a grant, send a
+/// task, verify the response MAC (#544).
+#[derive(Debug, Clone)]
+pub struct AuthenticatedSession {
+    signed_grant: SignedGrant,
+}
+
+impl AuthenticatedSession {
+    /// Open a session for `signed_grant`, after checking the grant is for
+    /// this device and unexpired at `now_ms` — a client never presents a
+    /// grant it cannot verify (fail-closed pre-flight).
+    pub fn open(
+        signed_grant: SignedGrant,
+        device: &[u8; 32],
+        now_ms: u64,
+    ) -> core::result::Result<Self, crate::grants::GrantError> {
+        signed_grant.verify(device, now_ms)?;
+        Ok(Self { signed_grant })
+    }
+
+    /// The session's grant.
+    pub const fn grant(&self) -> &SignedGrant {
+        &self.signed_grant
+    }
+
+    /// Wrap a task request for the wire.
+    pub fn wrap(&self, request: TaskRequest) -> AuthenticatedRequest {
+        AuthenticatedRequest {
+            signed_grant: self.signed_grant.clone(),
+            request,
+        }
+    }
+
+    /// Verify a received authenticated response: MAC valid under the
+    /// grant's response key AND the response answers this session's
+    /// outstanding request (the caller checks the id match against its
+    /// request, as `BridgeClient` already enforces).
+    pub fn verify_response(&self, response: &AuthenticatedResponse) -> bool {
+        response.verify(&self.signed_grant)
+    }
+}

--- a/crates/metaxu/src/vectors.rs
+++ b/crates/metaxu/src/vectors.rs
@@ -24,7 +24,8 @@ pub(crate) struct GoldenVector {
 }
 
 /// The golden vectors (envelope v1: magic "MTX1" LE, schema 1, major 1,
-/// minor 0). Segments annotated per byte run.
+/// minor 1). Segments annotated per byte run. MINOR-0 frames remain
+/// decodable per the compat rules (see `minor_0_frames_still_decode`).
 pub(crate) static GOLDEN_VECTORS: &[GoldenVector] = &[
     GoldenVector {
         name: "task-request-minimal",
@@ -32,7 +33,7 @@ pub(crate) static GOLDEN_VECTORS: &[GoldenVector] = &[
             0x4D, 0x54, 0x58, 0x31, // magic "MTX1"
             0x01, 0x00, // schema 1
             0x01, // major 1
-            0x00, // minor 0
+            0x01, // minor 1 (#544: authenticated kinds added)
             0x01, 0x00, // kind 1 = TaskRequest
             0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // correlation 7
             0x01, 0x00, 0x00, 0x00, // payload_len 1
@@ -48,7 +49,7 @@ pub(crate) static GOLDEN_VECTORS: &[GoldenVector] = &[
             0x4D, 0x54, 0x58, 0x31, // magic "MTX1"
             0x01, 0x00, // schema 1
             0x01, // major 1
-            0x00, // minor 0
+            0x01, // minor 1 (#544: authenticated kinds added)
             0x03, 0x00, // kind 3 = SttEvent
             0x2A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // correlation 42
             0x04, 0x00, 0x00, 0x00, // payload_len 4
@@ -160,6 +161,21 @@ mod tests {
                 confidence_milli: 0,
             }
         );
+    }
+
+    #[test]
+    fn minor_0_frames_still_decode() {
+        // The #544 MINOR bump must not strand MINOR-0 peers: a frame with
+        // minor=0 (the pre-#544 shape) decodes identically (#553 compat
+        // rule: older minor accepted).
+        let mut bytes = GOLDEN_VECTORS[0].bytes.to_vec();
+        bytes[7] = 0x00;
+        let frame = Envelope::decode(&bytes);
+        assert!(
+            frame.is_ok(),
+            "a MINOR-0 frame must still decode at MINOR 1"
+        );
+        assert_eq!(frame.ok().map(|f| f.header.minor), Some(0));
     }
 
     #[test]

--- a/crates/metaxu/src/witness.rs
+++ b/crates/metaxu/src/witness.rs
@@ -1,0 +1,296 @@
+//! The adversarial round-trip witness (#544): one authenticated
+//! Thumos↔Aletheia exchange and every failure mode, over real TCP.
+//!
+//! Cases (the issue's done-when, item 5):
+//! 1. happy path — verified grant, accepted task, MAC-verified response.
+//! 2. replay — a repeated request id is rejected.
+//! 3. expired grant — rejected at evaluation.
+//! 4. wrong runtime identity — a grant from an unpinned issuer is rejected;
+//!    and a grant for another device never authorizes this one.
+//! 5. unavailable network — a typed transport error, not a panic or a
+//!    silent empty response.
+//! 6. denied capability — a task outside the grant is rejected pre-action.
+
+use ed25519_dalek::SigningKey;
+use ulid::Ulid;
+
+use crate::envelope::{Envelope, MessageKind};
+use crate::grants::{Grant, SignedGrant};
+use crate::protocol::{
+    Capability, CapabilityGrant, DeviceIdentityRef, IdentityKind, TaskRequest, TaskStatus,
+};
+use crate::pylon::{self, Pylon};
+use crate::session::AuthenticatedSession;
+
+/// The runtime the witness pins (the pylon's identity).
+fn runtime_signing() -> SigningKey {
+    SigningKey::from_bytes(&[7u8; 32])
+}
+
+/// The device the witness presents.
+fn device_signing() -> SigningKey {
+    SigningKey::from_bytes(&[9u8; 32])
+}
+
+fn device_identity() -> DeviceIdentityRef {
+    DeviceIdentityRef::new(
+        IdentityKind::Device,
+        "witness-device",
+        device_signing().verifying_key().to_bytes(),
+    )
+}
+
+/// Issue a grant from the runtime to the device, expiring at `expires_at_ms`.
+fn runtime_grant(expires_at_ms: u64) -> SignedGrant {
+    SignedGrant::issue(
+        Grant {
+            issuer: runtime_signing().verifying_key().to_bytes(),
+            subject: device_signing().verifying_key().to_bytes(),
+            capabilities: vec![Capability::SmsSend],
+            issued_at_ms: 1_000,
+            expires_at_ms,
+            nonce: [0xA5; 16],
+        },
+        &runtime_signing(),
+    )
+}
+
+fn sms_request() -> TaskRequest {
+    TaskRequest::SendSms {
+        request_id: Ulid::from_bytes([5; 16]),
+        identity: device_identity(),
+        grants: vec![CapabilityGrant::new(
+            Capability::SmsSend,
+            "policy",
+            "grant-sms",
+        )],
+        to: "+15551234567".into(),
+        body: "witness: harmless typed task".into(),
+    }
+}
+
+/// Encode an authenticated request frame (kind 4).
+fn auth_frame(session: &AuthenticatedSession, request: TaskRequest) -> Vec<u8> {
+    let wrapped = session.wrap(request);
+    let payload = postcard::to_allocvec(&wrapped).unwrap_or_default();
+    Envelope::build(MessageKind::AuthenticatedRequest, 1, payload)
+        .unwrap_or_else(|_| unreachable!())
+        .encode()
+}
+
+/// One TCP exchange against a spawned pylon: send one frame, read the
+/// authenticated response.
+fn exchange(port: u16, frame: &[u8]) -> Vec<u8> {
+    use std::io::{Read, Write};
+    let mut stream = std::net::TcpStream::connect(("127.0.0.1", port))
+        .unwrap_or_else(|e| unreachable!("witness pylon must accept: {e}"));
+    let len = (frame.len() as u32).to_le_bytes();
+    stream.write_all(&len).unwrap_or_else(|_| unreachable!());
+    stream.write_all(frame).unwrap_or_else(|_| unreachable!());
+    let mut len_buf = [0u8; 4];
+    stream
+        .read_exact(&mut len_buf)
+        .unwrap_or_else(|_| unreachable!());
+    let out_len = u32::from_le_bytes(len_buf) as usize;
+    let mut out = vec![0u8; out_len];
+    stream
+        .read_exact(&mut out)
+        .unwrap_or_else(|_| unreachable!());
+    out
+}
+
+/// Decode an authenticated response and check its MAC under the session.
+fn verify_response(
+    session: &AuthenticatedSession,
+    frame: &[u8],
+) -> crate::session::AuthenticatedResponse {
+    let frame =
+        Envelope::decode(frame).unwrap_or_else(|e| unreachable!("response frame decodes: {e}"));
+    assert_eq!(frame.header.kind, MessageKind::AuthenticatedResponse);
+    let response: crate::session::AuthenticatedResponse =
+        postcard::from_bytes(&frame.payload).unwrap_or_else(|_| unreachable!());
+    assert!(
+        session.verify_response(&response),
+        "the response MAC must verify under the grant's response key"
+    );
+    response
+}
+
+#[test]
+fn happy_authenticated_round_trip() {
+    let (port, _handle) = pylon::spawn(Pylon::new(runtime_signing().verifying_key(), 5_000), 1);
+    let session = AuthenticatedSession::open(
+        runtime_grant(10_000),
+        &device_signing().verifying_key().to_bytes(),
+        5_000,
+    )
+    .unwrap_or_else(|e| unreachable!("grant verifies: {e}"));
+    let request = sms_request();
+    let response = verify_response(
+        &session,
+        &exchange(port, &auth_frame(&session, request.clone())),
+    );
+    assert_eq!(response.response.request_id, request.request_id());
+    assert!(
+        matches!(response.response.status, TaskStatus::Accepted { .. }),
+        "a verified grant + task must be accepted, got {:?}",
+        response.response.status
+    );
+}
+
+#[test]
+fn replay_is_rejected() {
+    let (port, _handle) = pylon::spawn(Pylon::new(runtime_signing().verifying_key(), 5_000), 2);
+    let session = AuthenticatedSession::open(
+        runtime_grant(10_000),
+        &device_signing().verifying_key().to_bytes(),
+        5_000,
+    )
+    .unwrap_or_else(|e| unreachable!("grant verifies: {e}"));
+    let frame = auth_frame(&session, sms_request());
+    let _ = verify_response(&session, &exchange(port, &frame));
+    let second = verify_response(&session, &exchange(port, &frame));
+    match second.response.status {
+        TaskStatus::Rejected { ref reason } => {
+            assert_eq!(
+                reason.as_str(),
+                pylon::reject::REPLAY,
+                "the repeated request must be a replay reject"
+            );
+        }
+        ref other => unreachable!("replay must reject, got {other:?}"),
+    }
+}
+
+#[test]
+fn expired_grant_is_rejected() {
+    let (port, _handle) = pylon::spawn(Pylon::new(runtime_signing().verifying_key(), 20_000), 1);
+    // The grant expired at 10_000; the pylon evaluates at 20_000. The
+    // client-side pre-flight ALSO refuses it (fail-closed both ends).
+    assert!(
+        AuthenticatedSession::open(
+            runtime_grant(10_000),
+            &device_signing().verifying_key().to_bytes(),
+            20_000
+        )
+        .is_err(),
+        "client pre-flight must refuse an expired grant"
+    );
+    // And the endpoint rejects it independently.
+    let session = AuthenticatedSession::open(
+        runtime_grant(10_000),
+        &device_signing().verifying_key().to_bytes(),
+        5_000,
+    )
+    .unwrap_or_else(|e| unreachable!("grant verifies at issue time: {e}"));
+    let response = verify_response(
+        &session,
+        &exchange(port, &auth_frame(&session, sms_request())),
+    );
+    match response.response.status {
+        TaskStatus::Rejected { ref reason } => {
+            assert_eq!(reason.as_str(), pylon::reject::GRANT_EXPIRED)
+        }
+        ref other => unreachable!("expired grant must reject, got {other:?}"),
+    }
+}
+
+#[test]
+fn wrong_runtime_identity_is_rejected() {
+    // The grant is signed by an impostor runtime (a different signing key
+    // than the pylon pins). Signature verifies under the impostor — and the
+    // pylon still refuses, because the issuer is not the pinned runtime.
+    let impostor = SigningKey::from_bytes(&[0xEE; 32]);
+    let forged = SignedGrant::issue(
+        Grant {
+            issuer: impostor.verifying_key().to_bytes(),
+            subject: device_signing().verifying_key().to_bytes(),
+            capabilities: vec![Capability::SmsSend],
+            issued_at_ms: 1_000,
+            expires_at_ms: 10_000,
+            nonce: [0xA5; 16],
+        },
+        &impostor,
+    );
+    let (port, _handle) = pylon::spawn(Pylon::new(runtime_signing().verifying_key(), 5_000), 1);
+    let session =
+        AuthenticatedSession::open(forged, &device_signing().verifying_key().to_bytes(), 5_000)
+            .unwrap_or_else(|e| {
+                unreachable!("the forged grant verifies under its own issuer: {e}")
+            });
+    let response = verify_response(
+        &session,
+        &exchange(port, &auth_frame(&session, sms_request())),
+    );
+    match response.response.status {
+        TaskStatus::Rejected { ref reason } => {
+            assert_eq!(reason.as_str(), pylon::reject::WRONG_ISSUER)
+        }
+        ref other => unreachable!("an unpinned issuer must reject, got {other:?}"),
+    }
+}
+
+#[test]
+fn grant_for_another_device_never_authorizes() {
+    let signed = SignedGrant::issue(
+        Grant {
+            issuer: runtime_signing().verifying_key().to_bytes(),
+            subject: [0x77; 32], // a different device
+            capabilities: vec![Capability::SmsSend],
+            issued_at_ms: 1_000,
+            expires_at_ms: 10_000,
+            nonce: [0xA5; 16],
+        },
+        &runtime_signing(),
+    );
+    assert!(
+        AuthenticatedSession::open(signed, &device_signing().verifying_key().to_bytes(), 5_000)
+            .is_err(),
+        "a grant for device B must not open a session for device A"
+    );
+}
+
+#[test]
+fn unavailable_network_is_a_typed_transport_error() {
+    // No listener on this port (bound-then-dropped to guarantee closure).
+    let port = std::net::TcpListener::bind(("127.0.0.1", 0))
+        .and_then(|l| l.local_addr().map(|a| a.port()))
+        .unwrap_or_else(|_| unreachable!());
+    let result = std::net::TcpStream::connect(("127.0.0.1", port));
+    assert!(result.is_err(), "connecting a dead port must error");
+    let err = result.err().unwrap_or_else(|| unreachable!());
+    assert_eq!(
+        err.kind(),
+        std::io::ErrorKind::ConnectionRefused,
+        "the transport error is typed (connection refused), not a panic or empty frame"
+    );
+}
+
+#[test]
+fn capability_outside_grant_is_denied() {
+    let (port, _handle) = pylon::spawn(Pylon::new(runtime_signing().verifying_key(), 5_000), 1);
+    let session = AuthenticatedSession::open(
+        runtime_grant(10_000),
+        &device_signing().verifying_key().to_bytes(),
+        5_000,
+    )
+    .unwrap_or_else(|e| unreachable!("grant verifies: {e}"));
+    // The grant carries only SendSms; a PlaceCall task is outside it.
+    let call = TaskRequest::PlaceCall {
+        request_id: Ulid::from_bytes([6; 16]),
+        identity: device_identity(),
+        grants: vec![CapabilityGrant::new(
+            Capability::CallDial,
+            "policy",
+            "grant-call",
+        )],
+        to: "+15557654321".into(),
+    };
+    let response = verify_response(&session, &exchange(port, &auth_frame(&session, call)));
+    match response.response.status {
+        TaskStatus::Rejected { ref reason } => {
+            assert_eq!(reason.as_str(), pylon::reject::CAPABILITY_DENIED)
+        }
+        ref other => unreachable!("an out-of-grant capability must deny, got {other:?}"),
+    }
+}

--- a/crates/metaxu/src/witness.rs
+++ b/crates/metaxu/src/witness.rs
@@ -189,7 +189,7 @@ fn expired_grant_is_rejected() {
     );
     match response.response.status {
         TaskStatus::Rejected { ref reason } => {
-            assert_eq!(reason.as_str(), pylon::reject::GRANT_EXPIRED)
+            assert_eq!(reason.as_str(), pylon::reject::GRANT_EXPIRED);
         }
         ref other => unreachable!("expired grant must reject, got {other:?}"),
     }
@@ -224,7 +224,7 @@ fn wrong_runtime_identity_is_rejected() {
     );
     match response.response.status {
         TaskStatus::Rejected { ref reason } => {
-            assert_eq!(reason.as_str(), pylon::reject::WRONG_ISSUER)
+            assert_eq!(reason.as_str(), pylon::reject::WRONG_ISSUER);
         }
         ref other => unreachable!("an unpinned issuer must reject, got {other:?}"),
     }
@@ -289,7 +289,7 @@ fn capability_outside_grant_is_denied() {
     let response = verify_response(&session, &exchange(port, &auth_frame(&session, call)));
     match response.response.status {
         TaskStatus::Rejected { ref reason } => {
-            assert_eq!(reason.as_str(), pylon::reject::CAPABILITY_DENIED)
+            assert_eq!(reason.as_str(), pylon::reject::CAPABILITY_DENIED);
         }
         ref other => unreachable!("an out-of-grant capability must deny, got {other:?}"),
     }

--- a/docs/protocols/aletheia-v1.md
+++ b/docs/protocols/aletheia-v1.md
@@ -21,8 +21,9 @@ Every frame is a 22-byte fixed header (little-endian) followed by exactly
 [0..4)   magic: u32      = "MTX1" (0x4D 0x54 0x58 0x31)
 [4..6)   schema: u16     = 1
 [6]      major: u8       = 1
-[7]      minor: u8       = 0
+[7]      minor: u8       = 1
 [8..10)  kind: u16       = 1 TaskRequest | 2 TaskResponse | 3 SttEvent
+                      4 AuthenticatedRequest | 5 AuthenticatedResponse (MINOR 1)
 [10..18) correlation_id: u64 (request ULID's first 8 bytes)
 [18..22) payload_len: u32
 ```
@@ -44,7 +45,36 @@ Every frame is a 22-byte fixed header (little-endian) followed by exactly
 - Frame bytes != 22 + payload_len: reject (`TruncatedFrame` /
   `TrailingBytes`) — decoding is exact, always.
 
-## 2. STT events (JSON over WebSocket)
+## 2. Authenticated exchange (envelope MINOR 1, #544)
+
+Two additive kinds carry one mutually authenticated round trip:
+
+- **AuthenticatedRequest** (kind 4): `SignedGrant` + `TaskRequest`. The
+  device presents a cryptographically verified, expiring grant on EVERY
+  request — no session state to confuse.
+- **AuthenticatedResponse** (kind 5): `TaskResponse` + HMAC-SHA256 over the
+  response payload, keyed by `HKDF-SHA256(ikm = grant.nonce, info =
+  "metaxu-response-v1")`. A verified response proves the responder knows
+  the signed nonce — the mutual half of the authentication.
+
+Grant semantics (`crates/metaxu/src/grants.rs`):
+
+- A `Grant` is issuer(runtime Ed25519 pubkey) → subject(device pubkey),
+  capability set, issue/expiry times (ms), and a 16-byte session nonce.
+  A `SignedGrant` is the grant's postcard bytes plus the issuer's Ed25519
+  signature. Verification proves: signature valid under the pinned runtime
+  key, subject == the presenting device, not expired (expiry exclusive).
+- The endpoint verifies each request statelessly: issuer pinned →
+  signature → expiry → device match → capability inside the grant →
+  request-id replay (per-endpoint seen set). Failures reject with typed
+  reasons (`grant_signature`, `grant_expired`, `wrong_device`,
+  `wrong_issuer`, `replay`, `capability_denied`, `bad_frame`).
+- The client pre-flights identically (fail-closed both ends).
+
+Payload ceilings: AuthenticatedRequest 34 KiB, AuthenticatedResponse
+33 KiB.
+
+## 3. STT events (JSON over WebSocket)
 
 Every event is versioned, session-correlated, sequenced, and typed:
 


### PR DESCRIPTION
## Summary

The bridge had a typed protocol surface but no authenticated device→runtime→device path, and grant claims looked security-relevant without any trusted issuer, expiry, peer identity, or enforcement. This lands the verified protocol path, exercised end-to-end over real TCP with the issue's full adversarial matrix.

**Verified, expiring, identity-bound grants** (`grants.rs`): `SignedGrant` — Ed25519-signed by the runtime, bound to both identities (issuer runtime key the device pins out of band; subject device key). `verify()` proves signature-under-pinned-key + subject-match + unexpired (exclusive boundary). Response authenticity is the mutual half: HMAC-SHA256 keyed by `HKDF(grant.nonce)`, so a verified response proves the responder knows the signed nonce.

**The session layer** (`session.rs`): `AuthenticatedSession` — fail-closed client pre-flight (never presents a grant it can't verify), wraps each task in `AuthenticatedRequest` (envelope kind 4), verifies each `AuthenticatedResponse` MAC (kind 5).

**The endpoint double** (`pylon.rs`): stateless per-request verification — pinned issuer, signature, expiry, device match, capability containment, request-id replay — with typed rejections (`grant_signature`, `grant_expired`, `wrong_device`, `wrong_issuer`, `replay`, `capability_denied`, `bad_frame`).

**The adversarial witness** (`witness.rs`, over real TCP):
1. happy round trip — verified grant, accepted harmless task, MAC-verified response;
2. replay — repeated request id rejected;
3. expired grant — rejected at the endpoint AND refused by client pre-flight;
4. wrong runtime identity — an impostor-issued grant (valid signature under the impostor!) rejected as `wrong_issuer`; and a grant for another device never opens a session;
5. unavailable network — typed `ConnectionRefused`, never a panic or empty frame;
6. out-of-grant capability — `capability_denied` before any action.

**Envelope MINOR 1** (kinds 4/5 + ceilings): the #553 additive-compat rule exercised for real — MINOR-0 frames still decode (pinned in `vectors.rs`), golden vectors advanced, `docs/protocols/aletheia-v1.md` documents the authenticated flow.

**Honest scope:** the on-device leg — a Thumos userspace process driving this session over a real channel (second-PL011 on qemu-virt per the plan; WiFi on hardware) — is tracked separately; this PR lands the verified protocol path it consumes. #544 stays open for it.

## Verification

- `cargo test -p metaxu`: **42/42 pass** — grant issue/verify (happy, wrong device, expired at/exclusive boundary, tampered capability, tampered nonce), response MAC keyed determinism, the six witness cases over real TCP, and every #553 envelope/vector test (incl. MINOR-0 backward decode).
- `cargo clippy -p metaxu --all-targets -- -D warnings`: clean (workspace lint set).
- `cargo fmt`: clean.

Refs #544