### PR TITLE
kinit: make an uninitialized eMMC device unrepresentable

### DIFF
--- a/crates/thumos/src/block.rs
+++ b/crates/thumos/src/block.rs
@@ -287,26 +287,27 @@ mod msdc_wrapper {
     use super::{BlockDevice, BlockError, SECTOR_SIZE};
     use crate::emmc::MsdcController;
 
-    /// Block device backed by the MT6739 MSDC eMMC controller.
+    /// An MSDC block device that has not been initialized yet.
     ///
-    /// Wraps [`MsdcController`] to provide the [`BlockDevice`] trait. Each
-    /// read/write call issues single-sector PIO transfers in a loop.
+    /// WHY (#619): this type exists so that "constructed but never initialized"
+    /// cannot reach an I/O call. It deliberately does NOT implement
+    /// [`BlockDevice`], and [`MsdcBlockDevice`] has no public constructor, so
+    /// the only route to a usable device is [`Self::init`]. A call site that
+    /// forgets to initialize now fails to compile rather than returning
+    /// [`BlockError::DeviceNotReady`] at the first read — which, at the
+    /// secure-boot GPT read, presented as an unconditional boot halt.
     ///
-    /// The controller must be initialized via [`MsdcBlockDevice::init`] before
-    /// any I/O. Sector count is fixed at construction (read from CSD or
-    /// hard-coded for the known eMMC part).
-    pub(crate) struct MsdcBlockDevice {
-        /// The underlying MSDC controller.
+    /// Sector count is fixed at construction (read from CSD or hard-coded for
+    /// the known eMMC part) and carried through initialization.
+    pub(crate) struct MsdcBlockDeviceUninit {
+        /// The underlying MSDC controller, not yet initialized.
         controller: MsdcController,
         /// Total sector count of the eMMC device.
         sector_count: u64,
     }
 
-    impl MsdcBlockDevice {
-        /// Create a new MSDC block device with a known sector count.
-        ///
-        /// The controller is NOT initialized — call [`MsdcBlockDevice::init`]
-        /// before issuing any I/O.
+    impl MsdcBlockDeviceUninit {
+        /// Create an uninitialized MSDC block device with a known sector count.
         pub(crate) fn new(sector_count: u64) -> Self {
             Self {
                 controller: MsdcController::new(),
@@ -314,7 +315,10 @@ mod msdc_wrapper {
             }
         }
 
-        /// Initialize the underlying MSDC controller.
+        /// Initialize the controller, yielding a usable [`MsdcBlockDevice`].
+        ///
+        /// Consumes `self`, so the uninitialized handle is gone on success and
+        /// cannot be used afterwards.
         ///
         /// # Safety
         ///
@@ -323,20 +327,43 @@ mod msdc_wrapper {
         ///
         /// # Errors
         ///
-        /// Returns [`BlockError::DeviceNotReady`] if hardware initialization fails.
+        /// Returns [`BlockError::DeviceNotReady`] if hardware initialization
+        /// fails. No [`MsdcBlockDevice`] is produced in that case.
         #[expect(
             unsafe_code,
             reason = "MMIO register access requires raw pointer dereference"
         )]
-        pub unsafe fn init(&mut self) -> Result<(), BlockError> {
+        pub unsafe fn init(mut self) -> Result<MsdcBlockDevice, BlockError> {
             // SAFETY: caller guarantees the MSDC register block is mapped, and
             // this is called exactly once after power-on per the function contract.
             unsafe {
                 self.controller
                     .init()
-                    .map_err(|_| BlockError::DeviceNotReady)
+                    .map_err(|_| BlockError::DeviceNotReady)?;
             }
+            Ok(MsdcBlockDevice {
+                controller: self.controller,
+                sector_count: self.sector_count,
+            })
         }
+    }
+
+    /// Block device backed by the MT6739 MSDC eMMC controller.
+    ///
+    /// Wraps [`MsdcController`] to provide the [`BlockDevice`] trait. Each
+    /// read/write call issues single-sector PIO transfers in a loop.
+    ///
+    /// INVARIANT: the controller is initialized. The only constructor is
+    /// [`MsdcBlockDeviceUninit::init`], which returns this type solely on the
+    /// success path, so holding an `MsdcBlockDevice` is itself the proof that
+    /// initialization ran and succeeded. The read/write paths therefore carry
+    /// no `is_initialized()` guard: it could not fail, and a check that cannot
+    /// fail reports the same green whether the property holds or not.
+    pub(crate) struct MsdcBlockDevice {
+        /// The underlying MSDC controller, initialized per the type invariant.
+        controller: MsdcController,
+        /// Total sector count of the eMMC device.
+        sector_count: u64,
     }
 
     impl BlockDevice for MsdcBlockDevice {
@@ -345,10 +372,6 @@ mod msdc_wrapper {
             reason = "MMIO register access requires raw pointer dereference"
         )]
         fn read_sectors(&self, lba: u64, count: u32, buf: &mut [u8]) -> Result<(), BlockError> {
-            if !self.controller.is_initialized() {
-                return Err(BlockError::DeviceNotReady);
-            }
-
             let end = lba
                 .checked_add(u64::from(count))
                 .ok_or(BlockError::OutOfBounds)?;
@@ -370,9 +393,11 @@ mod msdc_wrapper {
                     .try_into()
                     .map_err(|_| BlockError::InvalidArgument)?;
 
-                // SAFETY: controller.is_initialized() was verified above.
-                // The register block is valid for the lifetime of the device
-                // (hardware is memory-mapped and never unmapped on this SoC).
+                // SAFETY: the controller is initialized per this type's
+                // invariant — `MsdcBlockDeviceUninit::init` is its only
+                // constructor and yields it only on success. The register
+                // block is valid for the lifetime of the device (hardware is
+                // memory-mapped and never unmapped on this SoC).
                 unsafe {
                     self.controller
                         .read_sector(lba32, sector_buf)
@@ -387,10 +412,6 @@ mod msdc_wrapper {
             reason = "MMIO register access requires raw pointer dereference"
         )]
         fn write_sectors(&mut self, lba: u64, count: u32, buf: &[u8]) -> Result<(), BlockError> {
-            if !self.controller.is_initialized() {
-                return Err(BlockError::DeviceNotReady);
-            }
-
             let end = lba
                 .checked_add(u64::from(count))
                 .ok_or(BlockError::OutOfBounds)?;
@@ -410,8 +431,10 @@ mod msdc_wrapper {
                     .try_into()
                     .map_err(|_| BlockError::InvalidArgument)?;
 
-                // SAFETY: controller.is_initialized() was verified above.
-                // The register block is valid for the lifetime of the device.
+                // SAFETY: the controller is initialized per this type's
+                // invariant — `MsdcBlockDeviceUninit::init` is its only
+                // constructor and yields it only on success. The register
+                // block is valid for the lifetime of the device.
                 unsafe {
                     self.controller
                         .write_sector(lba32, sector_buf)
@@ -428,7 +451,7 @@ mod msdc_wrapper {
 }
 
 #[cfg(not(any(test, feature = "qemu")))]
-pub(crate) use msdc_wrapper::MsdcBlockDevice;
+pub(crate) use msdc_wrapper::{MsdcBlockDevice, MsdcBlockDeviceUninit};
 
 // ---------------------------------------------------------------------------
 // Block-level I/O helpers

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -39,7 +39,7 @@ use crate::gic;
 use crate::heap;
 // Gated: only the debug-console gate reads kconfig::DEBUG_CONSOLE.
 #[cfg(not(feature = "qemu"))]
-use crate::block::MsdcBlockDevice;
+use crate::block::{MsdcBlockDevice, MsdcBlockDeviceUninit};
 #[cfg(feature = "debug-console")]
 use crate::kconfig;
 #[cfg(not(feature = "qemu"))]
@@ -169,12 +169,12 @@ const fn boot_digit(key: crate::ui::Key) -> Option<u8> {
 fn encrypted_payload_device(
     data_key: &[u8; crate::security::XTS_KEY_SIZE],
 ) -> Option<crate::encryption::EncryptedBlockDevice<'static>> {
-    let mut phys = MsdcBlockDevice::new(board::LFS_PARTITION_START + board::LFS_PARTITION_SIZE);
+    let uninit = MsdcBlockDeviceUninit::new(board::LFS_PARTITION_START + board::LFS_PARTITION_SIZE);
     // SAFETY: the eMMC controller was initialized in Step 7; init() is
-    // called once here on a freshly constructed MsdcBlockDevice.
-    if unsafe { phys.init() }.is_err() {
+    // called once here on a freshly constructed device.
+    let Ok(phys) = (unsafe { uninit.init() }) else {
         return None;
-    }
+    };
     let payload = crate::block::PartitionBlockDevice::new(
         phys,
         board::LFS_PARTITION_START + board::LFS_PREAMBLE_SECTORS,
@@ -813,15 +813,29 @@ pub unsafe fn run() -> ! {
         // a read past it errors -> Unreadable -> Halt, by design (#467).
         // The physical device outlives `source` (the enum borrows it).
         #[cfg(not(feature = "qemu"))]
-        let mut phys_dev =
-            MsdcBlockDevice::new(board::LFS_PARTITION_START + board::LFS_PARTITION_SIZE);
+        let mut phys_dev = if state.emmc_ok {
+            let uninit =
+                MsdcBlockDeviceUninit::new(board::LFS_PARTITION_START + board::LFS_PARTITION_SIZE);
+            // SAFETY: the eMMC controller was initialized in Step 7; init() is
+            // called once here on a freshly constructed device. Step 7's
+            // controller is a separate instance, so its success says nothing
+            // about this one — this device must be initialized in its own
+            // right before any I/O (#619).
+            unsafe { uninit.init() }.ok()
+        } else {
+            None
+        };
         #[cfg(feature = "qemu")]
         let source = crate::secure_boot::BootImageSource::Absent;
         #[cfg(not(feature = "qemu"))]
-        let source = if state.emmc_ok {
-            crate::secure_boot::boot_image_source(&mut phys_dev)
-        } else {
-            crate::secure_boot::BootImageSource::Absent
+        let source = match phys_dev.as_mut() {
+            Some(dev) => crate::secure_boot::boot_image_source(dev),
+            // Absent, per BootImageSource's own contract: "no boot medium:
+            // qemu (no MSDC model) or an eMMC that failed init". A failed
+            // init is the degrade class, not the Unreadable halt class —
+            // Unreadable means a medium exists and its partition could not
+            // be read.
+            None => crate::secure_boot::BootImageSource::Absent,
         };
         match crate::secure_boot::evaluate_boot_image(&source) {
             crate::secure_boot::SecureBootDecision::Proceed { verified: true } => {
@@ -883,12 +897,12 @@ pub unsafe fn run() -> ! {
         // and NEVER writes here: the provisioning write happens only inside
         // the first-boot setup completion below.
         if state.emmc_ok {
-            let mut preamble_phys =
-                MsdcBlockDevice::new(board::LFS_PARTITION_START + board::LFS_PARTITION_SIZE);
+            let preamble_uninit =
+                MsdcBlockDeviceUninit::new(board::LFS_PARTITION_START + board::LFS_PARTITION_SIZE);
             // SAFETY: eMMC init succeeded in Step 7; init() is called once
-            // here on a freshly constructed MsdcBlockDevice.
-            match unsafe { preamble_phys.init() } {
-                Ok(()) => {
+            // here on a freshly constructed device.
+            match unsafe { preamble_uninit.init() } {
+                Ok(preamble_phys) => {
                     let mut view = crate::block::PartitionBlockDevice::new(
                         preamble_phys,
                         board::LFS_PARTITION_START,
@@ -1120,12 +1134,12 @@ pub unsafe fn run() -> ! {
             // reachable only on an UNPROVISIONED device (no preamble), so no
             // plaintext sector has been carved — byte-compatible with pre-#446
             // images.
-            let mut phys_dev = MsdcBlockDevice::new(board::LFS_PARTITION_START + sector_count);
+            let uninit = MsdcBlockDeviceUninit::new(board::LFS_PARTITION_START + sector_count);
 
             // SAFETY: eMMC controller was initialized successfully in Step 7.
-            // MsdcBlockDevice::init() is called once here; the controller is ready.
-            match unsafe { phys_dev.init() } {
-                Ok(()) => {
+            // init() is called once here on a freshly constructed device.
+            match unsafe { uninit.init() } {
+                Ok(phys_dev) => {
                     let blk_dev = crate::block::PartitionBlockDevice::new(
                         phys_dev,
                         board::LFS_PARTITION_START,
@@ -1145,12 +1159,13 @@ pub unsafe fn run() -> ! {
                         // transient I/O fault (#360).
                         Err(LfsError::InvalidSuperblock) => {
                             serial.log(" LFS mount failed (no superblock), formatting\r\n");
-                            let mut fmt_phys =
-                                MsdcBlockDevice::new(board::LFS_PARTITION_START + sector_count);
+                            let fmt_uninit = MsdcBlockDeviceUninit::new(
+                                board::LFS_PARTITION_START + sector_count,
+                            );
                             // SAFETY: eMMC controller was initialized successfully in
-                            // Step 7; fmt_phys.init() is called once here on a
-                            // freshly constructed MsdcBlockDevice.
-                            if unsafe { fmt_phys.init() }.is_ok() {
+                            // Step 7; init() is called once here on a freshly
+                            // constructed device.
+                            if let Ok(fmt_phys) = unsafe { fmt_uninit.init() } {
                                 let mut fmt_dev = crate::block::PartitionBlockDevice::new(
                                     fmt_phys,
                                     board::LFS_PARTITION_START,
@@ -1162,14 +1177,14 @@ pub unsafe fn run() -> ! {
                                     // VFS root is backed by durable storage from
                                     // this boot onward, not just after the NEXT
                                     // reboot (#343).
-                                    let mut remount_phys = MsdcBlockDevice::new(
+                                    let remount_uninit = MsdcBlockDeviceUninit::new(
                                         board::LFS_PARTITION_START + sector_count,
                                     );
                                     // SAFETY: eMMC controller was initialized successfully
-                                    // in Step 7; remount_phys.init() is called once here on
-                                    // a freshly constructed MsdcBlockDevice.
-                                    match unsafe { remount_phys.init() } {
-                                        Ok(()) => {
+                                    // in Step 7; init() is called once here on a freshly
+                                    // constructed device.
+                                    match unsafe { remount_uninit.init() } {
+                                        Ok(remount_phys) => {
                                             let remount_dev =
                                                 crate::block::PartitionBlockDevice::new(
                                                     remount_phys,


### PR DESCRIPTION
## Finding

Step 8b of `kinit::run` constructed an `MsdcBlockDevice` and handed it to `secure_boot::boot_image_source` without ever calling `init()`. The controller's `initialized` flag stayed false, so `read_sectors` rejected the first GPT sector with `DeviceNotReady` → `GptError::Io` → `BootImageSource::Unreadable` → `SecureBootDecision::Halt`.

**Every hardware boot stopped there, before secure-boot verification was reached.** The five sibling construction sites in the same file all call `init()`; the trust-chain gate was the one that did not.

It was undetectable by any automated check: the whole `msdc_wrapper` module is `#[cfg(not(any(test, feature = "qemu")))]`, and the qemu arm substitutes `BootImageSource::Absent`. Only a physical M7 would ever have reported it.

## Correction — the type, not a lint

A lint or a review checklist can only ever check a *proxy* for "was `init()` called before first I/O". The type can carry the property itself:

```
MsdcBlockDeviceUninit::new(..) --(unsafe) init()--> Result<MsdcBlockDevice, BlockError>
```

`MsdcBlockDevice` loses its constructor. The only route to one is a successful `init()`, which consumes the uninitialized handle. `MsdcBlockDeviceUninit` deliberately does not implement `BlockDevice`.

Because holding the type is now proof that initialization succeeded, the `is_initialized()` guards in `read_sectors`/`write_sectors` are removed — they could no longer fail, and a check that cannot fail reports the same green whether the property holds or not. The `SAFETY` comments cite the type invariant in their place.

Step 8b additionally maps a failed init to `BootImageSource::Absent`, per that enum's own contract — *"no boot medium: qemu (no MSDC model) or an eMMC that failed init"*. Absent degrades; Unreadable halts. A medium that will not initialize is the degrade class, not the halt class.

## Verification

armv7a cross-build green. The guarantee was then falsified rather than assumed — a type never seen refusing the defect it exists to prevent is an unverified claim:

| probe | compiler response |
|---|---|
| the original defect: hand an uninitialized device to `boot_image_source` | `E0277: the trait bound MsdcBlockDeviceUninit: BlockDevice is not satisfied` |
| construct `MsdcBlockDevice` directly | `E0599: no function or associated item named 'new' found` |
| tree restored | builds clean |

## Scope note

This makes the defect class unrepresentable at compile time on every target, including the one that cannot be emulated. It does not make the wrapper's *logic* testable — the bounds arithmetic, the per-sector loop, and the `u32` narrowing remain unexercised off-hardware because `MsdcController` has no trait seam. That gap is #631.

Refs #619 #467 #631
