### PR TITLE
release: bump the kernel lockfile's path-dep on every release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,15 +5,43 @@
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
   "changelog-sections": [
-    {"type": "feat", "section": "Features"},
-    {"type": "fix", "section": "Bug Fixes"},
-    {"type": "perf", "section": "Performance"},
-    {"type": "chore", "section": "Maintenance", "hidden": true},
-    {"type": "docs", "hidden": true},
-    {"type": "test", "hidden": true},
-    {"type": "refactor", "hidden": true},
-    {"type": "ci", "hidden": true},
-    {"type": "style", "hidden": true}
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "perf",
+      "section": "Performance"
+    },
+    {
+      "type": "chore",
+      "section": "Maintenance",
+      "hidden": true
+    },
+    {
+      "type": "docs",
+      "hidden": true
+    },
+    {
+      "type": "test",
+      "hidden": true
+    },
+    {
+      "type": "refactor",
+      "hidden": true
+    },
+    {
+      "type": "ci",
+      "hidden": true
+    },
+    {
+      "type": "style",
+      "hidden": true
+    }
   ],
   "packages": {
     ".": {
@@ -48,6 +76,11 @@
           "type": "toml",
           "path": "fuzz/Cargo.lock",
           "jsonpath": "$.package[?(@.name == 'klesis')].version"
+        },
+        {
+          "type": "toml",
+          "path": "crates/thumos/Cargo.lock",
+          "jsonpath": "$.package[?(@.name == 'sema-core')].version"
         }
       ]
     }


### PR DESCRIPTION
## Finding

`crates/thumos/Cargo.lock` sat one release behind the workspace: it pinned `sema-core 0.1.16` against a workspace at `0.1.17`.

The kernel crate is excluded from the Cargo workspace and carries its own lockfile, so release-please's workspace version bump never reached it — the same structural gap PR #629 closed for `fuzz/Cargo.lock`.

## Evidence

`crates/thumos/Cargo.lock` (pre-fix), the only non-sourced package besides the kernel itself:

```toml
[[package]]
name = "sema-core"
version = "0.1.16"
```

against `Cargo.toml`'s `version = "0.1.17"`.

`release-please-config.json` `extra-files` covered `Cargo.lock`, `crates/eidolon/Cargo.toml`, and the three `fuzz/Cargo.lock` entries — nothing for `crates/thumos/Cargo.lock`.

## Why this matters

The drift is silent and monotonic: every release widens it, and nothing reds. A stale lockfile means the kernel builds against a resolved dependency set that no longer matches what the workspace declares — and the kernel is the one crate whose build cannot be checked by the workspace gate, since it is excluded from it.

## Desired correction

**The fix is the config, not the regeneration.** An `extra-files` entry now bumps the `sema-core` pin on every release, following the pattern #629 established. The one-time `cargo update -p sema-core` in this PR only clears the drift already accumulated — regenerating without the config entry would put the lockfile one release behind again at the very next cut.

Scoped to `sema-core` deliberately, and this is the part worth checking rather than assuming: it is the kernel crate's **only** path dependency (`crates/thumos/Cargo.toml:51`) and the only non-sourced package in that lockfile besides `thumos` itself, which is versioned independently at `0.1.0` and is not a workspace member. An entry for any other crate would match nothing — harmless per `RELEASES.md`, but it would assert a dependency edge that does not exist.

**Verification:** `cargo check --target armv7a-none-eabi` → 0 against the regenerated lockfile; target-test-ledger, board-seam, and convergence checkers all → 0.

Closes #644
