### PR TITLE
lfs: guard the compactor and LfsImap::deserialize against unvalidated imap block numbers

### DIFF
--- a/crates/thumos/src/lfs.rs
+++ b/crates/thumos/src/lfs.rs
@@ -529,12 +529,16 @@ pub(crate) fn mount(mut dev: Box<dyn BlockDevice>) -> Result<Lfs, LfsError> {
         superblock.checkpoint_block_b,
     )?;
 
-    // Load imap from checkpoint.
+    // Load imap from checkpoint. superblock.block_count is passed through
+    // as the extent bound for every parsed entry (#643) -- the same
+    // geometry validate_block_num applies below to imap-derived pointers
+    // at load_inode/unlink, enforced here at parse time instead.
     let imap = LfsImap::load_from_disk(
         dev.as_mut(),
         &mut cache,
         checkpoint.imap_block,
         checkpoint.imap_block_count,
+        superblock.block_count,
     )?;
 
     // Sanity-bound segment_bitmap_count before trusting it to drive an
@@ -815,13 +819,17 @@ impl Lfs {
         let mut dev = self.dev.borrow_mut();
         let mut cache = self.cache.borrow_mut();
 
-        // Run one compaction pass.
+        // Run one compaction pass. block_count is the same imap-pointer
+        // extent bound applied at load_inode/unlink (#624), threaded
+        // through so the compactor's own imap walk is guarded too
+        // (#643).
         let _copied = lfs_compact::compact_one_segment(
             dev.as_mut(),
             &mut cache,
             writer,
             &mut self.imap,
             &mut self.segments,
+            self.superblock.block_count,
         )
         .map_err(|_| VfsError::IoError)?;
 

--- a/crates/thumos/src/lfs_compact.rs
+++ b/crates/thumos/src/lfs_compact.rs
@@ -79,9 +79,10 @@ pub(crate) fn compact_one_segment(
     writer: &mut LfsWriter,
     imap: &mut LfsImap,
     seg_mgr: &mut LfsSegmentManager,
+    device_blocks: u64,
 ) -> Result<u32, LfsError> {
     // Build a map of which blocks in each segment are live.
-    let candidate = pick_candidate(dev, cache, imap, seg_mgr, writer)?;
+    let candidate = pick_candidate(dev, cache, imap, seg_mgr, writer, device_blocks)?;
     let seg_idx = candidate.segment_idx;
     let seg_start = seg_mgr.segment_start_block(seg_idx);
     let seg_end = seg_start + u64::from(seg_mgr.segment_size());
@@ -113,7 +114,16 @@ pub(crate) fn compact_one_segment(
 
         // Update any inode direct pointers that reference this old block.
         // We need to find which inode references this data block and update it.
-        update_data_block_references(dev, cache, imap, seg_mgr, writer, old_block, new_block)?;
+        update_data_block_references(
+            dev,
+            cache,
+            imap,
+            seg_mgr,
+            writer,
+            old_block,
+            new_block,
+            device_blocks,
+        )?;
         copied += 1;
     }
 
@@ -123,7 +133,7 @@ pub(crate) fn compact_one_segment(
     // segment is handed back to the allocator -- freeing with live blocks
     // still present is exactly the silent data-loss defect this guards
     // against (#315).
-    if segment_has_live_blocks(dev, cache, imap, seg_start, seg_end)? {
+    if segment_has_live_blocks(dev, cache, imap, seg_start, seg_end, device_blocks)? {
         return Err(LfsError::Corrupt);
     }
 
@@ -145,11 +155,20 @@ fn segment_has_live_blocks(
     imap: &LfsImap,
     seg_start: u64,
     seg_end: u64,
+    device_blocks: u64,
 ) -> Result<bool, LfsError> {
     for (_, block) in imap.iter() {
         if block >= seg_start && block < seg_end {
             return Ok(true);
         }
+
+        // WARNING: imap entries are on-disk, untrusted data -- the same
+        // class lfs.rs's Lfs::validate_block_num already bounds before
+        // reaching the block cache at load_inode/unlink (#624). The
+        // compactor walks every imap entry each pass, so an unguarded
+        // entry here can serve one file's content as another's, or
+        // misparse arbitrary device bytes as a DiskInode (#643).
+        validate_block_num(block, device_blocks)?;
 
         let mut buf = [0u8; BLOCK_SIZE];
         cache.read(dev, block, &mut buf)?;
@@ -202,6 +221,7 @@ fn pick_candidate(
     imap: &LfsImap,
     seg_mgr: &LfsSegmentManager,
     writer: &LfsWriter,
+    device_blocks: u64,
 ) -> Result<CompactCandidate, LfsError> {
     let seg_count = seg_mgr.segment_count();
     let seg_size = seg_mgr.segment_size();
@@ -214,6 +234,13 @@ fn pick_candidate(
     // be built without re-reading inodes for each candidate segment.
     let mut live_data_pointers: Vec<u64> = Vec::new();
     for &(_, inode_block) in &imap_blocks {
+        // WARNING: imap entries are on-disk, untrusted data -- the same
+        // class lfs.rs's Lfs::validate_block_num already bounds before
+        // reaching the block cache at load_inode/unlink (#624). This is
+        // the compactor's own imap-derived read, unguarded before this
+        // fix (#643).
+        validate_block_num(inode_block, device_blocks)?;
+
         let mut buf = [0u8; BLOCK_SIZE];
         cache.read(dev, inode_block, &mut buf)?;
         let inode = DiskInode::read_from(&buf, 0)?;
@@ -288,6 +315,28 @@ fn collect_imap_entries(imap: &LfsImap) -> Vec<(u32, u64)> {
     imap.iter().collect()
 }
 
+/// Bound an imap-derived block number to the filesystem's own extent
+/// before it reaches the block cache.
+///
+/// Mirrors `Lfs::validate_block_num` (`lfs.rs`): imap entries are
+/// on-disk, untrusted data -- the imap is the pointer table that selects
+/// which block is authoritative for every inode, so an unguarded entry
+/// can serve one file's content as another's. `lfs.rs` already applies
+/// this bound at `load_inode`/`unlink` (#624); the compactor walks the
+/// same imap during every compaction pass and needs its own copy, since
+/// it has no `&Lfs` to call the method on (#643).
+///
+/// # Errors
+///
+/// Returns [`LfsError::Corrupt`] if `block_num` is 0 or `>=
+/// device_blocks`.
+fn validate_block_num(block_num: u64, device_blocks: u64) -> Result<(), LfsError> {
+    if block_num == 0 || block_num >= device_blocks {
+        return Err(LfsError::Corrupt);
+    }
+    Ok(())
+}
+
 /// After relocating a data block, find and update the inode that references it.
 ///
 /// Scans all inodes in the imap, loads each, checks direct block pointers
@@ -301,10 +350,18 @@ fn update_data_block_references(
     writer: &mut LfsWriter,
     old_block: u64,
     new_block: u64,
+    device_blocks: u64,
 ) -> Result<(), LfsError> {
     let entries = collect_imap_entries(imap);
 
     for (inode_id, inode_block) in entries {
+        // WARNING: imap entries are on-disk, untrusted data -- the same
+        // class lfs.rs's Lfs::validate_block_num already bounds before
+        // reaching the block cache at load_inode/unlink (#624). This scan
+        // walks the raw imap directly (not the pre-validated candidate
+        // buckets), so it needs its own guard (#643).
+        validate_block_num(inode_block, device_blocks)?;
+
         let mut buf = [0u8; BLOCK_SIZE];
         cache.read(dev, inode_block, &mut buf)?;
 
@@ -395,9 +452,15 @@ mod tests {
         let free_before = seg_mgr.free_count();
 
         // Compact: should free the segment containing the garbage v1 block.
-        let copied =
-            compact_one_segment(&mut dev, &mut cache, &mut writer, &mut imap, &mut seg_mgr)
-                .expect("compact");
+        let copied = compact_one_segment(
+            &mut dev,
+            &mut cache,
+            &mut writer,
+            &mut imap,
+            &mut seg_mgr,
+            512,
+        )
+        .expect("compact");
 
         // No live blocks in the garbage segment (imap points to v2).
         assert_eq!(copied, 0, "garbage-only segment should have 0 live blocks");
@@ -431,9 +494,15 @@ mod tests {
             .expect("seal");
 
         // Now compact. The inode is live, so it should be copied.
-        let copied =
-            compact_one_segment(&mut dev, &mut cache, &mut writer, &mut imap, &mut seg_mgr)
-                .expect("compact");
+        let copied = compact_one_segment(
+            &mut dev,
+            &mut cache,
+            &mut writer,
+            &mut imap,
+            &mut seg_mgr,
+            512,
+        )
+        .expect("compact");
 
         assert_eq!(copied, 1, "should copy 1 live inode block");
 
@@ -483,9 +552,15 @@ mod tests {
             .expect("seal");
 
         // Compact.
-        let copied =
-            compact_one_segment(&mut dev, &mut cache, &mut writer, &mut imap, &mut seg_mgr)
-                .expect("compact");
+        let copied = compact_one_segment(
+            &mut dev,
+            &mut cache,
+            &mut writer,
+            &mut imap,
+            &mut seg_mgr,
+            512,
+        )
+        .expect("compact");
 
         assert_eq!(copied, 2, "should copy 2 live inodes");
 
@@ -532,9 +607,15 @@ mod tests {
         // Compact: both the inode block and the data block it references
         // are live and must be relocated together, not silently dropped
         // (#315).
-        let copied =
-            compact_one_segment(&mut dev, &mut cache, &mut writer, &mut imap, &mut seg_mgr)
-                .expect("compact");
+        let copied = compact_one_segment(
+            &mut dev,
+            &mut cache,
+            &mut writer,
+            &mut imap,
+            &mut seg_mgr,
+            512,
+        )
+        .expect("compact");
         assert_eq!(copied, 2, "should copy 1 live inode + 1 live data block");
 
         // The data must still be reachable at its new address via the
@@ -557,6 +638,90 @@ mod tests {
             .expect("read relocated data block");
         assert_eq!(data_buf[0], 0xAB);
         assert_eq!(data_buf[1], 0xCD);
+    }
+
+    #[test]
+    fn compact_rejects_imap_entry_pointing_at_superblock() {
+        // WHY (#643): block 0 is the superblock, always present and
+        // always readable at the raw device level -- a pre-fix
+        // compaction pass would hand it straight to BlockCache::read and
+        // misparse superblock bytes as a DiskInode instead of failing.
+        // pick_candidate's own imap walk (distinct from load_inode's,
+        // and unguarded before this fix) is what's exercised here.
+        let mut dev = block_device_for_compact();
+        let mut cache = BlockCache::new();
+        let mut imap = LfsImap::new();
+        let mut seg_mgr = LfsSegmentManager::new(64, 8);
+        seg_mgr.mark_used(0);
+
+        let mut writer = LfsWriter::new(&mut seg_mgr).expect("create writer");
+
+        let inode = new_file_inode(42);
+        writer
+            .write_inode(&mut dev, &mut cache, &mut imap, &mut seg_mgr, 1, &inode)
+            .expect("write live inode");
+        writer
+            .seal_segment(&mut dev, &mut cache, &mut seg_mgr)
+            .expect("seal so it becomes a candidate");
+
+        // Corrupt an unrelated inode's imap entry to point at block 0.
+        // pick_candidate loads every live inode up front (not just the
+        // eventual candidate segment's), so this must be caught before
+        // any relocation happens.
+        imap.insert(99, 0);
+
+        let result = compact_one_segment(
+            &mut dev,
+            &mut cache,
+            &mut writer,
+            &mut imap,
+            &mut seg_mgr,
+            512,
+        );
+        assert!(
+            matches!(result, Err(LfsError::Corrupt)),
+            "compaction must reject an imap entry pointing at block 0 (the superblock), not read it as an inode"
+        );
+    }
+
+    #[test]
+    fn compact_rejects_imap_entry_beyond_device_extent() {
+        // WHY (#643): an imap entry at or past device_blocks is
+        // corruption -- the same bound Lfs::validate_block_num applies
+        // to imap-derived pointers at load_inode/unlink (#624), now also
+        // enforced on the compactor's own imap walk.
+        let mut dev = block_device_for_compact();
+        let mut cache = BlockCache::new();
+        let mut imap = LfsImap::new();
+        let mut seg_mgr = LfsSegmentManager::new(64, 8);
+        seg_mgr.mark_used(0);
+
+        let mut writer = LfsWriter::new(&mut seg_mgr).expect("create writer");
+
+        let inode = new_file_inode(42);
+        writer
+            .write_inode(&mut dev, &mut cache, &mut imap, &mut seg_mgr, 1, &inode)
+            .expect("write live inode");
+        writer
+            .seal_segment(&mut dev, &mut cache, &mut seg_mgr)
+            .expect("seal so it becomes a candidate");
+
+        // block_device_for_compact() is 512 blocks; 99_999 is far beyond
+        // the device's extent.
+        imap.insert(99, 99_999);
+
+        let result = compact_one_segment(
+            &mut dev,
+            &mut cache,
+            &mut writer,
+            &mut imap,
+            &mut seg_mgr,
+            512,
+        );
+        assert!(
+            matches!(result, Err(LfsError::Corrupt)),
+            "compaction must reject an imap entry beyond device_blocks"
+        );
     }
 
     #[test]
@@ -606,9 +771,15 @@ mod tests {
         // writer's current segment -- it is the sole compaction
         // candidate. The writer's current segment (2) is already full,
         // so relocating inode 1 will force an immediate seal.
-        let copied =
-            compact_one_segment(&mut dev, &mut cache, &mut writer, &mut imap, &mut seg_mgr)
-                .expect("compaction must not deadlock with only the reserve segment free");
+        let copied = compact_one_segment(
+            &mut dev,
+            &mut cache,
+            &mut writer,
+            &mut imap,
+            &mut seg_mgr,
+            512,
+        )
+        .expect("compaction must not deadlock with only the reserve segment free");
         assert_eq!(copied, 1, "should relocate the one live inode");
 
         // The reserve was consumed to land the relocated inode, but
@@ -698,9 +869,15 @@ mod tests {
         let block2_before = imap.get(2).expect("inode 2 in imap");
         let block3_before = imap.get(3).expect("inode 3 in imap");
 
-        let copied =
-            compact_one_segment(&mut dev, &mut cache, &mut writer, &mut imap, &mut seg_mgr)
-                .expect("compact");
+        let copied = compact_one_segment(
+            &mut dev,
+            &mut cache,
+            &mut writer,
+            &mut imap,
+            &mut seg_mgr,
+            512,
+        )
+        .expect("compact");
 
         assert_eq!(
             copied, 0,

--- a/crates/thumos/src/lfs_imap.rs
+++ b/crates/thumos/src/lfs_imap.rs
@@ -157,12 +157,26 @@ impl LfsImap {
 
     /// Deserialize an imap from bytes.
     ///
+    /// `device_blocks` is the filesystem's own `superblock.block_count` --
+    /// the same geometry bound `Lfs::validate_block_num` (`lfs.rs`)
+    /// enforces on `inode.direct[]` and on imap-derived pointers at
+    /// `load_inode`/`unlink`. The imap is on-disk, untrusted data: it is
+    /// the pointer table that selects which block is authoritative for
+    /// every inode, so an unguarded entry can serve one file's content as
+    /// another's, or misparse arbitrary device bytes as an inode. Every
+    /// block this filesystem itself allocates stays within `[1,
+    /// device_blocks)` (block 0 is the superblock, never an allocatable
+    /// data block); rejecting out-of-extent entries here means a
+    /// corrupted checkpoint fails at mount instead of at first use of the
+    /// bad entry (#643).
+    ///
     /// # Errors
     ///
-    /// Returns [`LfsError::Corrupt`] if the buffer is too short or contains
-    /// invalid data.
+    /// Returns [`LfsError::Corrupt`] if the buffer is too short, contains
+    /// invalid data, or any entry's block number is 0 or `>=
+    /// device_blocks`.
     #[must_use]
-    pub(crate) fn deserialize(buf: &[u8]) -> Result<Self, LfsError> {
+    pub(crate) fn deserialize(buf: &[u8], device_blocks: u64) -> Result<Self, LfsError> {
         if buf.len() < IMAP_HEADER_SIZE {
             return Err(LfsError::Corrupt);
         }
@@ -200,6 +214,14 @@ impl LfsImap {
                     .map_err(|_| LfsError::Corrupt)?,
             );
             offset += 8;
+
+            // WARNING: reject at load time, not first use -- an
+            // out-of-extent entry left in the map would still reach
+            // `BlockCache::read` unguarded the moment the compactor or a
+            // load_inode call walked to it (#643).
+            if block == 0 || block >= device_blocks {
+                return Err(LfsError::Corrupt);
+            }
 
             map.insert(inode_id, block);
         }
@@ -242,15 +264,21 @@ impl LfsImap {
 
     /// Read and deserialize the imap from consecutive blocks on disk.
     ///
+    /// `device_blocks` is forwarded to [`Self::deserialize`] as the
+    /// `superblock.block_count` extent bound for every parsed entry
+    /// (#643).
+    ///
     /// # Errors
     ///
     /// - [`LfsError::BlockIo`] if any block read fails.
-    /// - [`LfsError::Corrupt`] if the deserialized data is invalid.
+    /// - [`LfsError::Corrupt`] if the deserialized data is invalid, or any
+    ///   entry's block number is 0 or `>= device_blocks`.
     pub(crate) fn load_from_disk(
         dev: &mut dyn BlockDevice,
         cache: &mut BlockCache,
         start_block: u64,
         block_count: u32,
+        device_blocks: u64,
     ) -> Result<Self, LfsError> {
         // WHY: block_count is an attacker-controlled on-disk field
         // (CheckpointHeader::imap_block_count, validated for magic only —
@@ -275,7 +303,7 @@ impl LfsImap {
             data.extend_from_slice(&buf);
         }
 
-        Self::deserialize(&data)
+        Self::deserialize(&data, device_blocks)
     }
 }
 
@@ -335,7 +363,7 @@ mod tests {
         let mut buf = Vec::new();
         imap.serialize(&mut buf);
 
-        let restored = LfsImap::deserialize(&buf).expect("deserialize should succeed");
+        let restored = LfsImap::deserialize(&buf, 2048).expect("deserialize should succeed");
         assert_eq!(restored.get(0), Some(10));
         assert_eq!(restored.get(1), Some(20));
         assert_eq!(restored.get(100), Some(300));
@@ -361,8 +389,9 @@ mod tests {
 
         // Create a fresh cache to prove we're reading from disk.
         let mut cache2 = BlockCache::new();
-        let restored = LfsImap::load_from_disk(&mut dev, &mut cache2, start_block, block_count)
-            .expect("load should succeed");
+        let restored =
+            LfsImap::load_from_disk(&mut dev, &mut cache2, start_block, block_count, 2048)
+                .expect("load should succeed");
 
         assert_eq!(restored.len(), 50);
         for i in 0..50 {
@@ -376,7 +405,7 @@ mod tests {
 
     #[test]
     fn deserialize_rejects_truncated_data() {
-        let result = LfsImap::deserialize(&[0; 2]);
+        let result = LfsImap::deserialize(&[0; 2], 2048);
         assert!(
             matches!(result, Err(LfsError::Corrupt)),
             "expected Corrupt error for truncated data"
@@ -391,7 +420,7 @@ mod tests {
         // Only 4 bytes instead of 12.
         buf.extend_from_slice(&0u32.to_le_bytes());
 
-        let result = LfsImap::deserialize(&buf);
+        let result = LfsImap::deserialize(&buf, 2048);
         assert!(
             matches!(result, Err(LfsError::Corrupt)),
             "expected Corrupt error for short entry data"
@@ -404,7 +433,7 @@ mod tests {
         let mut buf = Vec::new();
         imap.serialize(&mut buf);
 
-        let restored = LfsImap::deserialize(&buf).expect("deserialize empty");
+        let restored = LfsImap::deserialize(&buf, 2048).expect("deserialize empty");
         assert!(restored.is_empty());
     }
 
@@ -418,10 +447,51 @@ mod tests {
         buf.extend_from_slice(&0xFFFF_FFFFu32.to_le_bytes());
         buf.extend_from_slice(&[0u8; 16]);
 
-        let result = LfsImap::deserialize(&buf);
+        let result = LfsImap::deserialize(&buf, 2048);
         assert!(
             matches!(result, Err(LfsError::Corrupt)),
             "overflowing count must be rejected as Corrupt, not wrap and OOB-index"
+        );
+    }
+
+    #[test]
+    fn deserialize_rejects_entry_pointing_at_superblock() {
+        // WHY (#643): block 0 is the superblock, never an allocatable
+        // data block -- a pre-fix deserialize() accepted any u64,
+        // letting a crafted or corrupted checkpoint place an inode at
+        // block 0 and misparse superblock bytes as that inode's data the
+        // first time something walked to it.
+        let mut imap = LfsImap::new();
+        imap.insert(7, 100);
+        let mut buf = Vec::new();
+        imap.serialize(&mut buf);
+        // Overwrite entry 7's block field (offset: 4 header + 4 inode_id)
+        // with 0.
+        buf[8..16].copy_from_slice(&0u64.to_le_bytes());
+
+        let result = LfsImap::deserialize(&buf, 2048);
+        assert!(
+            matches!(result, Err(LfsError::Corrupt)),
+            "an entry pointing at block 0 (the superblock) must be rejected at load time"
+        );
+    }
+
+    #[test]
+    fn deserialize_rejects_entry_beyond_device_extent() {
+        // WHY (#643): an entry at or past `device_blocks` (the
+        // filesystem's own superblock.block_count) is corruption -- the
+        // same bound `Lfs::validate_block_num` applies to imap-derived
+        // pointers at load_inode/unlink, now enforced at parse time
+        // instead of at first use.
+        let mut imap = LfsImap::new();
+        imap.insert(3, 2048);
+        let mut buf = Vec::new();
+        imap.serialize(&mut buf);
+
+        let result = LfsImap::deserialize(&buf, 2048);
+        assert!(
+            matches!(result, Err(LfsError::Corrupt)),
+            "an entry equal to device_blocks must be rejected as out of extent"
         );
     }
 
@@ -433,7 +503,7 @@ mod tests {
         let mut dev = MemBlockDevice::new(64).expect("create device"); // 32 KiB device
         let mut cache = BlockCache::new();
 
-        let result = LfsImap::load_from_disk(&mut dev, &mut cache, 0, 262_145);
+        let result = LfsImap::load_from_disk(&mut dev, &mut cache, 0, 262_145, 8);
         assert!(
             matches!(result, Err(LfsError::Corrupt)),
             "block_count implying ~1 GiB on a 32 KiB device must be rejected before allocating"
@@ -446,7 +516,7 @@ mod tests {
         let mut dev = MemBlockDevice::new(64).expect("create device");
         let mut cache = BlockCache::new();
 
-        let result = LfsImap::load_from_disk(&mut dev, &mut cache, 0, u32::MAX);
+        let result = LfsImap::load_from_disk(&mut dev, &mut cache, 0, u32::MAX, 8);
         assert!(
             matches!(result, Err(LfsError::Corrupt)),
             "overflowing block_count must be rejected, not wrap into a tiny allocation"
@@ -480,8 +550,9 @@ mod tests {
         );
 
         let mut cache2 = BlockCache::new();
-        let restored = LfsImap::load_from_disk(&mut dev, &mut cache2, start_block, block_count)
-            .expect("load should succeed");
+        let restored =
+            LfsImap::load_from_disk(&mut dev, &mut cache2, start_block, block_count, 8192)
+                .expect("load should succeed");
 
         assert_eq!(restored.len(), ENTRY_COUNT as usize);
         for i in 0..ENTRY_COUNT {

--- a/crates/thumos/src/lfs_writer.rs
+++ b/crates/thumos/src/lfs_writer.rs
@@ -587,12 +587,14 @@ mod tests {
         assert_eq!(header.sequence, checkpoint_seq);
         assert_eq!(header.next_inode, 3);
 
-        // Load the imap from the checkpoint and verify.
+        // Load the imap from the checkpoint and verify. Device is 8 MB /
+        // BLOCK_SIZE (see block_device_for_writer) = 2048 blocks.
         let restored_imap = LfsImap::load_from_disk(
             &mut dev,
             &mut cache2,
             header.imap_block,
             header.imap_block_count,
+            2048,
         )
         .expect("load imap");
 

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -341,12 +341,12 @@ mechanism = "host"
 
 [[module]]
 name = "lfs_compact"
-tests = 9
+tests = 11
 mechanism = "host"
 
 [[module]]
 name = "lfs_imap"
-tests = 11
+tests = 13
 mechanism = "host"
 
 [[module]]


### PR DESCRIPTION
## Finding

`#624` (load_inode and unlink pass unvalidated imap block numbers to the block cache) is fixed for `load_inode` and `unlink` in `crates/thumos/src/lfs.rs`, but two more imap-derived read paths named in its own "Desired correction" still hand raw, unvalidated `u64` block numbers to `BlockCache::read`: the compactor in `crates/thumos/src/lfs_compact.rs`, and `LfsImap::deserialize` in `crates/thumos/src/lfs_imap.rs`.

## Evidence

`crates/thumos/src/lfs_compact.rs` had three separate unguarded reads, all walking the raw imap directly:

`pick_candidate` (pre-fix, then at lines 217-219):
```rust
for &(_, inode_block) in &imap_blocks {
    let mut buf = [0u8; BLOCK_SIZE];
    cache.read(dev, inode_block, &mut buf)?;
```

`segment_has_live_blocks` (pre-fix, then at lines 150-156):
```rust
for (_, block) in imap.iter() {
    if block >= seg_start && block < seg_end {
        return Ok(true);
    }
    let mut buf = [0u8; BLOCK_SIZE];
    cache.read(dev, block, &mut buf)?;
```

`update_data_block_references` (pre-fix, then at lines 305-309) — not named in the issue's evidence but the same defect class, same file:
```rust
let entries = collect_imap_entries(imap);
for (inode_id, inode_block) in entries {
    let mut buf = [0u8; BLOCK_SIZE];
    cache.read(dev, inode_block, &mut buf)?;
```

`crates/thumos/src/lfs_imap.rs:197-204` (pre-fix) — `deserialize` accepted any `u64`:
```rust
let block = u64::from_le_bytes(
    buf[offset..offset + 8]
        .try_into()
        .map_err(|_| LfsError::Corrupt)?,
);
offset += 8;

map.insert(inode_id, block);
```

## Why this matters

The imap is the pointer table that selects which block is authoritative for every inode, so an unguarded entry can serve one file's content as another's, or misparse arbitrary device bytes (including the superblock at block 0) as a `DiskInode`. `load_inode`/`unlink` are bounded since `#624`, but the compactor walks the same imap during every compaction pass through three of its own reads, none of which shared that guard. `deserialize` closes the gap at its earliest point: a corrupted checkpoint now fails at mount instead of at first use of the bad entry, matching the mount-time geometry checks already applied to `segment_bitmap_count`, the checkpoint header, and `LfsSegmentManager::deserialize`'s own `device_blocks` bound.

## Desired correction

A private `validate_block_num` helper in `lfs_compact.rs` (mirroring `Lfs::validate_block_num` in `lfs.rs`, since the free functions here have no `&Lfs` to call the method on) is applied at all three raw-imap-read sites before the block reaches `BlockCache::read`. `compact_one_segment`, `pick_candidate`, `segment_has_live_blocks`, and `update_data_block_references` now take a `device_blocks: u64` parameter, threaded from `Lfs::maybe_compact`'s `self.superblock.block_count`.

`LfsImap::deserialize` now takes `device_blocks: u64` and rejects any entry with a block number of 0 or `>= device_blocks` at parse time, matching `Lfs::validate_block_num`'s exact bound. `load_from_disk` forwards the bound through; `mount()` supplies `superblock.block_count`, the same pattern already used for `LfsSegmentManager::deserialize`'s `device_blocks` parameter.

Two new tests per file (`compact_rejects_imap_entry_pointing_at_superblock`, `compact_rejects_imap_entry_beyond_device_extent`, `deserialize_rejects_entry_pointing_at_superblock`, `deserialize_rejects_entry_beyond_device_extent`) each fail without the fix. The target-test ledger is reconciled in the same change.

**Verification** (worktree `w4-imap`, branch rebased on current `origin/main`):
- `cargo fmt --manifest-path Cargo.toml -- --check` — EXIT=0
- `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — EXIT=0, 2399 passed, 1 skipped
- `cargo check --target armv7a-none-eabi` — EXIT=0
- `cargo check --features qemu --target armv7a-none-eabi` — EXIT=0
- `bash scripts/check-target-test-ledger.sh` — EXIT=0
- `bash scripts/check-board-seam.sh` — EXIT=0
- `bash scripts/check-convergence.sh` — EXIT=0

Closes #643
