### PR TITLE
metaxu: wire the authenticated session into BridgeClient (#544)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ thumos is pre-hardware. What is proven is the boot path under emulation and the 
 - **Hardware validation** on a physical AGM M7 - the frontier. QEMU exercises the boot path, not the MT6739's binary-only modem/WiFi/BT/GPS blobs.
 - **Boot-wiring**: implemented capabilities are not all reachable from the boot/service loop or from userspace yet; the wiring lands incrementally. Reachability is machine-checked, not prose: see the [capability inventory](docs/capability-inventory.toml) (every module classified; CI fails on drift).
 - **Real radio I/O**: WiFi packet TX/RX, scan, and association over WMT/STP are hardware work; boot degrades to a fail-closed loopback path when the data path is absent.
-- **Aletheia live runtime** ([docs/ALETHEIA-BRIDGE.md](docs/ALETHEIA-BRIDGE.md), `metaxu`): live transport, grant verification, and UI wiring are future work.
+- **Aletheia live runtime** ([docs/ALETHEIA-BRIDGE.md](docs/ALETHEIA-BRIDGE.md), `metaxu`): grant verification (Ed25519-signed, expiring, identity-bound) and its adversarial witness are implemented and tested; live transport, a live Aletheia-side endpoint, and UI wiring are still future work.
 
 ## Related
 

--- a/crates/metaxu/src/error.rs
+++ b/crates/metaxu/src/error.rs
@@ -70,6 +70,21 @@ where
         location: Location,
     },
 
+    /// An authenticated response's MAC did not verify under the session's
+    /// grant response key -- the response cannot be trusted: it may be
+    /// tampered, forged by a party that never held the grant's nonce, or
+    /// corrupted in transit. The response is discarded unread.
+    #[snafu(display(
+        "authenticated response for request {request_id} failed MAC verification at {location}"
+    ))]
+    ResponseAuthenticationFailed {
+        /// Submitted request identifier.
+        request_id: Ulid,
+        /// Source location where the error was attached.
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     /// The runtime response did not correspond to the submitted request.
     #[snafu(display(
         "response request id {response_id} did not match submitted request {request_id} at {location}"
@@ -138,6 +153,13 @@ impl Error<core::convert::Infallible> {
                 location,
             },
             Self::Envelope { source, location } => Error::Envelope { source, location },
+            Self::ResponseAuthenticationFailed {
+                request_id,
+                location,
+            } => Error::ResponseAuthenticationFailed {
+                request_id,
+                location,
+            },
             Self::ResponseRequestMismatch {
                 request_id,
                 response_id,

--- a/crates/metaxu/src/lib.rs
+++ b/crates/metaxu/src/lib.rs
@@ -2,10 +2,19 @@
 //! Thin capability bridge between Thumos device services and an
 //! Aletheia/Menos-resident runtime.
 //!
-//! `metaxu` defines the typed wire boundary only: task requests, capability
-//! grant claims, device-identity references, responses, and a synchronous
-//! transport abstraction. It intentionally does not embed runtime logic,
-//! authenticate grants, or require live Menos connectivity.
+//! `metaxu` defines the typed wire boundary: task requests, capability grant
+//! claims, device-identity references, responses, and a synchronous
+//! transport abstraction. It intentionally does not embed runtime logic or
+//! require live Menos connectivity.
+//!
+//! Two request paths exist. [`BridgeClient::submit`] sends a bare
+//! [`TaskRequest`] and only checks that the task carries a self-claimed
+//! [`CapabilityGrant`] locally -- suitable for an in-process transport where
+//! the runtime boundary is trusted by construction (tests, a same-address-
+//! space stub). [`BridgeClient::submit_authenticated`] (#544) is the path
+//! for an actual network peer: it presents a cryptographically verified,
+//! expiring [`SignedGrant`] on every request and refuses any response whose
+//! MAC does not prove the responder held the grant's signed nonce.
 
 mod client;
 mod envelope;
@@ -87,6 +96,75 @@ where
         )?;
 
         Ok(response)
+    }
+
+    /// Submit a task through a mutually authenticated session (#544): the
+    /// device presents a cryptographically verified, expiring grant on
+    /// every request and refuses any response whose MAC does not prove the
+    /// responder held the grant's signed nonce. This is the path a real
+    /// network-connected caller uses; [`Self::submit`] is for a trusted
+    /// in-process transport only.
+    ///
+    /// Capability enforcement here checks the session's VERIFIED grant
+    /// (`session.grant().grant.capabilities`) -- never the task's
+    /// self-claimed wire [`CapabilityGrant`] list [`Self::submit`] checks.
+    /// A caller cannot talk itself into a capability the runtime never
+    /// actually granted; this is the local confirmation gate the runtime
+    /// endpoint's own check backs up, not a substitute for it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::MissingCapability`] when the session's verified
+    /// grant does not cover the task's required capability -- checked
+    /// locally, before anything is sent. [`Error::Envelope`] /
+    /// [`Error::Encode`] if the request cannot be framed.
+    /// [`Error::Transport`] for transport failures (wrapping `T::Error` so
+    /// the concrete transport cause is preserved). [`Error::Envelope`] /
+    /// [`Error::Decode`] for a malformed response frame.
+    /// [`Error::ResponseAuthenticationFailed`] when the response MAC does
+    /// not verify under the session's grant -- the response is discarded,
+    /// never trusted. [`Error::ResponseRequestMismatch`] when the runtime
+    /// answers another request id.
+    pub fn submit_authenticated(
+        &mut self,
+        session: &AuthenticatedSession,
+        request: &TaskRequest,
+    ) -> Result<TaskResponse, T::Error> {
+        let required = request.required_capability();
+        session
+            .grant()
+            .grant
+            .capabilities
+            .contains(&required)
+            .then_some(())
+            .context(error::MissingCapabilitySnafu {
+                request_id: request.request_id(),
+                capability: required,
+            })?;
+
+        let request_id = request.request_id();
+        let request_frame =
+            session::encode_authenticated_request(session, request).map_err(error::Error::widen)?;
+        let response_frame = self
+            .transport
+            .exchange(&request_frame)
+            .context(error::TransportSnafu)?;
+        let authenticated =
+            session::decode_authenticated_response(&response_frame).map_err(error::Error::widen)?;
+
+        session
+            .verify_response(&authenticated)
+            .then_some(())
+            .context(error::ResponseAuthenticationFailedSnafu { request_id })?;
+
+        (authenticated.response.request_id == request_id)
+            .then_some(())
+            .context(error::ResponseRequestMismatchSnafu {
+                request_id,
+                response_id: authenticated.response.request_id,
+            })?;
+
+        Ok(authenticated.response)
     }
 }
 

