### PR TITLE
docs(contributing): record the release re-trigger step this repo needs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,24 @@ or the forge merge button. Default strategy is `squash`; `--strategy ff` or `--s
 
 Do not merge via GitHub. The GitHub mirror is read-only from the contributor's perspective: any merge performed there races the forge pr-sync worker.
 
+## Releases
+
+Release authority is declared in `basanos/standards/RELEASES.md`: the operator cuts MAJOR, an agent cuts MINOR and PATCH with no operator interaction required. Read it there.
+
+One mechanical step is specific to this repo's GitHub mirror and is expected on every cut. A release-please PR is authored by `GITHUB_TOKEN`, and GitHub does not run `on: pull_request` workflows for events its own token triggered — the recursion guard that stops a workflow from endlessly retriggering itself. The branch-protection required checks therefore never execute, and the PR sits with `mergeStateStatus: BLOCKED` reporting no checks at all rather than failing ones.
+
+Re-trigger them as a real-user actor, which is not subject to the guard:
+
+```bash
+gh run list --repo forkwright/thumos --branch release-please--branches--main \
+  --json databaseId,name,conclusion --jq '.[] | select(.conclusion=="action_required")'
+gh run rerun <id> --repo forkwright/thumos   # once per suppressed run
+```
+
+Then merge on green, as with any PR. The three required contexts are `cargo audit`, `cargo deny`, and `gate / gate` — read them from branch protection rather than trusting this list. `Dependabot Auto-Merge` stays `action_required` and is *not* required, so `UNSTABLE` with those three green is the expected terminal state for a release PR.
+
+The merge is not the release: release-please's `push`-to-`main` trigger creates the tag and GitHub release afterwards, and that run is not suppressed because a real user performed the merge. Confirm the tag exists before calling a release done.
+
 ## External contributors
 
 Thumos has a real external-contributor path - radio, baseband, and MTK tooling folks without kanon.lan access. The GitHub mirror at `github.com/forkwright/thumos` is fully functional for you:


### PR DESCRIPTION
## Finding

Every release-please PR on this repo arrives with its required status checks unexecuted, and the procedure to unblock it lived only in #476's body.

The PR is authored by `GITHUB_TOKEN`, and GitHub will not run `on: pull_request` workflows for events its own token triggered — the recursion guard that stops a workflow endlessly retriggering itself. Branch protection then waits on checks that were never allowed to start.

## Evidence

Observed on the 0.1.17 cut (PR #633) earlier today:

```
$ gh pr checks 633
no checks reported on the 'release-please--branches--main' branch

$ gh run list --branch release-please--branches--main
completed/action_required   Gate Attestation
completed/action_required   CI
completed/action_required   Security
```

Three `gh run rerun` calls as a real-user actor produced all ten checks green, and the release cut normally.

## Why this matters

The failure mode is that it does not look like a suppression. A release PR reads as `BLOCKED` with **no checks at all** rather than failing ones, which presents as a broken release rather than a trigger that was never permitted. Without the procedure written down, the next person to hit it re-derives it under time pressure — or, worse, concludes the release is genuinely blocked and holds it.

I did exactly that today: I held a ready patch release believing it was operator-gated, because a stale planning doc said so and nothing here said otherwise.

## Desired correction

`CONTRIBUTING.md` now carries the re-trigger procedure in a **Releases** section, plus the two things that actively mislead on a release PR:

- **`UNSTABLE` is the expected terminal state.** `Dependabot Auto-Merge` stays `action_required` and is not a required check; the three that are (`cargo audit`, `cargo deny`, `gate / gate`) go green.
- **The merge is not the release.** The tag comes from a later `push`-to-`main` run, which is *not* suppressed because a real user performed the merge. A merged release PR with no tag is a half-cut release that looks finished.

Release *authority* is not restated here — it points at `basanos/standards/RELEASES.md`, which owns it.

This documents rather than fixes, deliberately: fixing needs a PAT or GitHub App token, and that decision was made the other way — the manual step is three commands, and a long-lived credential on a public repo is not worth trading for them. The fleet-wide fix remains tracked at kanon#1092 and kanon#2403.

Refs #476
