### PR TITLE
fix(ledger): derive target-test-ledger counts from runnable tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,10 +108,15 @@ jobs:
         # both surfaces execute the identical suite.
         run: scripts/kernel-host-tests.sh
       - name: Target-test ledger check (#551)
-        # WHY (#551, restoring #124): declared-vs-executed must be auditable —
-        # reds when a test-bearing or target-sensitive module has no ledger
-        # row, a witness name rots, a sensitive host-only row loses its
-        # fidelity label, or a tests count drifts. Cheap, source-level.
+        # WHY (#551, restoring #124; #645): declared-vs-executed must be
+        # auditable — reds when a test-bearing or target-sensitive module has
+        # no ledger row, a witness name rots, a sensitive host-only row loses
+        # its fidelity label, or a declared tests count drifts from the
+        # RUNNABLE set `cargo nextest list` reports (#645: a module cfg'd out
+        # of the test build contributes zero regardless of its source text).
+        # Needs a build, but the "Kernel host tests" step just above already
+        # built this exact i686 target, so this is a cache hit, not a
+        # separate compile — placement in the job matters.
         run: scripts/check-target-test-ledger.sh
       - name: Board-seam invariant check (#534)
         # WHY (#534): the two-board reality is structural, not prose — reds

--- a/.kanon-ci.toml
+++ b/.kanon-ci.toml
@@ -67,8 +67,14 @@ timeout_secs = 900
 cmd = "sh -c 'rustup target add i686-unknown-linux-gnu && scripts/kernel-host-tests.sh'"
 timeout_secs = 1800
 
-# WHY (#551): declared-vs-executed audit for the kernel test obligations —
-# source-level, cheap, runs before the expensive witness stages.
+# WHY (#551; #645): declared-vs-executed audit for the kernel test
+# obligations — tests-count drift is checked against the RUNNABLE set
+# `cargo nextest list` reports, not source text (#645: text-regex counted a
+# module's tests even when a #[cfg] excluded it from every test build).
+# Runs right after "kernel host tests", which just built this exact i686
+# target — a cache hit, not a fresh compile — so this stage stays cheap in
+# this pipeline position specifically; do not reorder it away from that
+# stage.
 [stages."target test ledger"]
 cmd = "scripts/check-target-test-ledger.sh"
 timeout_secs = 300

--- a/crates/thumos/src/main.rs
+++ b/crates/thumos/src/main.rs
@@ -255,11 +255,20 @@ mod uart;
 #[cfg(not(feature = "qemu"))]
 mod usb;
 mod vfs;
-#[cfg(all(not(test), not(feature = "qemu")))]
+// WHY(host-test, #645): un-gated from not(test), matching display/keypad/usb
+// -- init/pet/disable are unsafe MMIO writers, but the module's own tests
+// only assert the register-offset and encoding CONSTANTS, never call them,
+// so the file is host-testable as-is. The prior `all(not(test), ...)` gate
+// excluded watchdog from every host test build; its 3 tests were dead
+// source under both cfgs (the #528 kinit/#631 emmc trap), which is what
+// #645 found and this line fixes. The two call sites (kinit::run,
+// exceptions::timer_irq) are themselves `#[cfg(not(test))]`, so nothing
+// new gets pulled into the host build by un-gating the module itself.
+#[cfg(not(feature = "qemu"))]
 mod watchdog;
 // WHY(qemu): virt models no MT6739 WDT; a no-op stub keeps the timer-IRQ
 // pet path and kinit call sites identical without touching MMIO.
-#[cfg(all(not(test), feature = "qemu"))]
+#[cfg(feature = "qemu")]
 #[path = "watchdog_qemu.rs"]
 mod watchdog;
 mod wifi;

--- a/crates/thumos/src/secure_boot.rs
+++ b/crates/thumos/src/secure_boot.rs
@@ -651,8 +651,6 @@ mod tests {
         );
     }
 
-    /// Test that split_image rejects images shorter than MIN_IMAGE_SIZE.
-    #[test]
     // -- Streamed Ed25519ph verify (#467) --
     #[test]
     fn unreadable_boot_partition_halts_never_degrades() {

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -4,11 +4,19 @@
 # target side, and the fidelity limits of any host fixture. Enforced by
 # scripts/check-target-test-ledger.sh: every such module has a row, 'both'
 # rows name real witness scripts, sensitive host-only rows carry a fidelity
-# note, and the tests count matches the source tree.
+# note, and the tests count matches the RUNNABLE set `cargo nextest list`
+# reports for the i686 host test binary (#645) -- not a count of `#[test]`
+# occurrences in source text, which cannot tell a module a #[cfg] excluded
+# from every test build from one that genuinely compiled and ran.
 #
 # #528/#533 are the proof-by-incident: host fixtures green while real-table
 # behavior was broken on every boot — host tests are structurally blind to
 # the section-overlay class. The 'both' rows are where that class lives.
+# #619/#631/#645 are the proof-by-incident for the tests-count rule itself:
+# emmc (31 tests) and watchdog (3 tests) were both cfg'd out of every test
+# build, so their tests existed as text, were counted as coverage, and had
+# never once been compiled -- exactly the failure mode a text-based count
+# cannot see.
 
 [[module]]
 name = "audio"
@@ -115,7 +123,7 @@ mechanism = "host"
 
 [[module]]
 name = "csprng"
-tests = 16
+tests = 15
 mechanism = "both"
 witness = "boot.sh"
 fidelity = "host tests use the deterministic seed path; hardware entropy health is device-bound"
@@ -468,7 +476,7 @@ witness = "boot.sh"
 
 [[module]]
 name = "reflex"
-tests = 4
+tests = 3
 mechanism = "host"
 
 [[module]]
@@ -549,7 +557,7 @@ mechanism = "host"
 
 [[module]]
 name = "secure_boot"
-tests = 29
+tests = 28
 mechanism = "both"
 witness = "boot.sh"
 

--- a/scripts/check-target-test-ledger.sh
+++ b/scripts/check-target-test-ledger.sh
@@ -1,23 +1,69 @@
 #!/usr/bin/env bash
 # check-target-test-ledger.sh — declared-vs-executed audit for the kernel's
-# test obligations (#551, restoring #124). Fails when:
+# test obligations (#551, restoring #124; runnable-derivation #645). Fails
+# when:
 #   (a) a module with #[test]s or target-sensitive patterns has no ledger row
 #   (b) a 'both'/'target' row names a witness script that does not exist
 #   (c) a target-sensitive host-only row carries no fidelity note
-#   (d) a row's tests count drifts from the source tree
+#   (d) a row's declared tests count does not match the RUNNABLE test count
+#       in the compiled i686 host test binary
 # Ledger: docs/target-test-ledger.toml. #528/#533 are the proof-by-incident:
 # host fixtures green while real-table behavior was broken on every boot.
+#
+# (d) used to count `#[test]` occurrences in source TEXT (#124's original
+# design). #619/#631/#645 are the proof that text is the wrong basis: emmc
+# (31 tests) and watchdog (3 tests) were both `#[cfg]`-excluded from every
+# test build, so their tests existed as text, were counted as coverage, and
+# had never once been compiled. (d) now derives its count from
+# `cargo nextest list` — the tests the i686 binary genuinely contains — so a
+# module that stops compiling reds immediately instead of reporting its old
+# count forever (Done-when in #645).
+#
+# COST: (d) needs a build. Both ci.yml and .kanon-ci.toml already run the
+# "kernel host tests" stage immediately before this one (same target, same
+# two feature passes below), so the i686 target is warm and `nextest list`
+# here is a cache hit, not a fresh compile — this stage's placement in the
+# pipeline is load-bearing, not incidental. Invoked standalone with no prior
+# build, this script builds first like any other nextest call.
 set -uo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 LEDGER="$REPO_ROOT/docs/target-test-ledger.toml"
 SRC="$REPO_ROOT/crates/thumos/src"
 WITNESS_DIR="$REPO_ROOT/scripts/witness"
+KERNEL_DIR="$REPO_ROOT/crates/thumos"
+MAIN_RS="$SRC/main.rs"
 
-python3 - "$LEDGER" "$SRC" "$WITNESS_DIR" <<'PYEOF'
-import re, sys, tomllib, glob, os
+command -v cargo-nextest >/dev/null || {
+    echo "LEDGER DRIFT: cargo-nextest not installed -- cannot derive runnable test counts (#645)" >&2
+    exit 1
+}
 
-ledger_path, src_dir, wit_dir = sys.argv[1:4]
+LIST_DEFAULT=$(mktemp)
+LIST_DEBUG=$(mktemp)
+trap 'rm -f "$LIST_DEFAULT" "$LIST_DEBUG" "$LIST_DEFAULT.err" "$LIST_DEBUG.err"' EXIT
+
+# Two passes mirror kernel-host-tests.sh's two nextest-run passes (#459):
+# default features, then --features debug-console (the only feature that
+# gates in extra host-testable modules -- console). Their union is the
+# runnable set this ledger is checked against.
+if ! (cd "$KERNEL_DIR" && cargo nextest list --bin thumos --target i686-unknown-linux-gnu \
+        --build-jobs "${THUMOS_BUILD_JOBS:-8}" --message-format json) >"$LIST_DEFAULT" 2>"$LIST_DEFAULT.err"; then
+    cat "$LIST_DEFAULT.err" >&2
+    echo "LEDGER DRIFT: cargo nextest list (default features) failed -- cannot derive runnable test counts" >&2
+    exit 1
+fi
+if ! (cd "$KERNEL_DIR" && cargo nextest list --bin thumos --target i686-unknown-linux-gnu \
+        --features debug-console --build-jobs "${THUMOS_BUILD_JOBS:-8}" --message-format json) >"$LIST_DEBUG" 2>"$LIST_DEBUG.err"; then
+    cat "$LIST_DEBUG.err" >&2
+    echo "LEDGER DRIFT: cargo nextest list (--features debug-console) failed -- cannot derive runnable test counts" >&2
+    exit 1
+fi
+
+python3 - "$LEDGER" "$SRC" "$WITNESS_DIR" "$MAIN_RS" "$LIST_DEFAULT" "$LIST_DEBUG" <<'PYEOF'
+import re, sys, tomllib, glob, os, json
+
+ledger_path, src_dir, wit_dir, main_rs_path, list_default_path, list_debug_path = sys.argv[1:7]
 try:
     rows = tomllib.load(open(ledger_path, "rb")).get("module", [])
 except Exception as e:
@@ -39,6 +85,170 @@ def fail(msg):
     print(f"LEDGER DRIFT: {msg}", file=sys.stderr)
     rc = 1
 
+# --- cfg evaluator -----------------------------------------------------------
+# main.rs expresses every declared module's availability with `test`,
+# `feature = "NAME"`, `not(EXPR)`, `all(EXPR, ...)`, `any(EXPR, ...)` -- the
+# exact grammar `#[cfg(...)]` uses on `mod` items in this crate. This walks
+# that grammar; it is not a general cfg parser and does not need to be.
+TOKEN_RE = re.compile(r'\(|\)|,|[A-Za-z_][A-Za-z0-9_]*|"[^"]*"|=')
+
+def _parse(tokens, env):
+    tok = tokens[0]
+    rest = tokens[1:]
+    if tok in ("not", "all", "any"):
+        assert rest and rest[0] == "(", f"expected '(' after {tok}"
+        rest = rest[1:]
+        args = []
+        while True:
+            v, rest = _parse(rest, env)
+            args.append(v)
+            if rest and rest[0] == ",":
+                rest = rest[1:]
+                continue
+            assert rest and rest[0] == ")", f"expected ')' closing {tok}(...)"
+            rest = rest[1:]
+            break
+        return ({"not": not args[0], "all": all(args), "any": any(args)}[tok], rest)
+    if tok == "test":
+        return (env["test"], rest)
+    if tok == "feature":
+        assert rest and rest[0] == "=", "expected '=' after feature"
+        name = rest[1].strip('"')
+        return (name in env["features"], rest[2:])
+    raise ValueError(f"unrecognized cfg token {tok!r}")
+
+def eval_cfg(expr, env):
+    toks = TOKEN_RE.findall(expr)
+    v, rest = _parse(toks, env)
+    assert not rest, f"leftover cfg tokens: {rest}"
+    return v
+
+# --- mod-declaration extraction ---------------------------------------------
+# Groups {ident: [(cfg_expr_or_None, path_override_or_None), ...]} from a
+# file's top-level `mod IDENT;` items. An attribute attaches only to the
+# `mod` line directly below it across blank/comment lines; any other
+# statement in between breaks the pairing. WHY: a naive "last #[cfg] seen"
+# scan mis-attributes a `#[cfg(not(test))]` guarding a preceding `use`
+# statement to an unrelated later `mod` -- caught while building this check.
+MOD_RE = re.compile(r'^(?:pub(?:\(crate\))? )?mod (\w+);')
+CFG_RE = re.compile(r'^#\[cfg\((.*)\)\]$')
+PATH_RE = re.compile(r'^#\[path\s*=\s*"([^"]+)"\]$')
+
+def extract_mod_decls(path):
+    decls = {}
+    pending_cfg = None
+    pending_path = None
+    for line in open(path):
+        s = line.strip()
+        m = CFG_RE.match(s)
+        if m:
+            pending_cfg = m.group(1)
+            continue
+        m = PATH_RE.match(s)
+        if m:
+            pending_path = m.group(1)
+            continue
+        if s == "" or s.startswith("//"):
+            continue
+        m = MOD_RE.match(s)
+        if m:
+            decls.setdefault(m.group(1), []).append((pending_cfg, pending_path))
+            pending_cfg = None
+            pending_path = None
+            continue
+        pending_cfg = None
+        pending_path = None
+    return decls
+
+def relpath_for(ident, path_override):
+    if path_override:
+        assert path_override.endswith(".rs"), f"non-.rs #[path] override: {path_override}"
+        return path_override[:-3]
+    return ident
+
+def active_relpath(decls, ident, env):
+    variants = decls.get(ident)
+    if not variants:
+        return None
+    active = [relpath_for(ident, path_override) for (cfg, path_override) in variants
+              if cfg is None or eval_cfg(cfg, env)]
+    if len(active) > 1:
+        raise AssertionError(f"'{ident}' has {len(active)} simultaneously-active mod declarations under {env}: {active}")
+    return active[0] if active else None
+
+main_decls = extract_mod_decls(main_rs_path)
+# idents main.rs declares more than once (path-swap families, e.g.
+# exceptions/exceptions_stub, watchdog/watchdog_qemu) -- only these need
+# per-env resolution below; every other module's ledger row name is its
+# Rust path with '::' replaced by '/', directly.
+overridden_idents = {ident for ident, variants in main_decls.items() if len(variants) > 1}
+
+def module_path_to_row_name(mod_path, env):
+    """mod_path is the '::'-joined Rust path before '::tests::<fn>' in a
+    nextest test id. Resolve it to the docs/target-test-ledger.toml row it
+    corresponds to under this build env. Nested idents that aren't path-swap
+    families (board::m7, board::virt -- gated in board/mod.rs, not main.rs,
+    and never sharing a name) need no resolution at all: '::' -> '/' on the
+    full path already matches their ledger row names directly."""
+    segs = mod_path.split("::")
+    head = segs[0]
+    if head in overridden_idents:
+        rp = active_relpath(main_decls, head, env)
+        # A test literally compiled under this ident in this env, so some
+        # declaration must have been active for it -- anything else means
+        # this resolver's model of main.rs disagrees with the binary that
+        # actually built, which is a bug in the resolver, not the ledger.
+        assert rp is not None, (
+            f"'{head}' produced a runnable test under {env} but no #[cfg] "
+            f"on its mod declarations evaluates true -- ledger-check cfg "
+            f"resolver is out of sync with main.rs"
+        )
+        segs[0] = rp
+    return "/".join(segs)
+
+# --- runnable test-case extraction ------------------------------------------
+# WHY no filter-match / ignored filtering: nextest's `filter-match` reflects
+# whether a test matches an explicit NAME filter (none is passed here), and
+# `ignored` reflects whether a DEFAULT run would skip it -- neither says
+# whether the test compiled. An #[ignore]d test is still a compiled,
+# individually-invocable test case (`cargo nextest run -- --ignored` runs
+# it); the old text-regex count never distinguished it either. Counting
+# every entry in `testcases` keeps this check's semantics aligned with what
+# it replaces: "how many #[test] fns does this module contain," not "how
+# many run by default."
+def iter_test_names(list_json_path):
+    data = json.load(open(list_json_path))
+    suites = data.get("rust-suites") or data.get("rust-binaries") or {}
+    for suite in suites.values():
+        cases = suite.get("test-cases") or suite.get("testcases") or {}
+        yield from cases.keys()
+
+TEST_SUFFIX_RE = re.compile(r'^(.*)::tests::[^:]+$')
+
+def runnable_row_counts(list_json_path, env):
+    seen = set()
+    for name in iter_test_names(list_json_path):
+        m = TEST_SUFFIX_RE.match(name)
+        if not m:
+            fail(f"nextest test id '{name}' does not match MODULE::tests::FN -- cannot attribute it to a ledger row")
+            continue
+        row_name = module_path_to_row_name(m.group(1), env)
+        seen.add((row_name, name))
+    counts = {}
+    for row_name, _name in seen:
+        counts[row_name] = counts.get(row_name, 0) + 1
+    return counts
+
+env_default = {"test": True, "features": frozenset()}
+env_debug = {"test": True, "features": frozenset({"debug-console"})}
+
+runnable = {}
+for row_name, n in runnable_row_counts(list_default_path, env_default).items():
+    runnable[row_name] = max(runnable.get(row_name, 0), n)
+for row_name, n in runnable_row_counts(list_debug_path, env_debug).items():
+    runnable[row_name] = max(runnable.get(row_name, 0), n)
+
+# --- (a)/(b)/(c)/(e): unchanged, source-level -------------------------------
 TARGET_PAT = re.compile(r'asm!|core::arch|global_asm|0x[0-9A-Fa-f]{6,}|read_volatile|write_volatile|page_table|l1_section|l2_entry|ttbr|cp15', re.I)
 
 witness_files = {os.path.basename(f) for f in glob.glob(os.path.join(wit_dir, "*.sh"))}
@@ -55,8 +265,6 @@ for f in sorted(glob.glob(os.path.join(src_dir, "**", "*.rs"), recursive=True)):
         continue
     if row is None:
         continue
-    if row.get("tests", -1) != tests:
-        fail(f"module '{m}': ledger says {row.get('tests')} tests, source has {tests}")
     mech = row.get("mechanism", "")
     if mech in ("both", "target"):
         wits = row.get("witness", "")
@@ -71,9 +279,26 @@ for m in by_name:
             or os.path.exists(os.path.join(src_dir, m, "mod.rs"))):
         fail(f"ledger row '{m}' has no source file")
 
+# --- (d): declared tests must match the RUNNABLE count (#645) --------------
+for name, row in sorted(by_name.items()):
+    declared = row.get("tests", -1)
+    actual = runnable.get(name, 0)
+    if declared == actual:
+        continue
+    mech = row.get("mechanism", "")
+    if mech in ("host", "both") and declared > 0 and actual == 0:
+        fail(
+            f"module '{name}' mechanism={mech} claims {declared} host tests but the i686 test "
+            f"binary contains zero runnable tests under that name -- the module is not compiled "
+            f"under cfg(test) (a #[cfg] gate excludes it; #645)"
+        )
+    else:
+        fail(f"module '{name}': ledger says {declared} tests, i686 test binary has {actual} runnable")
+
 if rc == 0:
     n_both = sum(1 for r in rows if r.get("mechanism") == "both")
     n_target = sum(1 for r in rows if r.get("mechanism") == "target")
-    print(f"target-test ledger: {len(rows)} rows checked, {n_both} both-mechanism, {n_target} target-only, no drift")
+    n_runnable = sum(runnable.values())
+    print(f"target-test ledger: {len(rows)} rows checked, {n_both} both-mechanism, {n_target} target-only, {n_runnable} runnable host tests, no drift")
 sys.exit(rc)
 PYEOF


### PR DESCRIPTION
## Finding

`scripts/check-target-test-ledger.sh` counted `#[test]` occurrences in source TEXT. A module `#[cfg]`-excluded from every test build was still credited with full coverage, because the checker never asked whether the module actually compiled — it only regex-matched the text sitting next to the tests it would never run.

## Evidence

`crates/thumos/src/main.rs:258` (before this PR):
```rust
#[cfg(all(not(test), not(feature = "qemu")))]
mod watchdog;
```
`docs/target-test-ledger.toml:698-701`:
```toml
[[module]]
name = "watchdog"
tests = 3
mechanism = "host"
fidelity = "watchdog peripheral is hardware-gated; host tests cover arming logic"
```

`not(test)` in that cfg means `mod watchdog;` was never compiled under `cargo nextest run --bin thumos --target i686-unknown-linux-gnu` — the exact command the "host" mechanism claims. Falsified by reverting to this exact state and running the pre-#645 checker against it:

```
$ bash old-check-target-test-ledger.sh
target-test ledger: 126 rows checked, 27 both-mechanism, 9 target-only, no drift
$ echo $?
0
```

Green. The checker never noticed watchdog's 3 tests were dead source — the same shape as `emmc` (31 tests, #631) before it, and the third instance in this class (#528 kinit, #631 emmc, watchdog here).

## Why this matters

An instrument that cannot observe its own subject reports a confident verdict about something it never examined, and the verdict is trusted precisely because it looks like every other verdict on the board. `watchdog` is small; `emmc` (the eMMC driver, where #619 — an uninitialized device halting every hardware boot — survived undetected) was not. A ledger claiming host coverage over a module that never compiled is a reason not to look.

## Desired correction (implemented)

1. **`scripts/check-target-test-ledger.sh` now derives tests-count from the runnable set, not source text.** It builds the i686 test binary via `cargo nextest list --bin thumos --target i686-unknown-linux-gnu` (two passes — default features + `--features debug-console`, mirroring `kernel-host-tests.sh`'s own two passes for the console module) and reconciles each ledger row's declared `tests` count against what genuinely compiled. A `host`/`both` row claiming tests it contributes zero of reds by name:
   ```
   LEDGER DRIFT: module 'watchdog' mechanism=host claims 3 host tests but the i686 test
   binary contains zero runnable tests under that name -- the module is not compiled
   under cfg(test) (a #[cfg] gate excludes it; #645)
   ```
   Resolving a compiled test's Rust module path back to its ledger row needed a small `#[cfg(...)]` evaluator (`test`/`feature = "X"`/`not`/`all`/`any` — the exact grammar `main.rs` uses on `mod` items), because several modules swap files under `#[path = "..."]` by cfg (`exceptions`/`exceptions_stub`, `heap`/`heap_stub`, `timer`/`timer_stub`, `uart`/`uart_stub`/`uart_pl011`) — the runnable Rust path and the ledger's file-based row name diverge for exactly these, and a naive lookup produces false positives.

   **Cost**: this needs a build. Both `ci.yml` and `.kanon-ci.toml` already run "kernel host tests" immediately before this stage (same target, same two feature passes), so `nextest list` here is a cache hit, not a fresh compile — the stage's position in the pipeline is now load-bearing and is called out in both files' comments.

2. **`watchdog`'s cfg fixed**: `#[cfg(not(feature = "qemu"))]` (dropped `not(test)`), matching the existing `display`/`keypad`/`usb` pattern. The module's own tests only assert register-offset and encoding *constants* — `WDT_MODE`, `WDT_RESTART_KEY`, `WDT_LENGTH_VAL` — never call `init`/`pet`/`disable` (the unsafe MMIO writers), so the file is host-testable exactly as written. Its 3 tests now genuinely compile and pass under `cargo nextest run --bin thumos --target i686-unknown-linux-gnu`. The qemu no-op stub (`watchdog_qemu.rs`) is untouched in behavior — its cfg is now the symmetric `#[cfg(feature = "qemu")]`.

3. **Deriving from the real runnable set surfaced 2 more pre-existing ledger inaccuracies** the old text-regex could never see (both discovered because the new checker would otherwise red on rows unrelated to watchdog):
   - `csprng`/`reflex`: each has a comment containing the literal string `#[test]` (e.g. "spawns a fresh OS process per `#[test]` fn"), inflating the old text-count by 1. Ledger corrected 16→15, 4→3; comments left as-is (legitimate prose).
   - `secure_boot`: a stray, duplicate `#[test]` attribute stacked on one function (`unreadable_boot_partition_halts_never_degrades`) above an orphaned doc comment for a *different*, already-covered test (`split_image_too_short` already exists). Dead code — removed. Ledger corrected 29→28.

## Falsification

Both directions confirmed with real recompiles (not simulated):

**Broken** (watchdog's cfg reverted to `all(not(test), not(feature = "qemu"))`):
```
$ bash scripts/check-target-test-ledger.sh
LEDGER DRIFT: module 'watchdog' mechanism=host claims 3 host tests but the i686 test
binary contains zero runnable tests under that name -- the module is not compiled
under cfg(test) (a #[cfg] gate excludes it; #645)
$ echo $?
1
```

**Fixed** (restored):
```
$ bash scripts/check-target-test-ledger.sh
target-test ledger: 126 rows checked, 27 both-mechanism, 9 target-only, 2417 runnable host tests, no drift
$ echo $?
0
```

**Pre-#645 checker on the broken state** (proving the original blindness, not just the new check's correctness):
```
$ bash old-check-target-test-ledger.sh   # scripts/check-target-test-ledger.sh @ origin/main
target-test ledger: 126 rows checked, 27 both-mechanism, 9 target-only, no drift
$ echo $?
0
```

**Done when** (from #645): the ledger's counts derive from the runnable test set — yes; a module whose tests cannot compile reds the check rather than passing it — yes, verified by real recompile above; no ledger row claims host coverage for a module that contributes zero runnable tests — yes, all 126 rows reconcile against the actual i686 binary.

Closes #645