### PR TITLE
docs(contributing): describe the hybrid gate that actually runs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Comments and approvals land through stoa. The merge button activates when all ga
 
 - CI status `Pass` (every stage in `.kanon-ci.toml` exits zero, or the stage's `fail_on` predicate reports success).
 - Independent verifier `Ok` (03f-e reproduces the headline claims from a fresh checkout of the head sha).
-- A `Gate-Passed: kanon <version>` trailer is present on the tip commit of the PR branch, or the merge will append one.
+- The `Gate Attestation` check (`.github/workflows/gate-attestation.yml`) reports success. A `Gate-Passed: kanon <version>` trailer on the tip commit takes the fast path; without one, the check runs a real `cargo fmt`/`check`/`clippy`/`nextest` build against the branch instead (skipped only for docs-only PRs). The AI-attribution check always runs, trailer or not, and no trailer is appended by the merge itself. **This check, and `.kanon-ci.toml`'s fmt/check/clippy/nextest stages, do not cover the kernel crate** (`crates/thumos`, excluded from the Cargo workspace) — only the separate, non-required `CI` workflow's kernel job (i686 host tests, armv7a cross-compile, QEMU boot) exercises it. A green `Gate Attestation` check does not attest the kernel.
 
 ## Merging
 
@@ -42,9 +42,9 @@ Comments and approvals land through stoa. The merge button activates when all ga
 kanon pr merge <pr_number>
 ```
 
-or the forge merge button. Default strategy is `squash`; `--strategy ff` or `--strategy rebase` are supported. The merge commit carries the `Gate-Passed` trailer.
+or the forge merge button. Default strategy is `squash`; `--strategy ff` or `--strategy rebase` are supported. A squash merge does not carry the source branch's `Gate-Passed` trailer forward — squashing drops per-commit trailers by construction, so no commit on `main` has one. That absence is expected, not a gap: `Gate Attestation`'s `push`-to-`main` trigger re-runs the full build against the merge commit itself, which is what actually attests `main`.
 
-Do not merge via GitHub. The GitHub mirror is read-only from the contributor's perspective: any merge performed there races the forge pr-sync worker and drops the trailer.
+Do not merge via GitHub. The GitHub mirror is read-only from the contributor's perspective: any merge performed there races the forge pr-sync worker.
 
 ## External contributors
 
@@ -53,7 +53,7 @@ Thumos has a real external-contributor path - radio, baseband, and MTK tooling f
 1. Fork on GitHub, open a PR against `forkwright/thumos:main` as you would on any OSS project.
 2. The 05d bidirectional sync ingests the PR into the forge. Review, CI, and the verifier all run there.
 3. Discussion may happen on either side; the forge thread is authoritative. The mirror sync relays merge state back to GitHub once the forge merges.
-4. The merge always happens on the forge so the `Gate-Passed` trailer and CI artifacts are preserved. GitHub closes your PR when the mirror sync observes the merge commit on `main`.
+4. The merge always happens on the forge; CI artifacts from that run are preserved there. The merge commit itself carries no `Gate-Passed` trailer — squash merges drop it — so `Gate Attestation` independently re-verifies the merge commit when it lands on `main` via GitHub's `push` trigger. GitHub closes your PR when the mirror sync observes the merge commit on `main`.
 
 You do not need a kanon.lan account to contribute. The GitHub path is a first-class inbound route, not a courtesy.
 


### PR DESCRIPTION
## Summary

CONTRIBUTING.md's Review/Merging/External-contributors sections still described the pre-hybrid-gate world: a `Gate-Passed` trailer framed as a mandatory requirement the merge would append if missing, and forge merges framed as preserving a trailer that GitHub merges would drop. Neither is how `.github/workflows/gate-attestation.yml` behaves.

## What changed

Three passages rewritten to state the real contract:

- **Review** (the merge-button gate list): a `Gate-Passed` trailer takes a fast path; without one, the check runs a real `cargo fmt`/`check`/`clippy`/`nextest` build instead (docs-only PRs exempt from that build); ai-attribution always runs; no trailer is appended by the merge. Also states the coverage gap the old text never mentioned: neither this gate nor `.kanon-ci.toml`'s fmt/check/clippy/nextest stages cover the kernel crate (`crates/thumos`, excluded from the workspace) — only the separate, non-required `CI` workflow's kernel job does. A green Gate Attestation check does not attest the kernel.
- **Merging**: a squash merge never carries the source branch's trailer forward — squashing drops per-commit trailers by construction, on GitHub or the forge, so no commit on `main` has one. That's expected, not a gap: the workflow's `push`-to-`main` trigger re-runs the full build against the merge commit itself, which is what actually attests `main`. Fixed the adjacent "Do not merge via GitHub" line too — it justified the policy by "drops the trailer," which is now internally inconsistent with the corrected claim above it (a trailer is dropped either way, not something a forge merge preserves).
- **External contributors** step 4: same trailer correction, same pointer to the `push` trigger as the actual attestation mechanism for `main`.

Left everything else in CONTRIBUTING.md (forge-as-authoritative-surface, `.kanon-ci.toml` description, branch naming) untouched — out of scope for this pass.

## Verification

Read `.github/workflows/gate-attestation.yml` in full (its header comment documents the hybrid-gate design end to end) and cross-checked recent `main` history: every recent merge commit is a GitHub-style squash (`(#NNN)` suffix, `Co-authored-by: admin` trailer) with no `Gate-Passed` trailer present, consistent with the corrected text.
