### PR TITLE
fix(thumos): scope the ui::Key/haphe::Key discriminant claim to what holds

### DIFF
--- a/crates/thumos/Cargo.lock
+++ b/crates/thumos/Cargo.lock
@@ -225,6 +225,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "haphe"
+version = "0.1.17"
+
+[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "sema-core"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "serde",
 ]
@@ -505,6 +509,7 @@ dependencies = [
  "aes",
  "cbc",
  "ed25519-dalek",
+ "haphe",
  "hkdf",
  "hmac",
  "pbkdf2",

--- a/crates/thumos/Cargo.toml
+++ b/crates/thumos/Cargo.toml
@@ -91,6 +91,15 @@ xts-mode = { version = "0.5", default-features = false }
 [build-dependencies]
 ed25519-dalek = { version = "2", default-features = false }
 
+# WHY (#615): dev-only so ui.rs's kernel-local `Key` enum can be pinned
+# against the REAL `haphe::input::Key` in a host test, instead of a
+# hand-copied constant that could itself drift unnoticed. Dev-dependencies
+# are excluded from `cargo build --release` (the armv7a-none-eabi shipped
+# kernel), so this adds no coupling to the flashed binary -- only to the
+# `--target i686-unknown-linux-gnu` test target.
+[dev-dependencies]
+haphe = { path = "../haphe" }
+
 # WHY: the kernel crate is excluded from the workspace (bare-metal target)
 # but still enforces the same lint floor -- EXCEPT unsafe_code. A bare-metal
 # kernel is inherently unsafe (MMIO, global_asm!, raw register access);

--- a/crates/thumos/src/ui.rs
+++ b/crates/thumos/src/ui.rs
@@ -474,10 +474,23 @@ pub(crate) fn draw_scaled_str_centered(
 // Input event types (kernel-side, mirroring haphe::input::Key)
 // ---------------------------------------------------------------------------
 
-/// Key codes matching haphe's key definitions.
+/// Key codes for the kernel-side input path.
 ///
 /// Duplicated here because haphe is a workspace crate and cannot be linked
-/// into the `#![no_std]` kernel. The discriminant values match `haphe::input::Key`.
+/// into the `#![no_std]` kernel's shipped (armv7a) target. Only the digit /
+/// star / hash / d-pad prefix (`Num0..=Right`, discriminants 0-15) is a
+/// genuine shared vocabulary with `haphe::input::Key` — the same physical
+/// matrix keys, pinned equal by the `shared_prefix_discriminants_match_haphe`
+/// test below (checked against the real `haphe` crate, not a copied
+/// constant). The extended range (16-21, `Ok`/`Lsk`/`Rsk`/`Call`/`End`/
+/// `Power`) is this enum's OWN vocabulary and is NOT required to match
+/// haphe's `Select`/`Call`/`End`/`Side`/`VolUp`/`VolDown` at the same
+/// discriminants — the two enums model different button sets above the
+/// matrix (this one has softkeys; haphe's has the volume rocker and side
+/// button instead), so a numeric cast between them for 16+ would silently
+/// mis-map keys (#615). A future userspace-to-kernel input bridge MUST
+/// convert through an explicit, exhaustive `match`, never a bare `as` cast,
+/// across this whole enum.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 #[non_exhaustive]
@@ -1012,6 +1025,50 @@ mod tests {
                 "duplicate discriminant {disc} in Key enum"
             );
             seen[disc as usize] = true;
+        }
+    }
+
+    /// Pins the ONLY genuine shared-vocabulary claim between `ui::Key` and
+    /// `haphe::input::Key`: the digit / star / hash / d-pad prefix
+    /// (discriminants 0-15) is the same physical matrix keys with the same
+    /// meaning in both enums, so a boot-path value can round-trip through
+    /// the raw `u8` without a lookup table. This imports the REAL `haphe`
+    /// crate (see Cargo.toml `[dev-dependencies]`, #615) rather than a
+    /// copied constant, so a discriminant change on EITHER side breaks this
+    /// test -- the two enums cannot drift apart silently again.
+    ///
+    /// Deliberately does NOT extend to 16-21: `ui::Key`'s `Ok`/`Lsk`/`Rsk`/
+    /// `Call`/`End`/`Power` and haphe's `Select`/`Call`/`End`/`Side`/
+    /// `VolUp`/`VolDown` are different button sets that happen to share a
+    /// numeric range -- they are NOT required to align (see the doc comment
+    /// on `Key` above).
+    #[test]
+    fn shared_prefix_discriminants_match_haphe() {
+        let pairs: [(Key, haphe::input::Key); 16] = [
+            (Key::Num0, haphe::input::Key::Num0),
+            (Key::Num1, haphe::input::Key::Num1),
+            (Key::Num2, haphe::input::Key::Num2),
+            (Key::Num3, haphe::input::Key::Num3),
+            (Key::Num4, haphe::input::Key::Num4),
+            (Key::Num5, haphe::input::Key::Num5),
+            (Key::Num6, haphe::input::Key::Num6),
+            (Key::Num7, haphe::input::Key::Num7),
+            (Key::Num8, haphe::input::Key::Num8),
+            (Key::Num9, haphe::input::Key::Num9),
+            (Key::Star, haphe::input::Key::Star),
+            (Key::Hash, haphe::input::Key::Hash),
+            (Key::Up, haphe::input::Key::Up),
+            (Key::Down, haphe::input::Key::Down),
+            (Key::Left, haphe::input::Key::Left),
+            (Key::Right, haphe::input::Key::Right),
+        ];
+        for (ui_key, haphe_key) in pairs {
+            assert_eq!(
+                ui_key as u8, haphe_key as u8,
+                "ui::Key::{ui_key:?} discriminant must match \
+                 haphe::input::Key::{haphe_key:?} -- both encode the same \
+                 physical matrix key"
+            );
         }
     }
 

