### PR TITLE
kinit: boot-time passphrase input subsystem — verify, derive, encrypted mount

### DIFF
--- a/crates/thumos/src/board/m7.rs
+++ b/crates/thumos/src/board/m7.rs
@@ -53,6 +53,12 @@ pub(crate) const LFS_PARTITION_START: u64 = 0x50C000;
 /// segment-aligned boundary.
 pub(crate) const LFS_PARTITION_SIZE: u64 = 0x600000;
 
+/// Sectors reserved at the userdata partition head for the plaintext
+/// secrets preamble (#449). The encrypted LFS payload starts this many
+/// sectors past `LFS_PARTITION_START` (#446); a pre-#446 unprovisioned
+/// image mounts plain AT the head (the dev/transition path).
+pub(crate) const LFS_PREAMBLE_SECTORS: u64 = 1;
+
 // ---------------------------------------------------------------------------
 // USB
 // ---------------------------------------------------------------------------
@@ -103,6 +109,42 @@ pub(crate) const KPD_EN: usize = 0x00;
 /// KPD debounce register offset.
 pub(crate) const KPD_DEBOUNCE: usize = 0x18;
 
+/// GPIO controller MMIO base (MT67xx standard bank base).
+///
+/// NOTE: standard MT67xx base — verify against the MT6739 TRM GPIO section.
+/// Mirrors haphe's `GPIO_BASE` (crates/haphe/src/gpio.rs); the #446 boot
+/// keypad reader scans the matrix through these registers because the KPD
+/// hardware block has no verified read-out register map.
+pub(crate) const GPIO_BASE: usize = 0x1000_5000;
+
+/// GPIO direction register bank offset (0 = input, 1 = output).
+pub(crate) const GPIO_DIR_BASE: usize = 0x000;
+
+/// GPIO data-out register bank offset.
+pub(crate) const GPIO_DOUT_BASE: usize = 0x100;
+
+/// GPIO data-in register bank offset (reads current pin level).
+pub(crate) const GPIO_DIN_BASE: usize = 0x200;
+
+/// GPIO pull-enable register bank offset.
+pub(crate) const GPIO_PULLEN_BASE: usize = 0x300;
+
+/// GPIO pull-select register bank offset (0 = pull-down, 1 = pull-up).
+pub(crate) const GPIO_PULLSEL_BASE: usize = 0x400;
+
+/// Keypad matrix row GPIO pins (driven low in turn during a scan).
+///
+/// NOTE: placeholder values pending AGM M7 schematic verification —
+/// mirrors haphe's `ROW_PINS`.
+pub(crate) const KEYPAD_ROW_PINS: [u8; 4] = [40, 41, 42, 43];
+
+/// Keypad matrix column GPIO pins (inputs with pull-up; a pressed key
+/// shorts the driven-low row to the column, reading low).
+///
+/// NOTE: placeholder values pending AGM M7 schematic verification —
+/// mirrors haphe's `COL_PINS`.
+pub(crate) const KEYPAD_COL_PINS: [u8; 3] = [44, 45, 46];
+
 // ---------------------------------------------------------------------------
 // Combo chip (WiFi / BT / GPS / FM over the WMT transport)
 // ---------------------------------------------------------------------------
