### PR TITLE
docs(inventory): derive crate roster + docs manifest, drop hand counts

### DIFF
--- a/.kanon-ci.toml
+++ b/.kanon-ci.toml
@@ -32,6 +32,7 @@ stages = [
     "convergence",
     "kernel qemu witnesses",
     "wiring inventory",
+    "doc inventory",
     "target test ledger",
     "cargo clippy",
     "cargo nextest",
@@ -98,6 +99,14 @@ timeout_secs = 3600
 # in the boot.log the witness stage just produced.
 [stages."wiring inventory"]
 cmd = "scripts/check-wiring-inventory.sh"
+timeout_secs = 300
+
+# WHY: the crate count was hand-typed in CLAUDE.md, ARCHITECTURE.md, and
+# _llm/README.md and disagreed with itself and with Cargo.toml; docs/
+# MANIFEST.toml omitted real docs/ files and nothing referenced it.
+# Source-level, cheap.
+[stages."doc inventory"]
+cmd = "scripts/check-doc-inventory.sh"
 timeout_secs = 300
 
 [stages."cargo clippy"]

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,7 +9,9 @@ Board specifics (MMIO maps, device set, bring-up behavior) live behind the `boar
 
 ## Crate map
 
-15 crates total: 1 bare-metal kernel binary + 14 workspace library crates.
+The kernel binary plus the workspace crates below make up the full crate
+set — verified 1:1 against `Cargo.toml` workspace members (plus the
+excluded kernel crate) by `scripts/check-doc-inventory.sh`.
 
 The kernel links `sema-core` (the canonical threat-semantics types) by path
 dependency — the first instance of the #545 convergence topology: shared
@@ -73,6 +75,12 @@ it live in `docs/convergence.toml` + `scripts/check-convergence.sh`.
 | Crate | Description |
 |-------|-------------|
 | `metaxu` | Aletheia/Thumos thin-client bridge protocol: typed tasks, capability grant claims, opaque identity references |
+
+**Build tooling**
+
+| Crate | Description |
+|-------|-------------|
+| `sphragis` | Boot-image signing tool: streamed Ed25519ph signer producing the payload‖signature layout the kernel's boot gate verifies (#467) |
 
 ## Dependency direction
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Full Rust from kernel to UI. No C we author, no Linux in the final system. Monol
 
 ## Key constraints
 
-- 14 crates (13 workspace userspace + `thumos` kernel binary, excluded from workspace), ~138K LOC (111K kernel + 27K userspace), ~2,900 tests (2,234 kernel on i686 + 661 workspace), zero clippy warnings. Phase 10 (radio intelligence + counter-surveillance) compiled/tested surface complete; end-to-end boot/userspace wiring gaps are tracked in README Known gaps. NOTE: these counts are hand-maintained and drift — measure before quoting (`ls crates/thumos/src/*.rs | wc -l`, `cargo nextest run --bin thumos --target i686-unknown-linux-gnu`).
+- Crate roster: ARCHITECTURE.md's crate map (verified 1:1 against `Cargo.toml` workspace members + the excluded kernel crate by `scripts/check-doc-inventory.sh`). ~138K LOC (111K kernel + 27K userspace), ~2,900 tests (2,234 kernel on i686 + 661 workspace), zero clippy warnings. Phase 10 (radio intelligence + counter-surveillance) compiled/tested surface complete; end-to-end boot/userspace wiring gaps are tracked in README Known gaps. NOTE: LOC/test counts are hand-maintained and drift — measure before quoting (`ls crates/thumos/src/*.rs | wc -l`, `cargo nextest run --bin thumos --target i686-unknown-linux-gnu`).
 - 1 GB RAM: every megabyte matters. No unnecessary services.
 - 240x320 display: no standard Android UI. Custom framebuffer or TUI.
 - Keypad + touchscreen input. T9-style or menu navigation.

--- a/_llm/README.md
+++ b/_llm/README.md
@@ -4,7 +4,7 @@ On-demand reference for AI agents. CLAUDE.md is instructions (always loaded, sho
 
 ## Why this exists
 
-Thumos is a 13-crate workspace (12 userspace + 1 bare-metal kernel) with a large kernel surface across 107 modules (run `cargo metadata` and `find crates/thumos/src -name '*.rs' | wc -l` for current counts). Loading every crate-level doc for every task burns tokens on context the task does not need. This directory compresses the canonical `docs/` markdown into TOML views that scan fast and diff mechanically against the source.
+Thumos is a Rust workspace (crate roster: `architecture.toml`, kept 1:1 with `Cargo.toml` workspace members + the excluded kernel crate by `../scripts/check-doc-inventory.sh`) with a large kernel surface across 107 modules (run `cargo metadata` and `find crates/thumos/src -name '*.rs' | wc -l` for current counts). Loading every crate-level doc for every task burns tokens on context the task does not need. This directory compresses the canonical `docs/` markdown into TOML views that scan fast and diff mechanically against the source.
 
 ## Files
 

--- a/_llm/architecture.toml
+++ b/_llm/architecture.toml
@@ -89,6 +89,21 @@ name = "eidolon"
 path = "crates/eidolon"
 role = "Framebuffer UI, widgets, status bar, dialer, and T9 rendering."
 
+[[architecture.crates]]
+name = "sema-core"
+path = "crates/sema-core"
+role = "no_std+alloc threat-semantics core: canonical ThreatLevel/Calibration types shared by sema and the kernel."
+
+[[architecture.crates]]
+name = "metaxu"
+path = "crates/metaxu"
+role = "Aletheia/Thumos thin-client bridge protocol: typed tasks, capability grant claims, and opaque identity references."
+
+[[architecture.crates]]
+name = "sphragis"
+path = "crates/sphragis"
+role = "Boot-image signing tool: streamed Ed25519ph signer for the kernel boot gate's payload/signature layout."
+
 [[interfaces]]
 name = "thumos kernel"
 kind = "kernel"

--- a/docs/MANIFEST.toml
+++ b/docs/MANIFEST.toml
@@ -74,3 +74,39 @@ type = "decision-record"
 evergreen = true
 description = "Read-only ADB audit of surveillance/telemetry systems in stock AGM M7 firmware."
 decided = "2026-03-18"
+
+[[doc]]
+path = "docs/MANIFEST.toml"
+type = "meta"
+evergreen = true
+description = "This inventory: every tracked file under docs/, kept in sync by scripts/check-doc-inventory.sh."
+
+[[doc]]
+path = "docs/KERNEL-WIRING-AUDIT.md"
+type = "decision-record"
+evergreen = true
+description = "Superseded pointer to docs/capability-inventory.toml (#550), the machine-checked capability-reachability inventory that replaced this doc's hand counts."
+
+[[doc]]
+path = "docs/convergence.toml"
+type = "decision-record"
+evergreen = true
+description = "Machine-checked convergence ledger for kernel/workspace type duplication and its dispositions (#545); scripts/check-convergence.sh fails CI on drift."
+
+[[doc]]
+path = "docs/target-test-ledger.toml"
+type = "decision-record"
+evergreen = true
+description = "Machine-checked declared-vs-executed test ledger for target-sensitive kernel modules (#551); scripts/check-target-test-ledger.sh fails CI on drift."
+
+[[doc]]
+path = "docs/protocols/aletheia-v1.md"
+type = "spec"
+evergreen = true
+description = "Versioned envelope + STT-event protocol contract between thumos and aletheia (#553)."
+
+[[doc]]
+path = "docs/surveillance/evidence-manifest.toml"
+type = "decision-record"
+evergreen = true
+description = "Machine-checkable evidence index for docs/SURVEILLANCE-AUDIT.md: firmware identity, retained artifacts with hashes, and claim-to-evidence epistemic labels (#556)."

--- a/scripts/check-doc-inventory.sh
+++ b/scripts/check-doc-inventory.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# check-doc-inventory.sh — crate-roster and docs/ manifest drift check.
+# Fails when:
+#   (a) the crate roster derived from Cargo.toml [workspace] members (plus
+#       the excluded kernel crate) disagrees with ARCHITECTURE.md's crate
+#       map table, or with _llm/architecture.toml's [[architecture.crates]]
+#       array, in either direction
+#   (b) `find docs -type f` and docs/MANIFEST.toml disagree in either
+#       direction: an undocumented file (orphan), or a manifest entry whose
+#       file no longer exists (ghost)
+# Cargo.toml is the SSOT for what crates exist; docs/MANIFEST.toml is the
+# SSOT for what files live in docs/. No doc may hand-restate either count —
+# this script is the only thing allowed to know the number.
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+python3 - "$REPO_ROOT" <<'PYEOF'
+import re, subprocess, sys, tomllib, os
+
+repo = sys.argv[1]
+
+rc = 0
+def fail(msg):
+    global rc
+    print(f"DOC DRIFT: {msg}", file=sys.stderr)
+    rc = 1
+
+def read_toml(rel):
+    with open(os.path.join(repo, rel), "rb") as f:
+        return tomllib.load(f)
+
+# --- derive the crate roster from Cargo.toml ---
+ws = read_toml("Cargo.toml")["workspace"]
+member_paths = list(ws.get("members", [])) + list(ws.get("exclude", []))
+roster = {}
+for m in member_paths:
+    pkg = read_toml(os.path.join(m, "Cargo.toml"))
+    roster[pkg["package"]["name"]] = m
+kernel_path = ws.get("exclude", [])
+kernel_crates = {read_toml(os.path.join(p, "Cargo.toml"))["package"]["name"] for p in kernel_path}
+
+# --- ARCHITECTURE.md's crate map table(s) ---
+arch_text = open(os.path.join(repo, "ARCHITECTURE.md")).read()
+m = re.search(r'\n## Crate map\n(.*?)\n## ', arch_text, re.S)
+if not m:
+    fail("ARCHITECTURE.md has no '## Crate map' section (or no '## ' heading follows it)")
+    arch_crates = set()
+else:
+    arch_crates = set(re.findall(r'^\|\s*`([a-z0-9_-]+)`\s*\|', m.group(1), re.M))
+for c in sorted(roster):
+    if c not in arch_crates:
+        fail(f"crate '{c}' ({roster[c]}) is not listed in ARCHITECTURE.md's crate map table")
+for c in sorted(arch_crates):
+    if c not in roster:
+        fail(f"ARCHITECTURE.md's crate map table lists '{c}', which is not a Cargo.toml workspace member")
+
+# --- _llm/architecture.toml's crate array ---
+llm = read_toml(os.path.join("_llm", "architecture.toml"))
+llm_crates = {c.get("name") for c in llm.get("architecture", {}).get("crates", [])}
+for c in sorted(roster):
+    if c not in llm_crates:
+        fail(f"crate '{c}' ({roster[c]}) is not listed in _llm/architecture.toml's [[architecture.crates]]")
+for c in sorted(llm_crates):
+    if c not in roster:
+        fail(f"_llm/architecture.toml lists crate '{c}', which is not a Cargo.toml workspace member")
+
+# --- docs/ manifest ---
+manifest = read_toml(os.path.join("docs", "MANIFEST.toml"))
+manifest_files = {d["path"] for d in manifest.get("doc", [])}
+found = subprocess.run(
+    ["find", "docs", "-type", "f"], cwd=repo, capture_output=True, text=True, check=True
+).stdout.splitlines()
+actual_files = set(found)
+
+for f in sorted(actual_files):
+    if f not in manifest_files:
+        fail(f"'{f}' exists under docs/ but has no entry in docs/MANIFEST.toml")
+for f in sorted(manifest_files):
+    if f not in actual_files:
+        fail(f"docs/MANIFEST.toml lists '{f}', which no longer exists")
+
+if rc == 0:
+    print(
+        f"doc inventory: {len(roster)} crates ({len(roster) - len(kernel_crates)} workspace + "
+        f"{len(kernel_crates)} kernel) verified across ARCHITECTURE.md + _llm/architecture.toml, "
+        f"{len(manifest_files)} docs/ files verified against MANIFEST.toml"
+    )
+sys.exit(rc)
+PYEOF


### PR DESCRIPTION
## Finding

`CLAUDE.md`, `ARCHITECTURE.md`, and `_llm/README.md` each hand-typed the workspace crate count and disagreed with each other and with `Cargo.toml` (14 / 15 / 13 — none of which is the real 16 = 15 workspace members + the excluded `thumos` kernel crate). `ARCHITECTURE.md`'s crate map table omitted `sphragis`; `_llm/architecture.toml`'s crate array omitted `metaxu`, `sema-core`, and `sphragis`. `docs/MANIFEST.toml` omitted six real files under `docs/` and nothing referenced it.

## Evidence

- `Cargo.toml:3-20` — 15 `[workspace] members` + `exclude = ["crates/thumos"]` = 16 real crates.
- `CLAUDE.md:43` (pre-fix) — `14 crates (13 workspace userspace + \`thumos\` kernel binary, excluded from workspace), ...`
- `ARCHITECTURE.md:12` (pre-fix) — `15 crates total: 1 bare-metal kernel binary + 14 workspace library crates.`
- `_llm/README.md:7` (pre-fix) — `Thumos is a 13-crate workspace (12 userspace + 1 bare-metal kernel) ...`
- `ARCHITECTURE.md`'s crate map table (pre-fix, lines 20-75) had no row for `sphragis` (real crate, `crates/sphragis`, documented in `docs/KERNEL-BUILD.md`).
- `_llm/architecture.toml`'s `[[architecture.crates]]` array (pre-fix, lines 27-90) had no entries for `metaxu`, `sema-core`, or `sphragis`, despite `_llm/README.md:34` stating the array "should map 1:1 with `Cargo.toml` workspace members plus the excluded kernel crate."
- `find docs -type f` listed 17 files; `docs/MANIFEST.toml`'s `[[doc]]` array (pre-fix) covered 11. Orphans: `docs/convergence.toml`, `docs/KERNEL-WIRING-AUDIT.md`, `docs/MANIFEST.toml` (itself), `docs/protocols/aletheia-v1.md`, `docs/surveillance/evidence-manifest.toml`, `docs/target-test-ledger.toml`.
- `grep -rn "MANIFEST.toml" --include="*.sh" --include="*.yml" --include="*.toml" .` (excluding `target/`, `vendor/`) returned exactly one hit: `docs/MANIFEST.toml:1` itself — no script, workflow, or CI stage read it.

## Why this matters

`_llm/README.md:29` states the file format's own rule: "**No derivable metrics** (crate counts, LOC, test counts). Those rot. Document the command that produces them instead." Line 7 of that same file violated the rule stated two lines below it. A number three docs restate independently will disagree — it already had, three ways — and an agent trusting any one of `CLAUDE.md`/`ARCHITECTURE.md`/`_llm/README.md` got a different, wrong answer. `_llm/architecture.toml` is the file `_llm/README.md`'s own stated loading order puts first ("Cold start on any thumos task: read `architecture.toml` first") — an agent following that instruction never learned `sphragis`, `metaxu`, or `sema-core` existed. `docs/MANIFEST.toml` documented its own existence to nobody; an unreferenced inventory is dead weight that drifts further every time a doc is added or removed.

## Desired correction

Added `scripts/check-doc-inventory.sh`, in the shape of the existing `scripts/check-wiring-inventory.sh` pattern:

- derives the crate roster from `Cargo.toml`'s `[workspace] members` + `exclude` (reading each member's real package name)
- diffs that roster against `ARCHITECTURE.md`'s crate map table and `_llm/architecture.toml`'s `[[architecture.crates]]` array, red on mismatch in either direction
- diffs `find docs -type f` against `docs/MANIFEST.toml`'s `[[doc]]` paths, red on orphans or ghosts
- wired into `.kanon-ci.toml` `[pipeline].stages` as the `"doc inventory"` stage

Fixed the docs so the checker passes: added the missing `sphragis` row to `ARCHITECTURE.md` (new **Build tooling** category), added `metaxu`/`sema-core`/`sphragis` to `_llm/architecture.toml`, added the 6 missing entries to `docs/MANIFEST.toml` (including a self-entry for `MANIFEST.toml`, since it lives under `docs/` and the checker walks that directory literally). Deleted the hand-typed crate counts in `CLAUDE.md`, `ARCHITECTURE.md`, and `_llm/README.md` rather than correcting them to 16 — replaced with pointers to the now-verified `ARCHITECTURE.md` crate map / `_llm/architecture.toml` array.

## Verification

Falsified both directions of the crate-roster check and both directions of the manifest check on the actual worktree, confirmed exit 0 before/after:

- Removed `sphragis` from `_llm/architecture.toml` → `DOC DRIFT: crate 'sphragis' (crates/sphragis) is not listed in _llm/architecture.toml's [[architecture.crates]]`, exit 1. Reverted → exit 0.
- Added a new workspace member (`crates/zzfake`) to `Cargo.toml` with no doc entries → `DOC DRIFT: crate 'zzfake' (crates/zzfake) is not listed in ARCHITECTURE.md's crate map table` + the `_llm/architecture.toml` equivalent, exit 1. Reverted → exit 0.
- Added an undocumented file under `docs/` → `DOC DRIFT: 'docs/zzprobe.md' exists under docs/ but has no entry in docs/MANIFEST.toml`, exit 1. Reverted → exit 0.
- Added a `docs/MANIFEST.toml` entry for a nonexistent file → `DOC DRIFT: docs/MANIFEST.toml lists 'docs/zzghost.md', which no longer exists`, exit 1. Reverted → exit 0.

Standard verification, all on verda (360-core builder), against this branch:

```
cd crates/thumos && cargo fmt --manifest-path Cargo.toml -- --check   # exit 0
cd crates/thumos && cargo nextest run --bin thumos --target i686-unknown-linux-gnu  # 2344 passed, 1 skipped, exit 0
cd crates/thumos && cargo build --release                              # exit 0
cargo fmt --all -- --check                                             # exit 0
cargo clippy --workspace --all-targets -- -D warnings                  # exit 0
cargo nextest run --workspace                                          # 724 passed, exit 0
scripts/check-doc-inventory.sh                                         # exit 0 (new stage)
```

No Rust source was touched by this PR (docs + CI wiring only); the fmt/clippy/nextest/build results confirm the tree is otherwise unaffected.

Closes #641
