### PR TITLE
fix(kinit): distinguish a corrupt secrets preamble from unprovisioned

### DIFF
--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -909,7 +909,7 @@ pub unsafe fn run() -> ! {
                         board::LFS_PREAMBLE_SECTORS,
                     );
                     match crate::secrets::load(&mut view) {
-                        Ok(Some(found)) => {
+                        Ok(crate::secrets::PreambleStatus::Valid(found)) => {
                             state.preamble = if found.boot_verifier.is_some() {
                                 PreambleLoad::Provisioned
                             } else {
@@ -917,7 +917,21 @@ pub unsafe fn run() -> ! {
                             };
                             boot_secrets = Some(found);
                         }
-                        Ok(None) => state.preamble = PreambleLoad::Unprovisioned,
+                        Ok(crate::secrets::PreambleStatus::Absent) => {
+                            state.preamble = PreambleLoad::Unprovisioned;
+                        }
+                        // #621: magic present but validation failed -- a
+                        // PROVISIONED device, not a blank one. Must never
+                        // collapse to Unprovisioned: that would let
+                        // first-boot setup overwrite the only copy of the
+                        // salt, or let the mount gate plain-mount (and
+                        // then format) the still-encrypted payload.
+                        Ok(crate::secrets::PreambleStatus::Corrupt) => {
+                            serial.log(
+                                " WARN Secrets preamble corrupt (magic present, validation failed) -- locking\r\n",
+                            );
+                            state.preamble = PreambleLoad::Corrupt;
+                        }
                         Err(e) => {
                             boot_log!(serial, " WARN Secrets preamble read failed: {:?}\r\n", e);
                             state.preamble = PreambleLoad::ReadFailed;

--- a/crates/thumos/src/kinit_plan.rs
+++ b/crates/thumos/src/kinit_plan.rs
@@ -121,14 +121,24 @@ impl BootStep {
 pub(crate) enum PreambleLoad {
     /// The read has not run yet (no eMMC, or the step was not reached).
     NotRead,
-    /// Header absent/corrupt: no salt, no verifier — the device has never
-    /// set a boot passphrase. First-boot setup may provision it.
+    /// Header absent (no magic — never written): no salt, no verifier —
+    /// the device has never set a boot passphrase. First-boot setup may
+    /// provision it.
     Unprovisioned,
     /// A valid header carrying a boot passphrase verifier.
     Provisioned,
     /// The read itself failed (I/O). Fail-closed: the payload state is
     /// UNKNOWN, so it is treated as locked.
     ReadFailed,
+    /// The sector carries the preamble magic but fails version,
+    /// slot-count, integrity, or zero-payload validation (#621): the
+    /// device WAS provisioned and this content is unusable, not blank.
+    /// Must never be treated as `Unprovisioned` — that would re-provision
+    /// over (destroying) the only copy of the original salt, or fall
+    /// through to a plain mount that formats the still-encrypted
+    /// userdata. Treated identically to `ReadFailed`: an unreadable
+    /// preamble and a corrupt one are the same UNKNOWN-so-locked state.
+    Corrupt,
 }
 
 /// What the boot passphrase step does (#446).
@@ -148,8 +158,9 @@ pub(crate) enum BootPassphrasePlan {
 ///
 /// Fail-closed ordering (#217): the trust root is checked FIRST — key
 /// derivation never runs on an unverified image. A preamble that was not
-/// read or could not be read never falls into setup: a transient fault
-/// must not masquerade as first boot.
+/// read, could not be read, or was read but fails validation never falls
+/// into setup (#621): a transient fault, or a corrupted-but-present
+/// header, must not masquerade as first boot.
 pub(crate) const fn boot_passphrase_plan(
     secure_boot_ok: bool,
     display_ok: bool,
@@ -162,7 +173,9 @@ pub(crate) const fn boot_passphrase_plan(
     match preamble {
         PreambleLoad::Provisioned => BootPassphrasePlan::Verify,
         PreambleLoad::Unprovisioned => BootPassphrasePlan::FirstBootSetup,
-        PreambleLoad::NotRead | PreambleLoad::ReadFailed => BootPassphrasePlan::Skip,
+        PreambleLoad::NotRead | PreambleLoad::ReadFailed | PreambleLoad::Corrupt => {
+            BootPassphrasePlan::Skip
+        }
     }
 }
 
@@ -184,7 +197,9 @@ pub(crate) enum MountPlan {
 ///   today's code already enforces);
 /// - a provisioned (locked) payload is NEVER plain-mounted or formatted —
 ///   without the derived key the only honest mount is none;
-/// - an unreadable preamble is treated as provisioned (unknown = locked).
+/// - an unreadable OR corrupt preamble is treated as provisioned (unknown
+///   = locked, #621) — never as unprovisioned, which would plain-mount
+///   and then format on the resulting `InvalidSuperblock`.
 pub(crate) const fn mount_plan(
     emmc_ok: bool,
     secure_boot_ok: bool,
@@ -199,9 +214,10 @@ pub(crate) const fn mount_plan(
     }
     match preamble {
         PreambleLoad::Unprovisioned => MountPlan::Plain,
-        PreambleLoad::Provisioned | PreambleLoad::ReadFailed | PreambleLoad::NotRead => {
-            MountPlan::RamfsFallback
-        }
+        PreambleLoad::Provisioned
+        | PreambleLoad::ReadFailed
+        | PreambleLoad::NotRead
+        | PreambleLoad::Corrupt => MountPlan::RamfsFallback,
     }
 }
 
@@ -879,6 +895,14 @@ mod tests {
             boot_passphrase_plan(true, true, true, PreambleLoad::NotRead),
             BootPassphrasePlan::Skip
         );
+        // #621: a corrupted-but-present preamble is a PROVISIONED device,
+        // never a first-boot candidate -- setup here would silently
+        // overwrite the only copy of the original salt.
+        assert_eq!(
+            boot_passphrase_plan(true, true, true, PreambleLoad::Corrupt),
+            BootPassphrasePlan::Skip,
+            "corrupt preamble must never be treated as first boot (#621)"
+        );
     }
 
     #[test]
@@ -908,6 +932,14 @@ mod tests {
         assert_eq!(
             mount_plan(true, true, PreambleLoad::NotRead, false),
             MountPlan::RamfsFallback
+        );
+        // #621: a corrupted-but-present preamble reaches neither the
+        // plain-mount arm nor a reformat -- it is locked on the same
+        // footing as an unreadable one, never treated as unprovisioned.
+        assert_eq!(
+            mount_plan(true, true, PreambleLoad::Corrupt, false),
+            MountPlan::RamfsFallback,
+            "corrupt preamble is locked, never plain-mounted or formatted (#621)"
         );
         // The two real mounts.
         assert_eq!(

--- a/crates/thumos/src/secrets.rs
+++ b/crates/thumos/src/secrets.rs
@@ -34,11 +34,17 @@
 //! the encrypted payload itself (and NEVER a raw SHA-256(passphrase)
 //! fast-path). It carries no entropy of its own beyond the passphrase.
 //!
-//! Provisioning is implicit: a missing, malformed, or corrupt header is
-//! (re)provisioned with a fresh random salt; a valid header is read back.
-//! The whole header fits one sector, so eMMC single-sector write
-//! atomicity bounds the torn-write window to "old salt or new salt", and
-//! the integrity tag detects the torn half.
+//! Two read entry points, deliberately different fail modes (#621):
+//! [`load_or_provision`] treats a missing OR corrupt header alike and
+//! (re)provisions a fresh random salt over either — the whole header fits
+//! one sector, so eMMC single-sector write atomicity bounds the torn-write
+//! window to "old salt or new salt", and the integrity tag detects the
+//! torn half. [`load`] is read-only and must NOT collapse that
+//! distinction: the boot path (kinit) needs "never written" (a legitimate
+//! first-boot candidate) kept apart from "written, then corrupted" (a
+//! provisioned device whose only salt copy a re-provision would destroy,
+//! or whose ciphertext a fallback plain-mount-and-format would destroy) —
+//! see [`PreambleStatus`] and `kinit_plan::PreambleLoad::Corrupt`.
 
 use crate::block::{BlockDevice, BlockError, SECTOR_SIZE};
 
@@ -70,6 +76,7 @@ pub(crate) const VERIFIER_LEN: usize = 32;
 const VERIFIER_OFFSET: usize = 80;
 
 /// The per-device secrets this boot derived from the preamble.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct DeviceSecrets {
     /// The PBKDF2 device salt: random at provisioning, plaintext on disk,
     /// stable across boots.
@@ -80,6 +87,26 @@ pub(crate) struct DeviceSecrets {
     pub(crate) boot_verifier: Option<[u8; VERIFIER_LEN]>,
 }
 
+/// Outcome of parsing a preamble sector image (#621).
+///
+/// `Absent` and `Corrupt` must never be conflated: only `Absent` is a
+/// legitimate first-boot candidate. `Corrupt` means a device WAS
+/// provisioned and the sector no longer validates — the caller must treat
+/// it the same as a read failure (unknown state = locked), never the same
+/// as `Absent` (which would re-provision over, or plain-mount-and-format,
+/// a payload that is still encrypted under the lost salt).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PreambleStatus {
+    /// No preamble magic: the sector has never been written by this
+    /// scheme (a factory-blank device).
+    Absent,
+    /// The preamble magic is present but the sector fails version,
+    /// slot-count, integrity-tag, or zero-payload validation.
+    Corrupt,
+    /// A structurally valid, integrity-checked header.
+    Valid(DeviceSecrets),
+}
+
 /// Compute the integrity tag over a sector image (tag field zeroed).
 fn integrity_of(sector: &[u8; SECTOR_SIZE]) -> [u8; 32] {
     let mut copy = *sector;
@@ -87,49 +114,57 @@ fn integrity_of(sector: &[u8; SECTOR_SIZE]) -> [u8; 32] {
     crate::security::sha256(&copy)
 }
 
-/// Read the secrets from a sector image, or `None` if the header is
-/// absent (bad magic/version/slot count) or corrupt (integrity
-/// mismatch). Returns the salt plus the boot verifier when the header
-/// carries one (slot count 2).
-fn parse(sector: &[u8; SECTOR_SIZE]) -> Option<([u8; SALT_LEN], Option<[u8; VERIFIER_LEN]>)> {
+/// Classify a sector image (#621): [`PreambleStatus::Absent`] when no
+/// preamble was ever written here (bad magic — the sole "never
+/// provisioned" signal); [`PreambleStatus::Corrupt`] when the magic is
+/// present but version, slot count, integrity tag, or a zero-payload
+/// guard fails (a provisioned device whose header is now unusable);
+/// otherwise [`PreambleStatus::Valid`] with the salt plus the boot
+/// verifier when the header carries one (slot count 2). Magic presence is
+/// the ONLY line between `Absent` and `Corrupt` — every check after it
+/// means "this was a preamble" and must not fall back to `Absent`.
+fn parse(sector: &[u8; SECTOR_SIZE]) -> PreambleStatus {
     if sector[..8] != MAGIC {
-        return None;
+        return PreambleStatus::Absent;
     }
-    let version = u32::from_le_bytes(sector[VERSION_OFFSET..VERSION_OFFSET + 4].try_into().ok()?);
-    if version != VERSION {
-        return None;
+    let mut version_bytes = [0u8; 4];
+    version_bytes.copy_from_slice(&sector[VERSION_OFFSET..VERSION_OFFSET + 4]);
+    if u32::from_le_bytes(version_bytes) != VERSION {
+        return PreambleStatus::Corrupt;
     }
-    let count = u32::from_le_bytes(
-        sector[SLOT_COUNT_OFFSET..SLOT_COUNT_OFFSET + 4]
-            .try_into()
-            .ok()?,
-    );
+    let mut count_bytes = [0u8; 4];
+    count_bytes.copy_from_slice(&sector[SLOT_COUNT_OFFSET..SLOT_COUNT_OFFSET + 4]);
+    let count = u32::from_le_bytes(count_bytes);
     if count != 1 && count != 2 {
-        return None;
+        return PreambleStatus::Corrupt;
     }
     if sector[INTEGRITY_OFFSET..INTEGRITY_OFFSET + 32] != integrity_of(sector) {
-        return None;
+        return PreambleStatus::Corrupt;
     }
     let mut salt = [0u8; SALT_LEN];
     salt.copy_from_slice(&sector[SALT_OFFSET..SALT_OFFSET + SALT_LEN]);
     if salt.iter().all(|&b| b == 0) {
         // An all-zero salt is never legitimate: it would silently re-create
-        // the shared-salt failure mode #449 exists to kill.
-        return None;
+        // the shared-salt failure mode #449 exists to kill. Magic and
+        // integrity both checked out, so this is corruption, not absence.
+        return PreambleStatus::Corrupt;
     }
-    let verifier = if count == 2 {
+    let boot_verifier = if count == 2 {
         let mut v = [0u8; VERIFIER_LEN];
         v.copy_from_slice(&sector[VERIFIER_OFFSET..VERIFIER_OFFSET + VERIFIER_LEN]);
         if v.iter().all(|&b| b == 0) {
             // An all-zero verifier is never legitimate: a zero slot would
             // turn a corrupt read into an empty-derivation oracle.
-            return None;
+            return PreambleStatus::Corrupt;
         }
         Some(v)
     } else {
         None
     };
-    Some((salt, verifier))
+    PreambleStatus::Valid(DeviceSecrets {
+        salt,
+        boot_verifier,
+    })
 }
 
 /// Render a header sector around `salt`, optionally carrying the boot
@@ -150,7 +185,14 @@ fn render(salt: &[u8; SALT_LEN], verifier: Option<&[u8; VERIFIER_LEN]>) -> [u8; 
 }
 
 /// Load the device secrets from the preamble, provisioning a fresh random
-/// salt when the header is absent or corrupt (#449).
+/// salt when the header is absent OR corrupt (#449).
+///
+/// WHY absent and corrupt are treated alike HERE (unlike [`load`], #621):
+/// this entry point is never used on the early boot probe — it is a
+/// blind provisioning helper, and its whole contract is "make the header
+/// valid, no matter what state it started in". The boot path instead uses
+/// the read-only [`load`], which keeps the two states apart so the caller
+/// can lock instead of overwrite.
 ///
 /// `dev` is the block view over the preamble region (a
 /// `PartitionBlockDevice` carved at the userdata partition head — #603);
@@ -169,11 +211,8 @@ pub(crate) fn load_or_provision<D: BlockDevice>(
 ) -> Result<DeviceSecrets, BlockError> {
     let mut sector = [0u8; SECTOR_SIZE];
     dev.read_sectors(0, 1, &mut sector)?;
-    if let Some((salt, boot_verifier)) = parse(&sector) {
-        return Ok(DeviceSecrets {
-            salt,
-            boot_verifier,
-        });
+    if let PreambleStatus::Valid(secrets) = parse(&sector) {
+        return Ok(secrets);
     }
 
     let mut salt = [0u8; SALT_LEN];
@@ -191,19 +230,23 @@ pub(crate) fn load_or_provision<D: BlockDevice>(
 /// The boot path probes the preamble before the trust gate is evaluated
 /// (the mount plan needs the fail-closed signal early), and a blind
 /// re-provision there would clobber a valid header after a transient
-/// fault — so this entry point never writes. `Ok(None)` means absent or
-/// corrupt (a first-boot candidate); `Err` means the read itself failed.
+/// fault — so this entry point never writes.
+///
+/// `Ok(PreambleStatus::Absent)` means no preamble was ever written (a
+/// first-boot candidate). `Ok(PreambleStatus::Corrupt)` means one WAS
+/// written and no longer validates — the caller must route this the same
+/// as a read failure, NEVER the same as `Absent` (#621): collapsing the
+/// two turns a bit flip into first-boot re-provisioning (destroys the
+/// salt) or a plain-mount-and-format (destroys the ciphertext). `Err`
+/// means the sector read itself failed.
 ///
 /// # Errors
 ///
 /// Returns [`BlockError`] when the sector read fails.
-pub(crate) fn load<D: BlockDevice>(dev: &mut D) -> Result<Option<DeviceSecrets>, BlockError> {
+pub(crate) fn load<D: BlockDevice>(dev: &mut D) -> Result<PreambleStatus, BlockError> {
     let mut sector = [0u8; SECTOR_SIZE];
     dev.read_sectors(0, 1, &mut sector)?;
-    Ok(parse(&sector).map(|(salt, boot_verifier)| DeviceSecrets {
-        salt,
-        boot_verifier,
-    }))
+    Ok(parse(&sector))
 }
 
 /// Store the boot passphrase verifier alongside the existing salt (#446).
@@ -266,7 +309,10 @@ mod tests {
         assert_eq!(sector[..8], MAGIC, "magic written");
         assert_eq!(
             parse(&sector),
-            Some((secrets.salt, None)),
+            PreambleStatus::Valid(DeviceSecrets {
+                salt: secrets.salt,
+                boot_verifier: None,
+            }),
             "header parses to the provisioned salt, no verifier yet"
         );
         assert_eq!(
@@ -298,13 +344,65 @@ mod tests {
         dev.read_sectors(0, 1, &mut sector).expect("read");
         sector[SALT_OFFSET] ^= 0xFF;
         dev.write_sectors(0, 1, &sector).expect("corrupt");
-        assert_eq!(parse(&sector), None, "corrupt payload must fail integrity");
+        assert_eq!(
+            parse(&sector),
+            PreambleStatus::Corrupt,
+            "corrupt payload (magic present, integrity fails) is Corrupt, never Absent (#621)"
+        );
 
+        // load_or_provision's OWN contract (unlike load's, see module doc)
+        // is to re-provision over Corrupt just like Absent.
         let second = load_or_provision(&mut dev, stream(0xB0)).expect("re-provision");
         assert_ne!(
             first.salt, second.salt,
             "re-provision generates a fresh salt"
         );
+    }
+
+    #[test]
+    fn load_distinguishes_corrupt_from_absent_and_never_reprovisions_either() {
+        // The #621 regression scenario at the `load()` boundary kinit
+        // actually calls: a genuinely blank device reports Absent...
+        let mut blank = MemBlockDevice::new(1).expect("blank device");
+        assert_eq!(
+            load(&mut blank).expect("load"),
+            PreambleStatus::Absent,
+            "never-written sector is Absent"
+        );
+
+        // ...while a PROVISIONED device whose sector was then corrupted
+        // (a bit flip outside the magic bytes -- the common case) must
+        // report Corrupt, not collapse to the same Absent state.
+        let mut provisioned = MemBlockDevice::new(1).expect("provisioned device");
+        load_or_provision(&mut provisioned, stream(0xA0)).expect("provision");
+        let mut sector = [0u8; SECTOR_SIZE];
+        provisioned
+            .read_sectors(0, 1, &mut sector)
+            .expect("read back");
+        sector[SALT_OFFSET] ^= 0xFF;
+        provisioned
+            .write_sectors(0, 1, &sector)
+            .expect("corrupt on disk");
+
+        let status = load(&mut provisioned).expect("load corrupt");
+        assert_eq!(
+            status,
+            PreambleStatus::Corrupt,
+            "a provisioned-then-corrupted sector must read as Corrupt, never Absent"
+        );
+        assert_ne!(
+            status,
+            PreambleStatus::Absent,
+            "Corrupt and Absent must route differently -- #621's whole point"
+        );
+
+        // load() is read-only regardless of outcome: the sector on disk
+        // is untouched by either call above.
+        let mut after = [0u8; SECTOR_SIZE];
+        provisioned
+            .read_sectors(0, 1, &mut after)
+            .expect("read after load");
+        assert_eq!(after, sector, "load must never write, corrupt or not");
     }
 
     #[test]
@@ -364,16 +462,24 @@ mod tests {
         // is what rejects it here.
         let salt = [0x11u8; SALT_LEN];
         let sector = render(&salt, Some(&[0u8; VERIFIER_LEN]));
-        assert_eq!(parse(&sector), None, "zero verifier is never legitimate");
+        assert_eq!(
+            parse(&sector),
+            PreambleStatus::Corrupt,
+            "zero verifier is never legitimate (magic + integrity pass, so this is corrupt, not absent)"
+        );
     }
 
     #[test]
     fn load_is_read_only_and_never_provisions() {
-        // A blank device: load reports None and writes NOTHING — the
+        // A blank device: load reports Absent and writes NOTHING — the
         // provisioning write is reserved for first-boot setup completion.
         let mut dev = MemBlockDevice::new(1).expect("device");
         let loaded = load(&mut dev).expect("load");
-        assert!(loaded.is_none(), "blank preamble loads as None");
+        assert_eq!(
+            loaded,
+            PreambleStatus::Absent,
+            "blank preamble loads as Absent"
+        );
         let mut sector = [0xAAu8; SECTOR_SIZE];
         dev.read_sectors(0, 1, &mut sector).expect("read back");
         assert!(
@@ -388,9 +494,10 @@ mod tests {
         let first = load_or_provision(&mut dev, stream(0xA0)).expect("provision");
         let verifier = sample_verifier();
         store_boot_verifier(&mut dev, &first.salt, &verifier).expect("store");
-        let loaded = load(&mut dev).expect("load").unwrap_or_else(|| {
-            unreachable!("a stored preamble parses");
-        });
+        let loaded = match load(&mut dev).expect("load") {
+            PreambleStatus::Valid(secrets) => secrets,
+            other => unreachable!("a stored preamble parses as Valid, got {other:?}"),
+        };
         assert_eq!(loaded.salt, first.salt);
         assert_eq!(loaded.boot_verifier, Some(verifier));
     }
@@ -406,7 +513,11 @@ mod tests {
         dev.read_sectors(0, 1, &mut sector).expect("read");
         sector[VERIFIER_OFFSET] ^= 0xFF;
         dev.write_sectors(0, 1, &sector).expect("corrupt");
-        assert_eq!(parse(&sector), None, "tampered verifier fails the tag");
+        assert_eq!(
+            parse(&sector),
+            PreambleStatus::Corrupt,
+            "tampered verifier fails the tag -- corrupt, not absent"
+        );
 
         // Re-provision yields a fresh salt and no verifier (the device
         // returns to the first-boot setup path — never a half-valid state).

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -555,7 +555,7 @@ witness = "boot.sh"
 
 [[module]]
 name = "secrets"
-tests = 9
+tests = 10
 mechanism = "host"
 fidelity = "provision/read proven on the RAM double; eMMC persistence + the 8d consumption path are the m7 boot (hardware-gated)"
 


### PR DESCRIPTION
## Finding

A corrupted secrets preamble sector (correct magic, but a version, slot-count, integrity-tag, or zero-payload check failing) was indistinguishable from a preamble that was never written. `secrets::parse()` returned `None` for both a missing magic (never provisioned) and an integrity-tag mismatch (provisioned, then corrupted), `secrets::load()` mapped that `None` onto `Ok(None)`, and `kinit.rs` collapsed the whole thing onto `PreambleLoad::Unprovisioned`. The distinction the rest of the boot decision needs was destroyed before it ever saw the state.

Both branches out of the collapsed `Unprovisioned` state ended in `lfs::format()` on a device that was in fact provisioned:

1. First-boot setup ran, drew a fresh CSPRNG salt, and `store_boot_verifier()` overwrote the sector — destroying the only copy of the original salt. The old ciphertext then decrypted to garbage under the new key, `mount()` returned `InvalidSuperblock`, and the encrypted arm formatted.
2. With no usable display, setup was skipped and the plain arm mounted the raw ciphertext, got `InvalidSuperblock`, and formatted — no user interaction at all.

This is the `#360` class ("must not trigger a reformat: that would silently destroy user data on a bit flip") reintroduced one layer up, exactly as filed.

## Evidence

Confirmed against current `main` (`720f96e`) before the fix — all cited lines still held:

- `crates/thumos/src/kinit.rs:920` (pre-fix): `Ok(None) => state.preamble = PreambleLoad::Unprovisioned,` — the collapse point.
- `crates/thumos/src/secrets.rs:95` / `:110` (pre-fix): both the bad-magic branch and the integrity-mismatch branch of `parse()` returned the same `None`.
- `crates/thumos/src/kinit_plan.rs` (pre-fix): `PreambleLoad::Unprovisioned` routed to `BootPassphrasePlan::FirstBootSetup` and `MountPlan::Plain`; only `ReadFailed`/`NotRead` routed to the locked disposition (`Skip` / `RamfsFallback`).
- `crates/thumos/src/kinit.rs` first-boot setup loop: draws a fresh salt via `csprng::kernel_random_bytes` and calls `secrets::store_boot_verifier`, unconditionally overwriting the sector once `BootPassphrasePlan::FirstBootSetup` is reached.
- `crates/thumos/src/kinit.rs` plain-mount arm: formats on `LfsError::InvalidSuperblock` with the (previously false) assumption that this arm is reachable only on a genuinely unprovisioned device.

## Why this matters

The boot passphrase / userdata-encryption scheme hangs off one 512-byte plaintext sector with no redundancy. A single-sector loss — a bit flip, a torn write, a partial flash, or (per the issue's threat model) an adversary with brief raw block access zeroing/scrambling that one sector via the documented `mtkclient` BROM path — did not degrade to a locked, recoverable device. It degraded to a silent, unrecoverable wipe of userdata presented to the owner as an ordinary first boot, with no boot log line, UI state, or on-disk artifact distinguishing it from a factory-fresh device.

## Desired correction

Stop conflating "absent" with "invalid" at the source, and route the corrupt case to the same fail-closed disposition `ReadFailed` already uses (never a third disposition):

- `secrets::parse()` now returns a `PreambleStatus` (`Absent` / `Corrupt` / `Valid`) instead of `Option<...>`. Magic presence is the ONLY line between `Absent` and `Corrupt` — every check after it (version, slot count, integrity tag, zero-payload guards) means "this was a preamble" and reports `Corrupt`, never falls back to `Absent`.
- `secrets::load()` — the read-only entry point kinit's early boot probe actually uses — now returns `Result<PreambleStatus, BlockError>`, surfacing the distinction to the caller. `secrets::load_or_provision()` (a blind-provisioning helper not used on the boot path) keeps its own documented contract of treating `Absent` and `Corrupt` alike, now explicit in its doc comment.
- `kinit_plan::PreambleLoad` grows a `Corrupt` variant. `boot_passphrase_plan` routes it to `BootPassphrasePlan::Skip` alongside `ReadFailed`/`NotRead` — never `FirstBootSetup`. `mount_plan` routes it to `MountPlan::RamfsFallback` alongside `Provisioned`/`ReadFailed`/`NotRead` — never `Plain`. No third disposition was introduced: `Corrupt` rides the same "unknown state = locked" path `ReadFailed` already established.
- `kinit.rs`'s collapse point (`Ok(None) => ... Unprovisioned`) is replaced with an explicit three-way match on `PreambleStatus`, logging a `WARN` for the corrupt case instead of silently treating it as blank.

Tests added/extended:
- `secrets::tests::load_distinguishes_corrupt_from_absent_and_never_reprovisions_either` — the `load()`-boundary #621 regression scenario: a genuinely blank device reports `Absent`; a provisioned device with one corrupted byte outside the magic reports `Corrupt`, never `Absent`; `load()` never writes either way.
- `secrets::tests::corrupt_header_reprovisions_with_a_new_salt`, `all_zero_verifier_is_rejected`, `tampered_verifier_fails_integrity_and_reprovisions`, `load_is_read_only_and_never_provisions` — updated to assert the new `PreambleStatus` outcomes.
- `kinit_plan::tests::boot_passphrase_plan_gates_on_trust_then_hardware_then_provisioning` — extended with `PreambleLoad::Corrupt => Skip`.
- `kinit_plan::tests::mount_plan_never_plain_mounts_a_locked_or_unknown_payload` — extended with `PreambleLoad::Corrupt => RamfsFallback`.

The `kinit.rs` boot-sequence glue itself (the eMMC read, `lfs::format()` call sites) is `#[cfg(not(test))]` and excluded from the host test build by design (#528) — it is not reachable off-hardware, so the pure decision functions in `kinit_plan.rs` are the host-testable seam for this invariant, per the existing pattern used for `ReadFailed`.

Out of scope, called out but not implemented here: the issue's "worth carrying" suggestion of a redundant second preamble copy. That is an additive resilience improvement (recoverable, not just survivable, single-sector corruption) orthogonal to this fix and not part of its "Done when" bar; a full-sector zero-wipe (attacker zeroes the whole sector, magic included) remains indistinguishable from a genuinely blank device by construction — that is the specific residual risk the redundant-copy suggestion targets.

## Verification

- `cargo fmt --manifest-path crates/thumos/Cargo.toml -- --check` — exit 0.
- `cd crates/thumos && cargo build --release` (armv7a cross-build) — exit 0, both before and after rebasing onto latest `origin/main`.
- `cd crates/thumos && cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — 2345 passed, 1 skipped (pre-existing, unrelated), both before and after the rebase.

Closes #621
