### PR TITLE
convergence: sema-core — canonical threat semantics, one implementation (#545)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,11 @@ jobs:
         # on any MT6739_* identifier outside board::m7 or any board-MMIO
         # value re-declared as a const outside board/. Cheap, source-level.
         run: scripts/check-board-seam.sh
+      - name: Convergence ratchet check (#545)
+        # WHY (#545): kernel↔workspace duplication only ever burns down —
+        # reds on an unclassified pair, a rising port-marker count, or a
+        # stale #126 pointer. Cheap, source-level.
+        run: scripts/check-convergence.sh
       - name: Kernel cross-compile (armv7a) + zero-warning gate (#431)
         # WHY (#431): the zero-warning gate lives in crates/thumos/.cargo/
         # config.toml's rustflags; scripts/kernel-build.sh builds through it

--- a/.kanon-ci.toml
+++ b/.kanon-ci.toml
@@ -77,6 +77,13 @@ timeout_secs = 300
 cmd = "scripts/check-board-seam.sh"
 timeout_secs = 300
 
+# WHY (#545): convergence is a ratchet, not a wish — port markers and
+# stale expectations only ever decrease, and every duplicated pair names
+# its disposition. Source-level, cheap.
+[stages."convergence"]
+cmd = "scripts/check-convergence.sh"
+timeout_secs = 300
+
 # WHY (#546): the full QEMU witness matrix (boot + fault + sleep + fork +
 # exec + forkexec + guard + brk + signal + crashloop) as one canonical runner — the
 # exact scripts ci.yml executes step-by-step.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,7 +9,13 @@ Board specifics (MMIO maps, device set, bring-up behavior) live behind the `boar
 
 ## Crate map
 
-14 crates total: 1 bare-metal kernel binary + 13 workspace library crates.
+15 crates total: 1 bare-metal kernel binary + 14 workspace library crates.
+
+The kernel links `sema-core` (the canonical threat-semantics types) by path
+dependency — the first instance of the #545 convergence topology: shared
+protocol/policy invariants live in no_std+alloc core crates the kernel and
+the workspace both consume; the full pair ledger and the ratchet enforcing
+it live in `docs/convergence.toml` + `scripts/check-convergence.sh`.
 
 ### Kernel binary (excluded from workspace)
 
@@ -52,6 +58,7 @@ Board specifics (MMIO maps, device set, bring-up behavior) live behind the `boar
 | `pteron` | Bluetooth HCI over STP, BLE scanning, LE Privacy address rotation |
 | `kelyphos` | WMT combo chip manager: firmware loading, STP framing, power control |
 | `sema` | Radio analysis: WiFi/BT/cell scanning, IMSI catcher detection |
+| `sema-core` | no_std+alloc threat semantics (canonical ThreatLevel/Calibration + band invariants, shared with the kernel, #545) |
 | `topos` | GPS NMEA parser, geofencing, position logging |
 
 **Security**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,9 +1049,17 @@ dependencies = [
  "jiff",
  "log",
  "postcard",
+ "sema-core",
  "serde",
  "snafu",
  "toml",
+]
+
+[[package]]
+name = "sema-core"
+version = "0.1.16"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/metaxu",
     "crates/pteron",
     "crates/sema",
+    "crates/sema-core",
     "crates/stegnos",
     "crates/topos",
 ]

--- a/crates/aither/src/lib.rs
+++ b/crates/aither/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(missing_docs)]
 #![expect(
     dead_code,
-    reason = "public API surface for future kernel binary integration (#126)"
+    reason = "API surface pending convergence — tracked in docs/convergence.toml (#545)"
 )]
 #![allow(unfulfilled_lint_expectations)]
 //! `WiFi` MAC driver and `WPA2`/`WPA3` supplicant. Scanning, association, EAPOL 4-way handshake, SAE key exchange.

--- a/crates/asphaleia/src/lib.rs
+++ b/crates/asphaleia/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(missing_docs)]
 #![expect(
     dead_code,
-    reason = "public API surface for future kernel binary integration (#126)"
+    reason = "API surface pending convergence — tracked in docs/convergence.toml (#545)"
 )]
 #![allow(unfulfilled_lint_expectations)]
 //! Security policy enforcement. Packet filtering, DNS-over-TLS, telemetry domain blocking, capability-based access control.

--- a/crates/eidolon/src/lib.rs
+++ b/crates/eidolon/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(missing_docs)]
 #![expect(
     dead_code,
-    reason = "public API surface for future kernel binary integration (#126)"
+    reason = "API surface pending convergence — tracked in docs/convergence.toml (#545)"
 )]
 #![allow(unfulfilled_lint_expectations)]
 //! User interface for the 240×320 framebuffer display. Widget system, keypad navigation, T9 text input, status bar.

--- a/crates/haphe/src/lib.rs
+++ b/crates/haphe/src/lib.rs
@@ -2,7 +2,7 @@
 #![deny(missing_docs)]
 #![expect(
     dead_code,
-    reason = "public API surface for future kernel binary integration (#126)"
+    reason = "API surface pending convergence — tracked in docs/convergence.toml (#545)"
 )]
 #![allow(unfulfilled_lint_expectations)]
 //! Input drivers for the AGM M7: GPIO keypad matrix scan, mtk-tpd touchscreen, event queue.

--- a/crates/kelyphos/src/lib.rs
+++ b/crates/kelyphos/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(missing_docs)]
 #![expect(
     dead_code,
-    reason = "public API surface for future kernel binary integration (#126)"
+    reason = "API surface pending convergence — tracked in docs/convergence.toml (#545)"
 )]
 #![allow(unfulfilled_lint_expectations)]
 //! WMT (Wireless Management Task) connectivity manager for the MT6739 combo chip.

--- a/crates/klesis/src/lib.rs
+++ b/crates/klesis/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(missing_docs)]
 #![expect(
     dead_code,
-    reason = "public API surface for future kernel binary integration (#126)"
+    reason = "API surface pending convergence — tracked in docs/convergence.toml (#545)"
 )]
 #![allow(unfulfilled_lint_expectations)]
 //! Telephony daemon for the MT6739 modem.

--- a/crates/krypta/src/lib.rs
+++ b/crates/krypta/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(missing_docs)]
 #![expect(
     dead_code,
-    reason = "public API surface for future kernel binary integration (#126)"
+    reason = "API surface pending convergence — tracked in docs/convergence.toml (#545)"
 )]
 #![allow(unfulfilled_lint_expectations)]
 //! End-to-end encrypted communication: X3DH key exchange plus message

--- a/crates/leipsanon/src/lib.rs
+++ b/crates/leipsanon/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(missing_docs)]
 #![expect(
     dead_code,
-    reason = "public API surface for future kernel binary integration (#126)"
+    reason = "API surface pending convergence — tracked in docs/convergence.toml (#545)"
 )]
 #![allow(unfulfilled_lint_expectations)]
 //! Emergency data destruction. Selective wipe of sensitive partitions

--- a/crates/pteron/src/lib.rs
+++ b/crates/pteron/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(missing_docs)]
 #![expect(
     dead_code,
-    reason = "public API surface for future kernel binary integration (#126)"
+    reason = "API surface pending convergence — tracked in docs/convergence.toml (#545)"
 )]
 #![allow(unfulfilled_lint_expectations)]
 //! Bluetooth driver: HCI transport over STP, BLE scanning and device discovery, classic pairing.

--- a/crates/sema-core/Cargo.toml
+++ b/crates/sema-core/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "sema-core"
+description = "no_std + alloc core types for radio-intelligence threat semantics (the canonical ThreatLevel/Calibration, shared by sema and the kernel)"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+repository.workspace = true
+
+[dependencies]
+serde = { version = "1", default-features = false, features = ["derive", "alloc"] }
+
+[lints]
+workspace = true
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-08-05"
+exit-criteria = "operator-reviewed hardware validation and release-readiness gate"

--- a/crates/sema-core/src/lib.rs
+++ b/crates/sema-core/src/lib.rs
@@ -1,0 +1,149 @@
+#![no_std]
+//! sema-core: the canonical threat-semantics types (#545).
+//!
+//! This crate is the single home of [`ThreatLevel`], [`Calibration`], and
+//! the band boundaries between them, shared by the `sema` workspace crate
+//! (the IMSI-catcher detector + evaluation harness) and the thumos kernel
+//! (the threat screen's display bands). It exists because the two sides
+//! drifted: the kernel's screen mapped scores at 25/50/75 while `sema`'s
+//! protocol invariants are 30/60/80 — one protocol, one implementation.
+//!
+//! `no_std` + alloc so the bare-metal kernel can link it via a path
+//! dependency; nothing here performs I/O.
+
+extern crate alloc;
+
+use alloc::string::String;
+
+use serde::{Deserialize, Serialize};
+
+/// Threat level derived from a cumulative threat score.
+///
+/// Thresholds (protocol invariants, changing them is a semver break):
+/// `<30` Low, `30–59` Medium, `60–79` High, `≥80` Critical. Their MEANING
+/// is provisional until the score behind them is `Calibration::Calibrated`
+/// (#555): the bands name score ranges, not yet validated detection
+/// confidence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[must_use]
+#[non_exhaustive]
+pub enum ThreatLevel {
+    /// Score below 30. Normal operating conditions (provisional band).
+    Low,
+    /// Score 30–59. Suspicious activity band (provisional).
+    Medium,
+    /// Score 60–79. High band — labeled "likely IMSI catcher" only after
+    /// calibration establishes what the band actually separates (#555).
+    High,
+    /// Score 80+. Critical band (provisional; see High).
+    Critical,
+}
+
+impl core::fmt::Display for ThreatLevel {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Low => f.write_str("LOW"),
+            Self::Medium => f.write_str("MEDIUM"),
+            Self::High => f.write_str("HIGH"),
+            Self::Critical => f.write_str("CRITICAL"),
+        }
+    }
+}
+
+/// The canonical band edges (the protocol invariants, #545/#555).
+pub(crate) const MEDIUM_AT: u32 = 30;
+/// High begins at this score.
+pub(crate) const HIGH_AT: u32 = 60;
+/// Critical begins at this score.
+pub(crate) const CRITICAL_AT: u32 = 80;
+
+/// Derive a [`ThreatLevel`] from a numeric score — the ONE boundary table.
+pub const fn level_from_score(score: u32) -> ThreatLevel {
+    match score {
+        0..MEDIUM_AT => ThreatLevel::Low,
+        MEDIUM_AT..HIGH_AT => ThreatLevel::Medium,
+        HIGH_AT..CRITICAL_AT => ThreatLevel::High,
+        _ => ThreatLevel::Critical,
+    }
+}
+
+/// Calibration provenance of a threat score (#555).
+///
+/// The detector's weights and thresholds ship as provisional defaults with
+/// no retained calibration corpus or evaluation behind them. Until the
+/// evaluation harness (`sema::eval`) reports an operating point over a
+/// versioned trace corpus, every score must be presented as UNCALIBRATED —
+/// never as validated operational severity. Any future automatic response
+/// must match on `Calibrated` before it may act.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[must_use]
+#[non_exhaustive]
+pub enum Calibration {
+    /// Weights/thresholds are the provisional hand-maintained defaults; no
+    /// corpus-backed evaluation has established an operating point.
+    Uncalibrated,
+    /// Weights/thresholds were derived from the named corpus version at the
+    /// recorded operating point, satisfying the recorded error budget.
+    Calibrated {
+        /// Version identifier of the trace corpus the evaluation ran over.
+        corpus: String,
+        /// The operating point (weight set + thresholds) the evaluation
+        /// selected, in config-serializable form.
+        operating_point: String,
+        /// The measured error rates at that operating point
+        /// (false-positive and false-negative rates, per mille).
+        error_budget_per_mille: (u32, u32),
+    },
+}
+
+impl core::fmt::Display for Calibration {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Uncalibrated => f.write_str("UNCALIBRATED"),
+            Self::Calibrated { corpus, .. } => write!(f, "calibrated({corpus})"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::borrow::ToOwned;
+    use alloc::format;
+    use alloc::string::ToString;
+
+    #[test]
+    fn band_boundaries_are_the_canonical_30_60_80() {
+        assert_eq!(level_from_score(0), ThreatLevel::Low);
+        assert_eq!(level_from_score(29), ThreatLevel::Low);
+        assert_eq!(level_from_score(30), ThreatLevel::Medium);
+        assert_eq!(level_from_score(59), ThreatLevel::Medium);
+        assert_eq!(level_from_score(60), ThreatLevel::High);
+        assert_eq!(level_from_score(79), ThreatLevel::High);
+        assert_eq!(level_from_score(80), ThreatLevel::Critical);
+        assert_eq!(level_from_score(u32::MAX), ThreatLevel::Critical);
+    }
+
+    #[test]
+    fn labels_are_stable() {
+        assert_eq!(ThreatLevel::Low.to_string(), "LOW");
+        assert_eq!(ThreatLevel::Medium.to_string(), "MEDIUM");
+        assert_eq!(ThreatLevel::High.to_string(), "HIGH");
+        assert_eq!(ThreatLevel::Critical.to_string(), "CRITICAL");
+        assert_eq!(Calibration::Uncalibrated.to_string(), "UNCALIBRATED");
+    }
+
+    #[test]
+    fn calibration_carries_corpus_provenance() {
+        let c = Calibration::Calibrated {
+            corpus: "corpus-v1".to_owned(),
+            operating_point: "defaults".to_owned(),
+            error_budget_per_mille: (50, 10),
+        };
+        assert!(format!("{c}").contains("corpus-v1"));
+    }
+}

--- a/crates/sema/Cargo.toml
+++ b/crates/sema/Cargo.toml
@@ -13,6 +13,7 @@ snafu = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
 postcard = { workspace = true }
+sema-core = { path = "../sema-core" }
 
 [dev-dependencies]
 toml = "0.8"

--- a/crates/sema/src/cell.rs
+++ b/crates/sema/src/cell.rs
@@ -162,78 +162,10 @@ impl core::fmt::Display for CipherAlgorithm {
 
 // ── Threat scoring ──────────────────────────────────────────────────────────
 
-/// Calibration provenance of a [`ThreatScore`] (#555).
-///
-/// The detector's weights and thresholds ship as **provisional defaults**
-/// with no retained calibration corpus or evaluation behind them. Until the
-/// evaluation harness (`crate::eval`) reports an operating point over a
-/// versioned trace corpus, every score must be presented as UNCALIBRATED —
-/// never as validated operational severity. This marker is how the type
-/// system carries that honesty: a score cannot exist without stating its
-/// provenance, and any future automatic response must match on
-/// `Calibrated` before it may act.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[must_use]
-#[non_exhaustive]
-pub(crate) enum Calibration {
-    /// Weights/thresholds are the provisional hand-maintained defaults; no
-    /// corpus-backed evaluation has established an operating point.
-    Uncalibrated,
-    /// Weights/thresholds were derived from the named corpus version at the
-    /// recorded operating point, satisfying the recorded error budget.
-    Calibrated {
-        /// Version identifier of the trace corpus the evaluation ran over.
-        corpus: String,
-        /// The operating point (weight set + thresholds) the evaluation
-        /// selected, in `Config`-serializable form.
-        operating_point: String,
-        /// The measured error rates at that operating point
-        /// (false-positive and false-negative rates, per mille).
-        error_budget_per_mille: (u32, u32),
-    },
-}
-
-impl core::fmt::Display for Calibration {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::Uncalibrated => f.write_str("UNCALIBRATED"),
-            Self::Calibrated { corpus, .. } => write!(f, "calibrated({corpus})"),
-        }
-    }
-}
-
-/// Threat level derived from the cumulative [`ThreatScore`].
-///
-/// Thresholds: `<30` Low, `30–59` Medium, `60–79` High, `≥80` Critical.
-/// These boundaries are protocol invariants (changing them is a semver
-/// break), but their MEANING is provisional until the score behind them is
-/// `Calibration::Calibrated` (#555): the bands name score ranges, not yet
-/// validated detection confidence.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[must_use]
-#[non_exhaustive]
-pub(crate) enum ThreatLevel {
-    /// Score below 30. Normal operating conditions (provisional band).
-    Low,
-    /// Score 30–59. Suspicious activity band (provisional).
-    Medium,
-    /// Score 60–79. High band — labeled "likely IMSI catcher" only after
-    /// calibration establishes what the band actually separates (#555).
-    High,
-    /// Score 80+. Critical band (provisional; see High).
-    Critical,
-}
-
-impl core::fmt::Display for ThreatLevel {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::Low => f.write_str("LOW"),
-            Self::Medium => f.write_str("MEDIUM"),
-            Self::High => f.write_str("HIGH"),
-            Self::Critical => f.write_str("CRITICAL"),
-        }
-    }
-}
+/// The canonical threat semantics now live in `sema_core` (#545) — one
+/// implementation, shared by this crate and the kernel. Re-exported here so
+/// existing paths (`crate::cell::ThreatLevel`, etc.) keep working.
+pub(crate) use sema_core::{Calibration, ThreatLevel, level_from_score};
 
 /// A contributing factor to the overall [`ThreatScore`].
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -284,16 +216,6 @@ impl core::fmt::Display for ThreatScore {
             self.factors.len(),
             if self.factors.len() == 1 { "" } else { "s" },
         )
-    }
-}
-
-/// Derive a [`ThreatLevel`] from a numeric score.
-const fn level_from_score(score: u32) -> ThreatLevel {
-    match score {
-        0..30 => ThreatLevel::Low,
-        30..60 => ThreatLevel::Medium,
-        60..80 => ThreatLevel::High,
-        _ => ThreatLevel::Critical,
     }
 }
 

--- a/crates/sema/src/lib.rs
+++ b/crates/sema/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(missing_docs)]
 #![expect(
     dead_code,
-    reason = "public API surface for future kernel binary integration (#126)"
+    reason = "API surface pending convergence — tracked in docs/convergence.toml (#545)"
 )]
 #![allow(unfulfilled_lint_expectations)]
 //! Radio analysis tools. `WiFi` AP scanning, `BT` device enumeration, cell tower logging, `IMSI` catcher detection via tower behavior analysis.

--- a/crates/stegnos/src/lib.rs
+++ b/crates/stegnos/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(missing_docs)]
 #![expect(
     dead_code,
-    reason = "public API surface for future kernel binary integration (#126)"
+    reason = "API surface pending convergence — tracked in docs/convergence.toml (#545)"
 )]
 #![allow(unfulfilled_lint_expectations)]
 //! Encrypted block device management. `dm-crypt` setup, LUKS key derivation, `TPM` `PCR` sealing, secure key storage.

--- a/crates/thumos/Cargo.lock
+++ b/crates/thumos/Cargo.lock
@@ -378,6 +378,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "sema-core"
+version = "0.1.16"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +507,7 @@ dependencies = [
  "postcard",
  "rand_chacha",
  "rand_core",
+ "sema-core",
  "serde",
  "sha2",
  "smoltcp",

--- a/crates/thumos/Cargo.toml
+++ b/crates/thumos/Cargo.toml
@@ -45,6 +45,10 @@ crashloop-probe = []
 
 [dependencies]
 aes = { version = "0.8", default-features = false }
+# WHY (#545): the canonical threat-semantics types (ThreatLevel/Calibration/
+# band boundaries) live in sema-core, shared with the workspace `sema` crate
+# — one implementation, no drifted duplicate in screen_threat.
+sema-core = { path = "../sema-core", default-features = false }
 # WHY: Megolm needs AES-256-CBC (audit #231). Use the audited RustCrypto `cbc`
 # mode crate rather than hand-rolled chaining/padding. no_std verified for
 # i686 + armv7a-none-eabi (crate is `no-std` categorised, alloc-only feature set).

--- a/crates/thumos/src/screen_threat.rs
+++ b/crates/thumos/src/screen_threat.rs
@@ -78,55 +78,48 @@ const MAX_DESC_LEN: usize = 48;
 const COLOR_ORANGE: u16 = color::from_rgb(255, 165, 0);
 
 // ---------------------------------------------------------------------------
-// Threat level (matches sema crate convention)
+// Threat level — the canonical type from sema-core (#545)
 // ---------------------------------------------------------------------------
 
-/// Threat severity level, ordered from lowest to highest.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[must_use]
-#[non_exhaustive]
-pub enum ThreatLevel {
-    /// No active threats detected.
-    Low,
-    /// Minor anomalies that may warrant attention.
-    Medium,
-    /// Active threat indicators present.
-    High,
-    /// Confirmed active attack or compromise.
-    Critical,
+/// The canonical threat severity level: defined ONCE in `sema_core` (the
+/// no_std+alloc core shared with the `sema` workspace crate) and re-exported
+/// here. The pre-#545 kernel copy drifted (bands 25/50/75 vs the canonical
+/// 30/60/80 protocol invariants) — the exact divergence class #545 exists
+/// to kill. Screen-specific presentation rides in the extension trait
+/// below; semantics stay in one place.
+pub use sema_core::ThreatLevel;
+
+/// Screen-side presentation for the canonical [`ThreatLevel`].
+pub(crate) trait ThreatLevelScreenExt {
+    /// RGB565 color for this threat level.
+    fn color(self) -> u16;
+    /// Display label for this threat level.
+    fn label(self) -> &'static str;
 }
 
-impl ThreatLevel {
-    /// RGB565 color for this threat level.
-    const fn color(self) -> u16 {
+impl ThreatLevelScreenExt for ThreatLevel {
+    fn color(self) -> u16 {
         match self {
             Self::Low => color::GREEN,
             Self::Medium => color::YELLOW,
             Self::High => COLOR_ORANGE,
             Self::Critical => color::RED,
+            // sema-core's ThreatLevel is non_exhaustive; a future band the
+            // screen doesn't know yet renders as attention, never "fine".
+            _ => COLOR_ORANGE,
         }
     }
 
-    /// Display label for the threat level.
-    const fn label(self) -> &'static str {
+    fn label(self) -> &'static str {
         match self {
             Self::Low => "LOW",
             Self::Medium => "MEDIUM",
             Self::High => "HIGH",
             Self::Critical => "CRITICAL",
+            // Non-exhaustive forward compat: unknown future bands read as
+            // unknown, not as a fabricated level name.
+            _ => "?",
         }
-    }
-}
-
-impl Default for ThreatLevel {
-    fn default() -> Self {
-        Self::Low
-    }
-}
-
-impl fmt::Display for ThreatLevel {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.label())
     }
 }
 
@@ -338,12 +331,8 @@ impl ThreatMonitor {
     /// Update the composite threat score and level.
     pub(crate) fn set_score(&mut self, score: u32) {
         self.current_score = score.min(100);
-        self.current_level = match self.current_score {
-            0..=25 => ThreatLevel::Low,
-            26..=50 => ThreatLevel::Medium,
-            51..=75 => ThreatLevel::High,
-            _ => ThreatLevel::Critical,
-        };
+        // #545: the canonical 30/60/80 band function, shared with sema.
+        self.current_level = sema_core::level_from_score(self.current_score);
     }
 
     /// Update modem status fields.

--- a/crates/topos/src/lib.rs
+++ b/crates/topos/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(missing_docs)]
 #![expect(
     dead_code,
-    reason = "public API surface for future kernel binary integration (#126)"
+    reason = "API surface pending convergence — tracked in docs/convergence.toml (#545)"
 )]
 #![allow(unfulfilled_lint_expectations)]
 //! GPS driver and position service for the MT6739 combo chip.

--- a/docs/convergence.toml
+++ b/docs/convergence.toml
@@ -1,0 +1,89 @@
+# Convergence ledger (issue #545) — the machine-checked record of the
+# kernel↔workspace duplication and its dispositions. scripts/check-convergence.sh
+# enforces: every pair here has a disposition + owner, every "ported from"
+# comment names a live pair below, and the #126 dead-code expectations only
+# ever burn DOWN (the ratchet — the counts below may not increase).
+#
+# Dispositions:
+#   converged        — one canonical implementation owns the invariant (name it)
+#   extract-core     — pull the shared protocol/state machine into a
+#                      no_std+alloc core crate both sides link (topology 1)
+#   kernel-owned     — the kernel copy is canonical; the workspace duplicate
+#                      deletes when its consumers are gone (topology 2)
+#   workspace-owned  — the workspace crate is canonical; the kernel copy is a
+#                      transport/board adapter only
+#
+# The ratchet: current "ported from" comments = 6 (firewall×2, gsm7, sms,
+# screen_dialer, plus gps/wifi/bluetooth/telephony doc headers count as
+# provenance notes, not live duplication markers — see notes per pair).
+
+[[pair]]
+name = "threat-semantics"
+kernel = "screen_threat.rs (was: divergent bands 25/50/75)"
+workspace = "sema (cell.rs ThreatLevel, canonical bands 30/60/80)"
+disposition = "converged"
+canonical = "sema-core (no_std+alloc; kernel links via path dep, sema re-exports)"
+owner = "#545 (this PR)"
+notes = "The live divergence that proved the class: screen bands and the detector's protocol invariants disagreed. Now one type, one boundary table, both consumers."
+
+[[pair]]
+name = "gps"
+kernel = "gps.rs (ported from topos)"
+workspace = "topos"
+disposition = "extract-core"
+canonical = "pending: topos-core (coordinate/geo types + parse) when the GPS NMEA path lands (#129 family)"
+owner = "unscheduled"
+notes = "gps.rs:3 doc header records the port. Not user-facing until the combo-chip GPS path lands."
+
+[[pair]]
+name = "wifi"
+kernel = "wifi.rs (ported from aither)"
+workspace = "aither"
+disposition = "extract-core"
+canonical = "pending: aither-core (scan/association state machine)"
+owner = "unscheduled"
+notes = "wifi.rs:3 doc header records the port."
+
+[[pair]]
+name = "bluetooth"
+kernel = "bluetooth.rs (ported from pteron)"
+workspace = "pteron"
+disposition = "workspace-owned"
+canonical = "pteron (RPA/privacy already canonical there, #455); kernel keeps the HCI board transport"
+owner = "unscheduled"
+notes = "bluetooth.rs:3 doc header records the port. After #455 the workspace side is the richer, spec-verified side."
+
+[[pair]]
+name = "telephony-sms"
+kernel = "telephony.rs, sms.rs, gsm7.rs (ported from klesis)"
+workspace = "klesis"
+disposition = "extract-core"
+canonical = "pending: klesis-core (PDU/gsm7/AT-parse cores)"
+owner = "unscheduled"
+notes = "Live 'ported from' comments: gsm7.rs:20, sms.rs:109."
+
+[[pair]]
+name = "firewall"
+kernel = "firewall.rs (packet parse + DNS extraction ported from asphaleia)"
+workspace = "asphaleia"
+disposition = "extract-core"
+canonical = "pending: asphaleia-core (packet/DNS parse, policy rules)"
+owner = "unscheduled"
+notes = "Live 'ported from' comments: firewall.rs:602, :681."
+
+[[pair]]
+name = "ui"
+kernel = "ui.rs, screen_dialer.rs (font behavior, dialer rendering ported from eidolon/haphe)"
+workspace = "eidolon, haphe"
+disposition = "extract-core"
+canonical = "pending: glyph/widget core shared by the kernel UI and eidolon"
+owner = "unscheduled"
+notes = "Live 'ported from' comment: screen_dialer.rs:11. eidolon -> haphe is the one real internal edge; the kernel consumes neither today."
+
+# The #126 ratchet: the dead-code expectations pointing at closed #126
+# (one per workspace crate lib.rs) now point here. They burn down as each
+# pair converges — the checker fails if the count ever increases.
+[ratchet]
+rule = "port-markers-and-126-expectations-never-increase"
+ported_from_comments = 5      # firewall×2, gsm7, sms, screen_dialer
+stale_126_expectations = 12   # one per workspace crate lib.rs that still points at closed #126

--- a/scripts/check-convergence.sh
+++ b/scripts/check-convergence.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# check-convergence.sh — the #545 convergence ratchet. Fails when:
+#   (a) a [[pair]] row lacks disposition/canonical/owner, or names a file
+#       that no longer exists;
+#   (b) a live "ported from" comment names a crate pair with no ledger row;
+#   (c) the port-marker or stale-expectation counts INCREASE over the
+#       recorded ratchet values (convergence only ever burns down);
+#   (d) any lib.rs still points at closed #126 (the pointer must be the
+#       live ledger, not a closed issue).
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+LEDGER="$REPO_ROOT/docs/convergence.toml"
+
+python3 - "$LEDGER" "$REPO_ROOT" <<'PYEOF'
+import re, sys, tomllib, glob, os
+
+ledger_path, root = sys.argv[1], sys.argv[2]
+try:
+    doc = tomllib.load(open(ledger_path, "rb"))
+except Exception as e:
+    print(f"CONVERGENCE DRIFT: docs/convergence.toml is not parseable TOML: {e}", file=sys.stderr)
+    sys.exit(1)
+
+pairs = doc.get("pair", [])
+ratchet = doc.get("ratchet", {})
+rc = 0
+
+def fail(msg):
+    global rc
+    print(f"CONVERGENCE DRIFT: {msg}", file=sys.stderr)
+    rc = 1
+
+# (a) row completeness + file existence.
+names = set()
+for p in pairs:
+    name = p.get("name")
+    if not name:
+        fail(f"a [[pair]] row has no name: {p}")
+        continue
+    if name in names:
+        fail(f"duplicate pair '{name}'")
+    names.add(name)
+    for key in ("kernel", "workspace", "disposition", "canonical", "owner"):
+        if not p.get(key):
+            fail(f"pair '{name}' missing '{key}'")
+    if p.get("disposition") not in ("converged", "extract-core", "kernel-owned", "workspace-owned"):
+        fail(f"pair '{name}' has invalid disposition '{p.get('disposition')}'")
+    for side in ("kernel", "workspace"):
+        ref = p.get(side, "")
+        for m in re.finditer(r'([a-z0-9_]+\.rs)', ref):
+            if not glob.glob(os.path.join(root, "crates", "*", "src", m.group(1))):
+                fail(f"pair '{name}' {side} references missing file {m.group(1)}")
+
+# (b) every live "ported from" comment must name a crate the ledger covers.
+covered = set()
+for p in pairs:
+    for m in re.finditer(r'`?([a-z]+(?:-[a-z]+)?)`?(?:\s|$|,|\.|/)', p.get("workspace", "")):
+        covered.add(m.group(1))
+    covered.add(p.get("workspace", "").split(",")[0].strip())
+live_ports = []
+for f in glob.glob(os.path.join(root, "crates", "*", "src", "*.rs")):
+    for i, line in enumerate(open(f, errors="ignore"), 1):
+        m = re.search(r'(?<![a-z])ported from `?(?:crates/)?([a-z-]+)', line)
+        if m:
+            live_ports.append((f, i, m.group(1)))
+            if not any(m.group(1) in p.get("workspace", "") for p in pairs):
+                fail(f"{os.path.relpath(f, root)}:{i} 'ported from {m.group(1)}' has no ledger row")
+
+# (c) the ratchet: counts may only decrease.
+if len(live_ports) > ratchet.get("ported_from_comments", 0):
+    fail(f"'ported from' comments increased: {len(live_ports)} > ratchet {ratchet.get('ported_from_comments')} (convergence only burns down)")
+
+stale = 0
+for f in glob.glob(os.path.join(root, "crates", "*", "src", "lib.rs")):
+    text = open(f, errors="ignore").read()
+    stale += text.count("public API surface for future kernel binary integration (#126)")
+if stale > ratchet.get("stale_126_expectations", 0):
+    fail(f"stale #126 expectations increased: {stale} > ratchet {ratchet.get('stale_126_expectations')}")
+
+# (d) no lib.rs may point at closed #126 at all going forward (the pointer
+# is the ledger now).
+for f in glob.glob(os.path.join(root, "crates", "*", "src", "lib.rs")):
+    text = open(f, errors="ignore").read()
+    if "#126" in text:
+        fail(f"{os.path.relpath(f, root)} still references closed #126 — point at docs/convergence.toml (#545)")
+
+if rc == 0:
+    print(f"convergence ledger: {len(pairs)} pairs classified, {len(live_ports)} port markers, 0 stale #126 pointers, ratchet holding")
+sys.exit(rc)
+PYEOF


### PR DESCRIPTION
## Summary

Thumos maintains two parallel capability layers — 13 (now 14) workspace libraries and independent kernel modules that port or duplicate their logic — with no runnable binary consuming the workspace layer except `eidolon -> haphe`. That violates define-once and makes security/correctness fixes non-transitive. This opens the convergence track: one live divergence converged as the exemplar, the full pair inventory machine-checked with a ratchet.

**The exemplar — the live ThreatLevel divergence, converged.** The kernel's `screen_threat` mapped scores at 25/50/75 while `sema`'s detector protocol invariants are 30/60/80 — a provable behavioral divergence of exactly the class this issue exists to kill (found while working #555). New `crates/sema-core` (no_std+alloc) now holds the canonical `ThreatLevel`, `Calibration`, and the band boundaries: `sema::cell` re-exports from it, and the kernel links it by path dependency — the first instance of the issue's preferred topology (shared invariants in no_std+alloc cores, kernel and userspace adapters on both ends). The kernel's divergent enum and band table are deleted; `screen_threat` keeps only its presentation extension (color/label).

**The machine-checked ledger** (`docs/convergence.toml` + `scripts/check-convergence.sh`, registered in ci.yml + `.kanon-ci.toml`): every duplicated pair from the issue's evidence gets a disposition + canonical owner + status — threat-semantics (converged, this PR), gps/wifi/bluetooth/telephony-sms/firewall/ui (extract-core or workspace-owned, with the named core crate pending its real consumer). The checker enforces the ratchet: "ported from" markers and stale expectations **only ever decrease**, every marker names a ledger row, and no lib.rs points at closed #126 (the 12 dead-code expectations now point at the live ledger; they burn down as pairs converge).

## Verification

- `cargo test -p sema -p sema-core`: **83/83 and 3/3 pass** through the re-export (no semantic change on the sema side).
- `cargo clippy --workspace --all-targets -- -D warnings` + `cargo test --workspace`: **clippy --workspace --all-targets -D warnings rc=0; cargo test --workspace rc=0**
- `scripts/kernel-host-tests.sh` (i686 + debug-console): **2311/2311 and 2315/2315 pass**
- `cargo check` (armv7a, m7) + `cargo check --features qemu` (virt): both clean — m7 rc=0, qemu rc=0. QEMU witness matrix: **ALL 10 PASS** (boot, kfault, sleep, fork, exec, forkexec, guard, brk, signal, crashloop) — the kernel compiles with the path dep on both boards.
- `scripts/check-convergence.sh`: 7 pairs classified, 5 port markers, 0 stale #126 pointers, ratchet holding.
- `cargo fmt`: clean.

Refs #545 (the track; remaining pairs land per the ledger as their consumers arrive)