### PR TITLE
lfs: make the compaction trigger reachable and reject a zero segment_size

### DIFF
--- a/crates/thumos/src/lfs.rs
+++ b/crates/thumos/src/lfs.rs
@@ -555,6 +555,7 @@ pub(crate) fn mount(mut dev: Box<dyn BlockDevice>) -> Result<Lfs, LfsError> {
         &seg_data,
         superblock.segment_count,
         superblock.segment_size,
+        superblock.block_count,
     )?;
 
     Ok(Lfs {
@@ -2374,6 +2375,79 @@ mod tests {
         assert!(
             matches!(result, Err(LfsError::Corrupt)),
             "an oversized segment_bitmap_count must be rejected, not used to drive an allocation"
+        );
+    }
+
+    /// A device wrapper whose writes always fail: used to prove a code
+    /// path (here, `mount()` rejecting a corrupt image) performs reads
+    /// only and never writes through to the disk it is validating,
+    /// regardless of what value would otherwise land there.
+    struct ReadOnlyDevice(MemBlockDevice);
+
+    impl BlockDevice for ReadOnlyDevice {
+        fn read_sectors(
+            &self,
+            lba: u64,
+            count: u32,
+            buf: &mut [u8],
+        ) -> Result<(), block::BlockError> {
+            self.0.read_sectors(lba, count, buf)
+        }
+
+        fn write_sectors(
+            &mut self,
+            _lba: u64,
+            _count: u32,
+            _buf: &[u8],
+        ) -> Result<(), block::BlockError> {
+            Err(block::BlockError::IoError)
+        }
+
+        fn sector_count(&self) -> u64 {
+            self.0.sector_count()
+        }
+    }
+
+    #[test]
+    fn mount_rejects_self_consistent_zero_segment_size() {
+        // WHY (SECURITY, #626): `LfsSuperblock::from_block` validates only
+        // magic/version, and the pre-fix `LfsSegmentManager::deserialize`
+        // check only compared the on-disk segment bitmap's stored geometry
+        // against the superblock's -- both drawn from the same untrusted
+        // image, so a self-consistent segment_size == 0 mounted cleanly.
+        // `segment_start_block` then collapses every segment to block 0,
+        // and the first ordinary write seals a `SegmentHeader` over the
+        // superblock. Craft that exact self-consistent corruption and
+        // confirm mount() now fails closed, through reads alone.
+        let mut dev = block_device_for_lfs();
+        format(&mut dev).expect("format");
+
+        // Corrupt the superblock's segment_size.
+        let mut sb_buf = [0u8; BLOCK_SIZE];
+        block::read_block(&dev, SUPERBLOCK_BLOCK, &mut sb_buf).expect("read superblock");
+        let mut sb = LfsSuperblock::from_block(&sb_buf).expect("parse superblock");
+        sb.segment_size = 0;
+        let corrupted_sb_block = sb.to_block();
+        block::write_block(&mut dev, SUPERBLOCK_BLOCK, &corrupted_sb_block)
+            .expect("write corrupted superblock");
+
+        // Corrupt the on-disk segment bitmap's stored segment_size to
+        // match, so the geometry is self-consistent -- the property the
+        // pre-fix mismatch check alone could not catch.
+        let mut cache = BlockCache::new();
+        let header = lfs_checkpoint::read_checkpoint(&mut dev, &mut cache, CHECKPOINT_SLOT_A)
+            .expect("read checkpoint");
+        let mut bitmap_block = [0u8; BLOCK_SIZE];
+        block::read_block(&dev, header.segment_bitmap_block, &mut bitmap_block)
+            .expect("read segment bitmap block");
+        bitmap_block[4..8].copy_from_slice(&0u32.to_le_bytes());
+        block::write_block(&mut dev, header.segment_bitmap_block, &bitmap_block)
+            .expect("write corrupted segment bitmap");
+
+        let result = mount(Box::new(ReadOnlyDevice(dev)));
+        assert!(
+            matches!(result, Err(LfsError::Corrupt)),
+            "a self-consistent on-disk segment_size == 0 must be rejected, not mounted"
         );
     }
 

--- a/crates/thumos/src/lfs.rs
+++ b/crates/thumos/src/lfs.rs
@@ -2378,6 +2378,45 @@ mod tests {
     }
 
     #[test]
+    fn create_write_unlink_loop_triggers_compaction_before_nospace() {
+        // Done-when (#625): an 8-segment filesystem driven only through
+        // ordinary write()/unlink() calls must trigger compaction and
+        // reclaim garbage before any NoSpace is returned. Before the fix,
+        // `needs_compaction`'s threshold compared raw `free_count()`
+        // against a floor of 1 -- but `allocate()` withholds the last
+        // free segment as a compaction reserve (#329), so ordinary writes
+        // can never drive `free_count()` below 1, and the trigger was
+        // unreachable on any filesystem under 20 segments.
+        use alloc::format;
+
+        let mut dev = block_device_for_lfs(); // 8 segments (2048 blocks).
+        format(&mut dev).expect("format");
+
+        let mut fs = mount(Box::new(dev)).expect("mount");
+        let root = fs.root_inode();
+
+        // Each iteration creates and immediately deletes a 48 KiB file
+        // (12 direct blocks at 4 KiB each, the maximum reachable without
+        // an indirect block), stranding its inode and data blocks as
+        // garbage for the next iteration to potentially reclaim. Run far
+        // more iterations than the device's raw 2048 blocks could ever
+        // absorb without reclaim (roughly 13 blocks of log traffic per
+        // iteration) -- sustained success across all of them is only
+        // possible if compaction is actually running.
+        let payload = [0xABu8; 12 * BLOCK_SIZE];
+        for i in 0..300 {
+            let name = format!("f{i}");
+            let file_id = fs
+                .create(root, &name, InodeType::RegularFile)
+                .unwrap_or_else(|e| panic!("create at iteration {i} failed: {e:?}"));
+            fs.write(file_id, 0, &payload)
+                .unwrap_or_else(|e| panic!("write at iteration {i} failed: {e:?}"));
+            fs.unlink(root, &name)
+                .unwrap_or_else(|e| panic!("unlink at iteration {i} failed: {e:?}"));
+        }
+    }
+
+    #[test]
     fn create_past_one_block_capacity_fails_without_dropping_entries() {
         use alloc::format;
 

--- a/crates/thumos/src/lfs_compact.rs
+++ b/crates/thumos/src/lfs_compact.rs
@@ -32,7 +32,8 @@ use crate::lfs_writer::{COMPACT_THRESHOLD_PERCENT, LfsWriter};
 
 /// Check whether compaction should be triggered based on free segment count.
 ///
-/// Returns `true` if the percentage of free segments is below the threshold.
+/// Returns `true` if the percentage of free segments available to ordinary
+/// writers is below the threshold.
 pub(crate) fn needs_compaction(seg_mgr: &LfsSegmentManager) -> bool {
     let total = seg_mgr.segment_count();
     if total == 0 {
@@ -41,7 +42,14 @@ pub(crate) fn needs_compaction(seg_mgr: &LfsSegmentManager) -> bool {
     let threshold = (u64::from(total) * u64::from(COMPACT_THRESHOLD_PERCENT) / 100) as u32;
     // Always require at least 1 free segment as the minimum threshold.
     let threshold = threshold.max(1);
-    seg_mgr.free_count() < threshold
+    // WHY: `LfsSegmentManager::allocate` withholds the last free segment as
+    // a compaction reserve (#329), so ordinary writers can never drive
+    // `free_count()` below 1. Comparing raw `free_count()` against a
+    // threshold that floors at 1 makes the trigger unreachable through any
+    // production write path on filesystems below 20 segments (#625) --
+    // compare the segments actually available to ordinary writers instead.
+    let usable_free = seg_mgr.free_count().saturating_sub(1);
+    usable_free < threshold
 }
 
 /// Compact one segment: pick the segment with the most garbage, copy its

--- a/crates/thumos/src/lfs_segment.rs
+++ b/crates/thumos/src/lfs_segment.rs
@@ -229,17 +229,39 @@ impl LfsSegmentManager {
     /// Deserialize a segment manager from bytes.
     ///
     /// The `segment_count` and `segment_size` parameters are used to validate
-    /// the deserialized data against expected filesystem geometry.
+    /// the deserialized data against expected filesystem geometry; `device_blocks`
+    /// bounds the geometry they describe against the device that actually
+    /// backs it.
     ///
     /// # Errors
     ///
-    /// Returns [`LfsError::Corrupt`] if the data is too short or the stored
-    /// geometry does not match the expected values.
+    /// Returns [`LfsError::Corrupt`] if the data is too short, the stored
+    /// geometry does not match the expected values, `segment_size` is zero,
+    /// or `segment_count * segment_size` extends past `device_blocks`.
     pub(crate) fn deserialize(
         data: &[u8],
         segment_count: u32,
         segment_size: u32,
+        device_blocks: u64,
     ) -> Result<Self, LfsError> {
+        // WHY (SECURITY, #626): `segment_size` is on-disk, attacker-controlled
+        // geometry. A self-consistent `segment_size == 0` collapses every
+        // segment's start block to 0 (`segment_start_block` multiplies by
+        // it), so the first ordinary write seals into the superblock. Reject
+        // zero outright, and reject any extent this device could not
+        // actually hold -- the same contract `validate_header_geometry`
+        // already applies to the imap and checkpoint-bitmap regions on this
+        // mount path.
+        if segment_size == 0 {
+            return Err(LfsError::Corrupt);
+        }
+        let extent = u64::from(segment_count)
+            .checked_mul(u64::from(segment_size))
+            .ok_or(LfsError::Corrupt)?;
+        if extent > device_blocks {
+            return Err(LfsError::Corrupt);
+        }
+
         if data.len() < 8 {
             return Err(LfsError::Corrupt);
         }
@@ -372,8 +394,8 @@ mod tests {
         mgr.free(2); // free seg 2
 
         let data = mgr.serialize();
-        let restored =
-            LfsSegmentManager::deserialize(&data, 16, 256).expect("deserialize should succeed");
+        let restored = LfsSegmentManager::deserialize(&data, 16, 256, 16 * 256)
+            .expect("deserialize should succeed");
 
         assert_eq!(restored.segment_count(), 16);
         assert_eq!(restored.segment_size(), 256);
@@ -413,17 +435,61 @@ mod tests {
         let data = mgr.serialize();
 
         // Wrong segment count.
-        let result = LfsSegmentManager::deserialize(&data, 16, 256);
+        let result = LfsSegmentManager::deserialize(&data, 16, 256, 1_000_000);
         assert!(
             matches!(result, Err(LfsError::Corrupt)),
             "expected Corrupt for wrong segment count"
         );
 
         // Wrong segment size.
-        let result = LfsSegmentManager::deserialize(&data, 8, 128);
+        let result = LfsSegmentManager::deserialize(&data, 8, 128, 1_000_000);
         assert!(
             matches!(result, Err(LfsError::Corrupt)),
             "expected Corrupt for wrong segment size"
+        );
+    }
+
+    #[test]
+    fn deserialize_rejects_zero_segment_size() {
+        // WHY (SECURITY, #626): a self-consistent on-disk `segment_size ==
+        // 0` collapses `segment_start_block` to 0 for every segment index,
+        // so the first ordinary write seals into the superblock. This must
+        // be rejected before the manager is ever constructed, regardless of
+        // whether the stored bitmap header agrees with it.
+        let mut data = Vec::new();
+        data.extend_from_slice(&8u32.to_le_bytes()); // stored segment_count
+        data.extend_from_slice(&0u32.to_le_bytes()); // stored segment_size = 0
+        data.push(0u8); // one bitmap byte for 8 segments
+
+        let result = LfsSegmentManager::deserialize(&data, 8, 0, 1_000_000);
+        assert!(
+            matches!(result, Err(LfsError::Corrupt)),
+            "segment_size == 0 must be rejected as Corrupt, self-consistent or not"
+        );
+    }
+
+    #[test]
+    fn deserialize_rejects_extent_exceeding_device_blocks() {
+        // A geometry that is internally self-consistent (stored data
+        // matches the requested segment_count/segment_size) but whose
+        // segment_count * segment_size extent runs past the device's
+        // actual block count could not have been produced by format() --
+        // reject it rather than construct a manager describing segments
+        // the device does not have.
+        let mgr = LfsSegmentManager::new(8, 256); // extent = 2048 blocks
+        let data = mgr.serialize();
+
+        let result = LfsSegmentManager::deserialize(&data, 8, 256, 2047);
+        assert!(
+            matches!(result, Err(LfsError::Corrupt)),
+            "an extent exceeding device_blocks must be rejected as Corrupt"
+        );
+
+        // The exact-fit boundary must still be accepted.
+        let result = LfsSegmentManager::deserialize(&data, 8, 256, 2048);
+        assert!(
+            result.is_ok(),
+            "an extent exactly matching device_blocks must be accepted"
         );
     }
 
@@ -440,7 +506,7 @@ mod tests {
         // Done-when (finding 31): fewer than 8 header bytes
         // (segment_count + segment_size, 4 bytes each) must be rejected
         // as Corrupt before any bitmap parsing is attempted.
-        let result = LfsSegmentManager::deserialize(&[0u8; 4], 8, 256);
+        let result = LfsSegmentManager::deserialize(&[0u8; 4], 8, 256, 1_000_000);
         assert!(
             matches!(result, Err(LfsError::Corrupt)),
             "fewer than 8 header bytes must be rejected as Corrupt"
@@ -458,7 +524,7 @@ mod tests {
         // byte_count requires (64 segments = 8 bitmap bytes; leave only 2).
         data.truncate(8 + 2);
 
-        let result = LfsSegmentManager::deserialize(&data, 64, 256);
+        let result = LfsSegmentManager::deserialize(&data, 64, 256, 1_000_000);
         assert!(
             matches!(result, Err(LfsError::Corrupt)),
             "a bitmap shorter than segment_count requires must be rejected as Corrupt"

--- a/crates/thumos/src/lfs_writer.rs
+++ b/crates/thumos/src/lfs_writer.rs
@@ -613,8 +613,8 @@ mod tests {
                 .expect("read seg bitmap");
             seg_data.extend_from_slice(&buf);
         }
-        let restored_seg =
-            LfsSegmentManager::deserialize(&seg_data, 8, 256).expect("deserialize segments");
+        let restored_seg = LfsSegmentManager::deserialize(&seg_data, 8, 256, 8 * 256)
+            .expect("deserialize segments");
 
         assert_eq!(restored_seg.segment_count(), 8);
         // Segment 0 and the writer's segments should be in use.

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -331,7 +331,7 @@ mechanism = "host"
 
 [[module]]
 name = "lfs"
-tests = 33
+tests = 35
 mechanism = "host"
 
 [[module]]
@@ -351,7 +351,7 @@ mechanism = "host"
 
 [[module]]
 name = "lfs_segment"
-tests = 12
+tests = 14
 mechanism = "host"
 
 [[module]]


### PR DESCRIPTION
## Finding

Two independent LFS defects, one per commit.

**#625 — the compaction trigger is unreachable below 20 segments.** `needs_compaction` compared raw `free_count()` against a threshold that floors at 1. But `LfsSegmentManager::allocate` withholds the last free segment as a compaction reserve (#329), so no ordinary write path can drive `free_count()` below 1. On a filesystem small enough that `total * COMPACT_THRESHOLD_PERCENT / 100` rounds under 1, the trigger could never fire — the partition returns ENOSPC with reclaimable garbage still on disk.

**#626 (security) — `mount()` accepts an on-disk `segment_size` of 0.** `segment_size` is attacker-controlled geometry. `segment_start_block` multiplies by it, so a self-consistent zero collapses every segment's start block to 0 and the first ordinary write seals into the superblock.

## Evidence

`crates/thumos/src/lfs_compact.rs` — the comparison was against raw free count:

```rust
let threshold = threshold.max(1);
seg_mgr.free_count() < threshold
```

`crates/thumos/src/lfs_segment.rs` — `deserialize` validated stored geometry against expected values but never rejected a zero `segment_size`, and never bounded the described extent against the device actually backing it.

## Why this matters

#625 is a liveness failure that only appears on small partitions — exactly the configuration least likely to be exercised in test and most likely on a constrained device.

#626 is the data-destruction class. The threat model here treats on-disk bytes as attacker-controlled (a tampered eMMC image), and this is a self-consistent value that passes every existing check while collapsing the segment layout onto the superblock.

## Desired correction

#625 compares the segments actually available to ordinary writers (`free_count().saturating_sub(1)`), with a WHY naming the #329 reserve that makes the raw count misleading.

#626 rejects `segment_size == 0` outright and additionally rejects any extent the device could not hold — `segment_count * segment_size > device_blocks` — using `checked_mul` so the bound itself cannot overflow. This required threading a `device_blocks` parameter through `deserialize`, which accounts for the `lfs_writer.rs` call-site change.

Tests cover both: a zero `segment_size` is rejected before the manager is ever constructed, and the compaction trigger fires on a small filesystem.

**Verification:** authored on verda; CI's kernel job (i686 host tests + armv7a cross-build) is the independent witness here — my own out-of-band run was inconclusive, so this PR is green-or-not on CI rather than on my say-so.

Closes #625
Closes #626
