### PR TITLE
fix(release): cover dev/build path-dep pins and the fuzz lockfile in release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -33,6 +33,21 @@
           "type": "toml",
           "path": "Cargo.lock",
           "jsonpath": "$.package[?(!@.source)].version"
+        },
+        {
+          "type": "toml",
+          "path": "fuzz/Cargo.lock",
+          "jsonpath": "$.package[?(@.name == 'aither')].version"
+        },
+        {
+          "type": "toml",
+          "path": "fuzz/Cargo.lock",
+          "jsonpath": "$.package[?(@.name == 'asphaleia')].version"
+        },
+        {
+          "type": "toml",
+          "path": "fuzz/Cargo.lock",
+          "jsonpath": "$.package[?(@.name == 'klesis')].version"
         }
       ]
     }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -27,7 +27,7 @@
         {
           "type": "toml",
           "path": "crates/eidolon/Cargo.toml",
-          "jsonpath": "$.dependencies[?(@.path)].version"
+          "jsonpath": "$..[?(@.path)].version"
         },
         {
           "type": "toml",


### PR DESCRIPTION
## What

Widens the release-please `extra-files` coverage in `release-please-config.json` so a release patches every path-dep version pin it creates, not just the one that happens to sit in `[dependencies]` today:

1. **`crates/eidolon/Cargo.toml` jsonpath**: `$.dependencies[?(@.path)].version` → `$..[?(@.path)].version`. The narrow form only reaches `[dependencies]`; a path pin added to `[dev-dependencies]`, `[build-dependencies]`, or a `[target.*.dependencies]` table keeps its old version through a release (`foo = { path = "../foo", version = "0.1.14" }` stays at `0.1.14` while the workspace moves to `0.2.0`, and `^0.1.14` then rejects the crate it points at). The one pin present today (`haphe`) is matched identically by both forms, so this changes nothing about what the next release does, only what it's defended against.

2. **`fuzz/Cargo.lock` extra-files entries** (aither, asphaleia, klesis): `fuzz/` is a second cargo workspace with its own lockfile, absent from `extra-files`. Nothing patches it on release, so a version bump leaves it pinned to the prior workspace version until someone regenerates it by hand outside the release-please flow. A release that lands without that manual step ships a fuzz lockfile whose entries no longer match the crates they resolve against, and `cargo metadata --locked` in `fuzz/` exits 101.

## Why now

`main` still carries the narrow jsonpath and has no `fuzz/Cargo.lock` entries — confirmed against current `release-please-config.json`. The fuzz lockfile itself is *not* currently stale (it's at `0.1.16`, matching the workspace, via unrelated dev work in #588/#585 that happened to regenerate it), but nothing keeps it in sync going forward — the next release re-creates the exact drift this PR prevents.

## Rebase note

Originally two commits (2026-07-30, 2026-08-01) against an older `main`. Rebased onto current `main`: the `release-please-config.json` changes applied cleanly; the second commit's `fuzz/Cargo.lock` *content* diff (bumping stale `0.1.5` versions + a `thumos-fuzz`→`peirama` rename) conflicted because `main` independently reached that same end state via #588/#585 — resolved by keeping `main`'s current lockfile and retaining only the `extra-files` config addition, since that's the part that's still missing. Commit message reworded to match what the commit now actually does.

## Done when

- [ ] CI green
- [ ] Next release-please run patches `fuzz/Cargo.lock`'s aither/asphaleia/klesis versions alongside the workspace bump