--- a/docs/convergence.toml
+++ b/docs/convergence.toml
@@ -87,7 +87,7 @@ workspace = "eidolon, haphe"
 disposition = "extract-core"
 canonical = "pending: glyph/widget core shared by the kernel UI and eidolon"
 owner = "unscheduled"
-notes = "Live 'ported from' comment: screen_dialer.rs:11. eidolon -> haphe is the one real internal edge; the kernel consumes neither today."
+notes = "Live 'ported from' comment: screen_dialer.rs:11. eidolon -> haphe is the one real internal edge; the kernel consumes neither today. ui::Key vs haphe::input::Key (#615): the digit/star/hash/d-pad prefix (0-15) is genuine shared vocabulary, pinned by ui::tests::shared_prefix_discriminants_match_haphe against the real haphe crate; the extended range (16-21) is two independent button sets that happen to share a numeric range and is deliberately NOT asserted equal."
 
 # The #126 ratchet: the dead-code expectations pointing at closed #126
 # (one per workspace crate lib.rs) now point here. They burn down as each

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -679,7 +679,7 @@ mechanism = "host"
 
 [[module]]
 name = "ui"
-tests = 20
+tests = 21
 mechanism = "both"
 witness = "boot.sh"
 


### PR DESCRIPTION
## Finding

`crates/thumos/src/ui.rs:479` (pre-fix) claimed the kernel-local `Key` enum's "discriminant values match `haphe::input::Key`". That was true only for the digit/star/hash/d-pad prefix (0-15); it was false for 16-21:

| value | `haphe::input::Key` | `ui::Key` |
|---|---|---|
| 16 | `Select` | `Ok` |
| 17 | `Call` | `Lsk` |
| 18 | `End` | `Rsk` |
| 19 | `Side` | `Call` |
| 20 | `VolUp` | `End` |
| 21 | `VolDown` | `Power` |

## Evidence

`crates/thumos/src/ui.rs` (before):
```rust
/// Key codes matching haphe's key definitions.
///
/// Duplicated here because haphe is a workspace crate and cannot be linked
/// into the `#![no_std]` kernel. The discriminant values match `haphe::input::Key`.
```

Both enums were read in full (`crates/haphe/src/input.rs`, `crates/thumos/src/ui.rs`) and every cross-crate usage of `ui::Key` was checked (`kinit.rs`, `keypad.rs`, every `screen_*.rs`, `lock_screen.rs`, `kardia.rs`): all of them `match` on named variants; none cast a raw `u8` into `ui::Key`. `thumos` has no dependency on `haphe` at all (excluded from the workspace, no_std), and no code anywhere casts a `haphe::input::Key` into a `ui::Key` or vice versa today — there is no live post-boot input bridge yet.

Looking at what each enum's upper range actually represents: `haphe::input::Key`'s 16-21 are physical buttons that the GPIO driver in `crates/haphe/src/gpio.rs` never actually emits (only the 4x3 matrix, 0-11, is wired) — `Select`/`Call`/`End`/`Side`/`VolUp`/`VolDown` exist only as enum declarations and test sentinels. Same for `ui::Key`'s 16-21 (`Ok`/`Lsk`/`Rsk`/`Call`/`End`/`Power`) — `keypad.rs`'s boot-time `KEY_MAP` only ever produces 0-11. So the two enums didn't drift from a single design that fell out of sync; they encode two genuinely different button sets for the region above the digit matrix (this one models softkeys, haphe's models the volume rocker + side button) that happen to share a numeric range. Renaming one to match the other would be fabricating a hardware mapping neither side has verified against the AGM M7 schematic.

## Why this matters

Any future code that trusted the old blanket claim and cast a `haphe::input::Key` (as `u8`) into a `ui::Key` would silently remap `Select`→`Ok` (a harmless rename) but also `Call`→`Lsk`, `End`→`Rsk`, `Side`→`Call`, `VolUp`→`End`, `VolDown`→`Power` — the physical End key (red phone, hang up) would read as a right softkey. The 4x3 boot matrix only emits 0-11 today, so the boot path is unaffected; the hazard is entirely in a not-yet-written post-boot input bridge.

## Desired correction

Scope the doc comment on `ui::Key` to the part that is actually true (the 0-15 prefix is a genuine shared vocabulary; 16-21 is not, by design), and make that boundary impossible to violate silently rather than merely documented:

- `crates/thumos/src/ui.rs`: rewrote the doc comment to state the true, narrower claim, and to require that any future cross-boundary conversion use an explicit, exhaustive `match` — never a bare `as` cast — across the whole enum.
- Added `ui::tests::shared_prefix_discriminants_match_haphe`, which imports the **real** `haphe` crate (new `[dev-dependencies]` entry in `crates/thumos/Cargo.toml`, test-target-only — dev-dependencies are excluded from `cargo build --release`, so the shipped armv7a kernel gains no coupling to haphe) and asserts `ui::Key::X as u8 == haphe::input::Key::X as u8` for each of the 16 shared prefix variants. A discriminant change on either side now fails this test at build time, not just a doc comment that can silently go stale again.
- Updated `docs/target-test-ledger.toml` (`ui` module: 20 → 21 tests) and `docs/convergence.toml` (the existing `ui`/`eidolon,haphe` pair's notes) so the repo's own drift checkers (`scripts/check-target-test-ledger.sh`, `scripts/check-convergence.sh`) stay green and carry the fact.

No conversion function was added — none exists in the tree and none is called for yet; inventing one now would mean guessing at an unverified physical mapping for the upper 6 keys. The doc comment states the requirement for whoever wires the real bridge.

Closes #615
