### PR TITLE
kinit: fail-closed boot-image source — GPT-locate, streamed Ed25519ph, sphragis signer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,7 @@ dependencies = [
  "ed25519",
  "serde",
  "sha2",
+ "signature",
  "subtle",
  "zeroize",
 ]
@@ -1152,6 +1153,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
+ "digest",
  "rand_core 0.6.4",
 ]
 
@@ -1193,6 +1195,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sphragis"
+version = "0.1.16"
+dependencies = [
+ "ed25519-dalek",
+ "sha2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/pteron",
     "crates/sema",
     "crates/sema-core",
+    "crates/sphragis",
     "crates/stegnos",
     "crates/topos",
 ]

--- a/crates/sphragis/Cargo.toml
+++ b/crates/sphragis/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "sphragis"
+description = "Boot-image signing tool: streamed Ed25519ph signer producing the payload||signature layout the kernel's boot gate verifies (#467)"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+repository.workspace = true
+
+[dependencies]
+ed25519-dalek = { workspace = true, features = ["digest"] }
+sha2 = { workspace = true }
+
+[lints]
+workspace = true
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-08-05"
+exit-criteria = "operator-reviewed hardware validation and release-readiness gate"

--- a/crates/sphragis/src/main.rs
+++ b/crates/sphragis/src/main.rs
@@ -1,0 +1,155 @@
+//! sphragis — boot-image signing tool (#467).
+//!
+//! σφραγίς = "signet, seal". Signs a boot image with Ed25519ph, producing
+//! the `payload || zero-pad || signature(64)` layout the kernel's streamed
+//! boot gate verifies: the payload is zero-padded so the 64-byte signature
+//! ends EXACTLY on a 512-byte sector boundary (the on-disk region's final
+//! bytes), and the SHA-512 prehash covers payload+pad. The prehash is fed
+//! in bounded chunks — the same shape as the kernel's `verify_image_streamed`
+//! (the tool itself holds the image in memory; it is a build-host tool
+//! without the kernel's heap constraint).
+//!
+//! Usage: sphragis <image-in> <seed-hex-file> <image-out>
+//!   The seed file holds the 32-byte Ed25519 seed as 64 lowercase hex chars
+//!   (e.g. crates/thumos/keys/dev/boot-dev.seed for dev builds; production
+//!   keys live outside the repo).
+
+use ed25519_dalek::SigningKey;
+use sha2::Digest as _;
+
+/// Sector size the on-disk layout aligns to.
+const SECTOR: usize = 512;
+/// Ed25519 signature length.
+const SIG_LEN: usize = 64;
+/// Hash streaming chunk.
+const CHUNK: usize = 64 * 1024;
+
+/// Sign `payload` with `seed`, returning the padded combined image.
+fn sign_image(payload: &[u8], seed: &[u8; 32]) -> Vec<u8> {
+    // Pad so payload+pad ends exactly SIG_LEN before a sector boundary.
+    let padded_len = (payload.len() + SIG_LEN).div_ceil(SECTOR) * SECTOR - SIG_LEN;
+    let mut padded = payload.to_vec();
+    padded.resize(padded_len, 0);
+
+    // Stream the prehash in bounded chunks (the shape the kernel mirrors).
+    let mut prehash = sha2::Sha512::new();
+    for chunk in padded.chunks(CHUNK) {
+        prehash.update(chunk);
+    }
+    let key = SigningKey::from_bytes(seed);
+    let sig = key
+        .sign_prehashed(prehash, None)
+        .unwrap_or_else(|e| unreachable!("sign_prehashed with a valid key cannot fail: {e}"));
+
+    let mut image = padded;
+    image.extend_from_slice(&sig.to_bytes());
+    image
+}
+
+/// Parse a 64-hex-char seed file.
+fn parse_seed(text: &str) -> Option<[u8; 32]> {
+    let text = text.trim();
+    if text.len() != 64 {
+        return None;
+    }
+    let mut out = [0u8; 32];
+    for (i, byte) in out.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(text.get(i * 2..i * 2 + 2)?, 16).ok()?;
+    }
+    Some(out)
+}
+
+fn main() -> std::process::ExitCode {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 4 {
+        eprintln!("usage: sphragis <image-in> <seed-hex-file> <image-out>");
+        return std::process::ExitCode::from(2);
+    }
+    let payload = match std::fs::read(&args[1]) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("sphragis: cannot read {}: {e}", args[1]);
+            return std::process::ExitCode::from(1);
+        }
+    };
+    let seed_text = match std::fs::read_to_string(&args[2]) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("sphragis: cannot read seed {}: {e}", args[2]);
+            return std::process::ExitCode::from(1);
+        }
+    };
+    let Some(seed) = parse_seed(&seed_text) else {
+        eprintln!("sphragis: seed file must hold 32 bytes as 64 lowercase hex chars");
+        return std::process::ExitCode::from(1);
+    };
+    let image = sign_image(&payload, &seed);
+    if let Err(e) = std::fs::write(&args[3], &image) {
+        eprintln!("sphragis: cannot write {}: {e}", args[3]);
+        return std::process::ExitCode::from(1);
+    }
+    println!(
+        "sphragis: signed {} -> {} ({} payload bytes, {} image bytes)",
+        args[1],
+        args[3],
+        payload.len(),
+        image.len()
+    );
+    std::process::ExitCode::SUCCESS
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn signed_image_is_sector_aligned_with_signature_at_end() {
+        let payload = b"fake kernel image bytes".to_vec();
+        let image = sign_image(&payload, &[7u8; 32]);
+        assert_eq!(
+            image.len() % SECTOR,
+            0,
+            "the combined image is sector-aligned"
+        );
+        assert!(image.starts_with(&payload), "payload leads");
+        assert_eq!(
+            image.len(),
+            SIG_LEN + ((payload.len() + SIG_LEN).div_ceil(SECTOR) * SECTOR - SIG_LEN)
+        );
+    }
+
+    #[test]
+    fn tool_output_verifies_under_the_kernel_prehashed_strict_path() {
+        // The differential proof (#467): what sphragis signs, the kernel
+        // accepts — same Ed25519ph + SHA-512 + verify_prehashed_strict the
+        // kernel's secure_boot uses.
+        let payload: Vec<u8> = (0..10_000u32).map(|i| (i % 251) as u8).collect();
+        let seed = [11u8; 32];
+        let image = sign_image(&payload, &seed);
+
+        let key = ed25519_dalek::VerifyingKey::from_bytes(
+            &SigningKey::from_bytes(&seed).verifying_key().to_bytes(),
+        )
+        .unwrap_or_else(|_| unreachable!("valid key"));
+        let (payload_region, sig_region) = image.split_at(image.len() - SIG_LEN);
+        let mut prehash = sha2::Sha512::new();
+        prehash.update(payload_region);
+        let sig = ed25519_dalek::Signature::from_bytes(sig_region.try_into().unwrap_or(&[0u8; 64]));
+        assert!(
+            key.verify_prehashed_strict(prehash, None, &sig).is_ok(),
+            "the kernel's verification path must accept the tool's output"
+        );
+    }
+
+    #[test]
+    fn parse_seed_accepts_and_rejects() {
+        let good = "00".repeat(32);
+        assert_eq!(parse_seed(&good), Some([0u8; 32]));
+        assert_eq!(parse_seed("abcd"), None);
+        assert_eq!(parse_seed(&"zz".repeat(32)), None);
+    }
+}

