### PR TITLE
ci: run the two gate stages that were defined and never listed

### DIFF
--- a/.kanon-ci.toml
+++ b/.kanon-ci.toml
@@ -28,6 +28,8 @@ stages = [
     "kernel build",
     "kernel trust anchor",
     "kernel host tests",
+    "board seam",
+    "convergence",
     "kernel qemu witnesses",
     "wiring inventory",
     "target test ledger",


### PR DESCRIPTION
## Finding

`.kanon-ci.toml` defines 13 `[stages.*]` blocks. `[pipeline].stages` listed 11. `"board seam"` and `"convergence"` were fully configured and never executed.

Both carry a WHY comment asserting exactly the enforcement they were not providing:

```toml
# WHY (#534): the board seam is a structural invariant, not a promise —
[stages."board seam"]

# WHY (#545): convergence is a ratchet, not a wish —
[stages."convergence"]
```

## Why this matters

Not a missing check — a **false green**. `kanon gate` is the command `CONTRIBUTING.md` tells agents to run before pushing, and it reported success while skipping two invariants. Only `.github/workflows/ci.yml`, which invokes the scripts as direct steps, still caught them. That falsifies ci.yml's own header claim to mirror this file, and it means the local gate and the hosted gate disagreed about what "passing" meant.

## Verification

By falsification, not by a green run — a stage nobody has watched fail is an unverified claim wearing a verdict's clothes:

| stage | injected violation | result |
|---|---|---|
| board seam | `MT6739_*` const outside `board::m7` | exit 1, `SEAM DRIFT`; removed → exit 0 |
| convergence | `#126` reference appended to `crates/sema/src/lib.rs` | exit 1, `CONVERGENCE DRIFT`; restored → exit 0 |

Both stages are green on the unmodified tree, so this wires in two passing checks rather than newly reddening main.

## Placement

Before `kernel qemu witnesses` rather than after. Both are source-level and cheap by their own WHY comments, so they belong where they fail fast.

## Desired correction upstream

The forward direction already errors — `ci_config.rs::validate()` rejects a `pipeline.stages` entry with no matching block. The reverse has no check, which is why this landed silently and why the class recurs on the next stage-adding PR in any fleet repo. Filed separately against kanon.

Refs #534 #545
