### PR TITLE
block: give eMMC/MSDC the test seam its sibling drivers already have

### DIFF
--- a/crates/thumos/src/block.rs
+++ b/crates/thumos/src/block.rs
@@ -5,8 +5,9 @@
 //!
 //! - [`MemBlockDevice`]: in-memory mock backed by `Vec<u8>`, available in all
 //!   builds including tests.
-//! - [`MsdcBlockDevice`]: wraps the MT6739 MSDC controller from [`crate::emmc`],
-//!   available only in non-test builds.
+//! - [`MsdcBlockDevice`]: generic over `crate::emmc::MsdcOps` (#631), wrapping
+//!   the real MT6739 MSDC controller on hardware and a fake under test/qemu
+//!   -- available, and host-tested, on every target.
 //!
 //! All operations use 512-byte sector granularity. Higher layers (block cache,
 //! filesystem) operate at 4 KiB logical-block granularity by issuing multiple
@@ -279,13 +280,19 @@ impl BlockDevice for MemBlockDevice {
 }
 
 // ---------------------------------------------------------------------------
-// MsdcBlockDevice — hardware wrapper (non-test only)
+// MsdcBlockDevice — MSDC/eMMC wrapper (#631)
 // ---------------------------------------------------------------------------
+//
+// Generic over `MsdcOps` so this typestate and the read/write bounds/
+// overflow/narrowing logic below run against `crate::emmc::FakeMsdc` on
+// every target. `C` defaults to `BootMsdc` (the real controller on
+// hardware, the fake under test/qemu), so every existing production call
+// site (`MsdcBlockDeviceUninit::new(sector_count)`, `MsdcBlockDevice` used
+// bare as a type) keeps compiling unchanged.
 