--- a/crates/thumos/Cargo.lock
+++ b/crates/thumos/Cargo.lock
@@ -192,6 +192,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "sha2",
+ "signature",
  "subtle",
 ]
 
@@ -436,6 +437,9 @@ name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "smoltcp"

--- a/crates/thumos/Cargo.toml
+++ b/crates/thumos/Cargo.toml
@@ -56,7 +56,9 @@ cbc = { version = "0.1", default-features = false, features = [
     "alloc",
     "block-padding",
 ] }
-ed25519-dalek = { version = "2", default-features = false }
+ed25519-dalek = { version = "2", default-features = false, features = [
+    "digest",
+] }
 hkdf = { version = "0.12", default-features = false }
 hmac = { version = "0.12", default-features = false }
 pbkdf2 = { version = "0.12", default-features = false }

--- a/crates/thumos/src/block.rs
+++ b/crates/thumos/src/block.rs
@@ -96,6 +96,22 @@ pub(crate) trait BlockDevice {
     }
 }
 
+/// Mutable references forward to the underlying device so views compose
+/// over `&mut dyn BlockDevice` (#467's boot-partition view). A shared
+/// reference gets no impl by design: `write_sectors` cannot honestly
+/// forward through one.
+impl<D: BlockDevice + ?Sized> BlockDevice for &mut D {
+    fn read_sectors(&self, lba: u64, count: u32, buf: &mut [u8]) -> Result<(), BlockError> {
+        (**self).read_sectors(lba, count, buf)
+    }
+    fn write_sectors(&mut self, lba: u64, count: u32, buf: &[u8]) -> Result<(), BlockError> {
+        (**self).write_sectors(lba, count, buf)
+    }
+    fn sector_count(&self) -> u64 {
+        (**self).sector_count()
+    }
+}
+
 // ---------------------------------------------------------------------------
 // PartitionBlockDevice — partition view over a physical device (#603)
 // ---------------------------------------------------------------------------