--- a/crates/metaxu/src/protocol.rs
+++ b/crates/metaxu/src/protocol.rs
@@ -361,7 +361,7 @@ impl TaskResponse {
 /// ULID (a ULID's leading 48 bits are its timestamp; the next bits are
 /// randomness -- 64 bits total is ample correlation space, documented in
 /// the envelope contract).
-fn correlation_of(id: ulid::Ulid) -> u64 {
+pub(crate) fn correlation_of(id: ulid::Ulid) -> u64 {
     let bytes = id.to_bytes();
     u64::from_le_bytes(bytes[..8].try_into().unwrap_or([0; 8]))
 }

--- a/crates/metaxu/src/session.rs
+++ b/crates/metaxu/src/session.rs
@@ -18,9 +18,12 @@
 //! adversarial witness runs against.
 
 use serde::{Deserialize, Serialize};
+use snafu::{IntoError as _, ResultExt as _};
 
+use crate::envelope::{Envelope, MessageKind};
+use crate::error::{DecodeSnafu, EncodeSnafu, EnvelopeSnafu};
 use crate::grants::SignedGrant;
-use crate::protocol::{TaskRequest, TaskResponse};
+use crate::protocol::{TaskRequest, TaskResponse, correlation_of};
 
 /// An authenticated task request: the verified grant plus the typed task
 /// (#544). Envelope kind 4 (MINOR 1).
@@ -105,4 +108,47 @@ impl AuthenticatedSession {
     pub fn verify_response(&self, response: &AuthenticatedResponse) -> bool {
         response.verify(&self.signed_grant)
     }
+}
+
+/// Encode an authenticated task request for transport, wrapped in the
+/// versioned envelope (kind 4, MINOR 1) (#544). This is the ONLY place a
+/// wire frame for the authenticated exchange is built -- `BridgeClient`
+/// and the adversarial witness both go through it, so there is one
+/// encoding, not a client copy and a test copy that can drift apart.
+pub(crate) fn encode_authenticated_request(
+    session: &AuthenticatedSession,
+    request: &TaskRequest,
+) -> crate::error::Result<Vec<u8>> {
+    let wrapped = session.wrap(request.clone());
+    let payload = postcard::to_allocvec(&wrapped).context(EncodeSnafu)?;
+    let frame = Envelope::build(
+        MessageKind::AuthenticatedRequest,
+        correlation_of(request.request_id()),
+        payload,
+    )
+    .context(EnvelopeSnafu)?;
+    Ok(frame.encode())
+}
+
+/// Decode an authenticated task response from transport bytes (kind 5,
+/// MINOR 1) (#544).
+///
+/// Does NOT verify the MAC -- the returned value is untrusted wire data
+/// until the caller checks it against the session, via
+/// [`AuthenticatedSession::verify_response`]. Splitting decode from verify
+/// keeps "parsed" and "trusted" distinct states, so a caller cannot act on
+/// a well-formed-but-unverified response by forgetting a step.
+pub(crate) fn decode_authenticated_response(
+    bytes: &[u8],
+) -> crate::error::Result<AuthenticatedResponse> {
+    let frame = Envelope::decode(bytes).context(EnvelopeSnafu)?;
+    if frame.header.kind != MessageKind::AuthenticatedResponse {
+        return Err(
+            EnvelopeSnafu.into_error(crate::envelope::EnvelopeError::UnexpectedKind {
+                expected: MessageKind::AuthenticatedResponse,
+                got: frame.header.kind,
+            }),
+        );
+    }
+    postcard::from_bytes(&frame.payload).context(DecodeSnafu)
 }

--- a/crates/metaxu/src/witness.rs
+++ b/crates/metaxu/src/witness.rs
@@ -1,15 +1,26 @@
 //! The adversarial round-trip witness (#544): one authenticated
 //! Thumos↔Aletheia exchange and every failure mode, over real TCP.
 //!
+//! Every case below drives `crate::BridgeClient::submit_authenticated` --
+//! the SAME method a real Thumos userspace process calls -- rather than
+//! hand-building envelope frames, so the witness proves the production API
+//! surface, not a parallel test-only path that could drift from it.
+//!
 //! Cases (the issue's done-when, item 5):
 //! 1. happy path — verified grant, accepted task, MAC-verified response.
 //! 2. replay — a repeated request id is rejected.
-//! 3. expired grant — rejected at evaluation.
+//! 3. expired grant — rejected at evaluation: client pre-flight AND the
+//!    endpoint refuse it, independently.
 //! 4. wrong runtime identity — a grant from an unpinned issuer is rejected;
-//!    and a grant for another device never authorizes this one.
-//! 5. unavailable network — a typed transport error, not a panic or a
-//!    silent empty response.
-//! 6. denied capability — a task outside the grant is rejected pre-action.
+//!    and a grant for another device never opens a session.
+//! 5. unavailable network — a typed transport error at connect, and again
+//!    mid-exchange when a peer accepts then closes without responding —
+//!    never a panic or a silent empty response.
+//! 6. denied capability, twice: the client refuses a task outside the
+//!    session's VERIFIED grant locally, before any network use; and the
+//!    endpoint refuses independently for a request that skips the client
+//!    (defense in depth -- the boundary does not depend on client
+//!    cooperation).
 
 use ed25519_dalek::SigningKey;
 use ulid::Ulid;
@@ -21,6 +32,8 @@ use crate::protocol::{
 };
 use crate::pylon::{self, Pylon};
 use crate::session::AuthenticatedSession;
+use crate::transport::BridgeTransport;
+use crate::{BridgeClient, Error};
 
 /// The runtime the witness pins (the pylon's identity).
 fn runtime_signing() -> SigningKey {
@@ -69,18 +82,57 @@ fn sms_request() -> TaskRequest {
     }
 }
 
-/// Encode an authenticated request frame (kind 4).
-fn auth_frame(session: &AuthenticatedSession, request: TaskRequest) -> Vec<u8> {
-    let wrapped = session.wrap(request);
-    let payload = postcard::to_allocvec(&wrapped).unwrap_or_default();
-    Envelope::build(MessageKind::AuthenticatedRequest, 1, payload)
-        .unwrap_or_else(|_| unreachable!())
-        .encode()
+/// A [`BridgeTransport`] over a length-prefixed TCP stream -- the same
+/// framing `pylon::spawn`'s server loop speaks. This is the shape a real
+/// Thumos userspace transport takes: connect, then hand frames to
+/// `BridgeClient` unmodified.
+struct TcpBridgeTransport {
+    stream: std::net::TcpStream,
 }
 
-/// One TCP exchange against a spawned pylon: send one frame, read the
-/// authenticated response.
-fn exchange(port: u16, frame: &[u8]) -> Vec<u8> {
+impl TcpBridgeTransport {
+    /// Connect to a pylon on `127.0.0.1:port`.
+    fn connect(port: u16) -> Self {
+        Self {
+            stream: std::net::TcpStream::connect(("127.0.0.1", port))
+                .unwrap_or_else(|e| unreachable!("witness pylon must accept: {e}")),
+        }
+    }
+}
+
+impl BridgeTransport for TcpBridgeTransport {
+    type Error = std::io::Error;
+
+    fn exchange(&mut self, request_frame: &[u8]) -> core::result::Result<Vec<u8>, Self::Error> {
+        use std::io::{Read, Write};
+        let len = (request_frame.len() as u32).to_le_bytes();
+        self.stream.write_all(&len)?;
+        self.stream.write_all(request_frame)?;
+        let mut len_buf = [0u8; 4];
+        self.stream.read_exact(&mut len_buf)?;
+        let out_len = u32::from_le_bytes(len_buf) as usize;
+        let mut out = vec![0u8; out_len];
+        self.stream.read_exact(&mut out)?;
+        Ok(out)
+    }
+}
+
+/// A transport that panics if ever invoked -- proves a caller path never
+/// reaches the network (used for the local-preflight-denial case).
+struct PanicIfCalledTransport;
+
+impl BridgeTransport for PanicIfCalledTransport {
+    type Error = std::io::Error;
+
+    fn exchange(&mut self, _request_frame: &[u8]) -> core::result::Result<Vec<u8>, Self::Error> {
+        unreachable!("a locally-denied capability must never reach the transport")
+    }
+}
+
+/// One raw TCP exchange against a spawned pylon, bypassing `BridgeClient`
+/// entirely -- used ONLY to prove the endpoint enforces on its own, for a
+/// caller that skips (or never had) the client's local preflight.
+fn raw_exchange(port: u16, frame: &[u8]) -> Vec<u8> {
     use std::io::{Read, Write};
     let mut stream = std::net::TcpStream::connect(("127.0.0.1", port))
         .unwrap_or_else(|e| unreachable!("witness pylon must accept: {e}"));
@@ -99,23 +151,6 @@ fn exchange(port: u16, frame: &[u8]) -> Vec<u8> {
     out
 }
 
-/// Decode an authenticated response and check its MAC under the session.
-fn verify_response(
-    session: &AuthenticatedSession,
-    frame: &[u8],
-) -> crate::session::AuthenticatedResponse {
-    let frame =
-        Envelope::decode(frame).unwrap_or_else(|e| unreachable!("response frame decodes: {e}"));
-    assert_eq!(frame.header.kind, MessageKind::AuthenticatedResponse);
-    let response: crate::session::AuthenticatedResponse =
-        postcard::from_bytes(&frame.payload).unwrap_or_else(|_| unreachable!());
-    assert!(
-        session.verify_response(&response),
-        "the response MAC must verify under the grant's response key"
-    );
-    response
-}
-
 #[test]
 fn happy_authenticated_round_trip() {
     let (port, _handle) = pylon::spawn(Pylon::new(runtime_signing().verifying_key(), 5_000), 1);
@@ -125,21 +160,25 @@ fn happy_authenticated_round_trip() {
         5_000,
     )
     .unwrap_or_else(|e| unreachable!("grant verifies: {e}"));
+    let mut client = BridgeClient::new(TcpBridgeTransport::connect(port));
     let request = sms_request();
-    let response = verify_response(
-        &session,
-        &exchange(port, &auth_frame(&session, request.clone())),
-    );
-    assert_eq!(response.response.request_id, request.request_id());
+    let response = client
+        .submit_authenticated(&session, &request)
+        .unwrap_or_else(|e| unreachable!("an authenticated submit must succeed: {e}"));
+    assert_eq!(response.request_id, request.request_id());
     assert!(
-        matches!(response.response.status, TaskStatus::Accepted { .. }),
+        matches!(response.status, TaskStatus::Accepted { .. }),
         "a verified grant + task must be accepted, got {:?}",
-        response.response.status
+        response.status
     );
 }
 
 #[test]
 fn replay_is_rejected() {
+    // The pylon answers one frame per accepted connection, so replaying a
+    // request means a second connection presenting the same frame -- the
+    // exact shape a real device retry (or an attacker's captured frame)
+    // takes.
     let (port, _handle) = pylon::spawn(Pylon::new(runtime_signing().verifying_key(), 5_000), 2);
     let session = AuthenticatedSession::open(
         runtime_grant(10_000),
@@ -147,10 +186,18 @@ fn replay_is_rejected() {
         5_000,
     )
     .unwrap_or_else(|e| unreachable!("grant verifies: {e}"));
-    let frame = auth_frame(&session, sms_request());
-    let _ = verify_response(&session, &exchange(port, &frame));
-    let second = verify_response(&session, &exchange(port, &frame));
-    match second.response.status {
+    let request = sms_request();
+
+    let mut first = BridgeClient::new(TcpBridgeTransport::connect(port));
+    let _ = first
+        .submit_authenticated(&session, &request)
+        .unwrap_or_else(|e| unreachable!("the first submit must succeed: {e}"));
+
+    let mut second = BridgeClient::new(TcpBridgeTransport::connect(port));
+    let replayed = second
+        .submit_authenticated(&session, &request)
+        .unwrap_or_else(|e| unreachable!("a replay still MAC-verifies as a rejection: {e}"));
+    match replayed.status {
         TaskStatus::Rejected { ref reason } => {
             assert_eq!(
                 reason.as_str(),
@@ -166,7 +213,8 @@ fn replay_is_rejected() {
 fn expired_grant_is_rejected() {
     let (port, _handle) = pylon::spawn(Pylon::new(runtime_signing().verifying_key(), 20_000), 1);
     // The grant expired at 10_000; the pylon evaluates at 20_000. The
-    // client-side pre-flight ALSO refuses it (fail-closed both ends).
+    // client-side pre-flight ALSO refuses it (fail-closed both ends) --
+    // this never reaches the network at all.
     assert!(
         AuthenticatedSession::open(
             runtime_grant(10_000),
@@ -176,18 +224,19 @@ fn expired_grant_is_rejected() {
         .is_err(),
         "client pre-flight must refuse an expired grant"
     );
-    // And the endpoint rejects it independently.
+    // And the endpoint rejects it independently, for a session opened
+    // while the grant was still valid but presented after it lapsed.
     let session = AuthenticatedSession::open(
         runtime_grant(10_000),
         &device_signing().verifying_key().to_bytes(),
         5_000,
     )
     .unwrap_or_else(|e| unreachable!("grant verifies at issue time: {e}"));
-    let response = verify_response(
-        &session,
-        &exchange(port, &auth_frame(&session, sms_request())),
-    );
-    match response.response.status {
+    let mut client = BridgeClient::new(TcpBridgeTransport::connect(port));
+    let response = client
+        .submit_authenticated(&session, &sms_request())
+        .unwrap_or_else(|e| unreachable!("an expired grant still MAC-verifies as a reject: {e}"));
+    match response.status {
         TaskStatus::Rejected { ref reason } => {
             assert_eq!(reason.as_str(), pylon::reject::GRANT_EXPIRED);
         }
@@ -198,8 +247,9 @@ fn expired_grant_is_rejected() {
 #[test]
 fn wrong_runtime_identity_is_rejected() {
     // The grant is signed by an impostor runtime (a different signing key
-    // than the pylon pins). Signature verifies under the impostor — and the
-    // pylon still refuses, because the issuer is not the pinned runtime.
+    // than the pylon pins). Signature verifies under the impostor -- and
+    // the pylon still refuses, because the issuer is not the pinned
+    // runtime.
     let impostor = SigningKey::from_bytes(&[0xEE; 32]);
     let forged = SignedGrant::issue(
         Grant {
@@ -218,11 +268,11 @@ fn wrong_runtime_identity_is_rejected() {
             .unwrap_or_else(|e| {
                 unreachable!("the forged grant verifies under its own issuer: {e}")
             });
-    let response = verify_response(
-        &session,
-        &exchange(port, &auth_frame(&session, sms_request())),
-    );
-    match response.response.status {
+    let mut client = BridgeClient::new(TcpBridgeTransport::connect(port));
+    let response = client
+        .submit_authenticated(&session, &sms_request())
+        .unwrap_or_else(|e| unreachable!("an unpinned issuer still MAC-verifies as a reject: {e}"));
+    match response.status {
         TaskStatus::Rejected { ref reason } => {
             assert_eq!(reason.as_str(), pylon::reject::WRONG_ISSUER);
         }
@@ -253,6 +303,8 @@ fn grant_for_another_device_never_authorizes() {
 #[test]
 fn unavailable_network_is_a_typed_transport_error() {
     // No listener on this port (bound-then-dropped to guarantee closure).
+    // A real device hits this before a `BridgeClient` can even be built --
+    // the transport trait takes an already-connected peer.
     let port = std::net::TcpListener::bind(("127.0.0.1", 0))
         .and_then(|l| l.local_addr().map(|a| a.port()))
         .unwrap_or_else(|_| unreachable!());
@@ -267,15 +319,47 @@ fn unavailable_network_is_a_typed_transport_error() {
 }
 
 #[test]
-fn capability_outside_grant_is_denied() {
-    let (port, _handle) = pylon::spawn(Pylon::new(runtime_signing().verifying_key(), 5_000), 1);
+fn mid_exchange_disconnect_surfaces_as_typed_transport_error() {
+    // A peer that accepts the connection then closes without responding --
+    // driven through the real `submit_authenticated` path, this must
+    // surface a typed `Error::Transport`, never panic or return an empty
+    // frame as if it were a valid response.
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap_or_else(|_| unreachable!());
+    let port = listener
+        .local_addr()
+        .map_or_else(|_| unreachable!(), |a| a.port());
+    let handle = std::thread::spawn(move || {
+        if let Ok((stream, _)) = listener.accept() {
+            drop(stream); // accept, then close without writing a response
+        }
+    });
     let session = AuthenticatedSession::open(
         runtime_grant(10_000),
         &device_signing().verifying_key().to_bytes(),
         5_000,
     )
     .unwrap_or_else(|e| unreachable!("grant verifies: {e}"));
-    // The grant carries only SendSms; a PlaceCall task is outside it.
+    let mut client = BridgeClient::new(TcpBridgeTransport::connect(port));
+    let result = client.submit_authenticated(&session, &sms_request());
+    assert!(
+        matches!(result, Err(Error::Transport { .. })),
+        "a peer that closes without responding must surface a typed transport error, got {result:?}"
+    );
+    handle.join().unwrap_or_else(|_| unreachable!());
+}
+
+#[test]
+fn capability_outside_grant_is_denied_locally_before_any_network_use() {
+    // The session's VERIFIED grant carries only SendSms; a PlaceCall task
+    // is outside it. The client must refuse before touching the
+    // transport -- `PanicIfCalledTransport` proves that, not just an
+    // assertion on the returned error.
+    let session = AuthenticatedSession::open(
+        runtime_grant(10_000),
+        &device_signing().verifying_key().to_bytes(),
+        5_000,
+    )
+    .unwrap_or_else(|e| unreachable!("grant verifies: {e}"));
     let call = TaskRequest::PlaceCall {
         request_id: Ulid::from_bytes([6; 16]),
         identity: device_identity(),
@@ -286,7 +370,63 @@ fn capability_outside_grant_is_denied() {
         )],
         to: "+15557654321".into(),
     };
-    let response = verify_response(&session, &exchange(port, &auth_frame(&session, call)));
+    let mut client = BridgeClient::new(PanicIfCalledTransport);
+    let result = client.submit_authenticated(&session, &call);
+    assert!(
+        matches!(
+            result,
+            Err(Error::MissingCapability {
+                capability: Capability::CallDial,
+                ..
+            })
+        ),
+        "a task outside the verified grant must be denied locally, got {result:?}"
+    );
+}
+
+#[test]
+fn capability_outside_grant_is_denied_by_the_endpoint() {
+    // Defense in depth: even a caller that skips `BridgeClient`'s local
+    // preflight (a hand-built frame, or a future buggy client) is refused
+    // by the endpoint itself. Built at the envelope layer directly so the
+    // out-of-grant frame reaches the pylon regardless of client-side
+    // policy.
+    let (port, _handle) = pylon::spawn(Pylon::new(runtime_signing().verifying_key(), 5_000), 1);
+    let session = AuthenticatedSession::open(
+        runtime_grant(10_000),
+        &device_signing().verifying_key().to_bytes(),
+        5_000,
+    )
+    .unwrap_or_else(|e| unreachable!("grant verifies: {e}"));
+    let call = TaskRequest::PlaceCall {
+        request_id: Ulid::from_bytes([6; 16]),
+        identity: device_identity(),
+        grants: vec![CapabilityGrant::new(
+            Capability::CallDial,
+            "policy",
+            "grant-call",
+        )],
+        to: "+15557654321".into(),
+    };
+    let wrapped = session.wrap(call);
+    let payload = postcard::to_allocvec(&wrapped).unwrap_or_else(|_| unreachable!());
+    let frame = Envelope::build(MessageKind::AuthenticatedRequest, 1, payload)
+        .unwrap_or_else(|_| unreachable!())
+        .encode();
+
+    let out = raw_exchange(port, &frame);
+    let response_frame =
+        Envelope::decode(&out).unwrap_or_else(|e| unreachable!("response frame decodes: {e}"));
+    assert_eq!(
+        response_frame.header.kind,
+        MessageKind::AuthenticatedResponse
+    );
+    let response: crate::session::AuthenticatedResponse =
+        postcard::from_bytes(&response_frame.payload).unwrap_or_else(|_| unreachable!());
+    assert!(
+        session.verify_response(&response),
+        "the rejection is still MAC-verified, not an unauthenticated error"
+    );
     match response.response.status {
         TaskStatus::Rejected { ref reason } => {
             assert_eq!(reason.as_str(), pylon::reject::CAPABILITY_DENIED);

--- a/docs/ALETHEIA-BRIDGE.md
+++ b/docs/ALETHEIA-BRIDGE.md
@@ -36,13 +36,48 @@ hardware identifiers must not cross this bridge.
 ## Current Surface
 
 - `crates/metaxu` is registered as a workspace crate.
-- Requests and responses serialize with `postcard`.
-- `BridgeClient` exchanges one request frame for one response frame through a
-  caller-provided transport.
-- The crate has an in-memory round-trip test for device -> runtime -> device.
-- The local preflight only checks that a request carries a grant for the needed
-  capability. It does not authenticate grants, check expiration, or prove remote
-  runtime identity.
+- Requests and responses serialize with `postcard`, framed in a versioned
+  envelope (magic + schema + major/minor + kind + correlation ID + declared
+  length, checked before any payload decode) so thumos and aletheia never
+  drift on wire assumptions (#553).
+- Two request paths exist on `BridgeClient` (#544):
+  - `submit` exchanges a bare task request/response pair through a
+    caller-provided transport, checking only that the task carries a
+    self-claimed grant locally -- suitable for a trusted in-process
+    transport, not a network peer.
+  - `submit_authenticated` presents a cryptographically verified, expiring
+    `SignedGrant` (Ed25519-signed by the runtime, bound to both the
+    issuer's and the device's identity) on every request, and refuses any
+    response whose HMAC does not prove the responder held the grant's
+    signed nonce. Capability enforcement checks the session's verified
+    grant, not the wire-claimed one. An adversarial witness exercises this
+    path over real TCP: replay, expired grant, wrong runtime identity, a
+    grant for the wrong device, unavailable network (at connect and
+    mid-exchange), and a denied capability (both the client's local
+    preflight and the endpoint's independent check).
+- Golden vectors (`crates/metaxu/src/vectors.rs`) pin the envelope's byte
+  shape so both repositories decode it identically.
+
+## What Remains
+
+The verified protocol path above is proven against a reference endpoint
+double (`pylon`) inside the `metaxu` crate itself -- a stand-in for the real
+Aletheia runtime, not a live one. Outstanding for a genuinely live round
+trip:
+
+- Bind `metaxu` to the selected live transport (second-PL011 on qemu-virt
+  per the phase plan; WiFi on hardware) through the declared firewall
+  boundary, without bypassing firewall policy.
+- Drive `submit_authenticated` from a real Thumos userspace process rather
+  than a host-side test harness.
+- Stand up (or point at) an actual Aletheia-side endpoint implementing the
+  pylon's verification contract, so the pinned runtime key is a real
+  runtime's key, not a witness fixture.
+- Connect nous capability presets to concrete `metaxu` grant issuance.
+- Route accepted device actions through the existing confirmation UI and
+  local service APIs.
+- Cross-link the corresponding Aletheia-side runtime endpoint when it
+  exists.
 
 ## Non-Goals
 
@@ -51,12 +86,3 @@ hardware identifiers must not cross this bridge.
 - No network or firewall boot path changes are part of this bridge decision.
 - No userspace spawn or init path changes are part of this bridge decision.
 - No dependency on a C toolchain or heavyweight runtime library is introduced.
-
-## Follow-Up Work
-
-- Bind `metaxu` to the selected live transport without bypassing firewall policy.
-- Connect nous capability presets to concrete `metaxu` grant verification.
-- Add runtime peer authentication and grant expiration checks.
-- Route accepted device actions through the existing confirmation UI and local
-  service APIs.
-- Cross-link the corresponding Aletheia-side runtime endpoint when it exists.


### PR DESCRIPTION
## Finding

PR #612 landed grant authentication, expiry, and remote-runtime identity for the Aletheia bridge protocol, but the crate's only production entry point (`BridgeClient::submit`) never used any of it -- the authenticated path (`AuthenticatedSession`, `SignedGrant`, the adversarial witness) existed only as test-only code. A real caller had no way to actually send an authenticated request; they would have had to hand-roll envelope framing themselves. `docs/ALETHEIA-BRIDGE.md` and `README.md` also still described grant authentication as absent, which was stale as of #612.

## Evidence

- `crates/metaxu/src/lib.rs` (before this PR): `BridgeClient::submit` encoded a bare `TaskRequest` and checked only the task's self-claimed `CapabilityGrant` -- no cryptographic verification, no MAC-checked response.
- `crates/metaxu/src/pylon.rs` and `crates/metaxu/src/witness.rs` are declared `#[cfg(test)]` in `lib.rs` -- excluded from the actual library artifact. The only code exercising `AuthenticatedSession` was the witness's own hand-built envelope frames (`auth_frame`/`exchange`/`verify_response`), never `BridgeClient`.
- `docs/ALETHEIA-BRIDGE.md` "Current Surface" (pre-PR): "does not authenticate grants, check expiration, or prove remote runtime identity" -- true when written, false after #612 merged, never updated.
- `README.md:58` (pre-PR): "live transport, grant verification, and UI wiring are future work" -- same staleness.

## Why this matters

#544 asks for one authenticated live Aletheia round trip. Cryptographic grant verification existing only inside a test module means no real Thumos userspace process could ever use it -- the "authenticated round trip" was provable only to itself. A caller (present or future) reaching for `metaxu`'s public API would find `submit`, use it, and get the unauthenticated path with no compiler signal that anything stronger existed.

## Desired correction / what this PR does

- `BridgeClient::submit_authenticated` (`lib.rs`): the production entry point for the authenticated exchange. Presents the session's cryptographically verified `SignedGrant` on every request, checks the task's required capability against the session's VERIFIED grant (not the wire-claimed one `submit` checks), refuses any response whose MAC doesn't prove the responder held the grant's nonce, and returns typed errors (`MissingCapability`, `Transport`, `Envelope`, `Decode`, the new `ResponseAuthenticationFailed`, `ResponseRequestMismatch`) for every failure mode -- never a panic, never a silent accept.
- `session::encode_authenticated_request` / `decode_authenticated_response` (`session.rs`): the one place an authenticated wire frame is built/parsed, shared by the client and the witness so there is no drift between what's tested and what ships.
- `Error::ResponseAuthenticationFailed` (`error.rs`): a tampered, forged, or corrupted response is now a typed, matchable error rather than something a caller could accidentally trust.
- The adversarial witness (`witness.rs`) now drives `BridgeClient::submit_authenticated` for every case instead of hand-building envelope frames -- it proves the production API surface, not a parallel path that could drift from it. Added: a mid-exchange-disconnect case (peer accepts then closes without responding -> typed `Error::Transport`, not a panic) and a local-preflight-denial case (a task outside the session's verified grant is refused before touching the transport at all -- proven with a transport that panics if invoked). The pre-existing server-side capability-denial case is kept, renamed, and now explicitly framed as defense-in-depth for a caller that skips the client.
- `docs/ALETHEIA-BRIDGE.md` and `README.md` updated to state what's actually implemented (verified, expiring, identity-bound grants; the adversarial witness) versus what's still outstanding.

## Honest scope

This proves the protocol path end-to-end through the crate's real public API, against a reference endpoint double (`pylon`) inside `metaxu` itself, over real TCP. It is not a live round trip: no running Aletheia instance exists in CI or on this box. Explicitly still open, restated in `docs/ALETHEIA-BRIDGE.md` "What Remains" -- **#544 stays open** for these, the same way #612 left it open before this PR:

- Binding `metaxu` to the selected live transport (second-PL011 on qemu-virt / WiFi on hardware) through the firewall boundary.
- Driving `submit_authenticated` from a real Thumos userspace process rather than a host-side test harness.
- An actual Aletheia-side endpoint implementing the pylon's verification contract (the pinned runtime key is currently a witness fixture, not a real runtime's key).
- Connecting nous capability presets to concrete grant issuance, and routing accepted actions through the confirmation UI.

Capability containment (#552 dependency): `metaxu::Capability` has 6 variants (`SmsSend`, `CallDial`, `ContactsRead`, `AudioCapture`, `AudioPlayback`, `DeviceIdentityReference`), none of which overlap the kernel's `NeverCapability`/`NEVER_ACTIONS` set (keys, SIGINT, panic trigger, security-disable; `crates/thumos/src/nous.rs`). `metaxu` has no dependency on `crates/thumos` and no path into its action dispatch (`crates/thumos/Cargo.toml` names no `metaxu` dependency; `metaxu` is a host-buildable workspace crate excluded from the kernel's armv7a build), so nothing added here can reach a NEVER action.

Filed separately (out of scope for this PR, pre-existing on `main`, not introduced by #544): #652 tracks `metaxu`'s kanon-lint debt (`unreachable-in-match`, `indexing-slicing`, `as-cast`, `bare-assert` -- 67 violations on `main` before this branch, proportionally extended by this PR's new test code in the file's own established idiom).

## Verification

- `cargo fmt --all -- --check`: EXIT=0.
- `vgate cargo check -p metaxu --all-targets`: EXIT=0.
- `vgate cargo clippy --workspace --all-targets -- -D warnings`: EXIT=0 (first run caught a real `clippy::map_unwrap_or` finding in the new mid-exchange-disconnect test; fixed, re-verified clean on both `-p metaxu` and `--workspace` scopes).
- `vgate cargo nextest run --workspace`: EXIT=0 -- 726 tests run: 726 passed, 0 skipped (8 of those are the metaxu witness cases, all through `submit_authenticated`).
- `bash scripts/check-target-test-ledger.sh`: no drift (scans `crates/thumos/src` only; `metaxu` is a workspace crate, out of its scope).
- `bash scripts/check-board-seam.sh`, `check-convergence.sh`, `check-doc-inventory.sh`: EXIT=0 each.

Refs #544