@@ -152,6 +194,7 @@ pub(crate) fn register_devices(registry: &mut DeviceRegistry) {
 
     // Input
     registry.register("mtk-kpd", KPD_BASE, 0); // Keypad
+    registry.register("gpio", GPIO_BASE, 0); // GPIO bank (boot keypad matrix scan)
     registry.register("mtk-tpd", 0x0, 0); // Touch (I2C, addr TBD from teardown)
 
     // Modem (ccci-family addresses; the ccci seam owns those drivers)
@@ -193,7 +236,7 @@ mod tests {
         let mut registry = DeviceRegistry::new();
         register_devices(&mut registry);
 
-        assert_eq!(registry.list().len(), 18);
+        assert_eq!(registry.list().len(), 19);
         let cases: &[(&str, usize)] = &[
             ("uart0", UART0_BASE),
             ("uart1", UART1_BASE),
@@ -201,6 +244,7 @@ mod tests {
             ("disp-rdma0", RDMA0_BASE),
             ("gc9306-lcm", GC9306_LCM_BASE),
             ("mtk-kpd", KPD_BASE),
+            ("gpio", GPIO_BASE),
             ("wmt-consys", CONSYS_BASE),
             ("wlan0", WLAN_BASE),
             ("musb-hdrc", MUSB_BASE),
@@ -216,7 +260,7 @@ mod tests {
         }
         assert_eq!(
             registry.count_by_status(crate::device::DeviceStatus::Registered),
-            18,
+            19,
             "all devices start in the Registered state"
         );
     }

--- a/crates/thumos/src/key_manager.rs
+++ b/crates/thumos/src/key_manager.rs
@@ -36,6 +36,14 @@ const LABEL_CSPRNG: &[u8] = b"thumos-csprng-v1";
 /// HKDF info label for ephemeral session keys.
 const LABEL_SESSION: &[u8] = b"thumos-session-v1";
 
+/// HKDF info label for the boot passphrase verifier (#446).
+///
+/// The verifier is not a key: it is stored plaintext in the secrets
+/// preamble (crate::secrets) so the boot gate can distinguish a correct
+/// passphrase from a wrong one before mounting. Deriving it from the
+/// primary key keeps verification at PBKDF2 strength per guess.
+const LABEL_VERIFY: &[u8] = b"thumos-verify-v1";
+
 // NOTE (#449): there is deliberately NO compile-time salt constant. The
 // PBKDF2 salt is a per-device random value generated at provisioning and
 // persisted in the on-disk secrets preamble (crate::secrets); every caller
@@ -110,7 +118,7 @@ impl<const N: usize> fmt::Display for SecureKey<N> {
 /// [`KeyManager::derive_partition_keys`] are `Copy`, so constructing a
 /// `SecureKey` from them leaves the original array un-zeroized; this
 /// closes that gap explicitly on every return path (#325).
-fn volatile_zero<const N: usize>(buf: &mut [u8; N]) {
+pub(crate) fn volatile_zero<const N: usize>(buf: &mut [u8; N]) {
     for byte in buf.iter_mut() {
         // SAFETY: write_volatile prevents dead-store elimination; byte
         // points into the caller-owned stack array.
@@ -286,6 +294,35 @@ impl KeyManager {
         volatile_zero(&mut session_bytes);
 
         result
+    }
+
+    /// Derive the boot passphrase verifier from a primary key (#446).
+    ///
+    /// The verifier is what first-boot setup stores in the secrets preamble
+    /// (crate::secrets, slot kind 4, plaintext) and what the boot passphrase
+    /// gate compares against (constant-time) BEFORE any mount. It is an
+    /// HKDF output over the primary key, so a stored verifier costs an
+    /// attacker one full PBKDF2 run per guess — the same as attacking the
+    /// encrypted payload directly. It is deliberately NOT
+    /// `SHA-256(passphrase)`, which would be a fast offline oracle.
+    ///
+    /// The verifier is public by construction, so the output is a plain
+    /// array, not a [`SecureKey`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SecurityError`] if HKDF derivation fails.
+    pub(crate) fn derive_boot_verifier(
+        primary: &SecureKey<KEY_SIZE>,
+    ) -> Result<[u8; KEY_SIZE], SecurityError> {
+        let mut out = [0u8; KEY_SIZE];
+        let result = security::hkdf_sha256(primary.as_bytes(), &[], LABEL_VERIFY, &mut out);
+        if result.is_err() {
+            // WHY: a half-derived verifier must never escape — same
+            // zero-on-every-path posture as derive_partition_keys (#325).
+            volatile_zero(&mut out);
+        }
+        result.map(|()| out)
     }
 
     /// Zeroize all partition keys and transition to long-sleep tier.
@@ -585,6 +622,46 @@ mod tests {
             key_a.as_bytes(),
             key_b.as_bytes(),
             "same passphrase + different device salts must derive different primary keys"
+        );
+    }
+
+    #[test]
+    fn boot_verifier_is_deterministic_per_primary() {
+        let primary = derive_test_primary(b"verifier determinism");
+        let v1 = KeyManager::derive_boot_verifier(&primary).expect("derive verifier");
+        let v2 = KeyManager::derive_boot_verifier(&primary).expect("derive verifier");
+        assert_eq!(v1, v2, "same primary must yield the same verifier");
+        assert_ne!(v1, [0u8; KEY_SIZE], "verifier must not be zero");
+    }
+
+    #[test]
+    fn boot_verifier_tracks_the_passphrase() {
+        let primary_a = derive_test_primary(b"correct horse");
+        let primary_b = derive_test_primary(b"battery staple");
+        let v_a = KeyManager::derive_boot_verifier(&primary_a).expect("verifier a");
+        let v_b = KeyManager::derive_boot_verifier(&primary_b).expect("verifier b");
+        assert_ne!(
+            v_a, v_b,
+            "different passphrases must verify differently (the boot gate's whole point)"
+        );
+    }
+
+    #[test]
+    fn boot_verifier_is_label_separated_from_partition_keys() {
+        let primary = derive_test_primary(b"label separation");
+        let verifier = KeyManager::derive_boot_verifier(&primary).expect("verifier");
+        let mut km = KeyManager::new();
+        km.derive_partition_keys(&primary).expect("partition keys");
+        let data = km.data_key().expect("data key").as_bytes();
+        assert_ne!(
+            &verifier[..],
+            &data[..KEY_SIZE],
+            "HKDF label separation: verifier must differ from the data key"
+        );
+        assert_ne!(
+            &verifier[..],
+            &primary.as_bytes()[..],
+            "the verifier is a derived value, never the primary itself"
         );
     }
 

--- a/crates/thumos/src/keypad.rs
+++ b/crates/thumos/src/keypad.rs
@@ -1,0 +1,354 @@
+//! Boot-time keypad matrix reader (#446).
+//!
+//! Poll-based GPIO matrix scan for the boot passphrase gate. The kernel
+//! cannot link haphe (a std workspace crate), so this mirrors haphe's
+//! proven scan/debounce algorithm (`crates/haphe/src/gpio.rs`) against the
+//! kernel's [`crate::ui::Key`] vocabulary. The KPD hardware block at
+//! `board::KPD_BASE` is only *enabled* by kinit (Step 8a) — no verified
+//! read-out register map exists for it — so the boot path scans the raw
+//! GPIO matrix directly, exactly as the userspace driver does.
+//!
+//! Pin assignments are placeholders pending AGM M7 schematic verification
+//! (the same caveat haphe carries); the board facts live in `board::m7`.
+//!
+//! Simplifications versus haphe, deliberate for the boot path: no input
+//! queue and no release/held events — the boot loop polls on a ~10 ms
+//! cadence and acts on confirmed *presses* (taps) only. Debounce state is
+//! still tracked per key so a press is reported once and re-arming
+//! requires a physical release.
+
+// WHY: the whole module is M7-only hardware access. It is compiled on the
+// host for tests (the scan/debounce logic is injected-matrix host-tested)
+// and in m7 kernel builds; the qemu build has no GPIO matrix and never
+// constructs the reader.
+
+use crate::board;
+use crate::ui::Key;
+
+/// Number of row lines in the key matrix.
+pub(crate) const ROW_COUNT: usize = board::KEYPAD_ROW_PINS.len();
+/// Number of column lines in the key matrix.
+pub(crate) const COL_COUNT: usize = board::KEYPAD_COL_PINS.len();
+/// Total keys in the matrix.
+pub(crate) const KEY_COUNT: usize = ROW_COUNT * COL_COUNT;
+
+/// Consecutive identical scans required before a press transition is
+/// accepted. At the boot loop's ~10 ms poll cadence this is ~30 ms of
+/// debounce, mirroring haphe's `DEBOUNCE_THRESHOLD`.
+pub(crate) const DEBOUNCE_THRESHOLD: u8 = 3;
+
+/// Key lookup table indexed by `[row][col]` — the standard 4x3 phone
+/// layout. Mirrors haphe's `KEY_MAP`, mapped to the kernel's `ui::Key`.
+///
+/// NOTE: the matrix yields only digits, Star, and Hash. The boot passphrase
+/// UX binds Star = backspace and Hash = submit (see kinit Step 8c), so a
+/// boot passphrase is effectively digits-only; the first-boot setup path
+/// constrains the alphabet the same way, keeping set/enter consistent.
+pub(crate) const KEY_MAP: [[Key; COL_COUNT]; ROW_COUNT] = [
+    [Key::Num1, Key::Num2, Key::Num3],
+    [Key::Num4, Key::Num5, Key::Num6],
+    [Key::Num7, Key::Num8, Key::Num9],
+    [Key::Star, Key::Num0, Key::Hash],
+];
+
+/// Register address and bit mask for `pin` within the register bank at
+/// `bank_base` (an offset from `board::GPIO_BASE`).
+///
+/// MT67xx layout: each bank controls 32 pins; the address stride within a
+/// bank is 8 (value at +0x00, set/clear aliases at +0x04). Mirrors haphe's
+/// `gpio_reg`.
+#[inline]
+pub(crate) fn gpio_reg(bank_base: usize, pin: u8) -> (usize, u32) {
+    let bank = usize::from(pin / 32);
+    let bit = u32::from(pin % 32);
+    (board::GPIO_BASE + bank_base + bank * 8, 1u32 << bit)
+}
+
+/// Snapshot of every matrix key's pressed state: bit `row * COL_COUNT +
+/// col` is set when that key is currently pressed. Mirrors haphe's
+/// `KeyMatrix`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) struct KeyMatrix(u16);
+
+impl KeyMatrix {
+    /// All keys released.
+    pub(crate) const fn none() -> Self {
+        Self(0)
+    }
+
+    /// Whether the key at (`row`, `col`) is pressed in this snapshot.
+    #[inline]
+    pub(crate) const fn is_pressed(self, row: usize, col: usize) -> bool {
+        // usize->u16: at most 12 keys; the bit index always fits.
+        let bit = (row * COL_COUNT + col) as u16;
+        (self.0 >> bit) & 1 == 1
+    }
+
+    /// Set or clear the bit for (`row`, `col`).
+    #[inline]
+    pub(crate) const fn set(&mut self, row: usize, col: usize, pressed: bool) {
+        // usize->u16: at most 12 keys; the bit index always fits.
+        let bit = (row * COL_COUNT + col) as u16;
+        if pressed {
+            self.0 |= 1 << bit;
+        } else {
+            self.0 &= !(1 << bit);
+        }
+    }
+}
+
+/// Per-key debounce state: the accepted stable level plus the candidate
+/// level accumulating confirmations. Mirrors haphe's `Debounce`.
+#[derive(Clone, Copy, Debug)]
+struct Debounce {
+    /// The stable (accepted) pressed state.
+    stable: bool,
+    /// Candidate state currently accumulating confirmations.
+    candidate: bool,
+    /// Consecutive scans agreeing on `candidate`.
+    count: u8,
+}
+
+impl Debounce {
+    const fn new() -> Self {
+        Self {
+            stable: false,
+            candidate: false,
+            count: 0,
+        }
+    }
+
+    /// Feed one raw reading. Returns `Some(true)` exactly on the scan that
+    /// confirms a release->press transition; releases and sub-threshold
+    /// wiggle only update internal state (the boot path acts on presses).
+    const fn update(&mut self, pressed: bool) -> Option<bool> {
+        if pressed == self.candidate {
+            if self.count < DEBOUNCE_THRESHOLD {
+                self.count += 1;
+            }
+            if self.count >= DEBOUNCE_THRESHOLD && pressed != self.stable {
+                self.stable = pressed;
+                return Some(pressed);
+            }
+        } else {
+            self.candidate = pressed;
+            self.count = 1;
+        }
+        None
+    }
+}
+
+/// Boot keypad scanner: one scan cycle per poll, debounce per key, emits
+/// the first confirmed press of the cycle.
+pub(crate) struct BootKeypad {
+    /// Per-key debounce state, laid out as `row * COL_COUNT + col`.
+    debounce: [Debounce; KEY_COUNT],
+}
+
+impl BootKeypad {
+    /// A fresh scanner (all keys released, no history).
+    pub(crate) const fn new() -> Self {
+        const DB: Debounce = Debounce::new();
+        Self {
+            debounce: [DB; KEY_COUNT],
+        }
+    }
+
+    /// Debounce-and-decode core: feed one raw matrix snapshot, get back
+    /// `Some(key)` on the first newly-confirmed press this cycle.
+    ///
+    /// This is the host-testable half; hardware reads reach it through
+    /// [`BootKeypad::poll`].
+    pub(crate) fn poll_with_matrix(&mut self, matrix: KeyMatrix) -> Option<Key> {
+        for (row, row_keys) in KEY_MAP.iter().enumerate() {
+            for (col, &key) in row_keys.iter().enumerate() {
+                let pressed = matrix.is_pressed(row, col);
+                // WHY get_mut: KEY_COUNT == ROW_COUNT * COL_COUNT by
+                // construction, but an indexing panic in the boot path is a
+                // bricked phone — stay total.
+                if let Some(slot) = self.debounce.get_mut(row * COL_COUNT + col)
+                    && let Some(true) = slot.update(pressed)
+                {
+                    return Some(key);
+                }
+            }
+        }
+        None
+    }
+
+    /// Configure the matrix GPIOs: rows as outputs driven high (inactive),
+    /// columns as inputs with pull-up.
+    #[cfg(not(test))]
+    pub(crate) fn init(&self) {
+        for &pin in &board::KEYPAD_ROW_PINS {
+            let (dir_addr, dir_mask) = gpio_reg(board::GPIO_DIR_BASE, pin);
+            let (dout_addr, dout_mask) = gpio_reg(board::GPIO_DOUT_BASE, pin);
+            // SAFETY: GPIO MMIO registers at board::GPIO_BASE-derived
+            // addresses, identity-mapped as device memory; written once at
+            // boot before the passphrase loop polls.
+            unsafe {
+                crate::mmio::write32(dir_addr, crate::mmio::read32(dir_addr) | dir_mask);
+                crate::mmio::write32(dout_addr, crate::mmio::read32(dout_addr) | dout_mask);
+            }
+        }
+        for &pin in &board::KEYPAD_COL_PINS {
+            let (dir_addr, dir_mask) = gpio_reg(board::GPIO_DIR_BASE, pin);
+            let (pullen_addr, pullen_mask) = gpio_reg(board::GPIO_PULLEN_BASE, pin);
+            let (pullsel_addr, pullsel_mask) = gpio_reg(board::GPIO_PULLSEL_BASE, pin);
+            // SAFETY: as above. DIR bit cleared = input; pull enabled and
+            // selected up so an idle column reads high.
+            unsafe {
+                crate::mmio::write32(dir_addr, crate::mmio::read32(dir_addr) & !dir_mask);
+                crate::mmio::write32(pullen_addr, crate::mmio::read32(pullen_addr) | pullen_mask);
+                crate::mmio::write32(
+                    pullsel_addr,
+                    crate::mmio::read32(pullsel_addr) | pullsel_mask,
+                );
+            }
+        }
+    }
+
+    /// One scan cycle against the hardware matrix.
+    #[cfg(not(test))]
+    pub(crate) fn poll(&mut self) -> Option<Key> {
+        self.poll_with_matrix(read_matrix())
+    }
+}
+
+/// Read the raw (un-debounced) matrix from hardware: drive each row low in
+/// turn, read the column bank, active-low. Mirrors haphe's `read_matrix`.
+#[cfg(not(test))]
+fn read_matrix() -> KeyMatrix {
+    let mut matrix = KeyMatrix::none();
+    for (row_idx, &row_pin) in board::KEYPAD_ROW_PINS.iter().enumerate() {
+        let (dout_addr, dout_mask) = gpio_reg(board::GPIO_DOUT_BASE, row_pin);
+        let first_col = board::KEYPAD_COL_PINS.first().copied().unwrap_or(0);
+        let (din_addr, _) = gpio_reg(board::GPIO_DIN_BASE, first_col);
+        // SAFETY: GPIO MMIO as in init(); rows/cols were configured by
+        // BootKeypad::init before the poll loop runs.
+        unsafe {
+            // Drive this row low.
+            crate::mmio::write32(dout_addr, crate::mmio::read32(dout_addr) & !dout_mask);
+        }
+        // WHY: GPIO propagation is sub-microsecond on MT67xx; a short spin
+        // lets the level settle before the column read.
+        for _ in 0..16u32 {
+            core::hint::spin_loop();
+        }
+        // SAFETY: read of the data-in bank as mapped above. All column pins
+        // live in the same 32-pin bank (44-46).
+        let din_word = unsafe { crate::mmio::read32(din_addr) };
+        for (col_idx, &col_pin) in board::KEYPAD_COL_PINS.iter().enumerate() {
+            let col_bit = u32::from(col_pin % 32);
+            // Pull-up keeps an idle column high; a pressed key shorts the
+            // driven-low row to the column and reads low.
+            let high = (din_word >> col_bit) & 1 == 1;
+            matrix.set(row_idx, col_idx, !high);
+        }
+        // SAFETY: restoring the row high (inactive) as mapped above.
+        unsafe {
+            crate::mmio::write32(dout_addr, crate::mmio::read32(dout_addr) | dout_mask);
+        }
+    }
+    matrix
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Feed `matrix` into `kp` exactly `n` times, returning the last poll.
+    fn scan_n(kp: &mut BootKeypad, matrix: KeyMatrix, n: usize) -> Option<Key> {
+        let mut out = None;
+        for _ in 0..n {
+            out = kp.poll_with_matrix(matrix);
+        }
+        out
+    }
+
+    #[test]
+    fn press_confirms_after_threshold_and_reports_once() {
+        let mut kp = BootKeypad::new();
+        let mut m = KeyMatrix::none();
+        m.set(0, 0, true); // Num1
+
+        // Below threshold: no event.
+        for _ in 0..(DEBOUNCE_THRESHOLD - 1) {
+            assert_eq!(kp.poll_with_matrix(m), None, "sub-threshold must not emit");
+        }
+        // At threshold: exactly one press event.
+        assert_eq!(kp.poll_with_matrix(m), Some(Key::Num1));
+        // Held steady: no repeat emission.
+        assert_eq!(scan_n(&mut kp, m, 10), None, "a held key must not re-emit");
+    }
+
+    #[test]
+    fn release_rearms_the_key() {
+        let mut kp = BootKeypad::new();
+        let mut m = KeyMatrix::none();
+        m.set(1, 1, true); // Num5
+
+        scan_n(&mut kp, m, DEBOUNCE_THRESHOLD as usize);
+        // Release past the threshold.
+        assert_eq!(
+            scan_n(&mut kp, KeyMatrix::none(), DEBOUNCE_THRESHOLD as usize + 2),
+            None,
+            "release emits nothing on the boot path"
+        );
+        // A second press confirms again.
+        assert_eq!(
+            scan_n(&mut kp, m, DEBOUNCE_THRESHOLD as usize),
+            Some(Key::Num5),
+            "key must re-arm after release"
+        );
+    }
+
+    #[test]
+    fn bounce_never_confirms() {
+        let mut kp = BootKeypad::new();
+        let mut m = KeyMatrix::none();
+        m.set(2, 2, true); // Num9
+        // Alternate pressed/released under the threshold: no stable press.
+        for _ in 0..20 {
+            assert_eq!(kp.poll_with_matrix(m), None);
+            assert_eq!(kp.poll_with_matrix(KeyMatrix::none()), None);
+        }
+    }
+
+    #[test]
+    fn key_map_layout_is_the_phone_pad() {
+        assert_eq!(KEY_MAP[0], [Key::Num1, Key::Num2, Key::Num3]);
+        assert_eq!(KEY_MAP[1], [Key::Num4, Key::Num5, Key::Num6]);
+        assert_eq!(KEY_MAP[2], [Key::Num7, Key::Num8, Key::Num9]);
+        assert_eq!(KEY_MAP[3], [Key::Star, Key::Num0, Key::Hash]);
+    }
+
+    #[test]
+    fn gpio_reg_addressing_matches_the_mt67xx_bank_formula() {
+        // Pin 8 in bank 0: base + bank offset, bit 8.
+        let (addr, mask) = gpio_reg(board::GPIO_DOUT_BASE, 8);
+        assert_eq!(addr, board::GPIO_BASE + board::GPIO_DOUT_BASE);
+        assert_eq!(mask, 1 << 8);
+        // Pin 40 (first row pin): bank 1, stride 8, bit 8.
+        let (addr, mask) = gpio_reg(board::GPIO_DIN_BASE, 40);
+        assert_eq!(addr, board::GPIO_BASE + board::GPIO_DIN_BASE + 8);
+        assert_eq!(mask, 1 << 8);
+    }
+
+    #[test]
+    fn first_confirmed_press_wins_the_cycle() {
+        let mut kp = BootKeypad::new();
+        let mut m = KeyMatrix::none();
+        m.set(0, 0, true); // Num1
+        m.set(3, 2, true); // Hash
+        assert_eq!(
+            scan_n(&mut kp, m, DEBOUNCE_THRESHOLD as usize),
+            Some(Key::Num1),
+            "scan order is row-major; Num1 precedes Hash"
+        );
+    }
+}

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -45,6 +45,10 @@ use crate::kconfig;
 #[cfg(not(feature = "qemu"))]
 use crate::kinit_plan::MODEM_BOOT_TIMEOUT_MS;
 use crate::kinit_plan::{BootState, UserspaceSpawnPlan, plan_userspace_spawn_from_vfs};
+// M7-only: the boot passphrase loops render the lock screen (the Screen
+// trait's draw) into the hardware framebuffer.
+#[cfg(not(feature = "qemu"))]
+use crate::ui::Screen as _;
 // M7-only: the panic-red fill exists only where a hardware framebuffer does.
 #[cfg(not(feature = "qemu"))]
 use crate::kinit_plan::PANIC_RED_RGB565;
@@ -133,6 +137,261 @@ pub(crate) unsafe fn fill_framebuffer(fb_addr: usize, width: u32, height: u32, c
 /// (`process::enable_scheduling()` is only reached at the end of `run`).
 ///
 /// WHY IRQs stay enabled: the timer ISR keeps petting the 5 s watchdog, so
+#[cfg(not(feature = "qemu"))]
+/// Map a keypad matrix key to its ASCII digit — the boot passphrase entry
+/// alphabet (#446). Star/Hash are control keys at boot (backspace/submit),
+/// never passphrase bytes.
+const fn boot_digit(key: crate::ui::Key) -> Option<u8> {
+    match key {
+        crate::ui::Key::Num0 => Some(b'0'),
+        crate::ui::Key::Num1 => Some(b'1'),
+        crate::ui::Key::Num2 => Some(b'2'),
+        crate::ui::Key::Num3 => Some(b'3'),
+        crate::ui::Key::Num4 => Some(b'4'),
+        crate::ui::Key::Num5 => Some(b'5'),
+        crate::ui::Key::Num6 => Some(b'6'),
+        crate::ui::Key::Num7 => Some(b'7'),
+        crate::ui::Key::Num8 => Some(b'8'),
+        crate::ui::Key::Num9 => Some(b'9'),
+        _ => None,
+    }
+}
+
+#[cfg(not(feature = "qemu"))]
+/// Build a fresh encrypted view over the userdata payload (#446): physical
+/// eMMC -> partition view one sector past the plaintext preamble -> AES-XTS
+/// wrapper. Returns `None` when the block device fails init (the caller
+/// logs and stays unmounted — fail-closed).
+///
+/// WHY the leak: `EncryptedBlockDevice` borrows its inner device while
+/// `lfs::mount` takes ownership — a one-time `Box::leak` of the small view
+/// struct satisfies both. Bounded (once per mount attempt) and deliberate.
+fn encrypted_payload_device(
+    data_key: &[u8; crate::security::XTS_KEY_SIZE],
+) -> Option<crate::encryption::EncryptedBlockDevice<'static>> {
+    let mut phys = MsdcBlockDevice::new(board::LFS_PARTITION_START + board::LFS_PARTITION_SIZE);
+    // SAFETY: the eMMC controller was initialized in Step 7; init() is
+    // called once here on a freshly constructed MsdcBlockDevice.
+    if unsafe { phys.init() }.is_err() {
+        return None;
+    }
+    let payload = crate::block::PartitionBlockDevice::new(
+        phys,
+        board::LFS_PARTITION_START + board::LFS_PREAMBLE_SECTORS,
+        board::LFS_PARTITION_SIZE - board::LFS_PREAMBLE_SECTORS,
+    );
+    let payload: &'static mut dyn crate::block::BlockDevice =
+        alloc::boxed::Box::leak(alloc::boxed::Box::new(payload));
+    Some(crate::encryption::EncryptedBlockDevice::new(
+        payload, *data_key,
+    ))
+}
+
+#[cfg(not(feature = "qemu"))]
+/// The boot verify loop (#446): poll the keypad, drive the lock screen,
+/// and on submit verify at PBKDF2 strength against the stored preamble
+/// verifier. On success the partition keys are derived into `key_manager`
+/// and the loop returns `true`. Throttle/wipe bookkeeping is the lock
+/// screen's own state machine; the wipe trigger executes the panic wipe
+/// and halts (never returns). Otherwise the loop runs until success — the
+/// gate is the only work this boot has until the passphrase lands.
+fn boot_verify_loop(
+    serial: &mut Uart,
+    lock: &mut crate::lock_screen::LockScreen,
+    keypad: &mut crate::keypad::BootKeypad,
+    fb: &mut [u16],
+    secrets: &crate::secrets::DeviceSecrets,
+    key_manager: &mut crate::key_manager::KeyManager,
+    display_ok: bool,
+) -> bool {
+    let Some(verifier) = secrets.boot_verifier else {
+        // Unreachable by construction (Verify is planned only for a
+        // provisioned preamble); stay total rather than panic.
+        return false;
+    };
+    let salt = secrets.salt;
+    loop {
+        let tick = crate::exceptions::uptime_ms() / 1000;
+        lock.advance_tick(tick);
+        if let Some(key) = keypad.poll() {
+            match boot_digit(key) {
+                Some(digit) => lock.push_passphrase_byte(digit),
+                None => match key {
+                    crate::ui::Key::Star => lock.backspace_passphrase(),
+                    crate::ui::Key::Hash => {
+                        let mut primary_out = None;
+                        let result = lock.submit_passphrase_with(tick, |entered| {
+                            let primary =
+                                match crate::key_manager::KeyManager::derive_from_passphrase(
+                                    entered, &salt,
+                                ) {
+                                    Ok(p) => p,
+                                    Err(_) => return false,
+                                };
+                            let candidate =
+                                match crate::key_manager::KeyManager::derive_boot_verifier(&primary)
+                                {
+                                    Ok(v) => v,
+                                    Err(_) => return false,
+                                };
+                            let matches =
+                                crate::lock_screen::constant_time_eq(&candidate, &verifier);
+                            if matches {
+                                primary_out = Some(primary);
+                            }
+                            matches
+                        });
+                        match result {
+                            crate::lock_screen::UnlockResult::Success => {
+                                if let Some(primary) = primary_out {
+                                    if key_manager.derive_partition_keys(&primary).is_ok() {
+                                        return true;
+                                    }
+                                }
+                                // A verified passphrase that cannot derive
+                                // partition keys is a crypto fault, not a
+                                // wrong passphrase — fail closed, stay locked.
+                                serial.log(" CRIT Key derivation failed after verify\r\n");
+                                return false;
+                            }
+                            crate::lock_screen::UnlockResult::WipeTrigger => {
+                                serial.log(" CRIT Passphrase attempt limit reached\r\n");
+                                // SAFETY: the panic wipe is the last kernel
+                                // action before halt_boot (which never
+                                // returns); dry_run=false zeroes the usable
+                                // range. key_manager holds no keys on this
+                                // path, so the wipe's key-zeroize is inert.
+                                // The WipeResult is deliberately discarded:
+                                // halt_boot never returns, so there is no
+                                // caller left to report it to.
+                                let _ = unsafe {
+                                    crate::panic_wipe::execute_panic_wipe(
+                                        key_manager,
+                                        crate::exceptions::uptime_ms(),
+                                        false,
+                                    )
+                                };
+                                halt_boot(serial, display_ok);
+                            }
+                            _ => {}
+                        }
+                    }
+                    _ => {}
+                },
+            }
+            lock.draw(&mut fb[..crate::ui::CONTENT_PIXELS]);
+        }
+        // ~10 ms poll cadence. The busy-wait is deliberate: boot is
+        // single-threaded here and the gate is the only outstanding work.
+        let wait_until = crate::exceptions::uptime_ms() + 10;
+        while crate::exceptions::uptime_ms() < wait_until {
+            core::hint::spin_loop();
+        }
+    }
+}
+
+#[cfg(not(feature = "qemu"))]
+/// First-boot setup (#446): enter, confirm, store the PBKDF2-strength
+/// verifier in the preamble, derive keys. Returns `true` once provisioning
+/// completes. There is deliberately no skip binding: dev-anchor builds
+/// never reach this loop (secure_boot_ok is false there), so every
+/// production-signed boot of an unprovisioned device sets a passphrase.
+fn boot_setup_loop(
+    serial: &mut Uart,
+    lock: &mut crate::lock_screen::LockScreen,
+    keypad: &mut crate::keypad::BootKeypad,
+    fb: &mut [u16],
+    preamble_view: &mut crate::block::PartitionBlockDevice<MsdcBlockDevice>,
+    key_manager: &mut crate::key_manager::KeyManager,
+) -> bool {
+    serial.log(" Set boot passphrase (6+ digits; Star backspace; Hash confirm)\r\n");
+    let mut confirming = false;
+    let mut first = [0u8; crate::lock_screen::MAX_PASSPHRASE_LEN];
+    let mut first_len = 0usize;
+    loop {
+        let tick = crate::exceptions::uptime_ms() / 1000;
+        lock.advance_tick(tick);
+        if let Some(key) = keypad.poll() {
+            match boot_digit(key) {
+                Some(digit) => lock.push_passphrase_byte(digit),
+                None => match key {
+                    crate::ui::Key::Star => lock.backspace_passphrase(),
+                    crate::ui::Key::Hash => {
+                        let entered_len = lock.passphrase_len() as usize;
+                        if !confirming {
+                            if entered_len >= crate::kinit_plan::MIN_BOOT_PASSPHRASE_LEN as usize {
+                                first[..entered_len].copy_from_slice(lock.passphrase_bytes());
+                                first_len = entered_len;
+                                lock.clear_passphrase();
+                                confirming = true;
+                                serial.log(" Confirm passphrase\r\n");
+                            } else {
+                                serial.log(" Passphrase too short (6+ digits)\r\n");
+                            }
+                        } else {
+                            let matches = entered_len == first_len
+                                && lock.passphrase_bytes() == &first[..first_len];
+                            if !matches {
+                                serial.log(" Mismatch -- start over\r\n");
+                                lock.clear_passphrase();
+                                confirming = false;
+                                crate::key_manager::volatile_zero(&mut first);
+                                first_len = 0;
+                            } else {
+                                let mut salt = [0u8; crate::secrets::SALT_LEN];
+                                if crate::csprng::kernel_random_bytes(&mut salt).is_err() {
+                                    serial.log(" CRIT CSPRNG unavailable -- cannot provision\r\n");
+                                    crate::key_manager::volatile_zero(&mut first);
+                                    return false;
+                                }
+                                let mut ok = false;
+                                if let Ok(primary) =
+                                    crate::key_manager::KeyManager::derive_from_passphrase(
+                                        lock.passphrase_bytes(),
+                                        &salt,
+                                    )
+                                {
+                                    if let Ok(verifier) =
+                                        crate::key_manager::KeyManager::derive_boot_verifier(
+                                            &primary,
+                                        )
+                                    {
+                                        if crate::secrets::store_boot_verifier(
+                                            preamble_view,
+                                            &salt,
+                                            &verifier,
+                                        )
+                                        .is_ok()
+                                            && key_manager.derive_partition_keys(&primary).is_ok()
+                                        {
+                                            ok = true;
+                                        }
+                                    }
+                                }
+                                lock.clear_passphrase();
+                                crate::key_manager::volatile_zero(&mut first);
+                                if ok {
+                                    serial.log(" Passphrase set -- userdata encrypted\r\n");
+                                    return true;
+                                }
+                                serial.log(" CRIT Provisioning failed (derive/store)\r\n");
+                                return false;
+                            }
+                        }
+                    }
+                    _ => {}
+                },
+            }
+            lock.draw(&mut fb[..crate::ui::CONTENT_PIXELS]);
+        }
+        // Same deliberate busy-wait cadence as the verify loop.
+        let wait_until = crate::exceptions::uptime_ms() + 10;
+        while crate::exceptions::uptime_ms() < wait_until {
+            core::hint::spin_loop();
+        }
+    }
+}
+
 /// the halt is a stable, visible state instead of a WDT reboot loop.
 ///
 /// WHY(qemu): exit code 6 (distinct from 0=ok / 1=panic / 5=loop-stall) so
@@ -203,9 +462,8 @@ fn debug_console_gate(serial: &mut Uart, mode_mgr: &crate::security_mode::ModeMa
 
     // WARNING (defense-in-depth): refuse to start under Sentinel/Panic.
     // NOTE: `mode_mgr` is freshly `ModeManager::default()`-constructed at
-    // Step 8g and nothing between there and here transitions it, so this
-    // currently always evaluates to Daily -- see the Step 8f WHY comment
-    // above. Kept as the structural check point so it becomes load-bearing
+    // Step 8f and nothing between there and here transitions it, so this
+    // currently always evaluates to Daily -- see the Step 8f WHY comment. Kept as the structural check point so it becomes load-bearing
     // the moment mode state is threaded through boot instead of re-derived
     // fresh every time (e.g. a mode persisted across a warm restart).
     if mode_mgr.mode() != crate::security_mode::SecurityMode::Daily {
@@ -592,7 +850,157 @@ pub unsafe fn run() -> ! {
     }
 
     // -----------------------------------------------------------------------
-    // Step 8c: Filesystem (LFS) -- trust-gated (#217)
+    // Step 8c: Passphrase entry and key derivation (#446)
+    // -----------------------------------------------------------------------
+    serial.log("[init] Passphrase entry\r\n");
+    // WHY before any mount (#446): once first-boot setup stores a verifier,
+    // the userdata payload is ciphertext (AES-XTS under the derived data
+    // key) — the mount needs the key, and a locked payload must never be
+    // plain-mounted or formatted. The secrets preamble (#449) is therefore
+    // probed here, READ-ONLY and ahead of the mount, and the mount plan
+    // keys off what it found.
+    //
+    // WHY the trust gate is checked first (#217): key derivation must never
+    // run on an unverified image — a tampered kernel could exfiltrate the
+    // passphrase.
+    //
+    // Boot pad binding (the 4x3 matrix yields only digits/Star/Hash):
+    // digits append, Star = backspace, Hash = submit/confirm. First-boot
+    // setup constrains the alphabet identically, so a passphrase set at
+    // setup is always enterable at boot.
+    #[cfg_attr(feature = "qemu", allow(unused_mut, unused_variables))]
+    let mut key_manager = crate::key_manager::KeyManager::new();
+    #[cfg(not(feature = "qemu"))]
+    let mut boot_secrets: Option<crate::secrets::DeviceSecrets> = None;
+    #[cfg(not(feature = "qemu"))]
+    let mut preamble_view: Option<crate::block::PartitionBlockDevice<MsdcBlockDevice>> = None;
+    #[cfg(not(feature = "qemu"))]
+    {
+        use crate::kinit_plan::PreambleLoad;
+
+        // Early read-only preamble probe — the mount gate's fail-closed
+        // signal. Runs whenever eMMC is up, independent of the trust gate,
+        // and NEVER writes here: the provisioning write happens only inside
+        // the first-boot setup completion below.
+        if state.emmc_ok {
+            let mut preamble_phys =
+                MsdcBlockDevice::new(board::LFS_PARTITION_START + board::LFS_PARTITION_SIZE);
+            // SAFETY: eMMC init succeeded in Step 7; init() is called once
+            // here on a freshly constructed MsdcBlockDevice.
+            match unsafe { preamble_phys.init() } {
+                Ok(()) => {
+                    let mut view = crate::block::PartitionBlockDevice::new(
+                        preamble_phys,
+                        board::LFS_PARTITION_START,
+                        board::LFS_PREAMBLE_SECTORS,
+                    );
+                    match crate::secrets::load(&mut view) {
+                        Ok(Some(found)) => {
+                            state.preamble = if found.boot_verifier.is_some() {
+                                PreambleLoad::Provisioned
+                            } else {
+                                PreambleLoad::Unprovisioned
+                            };
+                            boot_secrets = Some(found);
+                        }
+                        Ok(None) => state.preamble = PreambleLoad::Unprovisioned,
+                        Err(e) => {
+                            boot_log!(serial, " WARN Secrets preamble read failed: {:?}\r\n", e);
+                            state.preamble = PreambleLoad::ReadFailed;
+                        }
+                    }
+                    preamble_view = Some(view);
+                }
+                Err(e) => {
+                    boot_log!(serial, " WARN Preamble device init failed: {:?}\r\n", e);
+                    state.preamble = PreambleLoad::ReadFailed;
+                }
+            }
+        }
+    }
+
+    match crate::kinit_plan::boot_passphrase_plan(
+        state.secure_boot_ok,
+        state.display_ok,
+        state.input_ok,
+        state.preamble,
+    ) {
+        crate::kinit_plan::BootPassphrasePlan::Skip => {
+            serial.log(crate::kinit_plan::passphrase_skip_reason(
+                state.secure_boot_ok,
+                state.display_ok,
+                state.input_ok,
+            ));
+        }
+        #[cfg(not(feature = "qemu"))]
+        crate::kinit_plan::BootPassphrasePlan::Verify => {
+            if let Some(found) = boot_secrets.as_ref() {
+                // SAFETY: the plan guarantees display_ok, and the display
+                // init mapped FB_BASE as a writable RGB565 framebuffer of
+                // FRAMEBUFFER_PIXELS pixels. The slice is dropped at the
+                // end of this arm, before the kardia handoff re-derives
+                // its own framebuffer slice.
+                let fb = unsafe {
+                    core::slice::from_raw_parts_mut(board::FB_BASE as *mut u16, FRAMEBUFFER_PIXELS)
+                };
+                fb.fill(0);
+                let mut keypad = crate::keypad::BootKeypad::new();
+                keypad.init();
+                // WHY zero hashes: the boot gate never uses the raw
+                // SHA-256 compare — submit goes through
+                // submit_passphrase_with at PBKDF2 strength, so the
+                // stored-hash fields are inert in this construction.
+                let mut lock = crate::lock_screen::LockScreen::new([0u8; 32], [0u8; 32], [0u8; 32]);
+                if boot_verify_loop(
+                    &mut serial,
+                    &mut lock,
+                    &mut keypad,
+                    fb,
+                    found,
+                    &mut key_manager,
+                    state.display_ok,
+                ) {
+                    state.passphrase_ok = true;
+                    serial.log(" Passphrase: OK (keys derived)\r\n");
+                }
+            }
+        }
+        #[cfg(not(feature = "qemu"))]
+        crate::kinit_plan::BootPassphrasePlan::FirstBootSetup => {
+            if let Some(view) = preamble_view.as_mut() {
+                // SAFETY: as above — the plan guarantees display_ok.
+                let fb = unsafe {
+                    core::slice::from_raw_parts_mut(board::FB_BASE as *mut u16, FRAMEBUFFER_PIXELS)
+                };
+                fb.fill(0);
+                let mut keypad = crate::keypad::BootKeypad::new();
+                keypad.init();
+                let mut lock = crate::lock_screen::LockScreen::new([0u8; 32], [0u8; 32], [0u8; 32]);
+                if boot_setup_loop(
+                    &mut serial,
+                    &mut lock,
+                    &mut keypad,
+                    fb,
+                    view,
+                    &mut key_manager,
+                ) {
+                    state.passphrase_ok = true;
+                    state.preamble = crate::kinit_plan::PreambleLoad::Provisioned;
+                    serial.log(" Passphrase: SET (userdata encrypted)\r\n");
+                }
+            }
+        }
+        #[cfg(feature = "qemu")]
+        _ => {
+            // Virt never establishes trust (dev anchor, no boot medium), so
+            // the plan is always Skip on this board; the interactive arms'
+            // hardware paths are M7-only.
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Step 8d: Filesystem (LFS) -- trust-gated (#217), fail-closed on a
+    // locked payload (#446)
     // -----------------------------------------------------------------------
     serial.log("[init] Filesystem (LFS)\r\n");
     // Captures the mounted LFS so it can back the VFS root below instead
@@ -600,127 +1008,224 @@ pub unsafe fn run() -> ! {
     // does not end with a durably mounted filesystem.
     #[cfg_attr(feature = "qemu", allow(unused_mut))]
     let mut lfs_root: Option<alloc::boxed::Box<dyn crate::vfs::Filesystem>> = None;
-    // WHY (#217): persistent storage mounts ONLY on a verified boot --
-    // secure_boot.rs's contract is that the filesystem mounts AFTER the
-    // trust gate so a tampered kernel cannot reach encrypted data. A
-    // verification FAILURE has already halted above; this gate covers the
-    // no-boot-medium degrade, where nothing persistent may be touched.
+    // WHY (#217): persistent storage mounts ONLY on a verified boot -- a
+    // tampered kernel must never reach user data. WHY fail-closed on a
+    // provisioned-or-unreadable preamble (#446): the payload is ciphertext
+    // under a key this boot does not have — plain-mounting it reads garbage
+    // and the InvalidSuperblock reformat path would DESTROY it, so the only
+    // honest mount without the derived key is none.
     // WHY not(qemu): the mount path is eMMC + LFS-partition bring-up, which
     // exists only on the M7 (#534) -- virt models no block medium, so
     // `lfs_root` stays None there exactly as the runtime gate already
-    // produced, and the VFS root falls back to ramfs.
+    // produced, and the VFS root falls back to the initramfs.
     #[cfg(not(feature = "qemu"))]
-    if state.emmc_ok && state.secure_boot_ok {
-        use crate::block::MsdcBlockDevice;
-        use crate::lfs;
-        use crate::lfs_imap::LfsError;
+    match crate::kinit_plan::mount_plan(
+        state.emmc_ok,
+        state.secure_boot_ok,
+        state.preamble,
+        state.passphrase_ok,
+    ) {
+        crate::kinit_plan::MountPlan::Encrypted => {
+            use crate::lfs;
+            use crate::lfs_imap::LfsError;
 
-        // Compute device size in sectors from the partition constants.
-        let sector_count = board::LFS_PARTITION_SIZE;
-
-        // #603: the eMMC block device addresses the PHYSICAL medium (its LBA
-        // 0 is the eMMC's sector 0 -- the GPT/boot region), so its bound is
-        // the partition's END; the LFS mount then runs inside the userdata
-        // partition VIEW carved at LFS_PARTITION_START. Before the view, LFS
-        // would have formatted over the boot/vendor partitions.
-        let mut phys_dev = MsdcBlockDevice::new(board::LFS_PARTITION_START + sector_count);
-
-        // SAFETY: eMMC controller was initialized successfully in Step 7.
-        // MsdcBlockDevice::init() is called once here; the controller is ready.
-        match unsafe { phys_dev.init() } {
-            Ok(()) => {
-                let blk_dev = crate::block::PartitionBlockDevice::new(
-                    phys_dev,
-                    board::LFS_PARTITION_START,
-                    sector_count,
-                );
-                // Try to mount existing LFS.
-                match lfs::mount(alloc::boxed::Box::new(blk_dev)) {
-                    Ok(fs) => {
-                        serial.log(" LFS mounted OK\r\n");
-                        lfs_root = Some(alloc::boxed::Box::new(fs));
-                    }
-                    // A missing/invalid superblock means a genuine first
-                    // boot (or a never-formatted partition) -- format and
-                    // remount. Any OTHER error (Corrupt, BlockIo) is NOT
-                    // first boot and must not trigger a reformat: that
-                    // would silently destroy user data on a bit flip or a
-                    // transient I/O fault (#360).
-                    Err(LfsError::InvalidSuperblock) => {
-                        serial.log(" LFS mount failed (no superblock), formatting\r\n");
-                        let mut fmt_phys =
-                            MsdcBlockDevice::new(board::LFS_PARTITION_START + sector_count);
-                        // SAFETY: eMMC controller was initialized successfully in
-                        // Step 7; fmt_phys.init() is called once here on a
-                        // freshly constructed MsdcBlockDevice.
-                        if unsafe { fmt_phys.init() }.is_ok() {
-                            let mut fmt_dev = crate::block::PartitionBlockDevice::new(
-                                fmt_phys,
-                                board::LFS_PARTITION_START,
-                                sector_count,
-                            );
-                            if lfs::format(&mut fmt_dev).is_ok() {
-                                serial.log(" LFS formatted OK\r\n");
-                                // Remount the freshly formatted device so the
-                                // VFS root is backed by durable storage from
-                                // this boot onward, not just after the NEXT
-                                // reboot (#343).
-                                let mut remount_phys =
-                                    MsdcBlockDevice::new(board::LFS_PARTITION_START + sector_count);
-                                // SAFETY: eMMC controller was initialized successfully
-                                // in Step 7; remount_phys.init() is called once here on
-                                // a freshly constructed MsdcBlockDevice.
-                                match unsafe { remount_phys.init() } {
-                                    Ok(()) => {
-                                        let remount_dev = crate::block::PartitionBlockDevice::new(
-                                            remount_phys,
-                                            board::LFS_PARTITION_START,
-                                            sector_count,
-                                        );
-                                        match lfs::mount(alloc::boxed::Box::new(remount_dev)) {
-                                            Ok(fs) => {
-                                                serial.log(" LFS remounted OK\r\n");
-                                                lfs_root = Some(alloc::boxed::Box::new(fs));
-                                            }
-                                            Err(e) => {
-                                                boot_log!(
-                                                    serial,
-                                                    " WARN LFS remount after format failed: {:?}\r\n",
-                                                    e
-                                                );
-                                            }
-                                        }
-                                    }
-                                    Err(e) => {
-                                        boot_log!(
-                                            serial,
-                                            " WARN Block device re-init for remount failed: {:?}\r\n",
-                                            e
-                                        );
-                                    }
-                                }
-                            } else {
-                                serial.log(" WARN LFS format failed\r\n");
+            let data_key = key_manager.data_key().map(|k| *k.as_bytes());
+            match data_key {
+                Some(mut data_key) => {
+                    match encrypted_payload_device(&data_key) {
+                        Some(enc) => match lfs::mount(alloc::boxed::Box::new(enc)) {
+                            Ok(fs) => {
+                                serial.log(" LFS mounted (encrypted)\r\n");
+                                lfs_root = Some(alloc::boxed::Box::new(fs));
+                                state.encryption_ok = true;
                             }
-                        }
+                            // A missing/invalid superblock on the encrypted
+                            // view means the payload was never formatted
+                            // encrypted (the first boot after provisioning) —
+                            // format and remount. Any OTHER error (Corrupt,
+                            // BlockIo) must not trigger a reformat: that
+                            // would silently destroy user data (#360), the
+                            // same rule as the plain path.
+                            Err(LfsError::InvalidSuperblock) => {
+                                serial.log(" Encrypted LFS unformatted, formatting\r\n");
+                                if let Some(mut fmt_enc) = encrypted_payload_device(&data_key) {
+                                    if lfs::format(&mut fmt_enc).is_ok() {
+                                        serial.log(" Encrypted LFS formatted\r\n");
+                                        match encrypted_payload_device(&data_key) {
+                                            Some(remount_enc) => {
+                                                match lfs::mount(alloc::boxed::Box::new(
+                                                    remount_enc,
+                                                )) {
+                                                    Ok(fs) => {
+                                                        serial
+                                                            .log(" LFS remounted (encrypted)\r\n");
+                                                        lfs_root = Some(alloc::boxed::Box::new(fs));
+                                                        state.encryption_ok = true;
+                                                    }
+                                                    Err(e) => {
+                                                        boot_log!(
+                                                            serial,
+                                                            " WARN Encrypted LFS remount failed: {:?}\r\n",
+                                                            e
+                                                        );
+                                                    }
+                                                }
+                                            }
+                                            None => serial
+                                                .log(" WARN Device re-init for remount failed\r\n"),
+                                        }
+                                    } else {
+                                        serial.log(" WARN Encrypted LFS format failed\r\n");
+                                    }
+                                } else {
+                                    serial.log(" WARN Device init for format failed\r\n");
+                                }
+                            }
+                            Err(e) => {
+                                boot_log!(
+                                    serial,
+                                    " CRIT Encrypted LFS mount failed ({:?}) -- not reformatting, data at risk\r\n",
+                                    e
+                                );
+                            }
+                        },
+                        None => serial.log(" WARN Device init failed (encrypted payload)\r\n"),
                     }
-                    Err(e) => {
-                        boot_log!(
-                            serial,
-                            " CRIT LFS mount failed ({:?}) -- not reformatting, data at risk\r\n",
-                            e
-                        );
-                    }
+                    // WHY: EncryptedBlockDevice::new copied the key into its
+                    // own SecureKey; zero this stack copy on every path (#325
+                    // posture).
+                    crate::key_manager::volatile_zero(&mut data_key);
+                }
+                None => {
+                    // passphrase_ok implies loaded keys; a missing data key
+                    // here is a bug — fail closed (no mount), never panic.
+                    serial.log(" CRIT passphrase_ok without a data key\r\n");
                 }
             }
-            Err(e) => {
-                boot_log!(serial, " WARN Block device init failed: {:?}\r\n", e);
+        }
+        crate::kinit_plan::MountPlan::Plain => {
+            use crate::lfs;
+            use crate::lfs_imap::LfsError;
+
+            // Compute device size in sectors from the partition constants.
+            let sector_count = board::LFS_PARTITION_SIZE;
+
+            // #603: the eMMC block device addresses the PHYSICAL medium (its LBA
+            // 0 is the eMMC's sector 0 -- the GPT/boot region), so its bound is
+            // the partition's END; the LFS mount then runs inside the userdata
+            // partition VIEW carved at LFS_PARTITION_START. Before the view, LFS
+            // would have formatted over the boot/vendor partitions.
+            //
+            // WHY the plain mount is still at the partition head: this arm is
+            // reachable only on an UNPROVISIONED device (no preamble), so no
+            // plaintext sector has been carved — byte-compatible with pre-#446
+            // images.
+            let mut phys_dev = MsdcBlockDevice::new(board::LFS_PARTITION_START + sector_count);
+
+            // SAFETY: eMMC controller was initialized successfully in Step 7.
+            // MsdcBlockDevice::init() is called once here; the controller is ready.
+            match unsafe { phys_dev.init() } {
+                Ok(()) => {
+                    let blk_dev = crate::block::PartitionBlockDevice::new(
+                        phys_dev,
+                        board::LFS_PARTITION_START,
+                        sector_count,
+                    );
+                    // Try to mount existing LFS.
+                    match lfs::mount(alloc::boxed::Box::new(blk_dev)) {
+                        Ok(fs) => {
+                            serial.log(" LFS mounted OK\r\n");
+                            lfs_root = Some(alloc::boxed::Box::new(fs));
+                        }
+                        // A missing/invalid superblock means a genuine first
+                        // boot (or a never-formatted partition) -- format and
+                        // remount. Any OTHER error (Corrupt, BlockIo) is NOT
+                        // first boot and must not trigger a reformat: that
+                        // would silently destroy user data on a bit flip or a
+                        // transient I/O fault (#360).
+                        Err(LfsError::InvalidSuperblock) => {
+                            serial.log(" LFS mount failed (no superblock), formatting\r\n");
+                            let mut fmt_phys =
+                                MsdcBlockDevice::new(board::LFS_PARTITION_START + sector_count);
+                            // SAFETY: eMMC controller was initialized successfully in
+                            // Step 7; fmt_phys.init() is called once here on a
+                            // freshly constructed MsdcBlockDevice.
+                            if unsafe { fmt_phys.init() }.is_ok() {
+                                let mut fmt_dev = crate::block::PartitionBlockDevice::new(
+                                    fmt_phys,
+                                    board::LFS_PARTITION_START,
+                                    sector_count,
+                                );
+                                if lfs::format(&mut fmt_dev).is_ok() {
+                                    serial.log(" LFS formatted OK\r\n");
+                                    // Remount the freshly formatted device so the
+                                    // VFS root is backed by durable storage from
+                                    // this boot onward, not just after the NEXT
+                                    // reboot (#343).
+                                    let mut remount_phys = MsdcBlockDevice::new(
+                                        board::LFS_PARTITION_START + sector_count,
+                                    );
+                                    // SAFETY: eMMC controller was initialized successfully
+                                    // in Step 7; remount_phys.init() is called once here on
+                                    // a freshly constructed MsdcBlockDevice.
+                                    match unsafe { remount_phys.init() } {
+                                        Ok(()) => {
+                                            let remount_dev =
+                                                crate::block::PartitionBlockDevice::new(
+                                                    remount_phys,
+                                                    board::LFS_PARTITION_START,
+                                                    sector_count,
+                                                );
+                                            match lfs::mount(alloc::boxed::Box::new(remount_dev)) {
+                                                Ok(fs) => {
+                                                    serial.log(" LFS remounted OK\r\n");
+                                                    lfs_root = Some(alloc::boxed::Box::new(fs));
+                                                }
+                                                Err(e) => {
+                                                    boot_log!(
+                                                        serial,
+                                                        " WARN LFS remount after format failed: {:?}\r\n",
+                                                        e
+                                                    );
+                                                }
+                                            }
+                                        }
+                                        Err(e) => {
+                                            boot_log!(
+                                                serial,
+                                                " WARN Block device re-init for remount failed: {:?}\r\n",
+                                                e
+                                            );
+                                        }
+                                    }
+                                } else {
+                                    serial.log(" WARN LFS format failed\r\n");
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            boot_log!(
+                                serial,
+                                " CRIT LFS mount failed ({:?}) -- not reformatting, data at risk\r\n",
+                                e
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    boot_log!(serial, " WARN Block device init failed: {:?}\r\n", e);
+                }
             }
         }
-    } else if state.emmc_ok {
-        serial.log(" Skipped (secure boot not established -- fail-closed)\r\n");
-    } else {
-        serial.log(" Skipped (no eMMC)\r\n");
+        crate::kinit_plan::MountPlan::RamfsFallback => {
+            if state.emmc_ok && state.secure_boot_ok {
+                serial.log(" Skipped (payload locked or unreadable -- fail-closed)\r\n");
+            } else if state.emmc_ok {
+                serial.log(" Skipped (secure boot not established -- fail-closed)\r\n");
+            } else {
+                serial.log(" Skipped (no eMMC)\r\n");
+            }
+        }
     }
 
     // Initialize the VFS mount table, backed by the mounted LFS when one
@@ -746,56 +1251,7 @@ pub unsafe fn run() -> ! {
     }
 
     // -----------------------------------------------------------------------
-    // Step 8d: Passphrase entry and key derivation
-    // -----------------------------------------------------------------------
-    serial.log("[init] Passphrase entry\r\n");
-    // WHY (#217, fail-closed): key derivation must never run on an
-    // unverified image -- a tampered kernel could exfiltrate the
-    // passphrase. The trust root is checked FIRST, before hardware
-    // availability.
-    if !state.secure_boot_ok {
-        serial
-            .log(" WARN Passphrase entry refused (secure boot not established -- fail-closed)\r\n");
-    } else if state.display_ok && state.input_ok {
-        // WHY: passphrase must be entered before any encrypted data is
-        // accessed.  The lock screen renders on the display and accepts
-        // keypad input.  On success, the primary key is derived and
-        // partition sub-keys are produced.
-        //
-        // NOTE: In production, this blocks until the user enters the
-        // correct passphrase.  The lock screen is shown via
-        // crate::lock_screen::LockScreen and the result feeds into
-        // key_manager::derive_from_passphrase() with the per-device salt
-        // from crate::secrets' on-disk preamble (#449).  Placeholder here
-        // until the boot-time input loop is wired.
-        serial.log(" Passphrase: PENDING (awaiting boot input loop)\r\n");
-    } else {
-        serial.log(" WARN Passphrase entry skipped (no display/input)\r\n");
-    }
-
-    // -----------------------------------------------------------------------
-    // Step 8e: Encrypted filesystem mount
-    // -----------------------------------------------------------------------
-    serial.log("[init] Encrypted filesystem\r\n");
-    // WHY (#217, defense-in-depth): passphrase_ok is already unreachable
-    // without secure_boot_ok (Step 8d), but the decrypt gate re-checks the
-    // trust root explicitly so a future refactor of passphrase entry cannot
-    // silently reopen it.
-    if state.secure_boot_ok && state.passphrase_ok && state.emmc_ok {
-        // WHY: after passphrase derives the data key, wrap the eMMC block
-        // device in EncryptedBlockDevice for transparent AES-XTS encryption.
-        //
-        // NOTE: In production:
-        // let data_key = key_manager.data_key().as_bytes().clone();
-        // let enc_dev = EncryptedBlockDevice::new(&mut blk_dev, data_key);
-        // lfs::mount(Box::new(enc_dev));
-        serial.log(" Encryption: PENDING (awaiting key derivation)\r\n");
-    } else {
-        serial.log(" WARN Encrypted mount skipped (no passphrase/eMMC)\r\n");
-    }
-
-    // -----------------------------------------------------------------------
-    // Step 8f: Audit log initialization
+    // Step 8e: Audit log initialization
     // -----------------------------------------------------------------------
     serial.log("[init] Audit log\r\n");
     if state.secure_boot_ok {
@@ -813,7 +1269,7 @@ pub unsafe fn run() -> ! {
     }
 
     // -----------------------------------------------------------------------
-    // Step 8g: Security mode manager
+    // Step 8f: Security mode manager
     // -----------------------------------------------------------------------
     serial.log("[init] Security mode (Daily)\r\n");
     let mut pm = PowerManager::new();
@@ -831,8 +1287,9 @@ pub unsafe fn run() -> ! {
         // its all-Off default the whole time radios were live (a
         // policy/reality mismatch for any later mode-transition or
         // threat-response code that reads PowerManager state as ground
-        // truth). A full passphrase-derived pin_hash is not available yet
-        // (Step 8d is pending the boot input loop -- finding 48), so
+        // truth). A full passphrase-derived pin_hash is not threaded
+        // through yet (Step 8c derives the keys; the mode manager's
+        // pin-hash provisioning is separate work), so
         // ModeManager::default() is used: unprovisioned, but still Daily
         // mode, which is the correct policy to apply at this point.
         //
@@ -1393,7 +1850,7 @@ pub unsafe fn run() -> ! {
         None
     };
     // #403: interim SESSION audit key -- CSPRNG-seeded, volatile (RAM-only,
-    // zeroized on drop). The persistent, passphrase-derived audit key (Step 8f)
+    // zeroized on drop). The persistent, passphrase-derived audit key (Step 8e)
     // stays PENDING/deferred; this key derives nothing and unlocks nothing -- it
     // only gives the loop-owned firewall audit chain HMAC integrity for THIS
     // boot. Fails closed: an all-zero key (CSPRNG unavailable) makes log_event

--- a/crates/thumos/src/kinit_plan.rs
+++ b/crates/thumos/src/kinit_plan.rs
@@ -59,32 +59,34 @@ pub(crate) enum BootStep {
     GpioInput = 9,
     /// Measured boot signature verification (Ed25519).
     SecureBoot = 10,
-    /// Filesystem (LFS on eMMC) -- trust-gated on SecureBoot (#217).
-    Filesystem = 11,
-    /// Passphrase entry and key derivation.
-    Passphrase = 12,
-    /// Encrypted filesystem mount.
-    Encryption = 13,
+    /// Passphrase entry and key derivation (#446: runs BEFORE any mount —
+    /// once provisioned, the payload is ciphertext and only the derived
+    /// key opens it).
+    Passphrase = 11,
+    /// Filesystem mount — plain (unprovisioned) or wrapped in
+    /// `EncryptedBlockDevice` (derived data key). Trust-gated on
+    /// SecureBoot (#217); a locked payload is never plain-mounted (#446).
+    Filesystem = 12,
     /// Tamper-evident audit log initialization.
-    AuditLog = 14,
+    AuditLog = 13,
     /// Security mode manager (Daily/Sentinel/Panic).
-    SecurityMode = 15,
+    SecurityMode = 14,
     /// USB ACM serial console.
-    UsbSerial = 16,
+    UsbSerial = 15,
     /// CCCI modem link.
-    CcciModem = 17,
+    CcciModem = 16,
     /// Power manager.
-    PowerManager = 18,
+    PowerManager = 17,
     /// Network configuration (DHCP + DNS resolver).
-    Network = 19,
+    Network = 18,
     /// Bluetooth adapter initialization.
-    Bluetooth = 20,
+    Bluetooth = 19,
     /// GPS receiver initialization.
-    Gps = 21,
+    Gps = 20,
     /// Userspace process spawn attempted.
-    Userspace = 22,
+    Userspace = 21,
     /// Boot complete.
-    Complete = 23,
+    Complete = 22,
 }
 
 // WHY cfg_attr(not(test)): see the enum above -- the expectation applies to
@@ -98,7 +100,7 @@ pub(crate) enum BootStep {
 )]
 impl BootStep {
     /// Total number of boot steps.
-    pub(crate) const COUNT: usize = 24;
+    pub(crate) const COUNT: usize = 23;
 
     /// Returns true if `self` depends on `other` (i.e., `other` must
     /// be attempted before `self`).
@@ -110,6 +112,123 @@ impl BootStep {
 // ---------------------------------------------------------------------------
 // Boot state tracker
 // ---------------------------------------------------------------------------
+
+/// What the early read of the on-disk secrets preamble (#449) found (#446).
+///
+/// The read runs right after eMMC bring-up, BEFORE any mount, so the mount
+/// gate can never mistake a locked payload for an absent one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PreambleLoad {
+    /// The read has not run yet (no eMMC, or the step was not reached).
+    NotRead,
+    /// Header absent/corrupt: no salt, no verifier — the device has never
+    /// set a boot passphrase. First-boot setup may provision it.
+    Unprovisioned,
+    /// A valid header carrying a boot passphrase verifier.
+    Provisioned,
+    /// The read itself failed (I/O). Fail-closed: the payload state is
+    /// UNKNOWN, so it is treated as locked.
+    ReadFailed,
+}
+
+/// What the boot passphrase step does (#446).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BootPassphrasePlan {
+    /// Verify loop: prompt, verify against the stored verifier at PBKDF2
+    /// strength, derive keys on success.
+    Verify,
+    /// No verifier stored: first-boot setup (enter, confirm, store the
+    /// verifier, derive keys).
+    FirstBootSetup,
+    /// Passphrase entry does not run this boot (degraded path).
+    Skip,
+}
+
+/// Decide the boot passphrase step. Pure logic (#528 seam): kinit executes.
+///
+/// Fail-closed ordering (#217): the trust root is checked FIRST — key
+/// derivation never runs on an unverified image. A preamble that was not
+/// read or could not be read never falls into setup: a transient fault
+/// must not masquerade as first boot.
+pub(crate) const fn boot_passphrase_plan(
+    secure_boot_ok: bool,
+    display_ok: bool,
+    input_ok: bool,
+    preamble: PreambleLoad,
+) -> BootPassphrasePlan {
+    if !secure_boot_ok || !display_ok || !input_ok {
+        return BootPassphrasePlan::Skip;
+    }
+    match preamble {
+        PreambleLoad::Provisioned => BootPassphrasePlan::Verify,
+        PreambleLoad::Unprovisioned => BootPassphrasePlan::FirstBootSetup,
+        PreambleLoad::NotRead | PreambleLoad::ReadFailed => BootPassphrasePlan::Skip,
+    }
+}
+
+/// How the userdata payload mounts (#446).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MountPlan {
+    /// Wrap the payload view in `EncryptedBlockDevice` with the derived
+    /// data key; LFS mounts one sector past the preamble.
+    Encrypted,
+    /// Unprovisioned device: the plain LFS mount at the partition head
+    /// (the dev/transition path, byte-compatible with pre-#446 images).
+    Plain,
+    /// No persistent mount; the VFS root falls back to the initramfs.
+    RamfsFallback,
+}
+
+/// Decide the userdata mount. Fail-closed invariants:
+/// - no eMMC or no verified boot: nothing persistent mounts (the #217 gate
+///   today's code already enforces);
+/// - a provisioned (locked) payload is NEVER plain-mounted or formatted —
+///   without the derived key the only honest mount is none;
+/// - an unreadable preamble is treated as provisioned (unknown = locked).
+pub(crate) const fn mount_plan(
+    emmc_ok: bool,
+    secure_boot_ok: bool,
+    preamble: PreambleLoad,
+    passphrase_ok: bool,
+) -> MountPlan {
+    if !emmc_ok || !secure_boot_ok {
+        return MountPlan::RamfsFallback;
+    }
+    if passphrase_ok {
+        return MountPlan::Encrypted;
+    }
+    match preamble {
+        PreambleLoad::Unprovisioned => MountPlan::Plain,
+        PreambleLoad::Provisioned | PreambleLoad::ReadFailed | PreambleLoad::NotRead => {
+            MountPlan::RamfsFallback
+        }
+    }
+}
+
+/// Minimum boot passphrase length (digits) accepted at first-boot setup
+/// (#446). The boot pad alphabet is digits-only (Star/Hash are the
+/// backspace/submit control keys), so this floor is the brute-force
+/// margin alongside PBKDF2-100k, throttle escalation, and the 10-attempt
+/// wipe; it matches the PIN posture (`REQUIRED_PIN_LEN`).
+pub(crate) const MIN_BOOT_PASSPHRASE_LEN: u8 = 6;
+
+/// The boot-log line for a skipped passphrase step (#446) — one source for
+/// the M7 and QEMU arms. The QEMU boot witness greps the refusal wording
+/// verbatim (`Passphrase entry refused`), so these strings are a contract,
+/// not flavor.
+pub(crate) const fn passphrase_skip_reason(
+    secure_boot_ok: bool,
+    display_ok: bool,
+    input_ok: bool,
+) -> &'static str {
+    if !secure_boot_ok {
+        " WARN Passphrase entry refused (secure boot not established -- fail-closed)\r\n"
+    } else if !display_ok || !input_ok {
+        " WARN Passphrase entry skipped (no display/input)\r\n"
+    } else {
+        " WARN Passphrase entry skipped (preamble unreadable)\r\n"
+    }
+}
 
 /// Tracks which subsystems initialized successfully during boot.
 /// The panic handler and degradation logic read this to decide what
@@ -126,6 +245,10 @@ pub(crate) struct BootState {
     pub(crate) display_ok: bool,
     pub(crate) secure_boot_ok: bool,
     pub(crate) passphrase_ok: bool,
+    /// What the early secrets-preamble read found (#446) — the mount
+    /// gate's fail-closed signal. Not an ok-flag: excluded from
+    /// `ok_count`/`total_subsystems` (it is not a subsystem).
+    pub(crate) preamble: PreambleLoad,
     pub(crate) encryption_ok: bool,
     pub(crate) audit_ok: bool,
     pub(crate) security_mode_ok: bool,
@@ -154,6 +277,7 @@ impl BootState {
             display_ok: false,
             secure_boot_ok: false,
             passphrase_ok: false,
+            preamble: PreambleLoad::NotRead,
             encryption_ok: false,
             audit_ok: false,
             security_mode_ok: false,
@@ -375,7 +499,7 @@ mod tests {
     fn boot_step_count_matches_variants() {
         assert_eq!(
             BootStep::COUNT,
-            24,
+            23,
             "BootStep::COUNT must match the number of variants"
         );
     }
@@ -429,8 +553,13 @@ mod tests {
     fn boot_step_complete_is_last() {
         assert_eq!(
             BootStep::Complete as u8,
-            23,
+            22,
             "Complete must be the highest-numbered step"
+        );
+        assert_eq!(
+            BootStep::COUNT,
+            23,
+            "COUNT tracks the enum (#446 folded Encryption into Filesystem)"
         );
     }
 
@@ -675,20 +804,16 @@ mod tests {
             "SecureBoot must run after Display (errors need display)"
         );
         assert!(
-            BootStep::Filesystem.depends_on(BootStep::SecureBoot),
-            "Filesystem mount must run after SecureBoot (#217: a tampered image must never reach user data)"
-        );
-        assert!(
             BootStep::Passphrase.depends_on(BootStep::SecureBoot),
             "Passphrase entry must run after SecureBoot verification"
         );
         assert!(
-            BootStep::Encryption.depends_on(BootStep::Passphrase),
-            "Encryption mount must run after Passphrase derives keys"
+            BootStep::Filesystem.depends_on(BootStep::Passphrase),
+            "Filesystem mount must run after Passphrase derives keys (#446: a provisioned payload is ciphertext; the mount needs the data key)"
         );
         assert!(
-            BootStep::AuditLog.depends_on(BootStep::Encryption),
-            "AuditLog must run after Encryption (needs audit key)"
+            BootStep::AuditLog.depends_on(BootStep::Filesystem),
+            "AuditLog must run after Filesystem (needs audit key + a mounted log store)"
         );
         assert!(
             BootStep::SecurityMode.depends_on(BootStep::AuditLog),
@@ -703,13 +828,125 @@ mod tests {
 
     #[test]
     fn security_boot_steps_are_contiguous() {
-        // WHY (#217): the trust chain is consecutive with no gaps --
-        // verify, then mount, then derive keys, then decrypt, then audit.
+        // WHY (#217 + #446): the trust chain is consecutive with no gaps --
+        // verify, then derive keys from the entered passphrase, then mount
+        // (encrypted when provisioned), then audit. Passphrase strictly
+        // precedes Filesystem: a provisioned payload is ciphertext, so the
+        // mount needs the derived key, and a locked payload is never
+        // plain-mounted.
         assert_eq!(BootStep::SecureBoot as u8, 10);
-        assert_eq!(BootStep::Filesystem as u8, 11);
-        assert_eq!(BootStep::Passphrase as u8, 12);
-        assert_eq!(BootStep::Encryption as u8, 13);
-        assert_eq!(BootStep::AuditLog as u8, 14);
-        assert_eq!(BootStep::SecurityMode as u8, 15);
+        assert_eq!(BootStep::Passphrase as u8, 11);
+        assert_eq!(BootStep::Filesystem as u8, 12);
+        assert_eq!(BootStep::AuditLog as u8, 13);
+        assert_eq!(BootStep::SecurityMode as u8, 14);
+    }
+
+    #[test]
+    fn boot_passphrase_plan_gates_on_trust_then_hardware_then_provisioning() {
+        // Fail-closed first: no trust root, no derivation (#217).
+        assert_eq!(
+            boot_passphrase_plan(false, true, true, PreambleLoad::Provisioned),
+            BootPassphrasePlan::Skip,
+            "no secure boot -> skip even when provisioned"
+        );
+        // Hardware prerequisites.
+        assert_eq!(
+            boot_passphrase_plan(true, false, true, PreambleLoad::Provisioned),
+            BootPassphrasePlan::Skip,
+            "no display -> skip"
+        );
+        assert_eq!(
+            boot_passphrase_plan(true, true, false, PreambleLoad::Provisioned),
+            BootPassphrasePlan::Skip,
+            "no input -> skip"
+        );
+        // Provisioning states.
+        assert_eq!(
+            boot_passphrase_plan(true, true, true, PreambleLoad::Provisioned),
+            BootPassphrasePlan::Verify
+        );
+        assert_eq!(
+            boot_passphrase_plan(true, true, true, PreambleLoad::Unprovisioned),
+            BootPassphrasePlan::FirstBootSetup
+        );
+        // An unreadable/unread preamble never masquerades as first boot.
+        assert_eq!(
+            boot_passphrase_plan(true, true, true, PreambleLoad::ReadFailed),
+            BootPassphrasePlan::Skip,
+            "I/O fault is not a first boot"
+        );
+        assert_eq!(
+            boot_passphrase_plan(true, true, true, PreambleLoad::NotRead),
+            BootPassphrasePlan::Skip
+        );
+    }
+
+    #[test]
+    fn mount_plan_never_plain_mounts_a_locked_or_unknown_payload() {
+        // The pre-#446 gate: no eMMC or no trust root -> no persistent mount.
+        assert_eq!(
+            mount_plan(false, true, PreambleLoad::Unprovisioned, false),
+            MountPlan::RamfsFallback,
+            "no eMMC -> ramfs"
+        );
+        assert_eq!(
+            mount_plan(true, false, PreambleLoad::Unprovisioned, false),
+            MountPlan::RamfsFallback,
+            "no verified boot -> ramfs (#217)"
+        );
+        // The new fail-closed invariants (#446).
+        assert_eq!(
+            mount_plan(true, true, PreambleLoad::Provisioned, false),
+            MountPlan::RamfsFallback,
+            "provisioned but locked: never plain-mount or format"
+        );
+        assert_eq!(
+            mount_plan(true, true, PreambleLoad::ReadFailed, false),
+            MountPlan::RamfsFallback,
+            "unknown payload state is treated as locked"
+        );
+        assert_eq!(
+            mount_plan(true, true, PreambleLoad::NotRead, false),
+            MountPlan::RamfsFallback
+        );
+        // The two real mounts.
+        assert_eq!(
+            mount_plan(true, true, PreambleLoad::Provisioned, true),
+            MountPlan::Encrypted,
+            "derived key -> encrypted mount"
+        );
+        assert_eq!(
+            mount_plan(true, true, PreambleLoad::Unprovisioned, true),
+            MountPlan::Encrypted,
+            "first-boot setup also ends in the encrypted mount"
+        );
+        assert_eq!(
+            mount_plan(true, true, PreambleLoad::Unprovisioned, false),
+            MountPlan::Plain,
+            "unprovisioned dev path stays byte-compatible"
+        );
+    }
+
+    #[test]
+    fn boot_state_defaults_preamble_to_not_read() {
+        let state = BootState::new();
+        assert_eq!(state.preamble, PreambleLoad::NotRead);
+    }
+
+    #[test]
+    fn passphrase_skip_reason_pins_the_witness_contract_strings() {
+        // scripts/witness/boot.sh greps the untrusted-boot refusal verbatim.
+        assert!(
+            passphrase_skip_reason(false, true, true).contains("Passphrase entry refused"),
+            "the fail-closed wording is a QEMU witness contract"
+        );
+        assert!(
+            passphrase_skip_reason(true, false, true).contains("no display/input"),
+            "hardware-skip wording"
+        );
+        assert!(
+            passphrase_skip_reason(true, true, true).contains("preamble unreadable"),
+            "unreadable-preamble wording"
+        );
     }
 }

--- a/crates/thumos/src/lock_screen.rs
+++ b/crates/thumos/src/lock_screen.rs
@@ -36,7 +36,7 @@ use crate::ui::{
 // ---------------------------------------------------------------------------
 
 /// Maximum passphrase length in bytes.
-const MAX_PASSPHRASE_LEN: usize = 64;
+pub(crate) const MAX_PASSPHRASE_LEN: usize = 64;
 
 /// Maximum PIN length in digits.
 const MAX_PIN_LEN: usize = 10;
@@ -399,6 +399,27 @@ impl LockScreen {
     /// The caller is responsible for calling `KeyManager::derive_from_passphrase`
     /// on success — this method only verifies the hash.
     pub fn submit_passphrase(&mut self, current_tick: u64) -> UnlockResult {
+        let expected = self.passphrase_hash;
+        self.submit_passphrase_with(current_tick, move |entered| {
+            constant_time_eq(&security::sha256(entered), &expected)
+        })
+    }
+
+    /// Submit the current passphrase against a caller-supplied verification
+    /// strategy (#446).
+    ///
+    /// Identical throttle / attempt / wipe bookkeeping to
+    /// [`Self::submit_passphrase`]; only the verification differs. The boot
+    /// passphrase gate verifies at PBKDF2 strength — derive from the entered
+    /// bytes, compare the boot verifier constant-time — because no usable
+    /// hash store exists before the encrypted fs is mounted. `verify`
+    /// receives the entered passphrase bytes and must perform any
+    /// constant-time comparison itself.
+    pub fn submit_passphrase_with(
+        &mut self,
+        current_tick: u64,
+        verify: impl FnOnce(&[u8]) -> bool,
+    ) -> UnlockResult {
         // Check throttle.
         if self.is_throttled(current_tick) {
             let wait = self.throttle_remaining(current_tick);
@@ -412,11 +433,9 @@ impl LockScreen {
             return UnlockResult::Throttled { wait_secs: wait };
         }
 
-        // Hash the entered passphrase and compare (constant-time).
         let entered = &self.passphrase_buffer[..self.passphrase_len as usize];
-        let hash = security::sha256(entered);
 
-        if constant_time_eq(&hash, &self.passphrase_hash) {
+        if verify(entered) {
             self.on_success(UnlockResult::Success);
             UnlockResult::Success
         } else {
@@ -552,11 +571,26 @@ impl LockScreen {
     ///
     /// For T9-style input, the caller maps key sequences to characters.
     /// For simplicity, numeric keys append their digit character directly.
-    fn push_passphrase_byte(&mut self, byte: u8) {
+    /// `pub(crate)` for the boot-time input loop (#446).
+    pub(crate) fn push_passphrase_byte(&mut self, byte: u8) {
         if self.passphrase_len < MAX_PASSPHRASE_LEN as u8 {
             self.passphrase_buffer[self.passphrase_len as usize] = byte;
             self.passphrase_len += 1;
         }
+    }
+
+    /// Drop the last entered passphrase byte (boot input backspace, #446).
+    pub(crate) fn backspace_passphrase(&mut self) {
+        if self.passphrase_len > 0 {
+            self.passphrase_len -= 1;
+        }
+    }
+
+    /// Borrow the entered passphrase bytes (boot first-boot confirm
+    /// compare, #446). The buffer is zero-copy; callers must not persist
+    /// the slice past the next input mutation.
+    pub(crate) fn passphrase_bytes(&self) -> &[u8] {
+        &self.passphrase_buffer[..self.passphrase_len as usize]
     }
 
     /// Map a Key to a digit byte (b'0'..b'9').
@@ -741,9 +775,7 @@ impl Screen for LockScreen {
                     }
                     Key::Left => {
                         // Backspace.
-                        if self.passphrase_len > 0 {
-                            self.passphrase_len -= 1;
-                        }
+                        self.backspace_passphrase();
                         ScreenAction::None
                     }
                     Key::Star => {
@@ -929,6 +961,60 @@ mod tests {
         let result = screen.submit_passphrase(100);
         assert_eq!(result, UnlockResult::WrongPassphrase);
         assert_eq!(screen.attempts(), 1);
+    }
+
+    #[test]
+    fn submit_passphrase_with_passes_the_entered_bytes_to_the_strategy() {
+        let mut screen = make_screen();
+        for &byte in TEST_PASSPHRASE {
+            screen.push_passphrase_byte(byte);
+        }
+        // The injected strategy (boot: PBKDF2-strength verifier compare)
+        // must see exactly the entered bytes.
+        let result = screen.submit_passphrase_with(100, |entered| entered == TEST_PASSPHRASE);
+        assert_eq!(result, UnlockResult::Success);
+        assert_eq!(screen.attempts(), 0, "attempts reset on success");
+    }
+
+    #[test]
+    fn submit_passphrase_with_rejection_uses_the_same_bookkeeping() {
+        let mut screen = make_screen();
+        for &byte in TEST_PASSPHRASE {
+            screen.push_passphrase_byte(byte);
+        }
+        let result = screen.submit_passphrase_with(100, |_| false);
+        assert_eq!(result, UnlockResult::WrongPassphrase);
+        assert_eq!(screen.attempts(), 1);
+        assert_eq!(
+            screen.passphrase_len(),
+            0,
+            "failure clears the input buffer"
+        );
+    }
+
+    #[test]
+    fn submit_passphrase_with_honors_the_throttle_window() {
+        let mut screen = make_screen();
+        // Three failures at the same tick arm a 5-second throttle
+        // (throttle_delay(3) = 5); delay 0 for the first two attempts
+        // keeps every submit inside the window unthrottled.
+        for _ in 0..3 {
+            screen.push_passphrase_byte(b'x');
+            let r = screen.submit_passphrase_with(100, |_| false);
+            assert_eq!(r, UnlockResult::WrongPassphrase);
+        }
+        // A retry inside the window is throttled even when the injected
+        // verifier would pass — the strategy is not even invoked.
+        for &byte in TEST_PASSPHRASE {
+            screen.push_passphrase_byte(byte);
+        }
+        let r = screen.submit_passphrase_with(101, |_| true);
+        assert_eq!(r, UnlockResult::Throttled { wait_secs: 4 });
+        assert_eq!(
+            screen.passphrase_len(),
+            0,
+            "the throttled exit clears the buffer (#388)"
+        );
     }
 
     #[test]

--- a/crates/thumos/src/main.rs
+++ b/crates/thumos/src/main.rs
@@ -153,6 +153,10 @@ mod json_mini;
 mod kardia;
 mod kconfig;
 mod key_manager;
+// WHY not(qemu): the boot matrix reader scans M7 GPIO registers (board
+// facts that exist only in board::m7) — virt has no matrix to read.
+#[cfg(not(feature = "qemu"))]
+mod keypad;
 // WHY (#528): ONLY the hardware-init-bearing boot sequence (run(), the driver
 // init steps, halt/panic display) stays cfg(not(test)). kinit's pure planning
 // logic (BootStep ordering, BootState, userspace spawn planning) lives in

--- a/crates/thumos/src/secrets.rs
+++ b/crates/thumos/src/secrets.rs
@@ -6,23 +6,33 @@
 //! PBKDF2 device salt resists precomputation by being unique per device,
 //! not by being hidden — or sealed under the passphrase-derived primary
 //! key (reserved kinds; the seal lands with the boot-time passphrase
-//! loop, kinit Step 8d).
+//! loop, kinit Step 8c).
 //!
 //! # Layout (one 512-byte sector)
 //!
 //! ```text
 //! [0..8)    magic "THSECR\0\0"
 //! [8..12)   format version, u32 LE (= 1)
-//! [12..16)  slot count, u32 LE (= 1 today)
+//! [12..16)  slot count, u32 LE (1 = salt only; 2 = salt + boot verifier)
 //! [16..48)  integrity tag: SHA-256 of the sector with these 32 bytes zeroed
 //! [48..80)  slot 1 payload: the device salt (32 bytes, plaintext)
-//! [80..512) zero (future slots)
+//! [80..112) slot 2 payload: boot passphrase verifier (32 bytes, plaintext)
+//! [112..512) zero (future slots)
 //! ```
 //!
 //! Slot kinds: 1 = device salt (populated today); 2 = BT IRK (reserved,
 //! sealed — #455 stage 2); 3 = vault PIN verifier (reserved, sealed —
 //! the security-mode PIN store, whose `PIN_PBKDF2_SALT` is the same
-//! fixed-salt defect class as #449).
+//! fixed-salt defect class as #449); 4 = boot passphrase verifier
+//! (populated at first-boot setup, #446).
+//!
+//! The boot verifier is PLAINTEXT by construction, like the salt: it must
+//! be readable before any passphrase-derived key exists, and it is not a
+//! fast oracle — it is `HKDF(primary, "thumos-verify-v1")` where the
+//! primary is PBKDF2-HMAC-SHA256(passphrase, salt, 100_000), so a disk
+//! image buys an attacker exactly the same per-guess cost as attacking
+//! the encrypted payload itself (and NEVER a raw SHA-256(passphrase)
+//! fast-path). It carries no entropy of its own beyond the passphrase.
 //!
 //! Provisioning is implicit: a missing, malformed, or corrupt header is
 //! (re)provisioned with a fresh random salt; a valid header is read back.
@@ -53,11 +63,21 @@ const INTEGRITY_OFFSET: usize = 16;
 /// Byte offset of the device-salt payload.
 const SALT_OFFSET: usize = 48;
 
+/// Boot-verifier payload length in bytes.
+pub(crate) const VERIFIER_LEN: usize = 32;
+
+/// Byte offset of the boot passphrase verifier payload (slot kind 4).
+const VERIFIER_OFFSET: usize = 80;
+
 /// The per-device secrets this boot derived from the preamble.
 pub(crate) struct DeviceSecrets {
     /// The PBKDF2 device salt: random at provisioning, plaintext on disk,
     /// stable across boots.
     pub(crate) salt: [u8; SALT_LEN],
+    /// The boot passphrase verifier (`HKDF(primary, "thumos-verify-v1")`),
+    /// when first-boot setup has stored one. `None` means the device has
+    /// never set a boot passphrase — the first-boot setup path.
+    pub(crate) boot_verifier: Option<[u8; VERIFIER_LEN]>,
 }
 
 /// Compute the integrity tag over a sector image (tag field zeroed).
@@ -67,9 +87,11 @@ fn integrity_of(sector: &[u8; SECTOR_SIZE]) -> [u8; 32] {
     crate::security::sha256(&copy)
 }
 
-/// Read the device salt from a sector image, or `None` if the header is
-/// absent (bad magic/version) or corrupt (integrity mismatch).
-fn parse(sector: &[u8; SECTOR_SIZE]) -> Option<[u8; SALT_LEN]> {
+/// Read the secrets from a sector image, or `None` if the header is
+/// absent (bad magic/version/slot count) or corrupt (integrity
+/// mismatch). Returns the salt plus the boot verifier when the header
+/// carries one (slot count 2).
+fn parse(sector: &[u8; SECTOR_SIZE]) -> Option<([u8; SALT_LEN], Option<[u8; VERIFIER_LEN]>)> {
     if sector[..8] != MAGIC {
         return None;
     }
@@ -82,7 +104,7 @@ fn parse(sector: &[u8; SECTOR_SIZE]) -> Option<[u8; SALT_LEN]> {
             .try_into()
             .ok()?,
     );
-    if count != 1 {
+    if count != 1 && count != 2 {
         return None;
     }
     if sector[INTEGRITY_OFFSET..INTEGRITY_OFFSET + 32] != integrity_of(sector) {
@@ -95,16 +117,33 @@ fn parse(sector: &[u8; SECTOR_SIZE]) -> Option<[u8; SALT_LEN]> {
         // the shared-salt failure mode #449 exists to kill.
         return None;
     }
-    Some(salt)
+    let verifier = if count == 2 {
+        let mut v = [0u8; VERIFIER_LEN];
+        v.copy_from_slice(&sector[VERIFIER_OFFSET..VERIFIER_OFFSET + VERIFIER_LEN]);
+        if v.iter().all(|&b| b == 0) {
+            // An all-zero verifier is never legitimate: a zero slot would
+            // turn a corrupt read into an empty-derivation oracle.
+            return None;
+        }
+        Some(v)
+    } else {
+        None
+    };
+    Some((salt, verifier))
 }
 
-/// Render a header sector around `salt`.
-fn render(salt: &[u8; SALT_LEN]) -> [u8; SECTOR_SIZE] {
+/// Render a header sector around `salt`, optionally carrying the boot
+/// verifier (slot count 2 when present, 1 otherwise).
+fn render(salt: &[u8; SALT_LEN], verifier: Option<&[u8; VERIFIER_LEN]>) -> [u8; SECTOR_SIZE] {
     let mut sector = [0u8; SECTOR_SIZE];
     sector[..8].copy_from_slice(&MAGIC);
     sector[VERSION_OFFSET..VERSION_OFFSET + 4].copy_from_slice(&VERSION.to_le_bytes());
-    sector[SLOT_COUNT_OFFSET..SLOT_COUNT_OFFSET + 4].copy_from_slice(&1u32.to_le_bytes());
+    let count: u32 = u32::from(verifier.is_some()) + 1;
+    sector[SLOT_COUNT_OFFSET..SLOT_COUNT_OFFSET + 4].copy_from_slice(&count.to_le_bytes());
     sector[SALT_OFFSET..SALT_OFFSET + SALT_LEN].copy_from_slice(salt);
+    if let Some(v) = verifier {
+        sector[VERIFIER_OFFSET..VERIFIER_OFFSET + VERIFIER_LEN].copy_from_slice(v);
+    }
     let tag = integrity_of(&sector);
     sector[INTEGRITY_OFFSET..INTEGRITY_OFFSET + 32].copy_from_slice(&tag);
     sector
@@ -130,15 +169,68 @@ pub(crate) fn load_or_provision<D: BlockDevice>(
 ) -> Result<DeviceSecrets, BlockError> {
     let mut sector = [0u8; SECTOR_SIZE];
     dev.read_sectors(0, 1, &mut sector)?;
-    if let Some(salt) = parse(&sector) {
-        return Ok(DeviceSecrets { salt });
+    if let Some((salt, boot_verifier)) = parse(&sector) {
+        return Ok(DeviceSecrets {
+            salt,
+            boot_verifier,
+        });
     }
 
     let mut salt = [0u8; SALT_LEN];
     random(&mut salt);
-    let rendered = render(&salt);
+    let rendered = render(&salt, None);
     dev.write_sectors(0, 1, &rendered)?;
-    Ok(DeviceSecrets { salt })
+    Ok(DeviceSecrets {
+        salt,
+        boot_verifier: None,
+    })
+}
+
+/// Read-only load: parse the preamble WITHOUT provisioning (#446).
+///
+/// The boot path probes the preamble before the trust gate is evaluated
+/// (the mount plan needs the fail-closed signal early), and a blind
+/// re-provision there would clobber a valid header after a transient
+/// fault — so this entry point never writes. `Ok(None)` means absent or
+/// corrupt (a first-boot candidate); `Err` means the read itself failed.
+///
+/// # Errors
+///
+/// Returns [`BlockError`] when the sector read fails.
+pub(crate) fn load<D: BlockDevice>(dev: &mut D) -> Result<Option<DeviceSecrets>, BlockError> {
+    let mut sector = [0u8; SECTOR_SIZE];
+    dev.read_sectors(0, 1, &mut sector)?;
+    Ok(parse(&sector).map(|(salt, boot_verifier)| DeviceSecrets {
+        salt,
+        boot_verifier,
+    }))
+}
+
+/// Store the boot passphrase verifier alongside the existing salt (#446).
+///
+/// First-boot setup calls this after the user enters and confirms a new
+/// passphrase. `verifier` must be `key_manager::derive_boot_verifier`
+/// output — never the passphrase and never a raw hash of it (see the
+/// module doc for the no-fast-oracle argument). `salt` is the in-memory
+/// salt from [`load_or_provision`]; the sector is re-rendered whole, so
+/// the single-sector write remains the atomicity unit — a torn write
+/// reads back as a corrupt header and re-provisions, never as a
+/// half-updated verifier.
+///
+/// # Errors
+///
+/// Returns [`BlockError`] when the write fails.
+pub(crate) fn store_boot_verifier<D: BlockDevice>(
+    dev: &mut D,
+    salt: &[u8; SALT_LEN],
+    verifier: &[u8; VERIFIER_LEN],
+) -> Result<DeviceSecrets, BlockError> {
+    let rendered = render(salt, Some(verifier));
+    dev.write_sectors(0, 1, &rendered)?;
+    Ok(DeviceSecrets {
+        salt: *salt,
+        boot_verifier: Some(*verifier),
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -174,8 +266,12 @@ mod tests {
         assert_eq!(sector[..8], MAGIC, "magic written");
         assert_eq!(
             parse(&sector),
-            Some(secrets.salt),
-            "header parses to the provisioned salt"
+            Some((secrets.salt, None)),
+            "header parses to the provisioned salt, no verifier yet"
+        );
+        assert_eq!(
+            secrets.boot_verifier, None,
+            "fresh provision has no verifier"
         );
     }
 
@@ -221,5 +317,101 @@ mod tests {
             a.salt, b.salt,
             "per-device salts must differ (#449 done-when)"
         );
+    }
+
+    /// A verifier byte pattern that is definitely not all-zero.
+    fn sample_verifier() -> [u8; VERIFIER_LEN] {
+        let mut v = [0u8; VERIFIER_LEN];
+        for (i, b) in v.iter_mut().enumerate() {
+            *b = 0x40u8.wrapping_add(i as u8);
+        }
+        v
+    }
+
+    #[test]
+    fn stored_verifier_reads_back_with_the_salt_unchanged() {
+        let mut dev = MemBlockDevice::new(1).expect("device");
+        let first = load_or_provision(&mut dev, stream(0xA0)).expect("provision");
+        let verifier = sample_verifier();
+        let stored = store_boot_verifier(&mut dev, &first.salt, &verifier).expect("store verifier");
+        assert_eq!(stored.boot_verifier, Some(verifier));
+        assert_eq!(stored.salt, first.salt, "store preserves the salt");
+
+        // A later boot loads both slots; the differing stream proves no
+        // re-provision happened.
+        let loaded = load_or_provision(&mut dev, stream(0xB0)).expect("load");
+        assert_eq!(loaded.salt, first.salt, "salt stable across store+load");
+        assert_eq!(loaded.boot_verifier, Some(verifier), "verifier persists");
+
+        // The on-disk header declares two slots.
+        let mut sector = [0u8; SECTOR_SIZE];
+        dev.read_sectors(0, 1, &mut sector).expect("read back");
+        assert_eq!(
+            u32::from_le_bytes(
+                sector[SLOT_COUNT_OFFSET..SLOT_COUNT_OFFSET + 4]
+                    .try_into()
+                    .unwrap_or_else(|_| unreachable!("4-byte slice"))
+            ),
+            2,
+            "slot count 2 on disk"
+        );
+    }
+
+    #[test]
+    fn all_zero_verifier_is_rejected() {
+        // A structurally valid, correctly tagged sector carrying a zero
+        // verifier must not parse — the zero guard, not the integrity tag,
+        // is what rejects it here.
+        let salt = [0x11u8; SALT_LEN];
+        let sector = render(&salt, Some(&[0u8; VERIFIER_LEN]));
+        assert_eq!(parse(&sector), None, "zero verifier is never legitimate");
+    }
+
+    #[test]
+    fn load_is_read_only_and_never_provisions() {
+        // A blank device: load reports None and writes NOTHING — the
+        // provisioning write is reserved for first-boot setup completion.
+        let mut dev = MemBlockDevice::new(1).expect("device");
+        let loaded = load(&mut dev).expect("load");
+        assert!(loaded.is_none(), "blank preamble loads as None");
+        let mut sector = [0xAAu8; SECTOR_SIZE];
+        dev.read_sectors(0, 1, &mut sector).expect("read back");
+        assert!(
+            sector.iter().all(|&b| b == 0),
+            "load must not write to the sector"
+        );
+    }
+
+    #[test]
+    fn load_reads_back_a_stored_verifier() {
+        let mut dev = MemBlockDevice::new(1).expect("device");
+        let first = load_or_provision(&mut dev, stream(0xA0)).expect("provision");
+        let verifier = sample_verifier();
+        store_boot_verifier(&mut dev, &first.salt, &verifier).expect("store");
+        let loaded = load(&mut dev).expect("load").unwrap_or_else(|| {
+            unreachable!("a stored preamble parses");
+        });
+        assert_eq!(loaded.salt, first.salt);
+        assert_eq!(loaded.boot_verifier, Some(verifier));
+    }
+
+    #[test]
+    fn tampered_verifier_fails_integrity_and_reprovisions() {
+        let mut dev = MemBlockDevice::new(1).expect("device");
+        let first = load_or_provision(&mut dev, stream(0xA0)).expect("provision");
+        let verifier = sample_verifier();
+        store_boot_verifier(&mut dev, &first.salt, &verifier).expect("store");
+
+        let mut sector = [0u8; SECTOR_SIZE];
+        dev.read_sectors(0, 1, &mut sector).expect("read");
+        sector[VERIFIER_OFFSET] ^= 0xFF;
+        dev.write_sectors(0, 1, &sector).expect("corrupt");
+        assert_eq!(parse(&sector), None, "tampered verifier fails the tag");
+
+        // Re-provision yields a fresh salt and no verifier (the device
+        // returns to the first-boot setup path — never a half-valid state).
+        let second = load_or_provision(&mut dev, stream(0xC0)).expect("re-provision");
+        assert_ne!(second.salt, first.salt, "re-provision rerolls the salt");
+        assert_eq!(second.boot_verifier, None);
     }
 }

--- a/docs/KERNEL-BUILD.md
+++ b/docs/KERNEL-BUILD.md
@@ -223,6 +223,45 @@ today:
   released boot image. Release attestation is broken and tracked in #536. Do
   not present any current artifact as release-signed or release-attested.
 
+## Boot passphrase and encrypted userdata (#446)
+
+The boot-time input subsystem behind `passphrase_ok`:
+
+- **Flow.** kinit Step 8c probes the on-disk secrets preamble (#449)
+  read-only, right after eMMC bring-up and before any mount. A provisioned
+  device (preamble carries a verifier) runs the verify loop: poll the GPIO
+  keypad matrix, drive the lock screen, and on submit derive
+  PBKDF2-HMAC-SHA256(passphrase, salt, 100_000) and compare
+  `HKDF(primary, "thumos-verify-v1")` against the stored verifier
+  constant-time. Success derives the partition keys (Step 8c), and Step 8d
+  mounts the userdata payload through `EncryptedBlockDevice` (AES-256-XTS)
+  one sector past the preamble. An unprovisioned device runs first-boot
+  setup instead: enter, confirm, store the verifier, derive, mount
+  encrypted (formatting the payload on that first encrypted mount).
+- **The verifier is not a fast oracle.** It is a PBKDF2-strength derived
+  value, never `SHA-256(passphrase)` — a disk image buys an attacker the
+  same per-guess cost as attacking the ciphertext itself.
+- **Fail-closed mount.** A provisioned-but-locked payload (passphrase not
+  entered: refused, throttled out, or hardware missing) is never
+  plain-mounted and never formatted — the boot falls back to the
+  initramfs root, and the throttle/wipe state machine (10 attempts →
+  panic wipe) applies. An unreadable preamble is treated as locked.
+- **Boot pad binding.** The 4×3 matrix yields digits, Star, Hash only:
+  digits append, Star = backspace, Hash = submit/confirm. Boot passphrases
+  are digits-only (minimum 6), constrained identically at setup so a
+  passphrase is always enterable at boot. Post-boot symbol entry in
+  `lock_screen.rs` is unaffected.
+- **One-way transition.** Completing first-boot setup writes the preamble
+  sector at the userdata head and formats the payload encrypted. Plain
+  pre-provisioning content does NOT migrate — it is overwritten. qemu and
+  dev-anchor builds never reach the gate (secure boot cannot establish
+  trust there), so CI witnesses and dev iteration are unaffected.
+- **Hardware status.** The live GPIO matrix scan, the display render, and
+  the on-device verify/mount path are hardware-gated (pin assignments are
+  placeholders pending AGM M7 schematic verification, mirroring haphe);
+  host tests prove the scan/debounce logic, the preamble format, the
+  verifier derivation, and the gate matrices.
+
 ## Hardware path: unproven
 
 Everything on this page proves the kernel **under QEMU `-machine virt`

--- a/docs/capability-inventory.toml
+++ b/docs/capability-inventory.toml
@@ -21,7 +21,7 @@ notes = "PL0 isolation, graceful kill, fork/exec/brk/guard witnesses live in the
 id = "memory-fs"
 modules = ["block", "cache", "vfs", "devfs", "lfs", "lfs_imap", "lfs_segment", "lfs_checkpoint", "lfs_writer", "lfs_compact", "emmc", "ramfs"]
 tier = "kernel-wired"
-notes = "LFS mounts at boot (kinit Step 8c); no witness marker asserts persistence behavior in emulation yet."
+notes = "LFS mounts at boot (kinit Step 8d, encrypted when provisioned per #446); no witness marker asserts persistence behavior in emulation yet."
 
 [[capability]]
 id = "time"
@@ -87,9 +87,9 @@ hardware_reason = "PMIC/battery telemetry needs the physical device"
 
 [[capability]]
 id = "display-input"
-modules = ["display"]
+modules = ["display", "keypad"]
 tier = "kernel-wired"
-notes = "Rendered via the ui capability's synthetic framebuffer in emulation; the DDP pipeline is hardware-gated."
+notes = "Rendered via the ui capability's synthetic framebuffer in emulation; the DDP pipeline is hardware-gated. keypad (boot matrix reader, #446) is host-tested on injected matrices; the live GPIO scan is hardware-gated."
 
 [[capability]]
 id = "connectivity"

--- a/docs/convergence.toml
+++ b/docs/convergence.toml
@@ -27,6 +27,15 @@ owner = "#545 (this PR)"
 notes = "The live divergence that proved the class: screen bands and the detector's protocol invariants disagreed. Now one type, one boundary table, both consumers."
 
 [[pair]]
+name = "keypad-matrix-scan"
+kernel = "keypad.rs (mirrors haphe's scan/debounce algorithm, #446)"
+workspace = "haphe (gpio.rs)"
+disposition = "extract-core"
+canonical = "pending: matrix geometry + debounce state machine could lift into a no_std core crate when a second consumer justifies it; the event models genuinely differ today (boot taps vs queued press/release/held)"
+owner = "#446"
+notes = "The kernel boot reader reports confirmed presses only (no queue, no release/held events) and cannot link the std workspace crate; pin assignments are shared placeholders pending AGM M7 schematic verification."
+
+[[pair]]
 name = "gps"
 kernel = "gps.rs (ported from topos)"
 workspace = "topos"

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -308,9 +308,15 @@ fidelity = "constant table only — nothing target-executed to diverge"
 
 [[module]]
 name = "key_manager"
-tests = 13
+tests = 16
 mechanism = "host"
 fidelity = "KDF correctness is host-covered; on-device salt persistence is #449"
+
+[[module]]
+name = "keypad"
+tests = 6
+mechanism = "host"
+fidelity = "scan/debounce logic proven on injected matrices host-side; the live GPIO matrix read + pin assignments are the m7 boot path (hardware-gated, placeholders pending the AGM M7 schematic)"
 
 [[module]]
 name = "kinit"
@@ -320,7 +326,7 @@ witness = "boot.sh"
 
 [[module]]
 name = "kinit_plan"
-tests = 21
+tests = 25
 mechanism = "host"
 
 [[module]]
@@ -355,7 +361,7 @@ mechanism = "host"
 
 [[module]]
 name = "lock_screen"
-tests = 20
+tests = 23
 mechanism = "host"
 fidelity = "policy logic host-covered; boot-time passphrase input is #446"
 
@@ -549,7 +555,7 @@ witness = "boot.sh"
 
 [[module]]
 name = "secrets"
-tests = 4
+tests = 9
 mechanism = "host"
 fidelity = "provision/read proven on the RAM double; eMMC persistence + the 8d consumption path are the m7 boot (hardware-gated)"
 


### PR DESCRIPTION
## Summary

#446 remnant 2: kinit's passphrase step only logged "PENDING (awaiting boot input loop)" — `passphrase_ok` was never set, so the encrypted-mount gate could never fire and encrypted storage never engaged. This lands the whole boot-time input subsystem the issue's done-when requires: passphrase entered at boot → verified → keys derived → `passphrase_ok = true` → userdata mounts encrypted.

The five pieces, each host-tested:

1. **Poll-based keypad scancode read** (`keypad.rs`): a GPIO matrix scanner mirroring haphe's proven scan/debounce algorithm (the kernel cannot link the std workspace crate; the duplication is recorded in `docs/convergence.toml`). The KPD block kinit enables at Step 8a has no verified read-out register map, so the boot path scans the raw matrix exactly as the userspace driver does — rows driven low in turn, active-low column reads, 3-scan debounce. Hardware half is `#[cfg(not(test))]`; the logic is host-tested on injected matrices. Pin assignments carry the same placeholder-pending-schematic caveat as haphe's.
2. **Scancode decode + boot binding**: matrix position → `ui::Key` (digits/Star/Hash — the 4×3 pad yields no other keys). Boot binding: digits append, **Star = backspace, Hash = submit/confirm**. Boot passphrases are therefore digits-only (minimum 6); first-boot setup constrains the alphabet identically, so a passphrase set at setup is always enterable at boot.
3. **Boot-blocking input loops in Step 8c** driving `LockScreen`: the **verify loop** (provisioned device) and the **first-boot setup loop** (enter → confirm → store → derive). Throttle/wipe/duress bookkeeping is the lock screen's own state machine (`submit_passphrase_with`, a new injectable-verifier variant that shares every code path with the existing `submit_passphrase`); 10 wrong attempts executes the panic wipe and halts.
4. **The verifier, at PBKDF2 strength** (`secrets` slot kind 4 + `key_manager::derive_boot_verifier`): stored plaintext in the preamble (it must be readable before any key exists), but it is `HKDF(primary, "thumos-verify-v1")` — never `SHA-256(passphrase)`. A disk image buys an attacker one full PBKDF2-100k run per guess, the same cost as attacking the ciphertext directly; no faster oracle is introduced.
5. **Lock-screen UI render at boot**: the existing `draw()` renders the dot-masked entry, result feedback ("WRONG - TRY AGAIN", "WAIT...", "WIPING DEVICE"), and attempt counter into the framebuffer; stage prompts also go to the serial console.

**The reorder and the fail-closed mount (the load-bearing half):** passphrase now runs strictly BEFORE the mount (`BootStep` renumbered: Passphrase=11, Filesystem=12; the separate Encryption step folded into the mount). The secrets preamble is probed **read-only** right after eMMC bring-up, and the mount plan keys off it:

- `passphrase_ok` → encrypted mount of the payload view one sector past the preamble (`EncryptedBlockDevice`, AES-256-XTS, derived data key);
- unprovisioned + no passphrase → today's plain mount at the head, byte-compatible with pre-#446 images (dev/transition path);
- **provisioned but locked — or preamble unreadable — is never plain-mounted and never formatted.** The pre-#446 order (mount before passphrase) plus provisioning would have made a degraded boot format away the ciphertext via the `InvalidSuperblock` reformat path; that failure class is now structurally impossible (`kinit_plan::mount_plan`, host-pinned).

**One-way transition, disclosed:** completing first-boot setup writes the preamble sector at the userdata head and formats the payload encrypted. Pre-existing plain-LFS content does NOT migrate. qemu and dev-anchor builds never reach the gate (`secure_boot_ok` cannot establish there), so CI witnesses and dev iteration are unaffected.

**Also in this PR:** `kernel-host-tests.sh` exit-code propagation fix is NOT here — it landed separately as #617. This branch is rebased on it, so this PR's kernel job runs under the honest gate.

## Verification

- `scripts/kernel-host-tests.sh` (i686 + debug-console, under the fixed #617 gate): **2343/2343 and 2347/2347 passed** — keypad scan/debounce/addressing (6), secrets preamble round-trip + zero-guards + tamper + read-only `load` (9), verifier derivation determinism/label-separation (3 new), `submit_passphrase_with` success/rejection/throttle (3 new), gate matrices (`boot_passphrase_plan` × 7, `mount_plan` × 8, BootStep renumber pins).
- `cargo check` m7 (armv7a, `-D warnings`) + `--features qemu`: both rc=0
- `scripts/witness-run-all.sh`: ALL PASS, rc=0 — boot (incl. the "Passphrase entry refused" fail-closed contract), kread/kwrite/kexec/cp15 isolation, kfault rc=4-as-specified, sleep, fork, exec, forkexec, guard, brk, signal, crashloop (qemu boots take the initramfs path; the gate is not(qemu)-gated, witnesses unaffected)
- `scripts/check-target-test-ledger.sh` / `check-wiring-inventory.sh` / `check-board-seam.sh` / `check-convergence.sh`: no drift (keypad row + inventory classification + convergence pair added).
- `cargo fmt`: clean.

Remaining, hardware ledger (BROM session): the live GPIO matrix scan and pin assignments, the display render, the on-device verify → encrypted-mount happy path, the throttle/wipe behavior on-device, and validation of the KPD-hardware-vs-GPIO-bit-bang question (the scanner kinit enables at 8a may make the GPIO poll redundant — needs the MT6739 TRM or probing).

Closes #446