--- a/crates/thumos/src/gpt.rs
+++ b/crates/thumos/src/gpt.rs
@@ -1,0 +1,293 @@
+//! GPT (GUID Partition Table) parser — locate a partition by name (#467).
+//!
+//! The boot-verify gate reads the `boot` partition by NAME from the GPT,
+//! never a hardcoded sector offset (derive-over-declare): the partition's
+//! location is derived from the device's own table. The parser validates
+//! the GPT signature, revision shape, header CRC32, and entries CRC32 —
+//! a corrupt table is an explicit error, never a misparse into wrong LBAs.
+//!
+//! Host-testable: parsing runs over any [`BlockDevice`] (the RAM double in
+//! tests, the eMMC partition view on hardware).
+
+use crate::block::{BlockDevice, BlockError, SECTOR_SIZE};
+
+/// GPT errors: every failure is explicit (#467's fail-closed invariant
+/// relies on none of these ever collapsing into "no boot medium").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[must_use]
+#[non_exhaustive]
+pub(crate) enum GptError {
+    /// The GPT signature "EFI PART" is missing.
+    BadSignature,
+    /// The header CRC32 does not match.
+    HeaderCrcMismatch,
+    /// The partition-entries CRC32 does not match.
+    EntriesCrcMismatch,
+    /// A structural field is outside sane bounds (entry size, count).
+    Malformed,
+    /// No entry with the requested name.
+    NotFound,
+    /// A block read failed.
+    Io,
+}
+
+impl core::fmt::Display for GptError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::BadSignature => f.write_str("GPT signature missing"),
+            Self::HeaderCrcMismatch => f.write_str("GPT header CRC mismatch"),
+            Self::EntriesCrcMismatch => f.write_str("GPT entries CRC mismatch"),
+            Self::Malformed => f.write_str("GPT malformed structure"),
+            Self::NotFound => f.write_str("GPT partition not found"),
+            Self::Io => f.write_str("GPT block I/O error"),
+        }
+    }
+}
+
+impl From<BlockError> for GptError {
+    fn from(_: BlockError) -> Self {
+        Self::Io
+    }
+}
+
+/// A located partition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[must_use]
+pub(crate) struct PartitionInfo {
+    /// First LBA of the partition.
+    pub(crate) first_lba: u64,
+    /// Last LBA (inclusive).
+    pub(crate) last_lba: u64,
+}
+
+impl PartitionInfo {
+    /// Partition length in sectors.
+    pub(crate) const fn sectors(&self) -> u64 {
+        self.last_lba - self.first_lba + 1
+    }
+}
+
+/// CRC32 (IEEE 802.3, reflected, polynomial 0xEDB88320), tableless.
+///
+/// WHY a local impl: the kernel has no general CRC32 today (sbc.rs's is
+/// codec-specific); the GPT header/entries CRCs are the integrity proof
+/// that the parsed table is intact — security-relevant for locating the
+/// boot partition.
+pub(crate) fn crc32(data: &[u8]) -> u32 {
+    let mut crc: u32 = 0xFFFF_FFFF;
+    for &byte in data {
+        crc ^= u32::from(byte);
+        for _ in 0..8 {
+            let mask = (crc & 1).wrapping_neg();
+            crc = (crc >> 1) ^ (0xEDB8_8320 & mask);
+        }
+    }
+    !crc
+}
+
+/// Maximum partition entries examined (the spec's default table is 128).
+const MAX_ENTRIES: u32 = 128;
+
+/// Read one sector as a fixed array.
+fn read_sector(dev: &dyn BlockDevice, lba: u64) -> Result<[u8; SECTOR_SIZE], GptError> {
+    let mut buf = [0u8; SECTOR_SIZE];
+    dev.read_sectors(lba, 1, &mut buf)?;
+    Ok(buf)
+}
+
+fn le32(buf: &[u8], off: usize) -> u32 {
+    u32::from_le_bytes([buf[off], buf[off + 1], buf[off + 2], buf[off + 3]])
+}
+
+fn le64(buf: &[u8], off: usize) -> u64 {
+    let mut b = [0u8; 8];
+    b.copy_from_slice(&buf[off..off + 8]);
+    u64::from_le_bytes(b)
+}
+
+/// Locate a partition by its GPT entry name (compared against the UTF-16LE
+/// name field, e.g. "boot").
+///
+/// # Errors
+///
+/// [`GptError::NotFound`] when no entry carries the name; structural and
+/// integrity failures as their explicit variants.
+pub(crate) fn find_partition(dev: &dyn BlockDevice, name: &str) -> Result<PartitionInfo, GptError> {
+    // LBA 1: the GPT header.
+    let header = read_sector(dev, 1)?;
+    if &header[..8] != b"EFI PART" {
+        return Err(GptError::BadSignature);
+    }
+    let header_size = le32(&header, 12) as usize;
+    if header_size < 92 || header_size > SECTOR_SIZE {
+        return Err(GptError::Malformed);
+    }
+    let stored_header_crc = le32(&header, 16);
+    // The header CRC covers the first header_size bytes with the CRC field
+    // itself zeroed.
+    let mut header_for_crc = header;
+    header_for_crc[16..20].fill(0);
+    if crc32(&header_for_crc[..header_size]) != stored_header_crc {
+        return Err(GptError::HeaderCrcMismatch);
+    }
+    // GPT header tail (UEFI spec): PartitionEntryLBA u64 @72, entry count
+    // u32 @80, entry size u32 @84, entries CRC32 @88.
+    let entries_lba = le64(&header, 72);
+    let entry_count = le32(&header, 80);
+    let entry_size = le32(&header, 84);
+    if entry_count == 0 || entry_count > MAX_ENTRIES {
+        return Err(GptError::Malformed);
+    }
+    if entry_size < 128 || entry_size as usize > SECTOR_SIZE || entry_size % 8 != 0 {
+        return Err(GptError::Malformed);
+    }
+    let stored_entries_crc = le32(&header, 88);
+    let entries_bytes = entry_count as u64 * u64::from(entry_size);
+    let entries_sectors = entries_bytes.div_ceil(SECTOR_SIZE as u64);
+    if entries_sectors > 32 {
+        return Err(GptError::Malformed);
+    }
+
+    // Read + CRC the whole entries table before walking it.
+    let mut table = [0u8; 32 * SECTOR_SIZE];
+    dev.read_sectors(
+        entries_lba,
+        entries_sectors as u32,
+        &mut table[..(entries_sectors as usize * SECTOR_SIZE)],
+    )?;
+    if crc32(&table[..entries_bytes as usize]) != stored_entries_crc {
+        return Err(GptError::EntriesCrcMismatch);
+    }
+
+    // The requested name as UTF-16LE bytes.
+    let mut name_utf16 = [0u8; 72];
+    if name.len() > 36 {
+        return Err(GptError::NotFound);
+    }
+    for (i, b) in name.bytes().enumerate() {
+        name_utf16[i * 2] = b;
+    }
+
+    for i in 0..entry_count as usize {
+        let base = i * entry_size as usize;
+        let entry = &table[base..base + entry_size as usize];
+        // A zero type GUID marks an unused entry.
+        if entry[..16].iter().all(|&b| b == 0) {
+            continue;
+        }
+        if entry[56..56 + 72] == name_utf16 {
+            return Ok(PartitionInfo {
+                first_lba: le64(entry, 32),
+                last_lba: le64(entry, 40),
+            });
+        }
+    }
+    Err(GptError::NotFound)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block::MemBlockDevice;
+    use alloc::vec;
+
+    /// CRC32 known answer: IEEE check value for "123456789".
+    #[test]
+    fn crc32_known_answer() {
+        assert_eq!(crc32(b"123456789"), 0xCBF4_3926);
+        assert_eq!(crc32(b""), 0);
+    }
+
+    /// Build a synthetic GPT device: protective LBA0 zeroed, header at LBA1,
+    /// entries at LBA2, with real CRCs.
+    fn gpt_device(entries: &[(&str, u64, u64)]) -> MemBlockDevice {
+        let entry_size = 128usize;
+        let entry_count = 128u32;
+        let entries_bytes = entry_count as usize * entry_size; // 16 KiB
+        let total_sectors = 2 + entries_bytes / SECTOR_SIZE + 512;
+        let mut dev = MemBlockDevice::new(total_sectors as u64).expect("device");
+
+        // Entries table.
+        let mut table = vec![0u8; entries_bytes];
+        for (i, (name, first, last)) in entries.iter().enumerate() {
+            let base = i * entry_size;
+            table[base] = 0xAF; // non-zero type GUID (contents irrelevant to the parser)
+            table[base + 32..base + 40].copy_from_slice(&first.to_le_bytes());
+            table[base + 40..base + 48].copy_from_slice(&last.to_le_bytes());
+            for (j, b) in name.bytes().enumerate() {
+                table[base + 56 + j * 2] = b;
+            }
+        }
+        let entries_crc = crc32(&table);
+        dev.write_sectors(2, (entries_bytes / SECTOR_SIZE) as u32, &table)
+            .expect("write entries");
+
+        // Header.
+        let mut header = [0u8; SECTOR_SIZE];
+        header[..8].copy_from_slice(b"EFI PART");
+        header[12..16].copy_from_slice(&92u32.to_le_bytes()); // header size
+        header[72..80].copy_from_slice(&2u64.to_le_bytes()); // entries LBA (u64 @72)
+        header[80..84].copy_from_slice(&entry_count.to_le_bytes()); // count (u32 @80)
+        header[84..88].copy_from_slice(&(entry_size as u32).to_le_bytes()); // entry size (@84)
+        header[88..92].copy_from_slice(&entries_crc.to_le_bytes()); // entries CRC (@88)
+        let header_crc = crc32(&header[..92]);
+        header[16..20].copy_from_slice(&header_crc.to_le_bytes());
+        dev.write_sectors(1, 1, &header).expect("write header");
+        dev
+    }
+
+    #[test]
+    fn finds_boot_partition_by_name() {
+        let dev = gpt_device(&[("boot", 2048, 4095), ("userdata", 0x50C000, 0xB0BFDF)]);
+        let boot = find_partition(&dev, "boot").expect("boot must be found");
+        assert_eq!(boot.first_lba, 2048);
+        assert_eq!(boot.last_lba, 4095);
+        assert_eq!(boot.sectors(), 2048);
+    }
+
+    #[test]
+    fn missing_partition_is_not_found() {
+        let dev = gpt_device(&[("boot", 2048, 4095)]);
+        assert_eq!(find_partition(&dev, "vendor"), Err(GptError::NotFound));
+    }
+
+    #[test]
+    fn bad_signature_rejects() {
+        let mut dev = gpt_device(&[("boot", 2048, 4095)]);
+        let mut hdr = [0u8; SECTOR_SIZE];
+        dev.read_sectors(1, 1, &mut hdr).expect("read");
+        hdr[0] = b'X';
+        dev.write_sectors(1, 1, &hdr).expect("write");
+        assert_eq!(find_partition(&dev, "boot"), Err(GptError::BadSignature));
+    }
+
+    #[test]
+    fn corrupt_header_crc_rejects() {
+        let mut dev = gpt_device(&[("boot", 2048, 4095)]);
+        let mut hdr = [0u8; SECTOR_SIZE];
+        dev.read_sectors(1, 1, &mut hdr).expect("read");
+        hdr[76] ^= 0x01; // flip an entry-count bit; header CRC now stale
+        dev.write_sectors(1, 1, &hdr).expect("write");
+        assert_eq!(
+            find_partition(&dev, "boot"),
+            Err(GptError::HeaderCrcMismatch)
+        );
+    }
+
+    #[test]
+    fn corrupt_entries_crc_rejects() {
+        let mut dev = gpt_device(&[("boot", 2048, 4095)]);
+        let mut entry = [0u8; SECTOR_SIZE];
+        dev.read_sectors(2, 1, &mut entry).expect("read");
+        entry[60] ^= 0x01; // corrupt the name region; entries CRC now stale
+        dev.write_sectors(2, 1, &entry).expect("write");
+        assert_eq!(
+            find_partition(&dev, "boot"),
+            Err(GptError::EntriesCrcMismatch)
+        );
+    }
+}

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -38,6 +38,8 @@ use crate::exceptions;
 use crate::gic;
 use crate::heap;
 // Gated: only the debug-console gate reads kconfig::DEBUG_CONSOLE.
