### PR TITLE
ci(security): migrate cargo-deny to the 0.20 line

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -51,10 +51,10 @@ jobs:
         # direction (unscanned lockfile, entry for a deleted one) reds here.
         run: scripts/check-lockfile-manifest.sh
       - name: Install cargo-deny
-        # WHY: pinned off the 0.20 line — 0.20 changed the check-subcommand
-        # CLI (dropped `check --config`); scripts/security-scan.sh is verified
-        # against the 0.19 CLI. The 0.20 migration is tracked follow-up work.
-        run: cargo install cargo-deny --locked --version ^0.19
+        # WHY (#586): 0.20 moved --config from the check subcommand to the
+        # global position (`cargo-deny --config <path> check ...`, not
+        # `check --config <path>`); scripts/security-scan.sh passes it there.
+        run: cargo install cargo-deny --locked --version ^0.20
       - name: cargo deny (all graphs)
         # WHY (#547): advisories/licenses/bans/sources over EVERY graph in
         # the lockfile manifest (workspace, kernel, fuzz) — one script and

--- a/scripts/security-scan.sh
+++ b/scripts/security-scan.sh
@@ -25,8 +25,12 @@ while IFS='|' read -r lockfile label disposition; do
     case "$mode" in
         deny)
             manifest_dir=$(dirname "$lockfile")
-            cargo deny --manifest-path "$repo/$manifest_dir/Cargo.toml" \
-                check --config "$repo/deny.toml" advisories licenses bans sources || rc=1
+            # NOTE (#586): --config is global-position as of cargo-deny 0.20
+            # (it moved off the check subcommand mid-line; 0.19 accepted
+            # `check --config`, 0.20 rejects it with exit 2).
+            cargo deny --config "$repo/deny.toml" \
+                --manifest-path "$repo/$manifest_dir/Cargo.toml" \
+                check advisories licenses bans sources || rc=1
             ;;
         audit)
             # .cargo/audit.toml at the repo root holds the ignore SSOT; advisory


### PR DESCRIPTION
## Finding

#547 pinned the Security workflow's cargo-deny install to `^0.19` because 0.20 moved `--config` from the `check` subcommand to the global position, and `scripts/security-scan.sh` used the 0.19 shape (`check --config <path>`). Whether the 0.19 `[advisories]` scope values (`unmaintained = "all"`, `unsound = "all"`) and `[graph] all-features` still parsed identically under 0.20 was explicitly unverified in #586.

## Evidence

- `.github/workflows/security.yml` "Install cargo-deny" step pinned `--version ^0.19` with a WHY comment naming the CLI break.
- `scripts/security-scan.sh` deny-mode invocation: `cargo deny --manifest-path ... check --config "$repo/deny.toml" advisories licenses bans sources`.
- Verified locally against cargo-deny 0.20.2 (`cargo install cargo-deny --locked --version ^0.20`):
  - The old (0.19) invocation shape, `check --config <path>`, exits 2 on 0.20.2: `error: unexpected argument '--config' found`.
  - The new global-position shape, `--config <path> --manifest-path <path> check ...`, runs clean (exit 0) on all three scanned graphs (workspace, kernel, fuzz), with the same warning shapes as before (bans `multiple-versions=warn` duplicates, unmatched-skip, license/advisory-not-encountered) and no new denies — the 0.19 `deny.toml` config (`[advisories] unmaintained = "all"`, `unsound = "all"`, `[graph] all-features = true`) parses identically.

## Why this matters

The workflow install pin blocks picking up cargo-deny 0.20.x releases (bugfixes, new advisory-db features) until the CLI-shape mismatch is fixed, and the unverified config-parity claim was a real gap — a config value silently reinterpreted under 0.20 would weaken the gate without any CI signal.

## Desired correction

- Bump the pin to `^0.20` in `.github/workflows/security.yml`.
- Move `--config` to the global position in `scripts/security-scan.sh`.
- Re-run the #547 witness protocol against 0.20 (this PR, done locally on cargo-deny 0.20.2):
  - **RED**: temporarily removed the `RUSTSEC-2023-0089` (atomic-polyfill unmaintained) ignore entry from `deny.toml` — a genuinely reachable advisory in the workspace graph (`atomic-polyfill v1.0.3` via `heapless 0.7.17 → postcard 1.1.3 → sema/krypta`) — and ran `scripts/security-scan.sh deny`: exit 1, `error[unmaintained]: atomic-polyfill is unmaintained` (RUSTSEC-2023-0089).
  - **GREEN**: restored the ignore entry, re-ran the same script: exit 0, `advisories ok, bans ok, licenses ok, sources ok` on all three graphs.

No changes to `deny.toml` ship in this PR — the witness mutation was made and reverted locally only, to prove the migrated scanner actually catches a reachable advisory rather than silently passing everything.

Closes #586
