### PR TITLE
ci: kernel-host-tests propagates failing-pass exit codes

### DIFF
--- a/scripts/kernel-host-tests.sh
+++ b/scripts/kernel-host-tests.sh
@@ -26,15 +26,17 @@ fi
 rm -rf "$probe_dir"
 command -v cargo-nextest >/dev/null || { echo "FAIL: cargo-nextest not installed" >&2; exit 1; }
 
+pass1=0
 (cd "$KERNEL_DIR" && cargo nextest run --bin thumos --target i686-unknown-linux-gnu \
-    --build-jobs "${THUMOS_BUILD_JOBS:-8}" --test-threads "${THUMOS_TEST_THREADS:-8}")
+    --build-jobs "${THUMOS_BUILD_JOBS:-8}" --test-threads "${THUMOS_TEST_THREADS:-8}") || pass1=$?
 
 # WHY (#459): the debug console is now host-testable (heap/page/process stub
 # pattern), but its tests only exist under `--features debug-console`. A
 # second pass runs them — and asserts they actually execute, since this class
 # of bug is "tests never ran" (the gate left them dead source for weeks).
+pass2=0
 out=$(cd "$KERNEL_DIR" && cargo nextest run --bin thumos --target i686-unknown-linux-gnu \
-    --features debug-console --build-jobs "${THUMOS_BUILD_JOBS:-8}" --test-threads "${THUMOS_TEST_THREADS:-8}" 2>&1)
+    --features debug-console --build-jobs "${THUMOS_BUILD_JOBS:-8}" --test-threads "${THUMOS_TEST_THREADS:-8}" 2>&1) || pass2=$?
 printf '%s\n' "$out"
 # WHY a herestring, not a pipe: under `set -o pipefail`, `printf | grep -q`
 # returns 141 when grep exits on the first match and printf dies of SIGPIPE —
@@ -43,3 +45,11 @@ grep -q 'console::tests' <<<"$out" || {
     echo "FAIL #459: --features debug-console pass ran zero console::tests — the tests are dead again" >&2
     exit 1
 }
+# WHY (#616): no `set -e` here, so a red pass does not abort the script — and
+# without this check the script's exit code was the grep's, letting a failing
+# test pass ship rc=0 to CI. Both passes run to completion either way (a red
+# main pass must not hide the debug-console witness output).
+if [ "$pass1" -ne 0 ] || [ "$pass2" -ne 0 ]; then
+    echo "FAIL: kernel host tests failed (main pass rc=$pass1, debug-console pass rc=$pass2)" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary

`scripts/kernel-host-tests.sh` runs under `set -uo pipefail` (no `-e`). The main i686 nextest pass was a bare subshell command: when it failed, the script neither aborted nor recorded the failure, and the script's exit code came from the final `grep -q 'console::tests'` — so the kernel CI job and the admission gate could pass with failing kernel host tests. Observed live while verifying #446: a red `kinit_plan` test in both passes, log ending `error: test run failed`, script rc 0.

The fix captures each pass's rc and exits 1 when either failed. Both passes still run to completion either way — a red main pass must not hide the debug-console witness output, and the #459 dead-tests guard is unchanged.

## Verification

Shimmed-`cargo` matrix against the patched script (no vgate involvement, so the harness is exact):

- main pass fails → rc 1 (the hole: previously 0)
- both passes green → rc 0
- debug-console pass fails → rc 1
- console pass emitting zero `console::tests` lines → rc 1 (the #459 guard still fires)

CI on this PR exercises the patched script against the real suite.

Closes #616