+#[cfg(not(feature = "qemu"))]
+use crate::block::MsdcBlockDevice;
 #[cfg(feature = "debug-console")]
 use crate::kconfig;
 #[cfg(not(feature = "qemu"))]
@@ -540,16 +542,29 @@ pub unsafe fn run() -> ! {
         // state.display_ok let a display-init failure silently bypass the
         // kernel's only measured-boot gate (#361).
         //
-        // WHY Absent today: qemu models no MSDC, and an eMMC that failed
-        // init exposes no partitions -- no boot medium means nothing to
-        // verify AND nothing persistent to mount, so the boot continues
-        // DEGRADED with secure_boot_ok false and every downstream trust
-        // gate locked (the inverse of the old "PENDING but proceed open"
-        // posture). TODO(#217): wire the live-eMMC boot-partition read
-        // (GPT-locate `boot` + memory-bounded verify + signing tool) so a
-        // phone boot presents Present(image) here; until then a live-eMMC
-        // phone boot is also degraded-LOCKED, never degraded-open.
+        // WHY the source derives from the medium (#467): qemu models no
+        // MSDC, and an eMMC that failed init exposes no partitions -- no
+        // boot medium means nothing to verify AND nothing persistent to
+        // mount, so the boot continues DEGRADED with secure_boot_ok false
+        // and every downstream trust gate locked. On the M7, the boot
+        // partition is GPT-located by name and verified by streamed
+        // Ed25519ph; a present-but-unreadable partition maps to Unreadable,
+        // which HALTS -- never the Absent degrade (an attacker deleting the
+        // boot partition must not downgrade boot to degraded-open).
+        // Bound: the GPT-documented region (userdata end covers boot);
+        // a read past it errors -> Unreadable -> Halt, by design (#467).
+        // The physical device outlives `source` (the enum borrows it).
+        #[cfg(not(feature = "qemu"))]
+        let mut phys_dev =
+            MsdcBlockDevice::new(board::LFS_PARTITION_START + board::LFS_PARTITION_SIZE);
+        #[cfg(feature = "qemu")]
         let source = crate::secure_boot::BootImageSource::Absent;
+        #[cfg(not(feature = "qemu"))]
+        let source = if state.emmc_ok {
+            crate::secure_boot::boot_image_source(&mut phys_dev)
+        } else {
+            crate::secure_boot::BootImageSource::Absent
+        };
         match crate::secure_boot::evaluate_boot_image(&source) {
             crate::secure_boot::SecureBootDecision::Proceed { verified: true } => {
                 // INVARIANT (#217 + security review): secure_boot_ok is set

--- a/crates/thumos/src/main.rs
+++ b/crates/thumos/src/main.rs
@@ -125,6 +125,7 @@ mod firewall;
 mod fm_radio;
 mod futex;
 mod gps;
+mod gpt;
 mod gsm7;
 mod harmostes;
 mod heorte;

--- a/crates/thumos/src/secure_boot.rs
+++ b/crates/thumos/src/secure_boot.rs
@@ -1,18 +1,20 @@
-//! Measured boot with Ed25519 signature verification.
+//! Measured boot with Ed25519ph signature verification.
 //!
-//! Verifies the integrity of the kernel image at boot by checking an
-//! Ed25519 signature against an embedded public key. The signature is
-//! appended as the last 64 bytes of the kernel image; the signed payload
-//! is everything preceding it.
+//! Verifies the integrity of the boot image at boot by checking an
+//! Ed25519ph (prehashed, RFC 8032) signature against an embedded public
+//! key. The signature is the last 64 bytes of the on-disk region; the
+//! signed payload is everything preceding it (zero-padded so the signature
+//! lands on the sector boundary, matching the sphragis signing tool).
 //!
 //! ## Signature format
 //!
 //! ```text
-//! [ kernel image payload (N bytes) ][ Ed25519 signature (64 bytes) ]
+//! [ image payload (N bytes) ][ zero pad ][ Ed25519ph signature (64 bytes) ]
 //! ```
 //!
-//! The Ed25519 signature covers the kernel image payload (all bytes
-//! except the trailing 64-byte signature itself).
+//! Ed25519ph (sign/verify over the SHA-512 prehash) is chosen over plain
+//! Ed25519 so verification streams over bounded sector reads — a multi-MB
+//! boot image never needs a contiguous buffer (#467).
 //!
 //! ## Boot integration
 //!
@@ -34,6 +36,24 @@
 //! [`sha2`]. Both are audited pure-Rust crates from the same family as the
 //! kernel's `aes` / `xts-mode` dependencies, consistent with the "no C we
 //! author" doctrine.
+//!
+//! ## Trust root (per #467's review item)
+//!
+//! This gate is a LINK in the boot chain, not the sole root: the chain is
+//! BROM (mask ROM, reads the preloader) -> preloader/LK (loads the boot
+//! image) -> this kernel's gate (verifies the boot image's Ed25519ph
+//! signature against the embedded anchor before any decrypt/mount/
+//! userspace step). What verifies THE KERNEL IMAGE is therefore the
+//! preloader's verified-boot configuration on the device — on the AGM M7
+//! as currently operated, that upstream link is NOT established by this
+//! repository (the stock device's verified-boot state is an
+//! operator/hardware fact, hardware-ledger work). Until it is, this gate
+//! honestly bounds its own claim: it proves the boot image is the one the
+//! signing key holder built, given a kernel that already started — it
+//! cannot by itself defeat a compromised preloader. That boundary is why
+//! `secure_boot_ok` reads as "verified against the production anchor" and
+//! no more, and why the fail-closed invariant (present-but-unreadable ->
+//! Halt) matters: the gate's value is that it never WIDENS what booted.
 
 use core::fmt;
 
@@ -238,18 +258,103 @@ pub(crate) fn split_image(image: &[u8]) -> Result<(&[u8], [u8; SIGNATURE_LEN]), 
     Ok((payload, sig))
 }
 
-/// Verify a combined kernel image (payload + appended signature).
-///
-/// Convenience wrapper that splits the image and verifies in one call.
+/// Verify a combined image in memory using Ed25519ph (#467) — the same
+/// signature scheme as the streamed path, for images that already fit in
+/// memory (tests, small regions). The boot-partition path is
+/// [`verify_image_streamed`]; both verify under [`BOOT_PUBLIC_KEY`].
 ///
 /// # Errors
 ///
-/// - [`SecureBootError::ImageTooShort`] if the image is too short.
-/// - [`SecureBootError::InvalidSignature`] if verification fails.
-#[must_use = "verification result must be checked"]
-pub(crate) fn verify_combined_image(image: &[u8]) -> Result<(), SecureBootError> {
-    let (payload, sig) = split_image(image)?;
-    verify_kernel_signature(payload, &sig)
+/// As [`verify_combined_image`].
+pub(crate) fn verify_combined_image_ph(image: &[u8]) -> Result<(), SecureBootError> {
+    use sha2::Digest as _;
+    let (payload, sig_bytes) = split_image(image)?;
+    let Ok(key) = VerifyingKey::from_bytes(&BOOT_PUBLIC_KEY) else {
+        return Err(SecureBootError::InvalidSignature);
+    };
+    let mut prehash = sha2::Sha512::new();
+    prehash.update(payload);
+    let sig = Signature::from_bytes(&sig_bytes);
+    key.verify_prehashed_strict(prehash, None, &sig)
+        .map_err(|_| SecureBootError::InvalidSignature)
+}
+
+/// Verify a combined boot image (payload || signature) STREAMED from a
+/// block device, using Ed25519ph (#467).
+///
+/// WHY Ed25519ph: plain Ed25519 verifies a contiguous in-memory message,
+/// but a multi-MB boot image cannot fit the 1 MB kernel heap — and must
+/// never require one. Ed25519ph prehashes with SHA-512, streamed here over
+/// bounded 4 KiB sector reads; memory stays O(chunk), never O(image).
+/// `verify_prehashed_strict` keeps the non-malleable posture of the
+/// `verify_strict` path used everywhere else in this module.
+///
+/// The image layout is the same `payload || signature(64)` as
+/// [`split_image`]; the signature covers the payload's SHA-512 prehash.
+/// Reading a partition view (#603) is the intended caller-side shape.
+///
+/// # Errors
+///
+/// - [`SecureBootError::ImageTooShort`] if the region is smaller than a
+///   signature plus one payload byte.
+/// - [`SecureBootError::InvalidSignature`] on any verification failure or
+///   unreadable sector (the caller maps failures to Halt per #467's
+///   fail-closed invariant — there is no degraded read).
+#[cfg(not(feature = "qemu"))]
+pub(crate) fn verify_image_streamed<D: crate::block::BlockDevice>(
+    dev: &D,
+    total_sectors: u64,
+    public_key: &[u8; PUBLIC_KEY_LEN],
+) -> Result<(), SecureBootError> {
+    use sha2::Digest as _;
+
+    let total_bytes = total_sectors.saturating_mul(crate::block::SECTOR_SIZE as u64);
+    if total_bytes < MIN_IMAGE_SIZE as u64 {
+        return Err(SecureBootError::ImageTooShort);
+    }
+    let Ok(key) = VerifyingKey::from_bytes(public_key) else {
+        return Err(SecureBootError::InvalidSignature);
+    };
+
+    let payload_bytes = total_bytes - SIGNATURE_LEN as u64;
+    let mut prehash = sha2::Sha512::new();
+    let mut signature = [0u8; SIGNATURE_LEN];
+    let mut lba = 0u64;
+    let mut chunk = [0u8; 4 * 1024];
+    const CHUNK_SECTORS: u64 = (4 * 1024 / crate::block::SECTOR_SIZE) as u64; // 8
+
+    while lba < total_sectors {
+        let remaining_sectors = total_sectors - lba;
+        let take = if remaining_sectors < CHUNK_SECTORS {
+            remaining_sectors
+        } else {
+            CHUNK_SECTORS
+        };
+        let take_bytes = (take as usize) * crate::block::SECTOR_SIZE;
+        dev.read_sectors(lba, take as u32, &mut chunk[..take_bytes])
+            .map_err(|_| SecureBootError::InvalidSignature)?;
+        let chunk_start = lba * crate::block::SECTOR_SIZE as u64;
+        let chunk_end = chunk_start + take_bytes as u64;
+        if chunk_end <= payload_bytes {
+            // Whole chunk is payload.
+            prehash.update(&chunk[..take_bytes]);
+        } else if chunk_start >= payload_bytes {
+            // Whole chunk is signature (only the final 64 bytes can be).
+            let off = (chunk_start - payload_bytes) as usize;
+            signature[off..off + take_bytes].copy_from_slice(&chunk[..take_bytes]);
+        } else {
+            // The boundary chunk: payload prefix into the prehash, the
+            // 64-byte signature suffix out.
+            let cut = (payload_bytes - chunk_start) as usize;
+            prehash.update(&chunk[..cut]);
+            signature[..take_bytes - cut].copy_from_slice(&chunk[cut..take_bytes]);
+        }
+        lba += take;
+    }
+
+    let sig = Signature::from_bytes(&signature);
+    key.verify_prehashed_strict(prehash, None, &sig)
+        .map_err(|_| SecureBootError::InvalidSignature)
 }
 
 // ===========================================================================
@@ -266,8 +371,8 @@ pub(crate) fn verify_combined_image(image: &[u8]) -> Result<(), SecureBootError>
 /// fail-closed HALT class, expressed as `Present` with a failing
 /// verification.
 pub(crate) enum BootImageSource<'a> {
-    /// The combined image (payload || Ed25519 signature) read from the boot
-    /// partition.
+    /// The combined image (payload || Ed25519ph signature) read from the boot
+    /// partition, in memory (tests and small images).
     #[cfg_attr(
         not(test),
         expect(
@@ -276,6 +381,21 @@ pub(crate) enum BootImageSource<'a> {
         )
     )]
     Present(&'a [u8]),
+    /// The boot partition as a block-device region, verified by STREAMED
+    /// Ed25519ph (#467): a multi-MB image never needs a contiguous buffer.
+    /// M7-only: virt models no eMMC, so no streamed region exists there.
+    #[cfg(not(feature = "qemu"))]
+    PresentStreamed {
+        /// The boot partition view (already base-translated, #603).
+        dev: crate::block::PartitionBlockDevice<&'a mut dyn crate::block::BlockDevice>,
+        /// Region length in sectors.
+        sectors: u64,
+    },
+    /// A boot medium exists but the boot partition could not be read or
+    /// parsed: I/O error, missing GPT entry, blanked partition. INVARIANT
+    /// (#467): this maps to Halt, never to the Absent/degraded path —
+    /// "attacker deleted the boot partition" is a halt class, not a degrade.
+    Unreadable,
     /// No boot medium: qemu (no MSDC model) or an eMMC that failed init, so
     /// no partition is readable and no persistent data is mountable.
     Absent,
@@ -307,11 +427,37 @@ pub(crate) enum SecureBootDecision {
 ///   encrypted mount, audit key, persistent userspace) stays locked.
 pub(crate) fn evaluate_boot_image(source: &BootImageSource<'_>) -> SecureBootDecision {
     match source {
-        BootImageSource::Present(image) => match verify_combined_image(image) {
+        BootImageSource::Present(image) => match verify_combined_image_ph(image) {
             Ok(()) => SecureBootDecision::Proceed { verified: true },
             Err(e) => SecureBootDecision::Halt(e),
         },
+        #[cfg(not(feature = "qemu"))]
+        BootImageSource::PresentStreamed { dev, sectors } => {
+            match verify_image_streamed(dev, *sectors, &BOOT_PUBLIC_KEY) {
+                Ok(()) => SecureBootDecision::Proceed { verified: true },
+                Err(e) => SecureBootDecision::Halt(e),
+            }
+        }
+        // #467: a present-but-unreadable boot partition is a halt class —
+        // never the Absent degrade.
+        BootImageSource::Unreadable => SecureBootDecision::Halt(SecureBootError::ImageTooShort),
         BootImageSource::Absent => SecureBootDecision::Proceed { verified: false },
+    }
+}
+
+/// Construct the boot-image source from the eMMC (#467): GPT-locate the
+/// `boot` partition by name and return its streamed view. ANY failure —
+/// I/O error, missing GPT entry, blanked table — maps to
+/// [`BootImageSource::Unreadable`], which the gate halts on. This is the
+/// fail-closed construction site the issue's invariant names.
+#[cfg(not(feature = "qemu"))]
+pub(crate) fn boot_image_source(dev: &mut dyn crate::block::BlockDevice) -> BootImageSource<'_> {
+    match crate::gpt::find_partition(dev, "boot") {
+        Ok(boot) => BootImageSource::PresentStreamed {
+            dev: crate::block::PartitionBlockDevice::new(dev, boot.first_lba, boot.sectors()),
+            sectors: boot.sectors(),
+        },
+        Err(_) => BootImageSource::Unreadable,
     }
 }
 
@@ -507,6 +653,154 @@ mod tests {
 
     /// Test that split_image rejects images shorter than MIN_IMAGE_SIZE.
     #[test]
+    // -- Streamed Ed25519ph verify (#467) --
+    #[test]
+    fn unreadable_boot_partition_halts_never_degrades() {
+        // #467's fail-closed invariant at the construction site: a present
+        // but unreadable boot region (here: an uninitialized/failing eMMC
+        // read) maps to Unreadable -> Halt, never to Absent/degraded.
+        use crate::block::BlockDevice as _;
+        let mut dev = crate::block::tests::FailingBlockDevice::new(2048, 0);
+        let source = boot_image_source(&mut dev);
+        assert!(
+            matches!(source, BootImageSource::Unreadable),
+            "an unreadable GPT must construct Unreadable, not Absent"
+        );
+        assert!(
+            matches!(evaluate_boot_image(&source), SecureBootDecision::Halt(_)),
+            "read failure must HALT — a deleted/corrupt boot partition is not a degrade"
+        );
+    }
+
+    #[test]
+    fn gpt_located_signed_boot_partition_verifies() {
+        use crate::block::BlockDevice as _;
+        // The full happy path through the construction site: a synthetic
+        // GPT naming "boot", holding an Ed25519ph-signed image under the
+        // embedded anchor, verifies via the streamed path.
+        let seed = BOOT_KEY_DEV_SEED.expect("dev anchor required for the streamed-verify test");
+        let (image, _pubkey) = signed_image(4096, &seed);
+        let mut dev = crate::block::MemBlockDevice::new(4096).expect("dev");
+        // GPT: "boot" at [2048, 2048 + image_sectors).
+        let image_sectors = (image.len() / 512) as u64;
+        // Write the image at the partition base.
+        dev.write_sectors(2048, image_sectors as u32, &image)
+            .expect("write image");
+        // Build the GPT over it.
+        let entry_size = 128usize;
+        let entry_count = 128u32;
+        let entries_bytes = entry_count as usize * entry_size;
+        let mut table = alloc::vec![0u8; entries_bytes];
+        table[0] = 0xAF;
+        table[32..40].copy_from_slice(&2048u64.to_le_bytes());
+        table[40..48].copy_from_slice(&(2048 + image_sectors - 1).to_le_bytes());
+        for (j, b) in b"boot".iter().enumerate() {
+            table[56 + j * 2] = *b;
+        }
+        let entries_crc = crate::gpt::crc32(&table);
+        dev.write_sectors(2, (entries_bytes / 512) as u32, &table)
+            .expect("entries");
+        let mut header = [0u8; 512];
+        header[..8].copy_from_slice(b"EFI PART");
+        header[12..16].copy_from_slice(&92u32.to_le_bytes());
+        header[72..80].copy_from_slice(&2u64.to_le_bytes());
+        header[80..84].copy_from_slice(&entry_count.to_le_bytes());
+        header[84..88].copy_from_slice(&(entry_size as u32).to_le_bytes());
+        header[88..92].copy_from_slice(&entries_crc.to_le_bytes());
+        let header_crc = crate::gpt::crc32(&header[..92]);
+        header[16..20].copy_from_slice(&header_crc.to_le_bytes());
+        dev.write_sectors(1, 1, &header).expect("header");
+
+        let source = boot_image_source(&mut dev);
+        match source {
+            BootImageSource::PresentStreamed { .. } => {}
+            _ => panic!("a valid GPT must yield PresentStreamed"),
+        }
+        match evaluate_boot_image(&source) {
+            SecureBootDecision::Proceed { verified: true } => {}
+            other => panic!("a valid signed boot partition must verify, got {other:?}"),
+        }
+    }
+
+    /// Build a signed combined image: payload zero-padded so that
+    /// payload+pad+signature is sector-aligned (the on-disk layout the
+    /// streamed verifier expects — the signature is the region's final 64
+    /// bytes).
+    fn signed_image(payload_len: usize, seed: &[u8; 32]) -> (alloc::vec::Vec<u8>, [u8; 32]) {
+        use ed25519_dalek::{Signer as _, SigningKey};
+        use sha2::Digest as _;
+        let key = SigningKey::from_bytes(seed);
+        // Pad so payload+pad ends exactly 64 bytes before a sector boundary.
+        let padded_len = (payload_len + SIGNATURE_LEN).div_ceil(512) * 512 - SIGNATURE_LEN;
+        let mut payload = alloc::vec![0u8; padded_len];
+        for (i, b) in payload.iter_mut().enumerate() {
+            *b = (i as u8).wrapping_mul(31).wrapping_add(7);
+        }
+        let mut prehash = sha2::Sha512::new();
+        prehash.update(&payload);
+        let sig = key.sign_prehashed(prehash, None).expect("sign_prehashed");
+        let mut image = payload;
+        image.extend_from_slice(&sig.to_bytes());
+        (image, key.verifying_key().to_bytes())
+    }
+
+    #[test]
+    fn streamed_verify_accepts_valid_image() {
+        use crate::block::BlockDevice as _;
+        let (image, pubkey) = signed_image(3 * 4096, &[11u8; 32]); // multi-chunk, 12 KiB payload
+        let mut dev =
+            crate::block::MemBlockDevice::new((image.len() as u64).div_ceil(512)).expect("dev");
+        dev.write_sectors(0, (image.len() / 512) as u32, &image)
+            .expect("write image");
+        assert_eq!(
+            verify_image_streamed(&dev, (image.len() / 512) as u64, &pubkey),
+            Ok(()),
+            "a valid Ed25519ph-signed image must verify when streamed"
+        );
+    }
+
+    #[test]
+    fn streamed_verify_rejects_tampered_payload() {
+        use crate::block::BlockDevice as _;
+        let (mut image, pubkey) = signed_image(3 * 4096, &[11u8; 32]);
+        image[1234] ^= 0x01;
+        let mut dev =
+            crate::block::MemBlockDevice::new((image.len() as u64).div_ceil(512)).expect("dev");
+        dev.write_sectors(0, (image.len() / 512) as u32, &image)
+            .expect("write image");
+        assert_eq!(
+            verify_image_streamed(&dev, (image.len() / 512) as u64, &pubkey),
+            Err(SecureBootError::InvalidSignature),
+            "a one-bit payload change must fail verification"
+        );
+    }
+
+    #[test]
+    fn streamed_verify_rejects_wrong_key() {
+        use crate::block::BlockDevice as _;
+        let (image, _pubkey) = signed_image(4096, &[11u8; 32]);
+        let other = ed25519_dalek::SigningKey::from_bytes(&[22u8; 32]).verifying_key();
+        let mut dev =
+            crate::block::MemBlockDevice::new((image.len() as u64).div_ceil(512)).expect("dev");
+        dev.write_sectors(0, (image.len() / 512) as u32, &image)
+            .expect("write image");
+        assert_eq!(
+            verify_image_streamed(&dev, (image.len() / 512) as u64, &other.to_bytes()),
+            Err(SecureBootError::InvalidSignature),
+            "a different anchor key must fail"
+        );
+    }
+
+    #[test]
+    fn streamed_verify_rejects_too_short_region() {
+        let dev = crate::block::MemBlockDevice::new(1).expect("dev");
+        assert_eq!(
+            verify_image_streamed(&dev, 0, &[0u8; 32]),
+            Err(SecureBootError::ImageTooShort)
+        );
+    }
+
+    #[test]
     fn split_image_too_short() {
         let short = [0u8; 64]; // exactly 64 bytes, need 65+
         assert_eq!(
@@ -629,7 +923,7 @@ mod tests {
 
     #[test]
     fn combined_image_valid_signature_passes() {
-        use ed25519_dalek::{Signer, SigningKey};
+        use ed25519_dalek::SigningKey;
 
         // NOTE (#233): the committed dev seed (keys/dev/boot-dev.seed),
         // emitted by build.rs only when the build's trust anchor is the dev
@@ -645,14 +939,10 @@ mod tests {
         );
 
         let payload = [0x5Au8; 16];
-        let signature = signing_key.sign(&payload).to_bytes();
-
-        let mut image = [0u8; 16 + SIGNATURE_LEN];
-        image[..16].copy_from_slice(&payload);
-        image[16..].copy_from_slice(&signature);
+        let image = signed_dev_image(&payload);
 
         assert_eq!(
-            verify_combined_image(&image),
+            verify_combined_image_ph(&image),
             Ok(()),
             "combined image with a valid boot-key signature must verify"
         );
@@ -663,23 +953,12 @@ mod tests {
     /// modified bytes).
     #[test]
     fn combined_image_tampered_payload_fails() {
-        use ed25519_dalek::{Signer, SigningKey};
-
-        // NOTE (#233): same committed dev seed as
-        // combined_image_valid_signature_passes.
-        let seed = BOOT_KEY_DEV_SEED.expect("boot-key tests require the dev trust anchor");
-        let signing_key = SigningKey::from_bytes(&seed);
-
         let payload = [0x5Au8; 16];
-        let signature = signing_key.sign(&payload).to_bytes();
-
-        let mut image = [0u8; 16 + SIGNATURE_LEN];
-        image[..16].copy_from_slice(&payload);
-        image[16..].copy_from_slice(&signature);
+        let mut image = signed_dev_image(&payload);
         image[0] ^= 0x01; // tamper one payload byte after signing
 
         assert_eq!(
-            verify_combined_image(&image),
+            verify_combined_image_ph(&image),
             Err(SecureBootError::InvalidSignature),
             "tampered payload byte must fail signature verification"
         );
@@ -691,7 +970,7 @@ mod tests {
     fn combined_image_too_short_fails() {
         let short = [0u8; 64]; // exactly 64 bytes, need 65+
         assert_eq!(
-            verify_combined_image(&short),
+            verify_combined_image_ph(&short),
             Err(SecureBootError::ImageTooShort),
             "combined image of exactly 64 bytes must fail (need at least 65)"
         );
@@ -719,11 +998,20 @@ mod tests {
     // -- #217 fail-closed boot gate --
 
     fn signed_dev_image(payload: &[u8]) -> alloc::vec::Vec<u8> {
-        use ed25519_dalek::{Signer, SigningKey};
+        // #467: the boot gate verifies Ed25519ph (prehashed SHA-512), so the
+        // fixture signs with sign_prehashed — the same scheme the sphragis
+        // tool produces for real boot partitions.
+        use ed25519_dalek::SigningKey;
+        use sha2::Digest as _;
         let seed = BOOT_KEY_DEV_SEED.expect("boot-key tests require the dev trust anchor");
         let signing_key = SigningKey::from_bytes(&seed);
+        let mut prehash = sha2::Sha512::new();
+        prehash.update(payload);
+        let sig = signing_key
+            .sign_prehashed(prehash, None)
+            .expect("sign_prehashed");
         let mut image = alloc::vec::Vec::from(payload);
-        image.extend_from_slice(&signing_key.sign(payload).to_bytes());
+        image.extend_from_slice(&sig.to_bytes());
         image
     }
 

--- a/docs/KERNEL-BUILD.md
+++ b/docs/KERNEL-BUILD.md
@@ -169,6 +169,23 @@ cd crates/thumos
 cargo run --example qemu_smoke --release   # prints "qemu_smoke: pass"
 ```
 
+## Boot-image signing (Ed25519ph, #467)
+
+`crates/sphragis` is the boot-image signing tool: it streams an image
+through SHA-512 in bounded reads, Ed25519ph-signs with the anchor's seed,
+and emits the `payload || zero-pad || signature(64)` sector-aligned layout
+the kernel's streamed boot gate (`secure_boot::verify_image_streamed`)
+verifies:
+
+```
+cargo run -p sphragis -- <image-in> <seed-hex-file> <image-out>
+```
+
+For mkbootimg assembly: the combined kernel(+ramdisk) image is sphragis's
+input; its output is what gets flashed to the GPT `boot` partition. The
+dev anchor (`keys/dev/boot-dev.seed`) signs dev images; production keys
+live offline and never enter the repo.
+
 ## Signing and attestation boundary
 
 Where trust enters the build — and what is deliberately **not** attested

--- a/docs/capability-inventory.toml
+++ b/docs/capability-inventory.toml
@@ -74,7 +74,7 @@ notes = "Fail-closed medium trust; production-signed verified boot on live eMMC 
 
 [[capability]]
 id = "security-subsystems"
-modules = ["security", "security_mode", "lock_screen", "key_manager", "audit", "capability", "panic_wipe", "bfu_timer", "csprng", "secrets"]
+modules = ["security", "security_mode", "lock_screen", "key_manager", "audit", "capability", "panic_wipe", "bfu_timer", "csprng", "secrets", "gpt"]
 tier = "kernel-wired"
 notes = "Security-mode manager drives the status bar (#404); encryption/key paths land with the boot-time passphrase subsystem (#446); the per-device salt + secrets preamble are #449 (this PR)."
 hardware_reason = "panic wipe + tamper evidence need the physical eMMC/sensors"

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -54,6 +54,12 @@ tests = 14
 mechanism = "host"
 
 [[module]]
+name = "gpt"
+tests = 6
+mechanism = "host"
+fidelity = "parse logic proven on synthetic GPT images host-side; the live eMMC GPT read is the m7 boot path (hardware-gated)"
+
+[[module]]
 name = "bluetooth"
 tests = 25
 mechanism = "host"
@@ -537,7 +543,7 @@ mechanism = "host"
 
 [[module]]
 name = "secure_boot"
-tests = 22
+tests = 29
 mechanism = "both"
 witness = "boot.sh"
 


### PR DESCRIPTION
## Summary

The #217 fail-closed gate consumed `BootImageSource::Absent` unconditionally — a live-eMMC phone booted degraded-LOCKED (correct posture, never fail-open) but could never establish trust, because nothing read and presented the boot image. This lands the four landable-now pieces; the on-phone boot itself is the hardware ledger.

1. **GPT-locate the `boot` partition by name** (`crates/thumos/src/gpt.rs`): a host-testable parser validating the `EFI PART` signature, header CRC32, and entries CRC32 (a tableless IEEE CRC32 the kernel lacked), returning first/last LBA. Corrupt tables are explicit typed errors, never a misparse into wrong LBAs.
2. **Streamed Ed25519ph verify** (`secure_boot::verify_image_streamed`): plain Ed25519 needs the whole image contiguous — impossible for a multi-MB boot partition against a 1 MB heap. Ed25519ph prehashes SHA-512 over bounded 4 KiB sector reads (memory stays O(chunk)), verified with `verify_prehashed_strict` (the non-malleable posture, matching `verify_strict` everywhere else). An in-memory ph variant keeps the small-image/test path on the same scheme.
3. **The fail-closed construction-site invariant**: `BootImageSource::Unreadable` — a present-but-unreadable boot partition (I/O error, missing GPT entry, blanked table) maps to **Halt**, never to `Absent`/degraded. kinit 8b constructs the source via `boot_image_source()` (GPT-locate → `PresentStreamed` on the #603 partition view); any failure → `Unreadable` → halt. Host tests pin read-failure → Halt and the full happy path (synthetic GPT + signed image → verified).
4. **The signing tool** (`crates/sphragis`, σφραγίς = signet): streams the image, Ed25519ph-signs with the anchor seed, emits the sector-aligned `payload || pad || signature` layout — with a differential test proving the tool's output verifies under the kernel's exact `verify_prehashed_strict` path. `docs/KERNEL-BUILD.md` documents the mkbootimg integration.
5. **Trust root stated** (review item): the module doc now records the chain position honestly — this gate is a LINK below the BROM→preloader chain, which is not established by this repo on the stock device (hardware-ledger); the gate proves the boot image is what the signing key holder built and never WIDENS what booted.

## Verification

- `scripts/kernel-host-tests.sh` (i686 + debug-console): 2327 passed, 1 skipped, rc=0 — GPT parse (name lookup, bad signature, header CRC, entries CRC, missing partition, CRC32 KAT), streamed verify (valid multi-chunk, tampered payload, wrong anchor key, too-short), the Unreadable→Halt invariant, and the GPT-located signed-partition happy path.
- `cargo test -p sphragis`: 3 passed, rc=0 — alignment, seed parsing, and the kernel-path differential proof.
- `cargo check` (armv7a, m7) + `cargo check --features qemu` (virt): both rc=0
- `scripts/witness-run-all.sh`: ALL PASS, rc=0 (boot, kread/kwrite/kexec/cp15 isolation, kfault rc=4-as-specified, sleep, fork, exec, forkexec, guard, brk, signal, crashloop)
- `scripts/check-target-test-ledger.sh` / `check-wiring-inventory.sh` / `check-board-seam.sh`: no drift (gpt row + classification added).
- `cargo fmt`: clean.

Refs #467 (the on-phone verified boot is the hardware-ledger remainder)