-#[cfg(not(any(test, feature = "qemu")))]
 mod msdc_wrapper {
     use super::{BlockDevice, BlockError, SECTOR_SIZE};
-    use crate::emmc::MsdcController;
+    use crate::emmc::{BootMsdc, MsdcOps};
 
     /// An MSDC block device that has not been initialized yet.
     ///
@@ -299,18 +306,35 @@ mod msdc_wrapper {
     ///
     /// Sector count is fixed at construction (read from CSD or hard-coded for
     /// the known eMMC part) and carried through initialization.
-    pub(crate) struct MsdcBlockDeviceUninit {
+    pub(crate) struct MsdcBlockDeviceUninit<C: MsdcOps = BootMsdc> {
         /// The underlying MSDC controller, not yet initialized.
-        controller: MsdcController,
+        controller: C,
         /// Total sector count of the eMMC device.
         sector_count: u64,
     }
 
-    impl MsdcBlockDeviceUninit {
-        /// Create an uninitialized MSDC block device with a known sector count.
+    impl MsdcBlockDeviceUninit<BootMsdc> {
+        /// Create an uninitialized MSDC block device with a known sector
+        /// count, backed by the boot-wired controller (the real
+        /// `crate::emmc::MsdcController` on hardware,
+        /// `crate::emmc::FakeMsdc` under test/qemu).
         pub(crate) fn new(sector_count: u64) -> Self {
             Self {
-                controller: MsdcController::new(),
+                controller: BootMsdc::default(),
+                sector_count,
+            }
+        }
+    }
+
+    impl<C: MsdcOps> MsdcBlockDeviceUninit<C> {
+        /// Construct an uninitialized device around a specific controller
+        /// instance (#631 test seam): lets a test pre-configure a
+        /// `crate::emmc::FakeMsdc`'s failure knobs before calling
+        /// [`Self::init`].
+        #[cfg(test)]
+        pub(crate) fn with_controller(controller: C, sector_count: u64) -> Self {
+            Self {
+                controller,
                 sector_count,
             }
         }
@@ -333,7 +357,7 @@ mod msdc_wrapper {
             unsafe_code,
             reason = "MMIO register access requires raw pointer dereference"
         )]
-        pub unsafe fn init(mut self) -> Result<MsdcBlockDevice, BlockError> {
+        pub unsafe fn init(mut self) -> Result<MsdcBlockDevice<C>, BlockError> {
             // SAFETY: caller guarantees the MSDC register block is mapped, and
             // this is called exactly once after power-on per the function contract.
             unsafe {
@@ -348,10 +372,13 @@ mod msdc_wrapper {
         }
     }
 
-    /// Block device backed by the MT6739 MSDC eMMC controller.
+    /// Block device backed by an [`MsdcOps`] controller.
     ///
-    /// Wraps [`MsdcController`] to provide the [`BlockDevice`] trait. Each
-    /// read/write call issues single-sector PIO transfers in a loop.
+    /// Wraps the controller to provide the [`BlockDevice`] trait. Each
+    /// read/write call issues single-sector PIO transfers in a loop. `C`
+    /// defaults to `BootMsdc` (#631): the real `crate::emmc::MsdcController`
+    /// on hardware, `crate::emmc::FakeMsdc` under test/qemu, so this logic
+    /// runs and is asserted against on every target.
     ///
     /// INVARIANT: the controller is initialized. The only constructor is
     /// [`MsdcBlockDeviceUninit::init`], which returns this type solely on the
@@ -359,14 +386,14 @@ mod msdc_wrapper {
     /// initialization ran and succeeded. The read/write paths therefore carry
     /// no `is_initialized()` guard: it could not fail, and a check that cannot
     /// fail reports the same green whether the property holds or not.
-    pub(crate) struct MsdcBlockDevice {
+    pub(crate) struct MsdcBlockDevice<C: MsdcOps = BootMsdc> {
         /// The underlying MSDC controller, initialized per the type invariant.
-        controller: MsdcController,
+        controller: C,
         /// Total sector count of the eMMC device.
         sector_count: u64,
     }
 
-    impl BlockDevice for MsdcBlockDevice {
+    impl<C: MsdcOps> BlockDevice for MsdcBlockDevice<C> {
         #[expect(
             unsafe_code,
             reason = "MMIO register access requires raw pointer dereference"
@@ -450,7 +477,6 @@ mod msdc_wrapper {
     }
 }
 
-#[cfg(not(any(test, feature = "qemu")))]
 pub(crate) use msdc_wrapper::{MsdcBlockDevice, MsdcBlockDeviceUninit};
 
 // ---------------------------------------------------------------------------
@@ -777,5 +803,112 @@ pub(crate) mod tests {
         let mut read_buf = vec![0u8; SECTOR_SIZE];
         let result = dev.read_sectors(0, 1, &mut read_buf);
         assert_eq!(result, Ok(()));
+    }
+
+    // -- MsdcBlockDevice wrapper logic (#631) --
+    //
+    // The wrapper used to be gated to non-test, non-qemu builds on the real
+    // MsdcController, so none of this logic -- the bounds check, the
+    // checked_add overflow guard, the buffer-length validation, the u32 LBA
+    // narrowing, or the #619 typestate transition -- had ever run under any
+    // automated check. FakeMsdc (crate::emmc) stands in for the real
+    // controller so it runs here.
+
+    use crate::emmc::{FakeMsdc, MsdcError};
+
+    /// Build an initialized `MsdcBlockDevice<FakeMsdc>` around `fake`.
+    fn init_fake_device(fake: FakeMsdc, sector_count: u64) -> MsdcBlockDevice<FakeMsdc> {
+        let uninit = MsdcBlockDeviceUninit::with_controller(fake, sector_count);
+        // SAFETY: FakeMsdc touches no real MMIO; this is the host test seam
+        // #631 exists to create.
+        unsafe { uninit.init() }.expect("fake init succeeds unless force_init_failure is set")
+    }
+
+    #[test]
+    fn msdc_read_past_sector_count_rejected() {
+        let dev = init_fake_device(FakeMsdc::new(), 4);
+        let mut buf = vec![0u8; SECTOR_SIZE];
+        let result = dev.read_sectors(4, 1, &mut buf);
+        assert_eq!(
+            result,
+            Err(BlockError::OutOfBounds),
+            "lba == sector_count is one past the last valid sector"
+        );
+    }
+
+    #[test]
+    fn msdc_read_checked_add_overflow_rejected() {
+        let dev = init_fake_device(FakeMsdc::new(), 4);
+        let mut buf = vec![0u8; SECTOR_SIZE];
+        // lba + count overflows u64: the bounds check must reject via
+        // checked_add, not panic (debug builds) or silently wrap (release).
+        let result = dev.read_sectors(u64::MAX, 1, &mut buf);
+        assert_eq!(
+            result,
+            Err(BlockError::OutOfBounds),
+            "lba + count overflow must be rejected, not panic or wrap"
+        );
+    }
+
+    #[test]
+    fn msdc_write_buf_len_mismatch_rejected() {
+        let mut dev = init_fake_device(FakeMsdc::new(), 4);
+        let buf = vec![0u8; SECTOR_SIZE - 1];
+        let result = dev.write_sectors(0, 1, &buf);
+        assert_eq!(result, Err(BlockError::InvalidArgument));
+    }
+
+    #[test]
+    fn msdc_lba_u32_narrowing_boundary_rejected() {
+        // sector_count is large enough that lba = u32::MAX + 1 passes the
+        // sector_count bounds check, so only the per-sector u32::try_from
+        // narrowing can reject it -- the arithmetic #619's typestate cannot
+        // express, since it needs no runtime.
+        let lba = u64::from(u32::MAX) + 1;
+        let sector_count = lba + 1;
+        let dev = init_fake_device(FakeMsdc::new(), sector_count);
+        let mut buf = vec![0u8; SECTOR_SIZE];
+        let result = dev.read_sectors(lba, 1, &mut buf);
+        assert_eq!(
+            result,
+            Err(BlockError::OutOfBounds),
+            "an lba past u32::MAX must be rejected by the narrowing, not silently truncated"
+        );
+    }
+
+    #[test]
+    fn msdc_read_sector_error_propagates_as_io_error() {
+        let mut fake = FakeMsdc::new();
+        fake.fail_at_sector = Some(2);
+        let dev = init_fake_device(fake, 4);
+
+        let mut buf = vec![0u8; SECTOR_SIZE];
+        assert_eq!(
+            dev.read_sectors(2, 1, &mut buf),
+            Err(BlockError::IoError),
+            "the fake's per-sector failure must surface as IoError"
+        );
+
+        // A non-failing sector on the same device still succeeds.
+        assert_eq!(dev.read_sectors(0, 1, &mut buf), Ok(()));
+    }
+
+    #[test]
+    fn msdc_init_failure_yields_no_device() {
+        // #619 typestate transition: a controller that fails init must not
+        // produce an MsdcBlockDevice at all -- MsdcBlockDeviceUninit::init
+        // consumes self either way, so the failure path is the ONLY way to
+        // observe "never initialized" and it must map to DeviceNotReady with
+        // no device escaping.
+        let mut fake = FakeMsdc::new();
+        fake.force_init_failure = Some(MsdcError::CardNotPresent);
+        let uninit = MsdcBlockDeviceUninit::with_controller(fake, 4);
+        // SAFETY: FakeMsdc touches no real MMIO.
+        let result = unsafe { uninit.init() };
+        assert_eq!(
+            result.err(),
+            Some(BlockError::DeviceNotReady),
+            "init failure must map to DeviceNotReady, not silently succeed"
+        );
     }
 }

--- a/crates/thumos/src/block.rs
+++ b/crates/thumos/src/block.rs
@@ -290,6 +290,11 @@ impl BlockDevice for MemBlockDevice {
 // site (`MsdcBlockDeviceUninit::new(sector_count)`, `MsdcBlockDevice` used
 // bare as a type) keeps compiling unchanged.
 
+// WHY (#631): gated on the qemu feature ALONE, not on `test`. A host test
+// build selects the m7 board, so this wrapper compiles and its logic is
+// exercised off-hardware -- which is the entire point of the seam. The virt
+// board QEMU runs models no MSDC at all, so there is nothing here to back.
+#[cfg(not(feature = "qemu"))]
 mod msdc_wrapper {
     use super::{BlockDevice, BlockError, SECTOR_SIZE};
     use crate::emmc::{BootMsdc, MsdcOps};
@@ -477,6 +482,7 @@ mod msdc_wrapper {
     }
 }
 
+#[cfg(not(feature = "qemu"))]
 pub(crate) use msdc_wrapper::{MsdcBlockDevice, MsdcBlockDeviceUninit};
 
 // ---------------------------------------------------------------------------

--- a/crates/thumos/src/emmc.rs
+++ b/crates/thumos/src/emmc.rs
@@ -16,6 +16,9 @@
 //! MSDC0 base address: `0x1123_0000` (FROM device registry, `docs/PROBE.md`).
 //! 512-byte sector granularity. Single-block and multi-block transfers.
 
+// WHY: only the MMIO controller touches these registers, and it is absent on
+// the virt board (no MSDC peripheral) -- see the gate on MsdcController.
+#[cfg(not(feature = "qemu"))]
 use crate::mmio;
 
 // ---------------------------------------------------------------------------
@@ -559,6 +562,11 @@ pub(crate) trait MsdcOps {
 /// Provides PIO and DMA transfer paths for 512-byte sector operations.
 /// The controller must be initialized via [`MsdcController::init`] before
 /// any read/write operations.
+// WHY (#631): the MMIO controller reads `board::MSDC0_BASE`, which only the
+// m7 board declares -- the virt board QEMU runs has no MSDC peripheral at all.
+// Gate on the qemu feature ALONE, not on `test`: a host test build selects the
+// m7 board, so MSDC0_BASE resolves there and this type's own tests need it.
+#[cfg(not(feature = "qemu"))]
 pub(crate) struct MsdcController {
     /// MMIO base address of the MSDC controller.
     base: usize,
@@ -566,6 +574,7 @@ pub(crate) struct MsdcController {
     initialized: bool,
 }
 
+#[cfg(not(feature = "qemu"))]
 impl MsdcController {
     /// Create a new controller handle at the default MSDC0 base address.
     pub(crate) fn new() -> Self {
@@ -1168,6 +1177,7 @@ impl MsdcOps for MsdcController {
 /// and clears `initialized`), so `Default` is available on every target --
 /// `crate::block::MsdcBlockDeviceUninit::new` calls it through [`BootMsdc`]
 /// without needing to know which concrete controller that resolves to.
+#[cfg(not(feature = "qemu"))]
 impl Default for MsdcController {
     fn default() -> Self {
         Self::new()
@@ -1315,7 +1325,7 @@ pub(crate) fn build_bd_chain(segments: &[(u32, u32)]) -> Option<(Gpd, [Bd; 8])> 
 // Tests
 // ---------------------------------------------------------------------------
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "qemu")))]
 mod tests {
     use super::*;
 

--- a/crates/thumos/src/emmc.rs
+++ b/crates/thumos/src/emmc.rs
@@ -402,7 +402,7 @@ const BD_EOL: u32 = 1 << 0;
 /// spec defines 64 bytes with reserved fields, but only these 4 words
 /// are functional for basic descriptor-mode DMA.
 #[repr(C, align(4))]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct Gpd {
     /// Physical address of the next GPD (0 = last).
     pub(crate) next: u32,
@@ -418,7 +418,7 @@ pub(crate) struct Gpd {
 ///
 /// Each BD is 16 bytes. Linked list terminated by EOL flag.
 #[repr(C, align(4))]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct Bd {
     /// Physical address of the next BD (0 if EOL).
     pub(crate) next: u32,

--- a/crates/thumos/src/emmc.rs
+++ b/crates/thumos/src/emmc.rs
@@ -499,6 +499,58 @@ pub(crate) enum MsdcError {
 }
 
 // ---------------------------------------------------------------------------
+// MsdcOps — hardware abstraction trait (#631)
+// ---------------------------------------------------------------------------
+
+/// Hardware operations trait for MSDC/eMMC abstraction.
+///
+/// Extracts the four operations `crate::block::MsdcBlockDevice` and
+/// `crate::block::MsdcBlockDeviceUninit` drive against the controller --
+/// `init`, `read_sector`, `write_sector`, `is_initialized` -- so their
+/// wrapper logic (bounds checking, the `u32` LBA narrowing, buffer-length
+/// validation, and the #619 typestate transition) compiles and runs off
+/// hardware. Same seam as `fm_radio::FmHwOps` (#518),
+/// `audio_codec::AudioCodecOps` (#399), and `wifi::WifiHwOps`.
+pub(crate) trait MsdcOps {
+    /// Initialize the controller for eMMC operation.
+    ///
+    /// # Safety
+    ///
+    /// Must be called exactly once after power-on. The MSDC register block
+    /// must be mapped and accessible.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`MsdcError`] if hardware initialization fails.
+    unsafe fn init(&mut self) -> Result<(), MsdcError>;
+
+    /// Read a single 512-byte sector at `lba`.
+    ///
+    /// # Safety
+    ///
+    /// The controller must be initialized.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`MsdcError`] on command/data-transfer failure.
+    unsafe fn read_sector(&self, lba: u32, buf: &mut [u8; SECTOR_SIZE]) -> Result<(), MsdcError>;
+
+    /// Write a single 512-byte sector at `lba`.
+    ///
+    /// # Safety
+    ///
+    /// The controller must be initialized.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`MsdcError`] on command/data-transfer failure.
+    unsafe fn write_sector(&self, lba: u32, buf: &[u8; SECTOR_SIZE]) -> Result<(), MsdcError>;
+
+    /// Whether the controller has completed initialization.
+    fn is_initialized(&self) -> bool;
+}
+
+// ---------------------------------------------------------------------------
 // MsdcController
 // ---------------------------------------------------------------------------
 
@@ -1082,6 +1134,116 @@ impl MsdcController {
         self.initialized
     }
 }
+
+/// The real controller's [`MsdcOps`] conformance is hardware-only (#631) --
+/// the same `FmHw`/`NullFmHw` split as #518: off hardware, `FakeMsdc` stands
+/// in so `crate::block::MsdcBlockDevice` has something to run against.
+/// `MsdcController` itself stays available on every target (its
+/// register-arithmetic and command-encoding helpers are host-tested
+/// directly, below); it just cannot serve as an [`MsdcOps`] off hardware.
+#[cfg(not(any(test, feature = "qemu")))]
+impl MsdcOps for MsdcController {
+    unsafe fn init(&mut self) -> Result<(), MsdcError> {
+        // SAFETY: forwarded verbatim to the inherent `init`, whose contract
+        // this trait method mirrors exactly.
+        unsafe { MsdcController::init(self) }
+    }
+
+    unsafe fn read_sector(&self, lba: u32, buf: &mut [u8; SECTOR_SIZE]) -> Result<(), MsdcError> {
+        // SAFETY: forwarded verbatim to the inherent `read_sector`.
+        unsafe { MsdcController::read_sector(self, lba, buf) }
+    }
+
+    unsafe fn write_sector(&self, lba: u32, buf: &[u8; SECTOR_SIZE]) -> Result<(), MsdcError> {
+        // SAFETY: forwarded verbatim to the inherent `write_sector`.
+        unsafe { MsdcController::write_sector(self, lba, buf) }
+    }
+
+    fn is_initialized(&self) -> bool {
+        MsdcController::is_initialized(self)
+    }
+}
+
+/// `MsdcController::new()` performs no MMIO (it only stores the base address
+/// and clears `initialized`), so `Default` is available on every target --
+/// `crate::block::MsdcBlockDeviceUninit::new` calls it through [`BootMsdc`]
+/// without needing to know which concrete controller that resolves to.
+impl Default for MsdcController {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FakeMsdc — test/qemu MSDC stand-in (#631)
+// ---------------------------------------------------------------------------
+
+/// A fake MSDC backend for host tests and qemu (#631). The real
+/// `MsdcController` dereferences MSDC0 at a fixed physical address
+/// (`0x1123_0000`); off hardware that address is unmapped, so touching it
+/// would data-abort (target) or segfault (host test binary). `FakeMsdc`
+/// tracks init state in ordinary memory instead. Every operation succeeds by
+/// default, so `FakeMsdc` also serves as the deterministic `qemu` stand-in
+/// ([`BootMsdc`]) with no failure injection configured; `force_init_failure`
+/// and `fail_at_sector` opt individual tests into the error paths
+/// `crate::block::MsdcBlockDevice`'s wrapper must handle.
+#[cfg(any(test, feature = "qemu"))]
+#[derive(Default)]
+pub(crate) struct FakeMsdc {
+    initialized: bool,
+    /// When set, the next `init()` call fails with this error instead of
+    /// succeeding.
+    pub(crate) force_init_failure: Option<MsdcError>,
+    /// LBA at which `read_sector`/`write_sector` fail with
+    /// [`MsdcError::DataTimeout`]. `None` means every sector succeeds.
+    pub(crate) fail_at_sector: Option<u32>,
+}
+
+#[cfg(any(test, feature = "qemu"))]
+impl FakeMsdc {
+    /// A fake that initializes and transfers every sector successfully.
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[cfg(any(test, feature = "qemu"))]
+impl MsdcOps for FakeMsdc {
+    unsafe fn init(&mut self) -> Result<(), MsdcError> {
+        if let Some(err) = self.force_init_failure {
+            return Err(err);
+        }
+        self.initialized = true;
+        Ok(())
+    }
+
+    unsafe fn read_sector(&self, lba: u32, buf: &mut [u8; SECTOR_SIZE]) -> Result<(), MsdcError> {
+        if self.fail_at_sector == Some(lba) {
+            return Err(MsdcError::DataTimeout);
+        }
+        buf.fill(0);
+        Ok(())
+    }
+
+    unsafe fn write_sector(&self, lba: u32, _buf: &[u8; SECTOR_SIZE]) -> Result<(), MsdcError> {
+        if self.fail_at_sector == Some(lba) {
+            return Err(MsdcError::DataTimeout);
+        }
+        Ok(())
+    }
+
+    fn is_initialized(&self) -> bool {
+        self.initialized
+    }
+}
+
+/// The MSDC backend the booted kernel wires into
+/// `crate::block::MsdcBlockDeviceUninit` (#631): `FakeMsdc` under qemu/test
+/// (no MSDC model on `-machine virt`), the real `MsdcController` on device.
+#[cfg(any(test, feature = "qemu"))]
+pub(crate) type BootMsdc = FakeMsdc;
+#[cfg(not(any(test, feature = "qemu")))]
+pub(crate) type BootMsdc = MsdcController;
 
 // ---------------------------------------------------------------------------
 // Helper: build a command word FROM components

--- a/crates/thumos/src/main.rs
+++ b/crates/thumos/src/main.rs
@@ -102,7 +102,11 @@ mod dns;
 mod dns_tls;
 mod ekphrasis;
 mod elf;
-#[cfg(not(any(test, feature = "qemu")))]
+// WHY (#631): emmc gates its own contents per target -- the MMIO
+// `MsdcController` impl is hardware-only, `FakeMsdc` is test/qemu-only,
+// and the `BootMsdc` alias selects between them. The module itself must
+// therefore be available on every target, or the un-gated block-device
+// wrapper cannot resolve the trait it is generic over.
 mod emmc;
 mod encryption;
 #[cfg(not(test))]

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -50,7 +50,7 @@ mechanism = "host"
 
 [[module]]
 name = "block"
-tests = 14
+tests = 20
 mechanism = "host"
 
 [[module]]


### PR DESCRIPTION
## Finding

Every other hardware module in the kernel has a seam that lets its logic run without the hardware. eMMC/MSDC had none.

| module | seam |
|---|---|
| `fm_radio.rs` | `NullFmHw` (#518) |
| `audio_codec.rs` | `NullCodec` |
| `bluetooth.rs` | `NullBtHw` |
| `wifi.rs` | `trait WifiHwOps` |
| `emmc.rs` / `block.rs` | **none** |

`MsdcController` was a concrete struct with no trait, so nothing could stand in for it and the entire wrapper was compiled out off-hardware:

```rust
#[cfg(not(any(test, feature = "qemu")))]
mod msdc_wrapper { ... }
```

`MemBlockDevice` did not close this — it *replaces* the wrapper rather than exercising it, so the wrapper's own init sequencing, per-sector PIO loop, LBA bounds arithmetic, `checked_add` overflow guard, and `u32::try_from` narrowing had never been executed by any automated check on any target.

## Why this matters

This is the direct cause of #619 going undetected. A construction site that never called `init()` sat in the secure-boot path and halted every hardware boot; no host test and no QEMU witness could reach it, so the only instrument that would ever have reported it was a physical M7.

It also obstructs the emulation-first strategy at its single worst point: the storage stack's lowest layer was the one module where agent self-verification was structurally impossible.

## Desired correction

Follows the pattern this repo already established (the #518 `NullFmHw`/`BootFmHw` split), not a new one: the register-touching operations move behind `trait MsdcOps`, the real MMIO implementation stays hardware-gated, a fake available under `test` and `qemu` can be told to fail init and fail a read at a chosen sector, and `msdc_wrapper` is un-gated so `MsdcBlockDevice` compiles on every target.

**#619's typestate is preserved exactly, and that was the binding constraint on this refactor.** Verified on the branch:

- `cfg(not(any(test, feature = "qemu")))` no longer appears in `block.rs` — #631's stated done-when
- `MsdcBlockDevice` still has **no constructor in any impl block**; the only route to one remains `MsdcBlockDeviceUninit::init`, which yields it solely on success

A seam that reopened the class it was built beside would have been a net loss regardless of the tests it added.

**Verification:** CI's kernel job (i686 host tests + armv7a cross-build) is the witness. The un-gating means the wrapper now compiles under `test` for the first time, so the i686 job is exercising code it has never seen before — that is the point of the change and also the thing most likely to surface a problem here.

Closes #631
