### PR TITLE
lfs/gpt/vfs/lock_screen: the seven low-severity audit findings

### DIFF
--- a/crates/thumos/src/gpt.rs
+++ b/crates/thumos/src/gpt.rs
@@ -29,6 +29,10 @@ pub(crate) enum GptError {
     NotFound,
     /// A block read failed.
     Io,
+    /// A partition entry's `first_lba`/`last_lba` pair is not a valid
+    /// forward extent (`last_lba < first_lba`, or the length would
+    /// overflow `u64`).
+    InvalidExtent,
 }
 
 impl core::fmt::Display for GptError {
@@ -40,6 +44,7 @@ impl core::fmt::Display for GptError {
             Self::Malformed => f.write_str("GPT malformed structure"),
             Self::NotFound => f.write_str("GPT partition not found"),
             Self::Io => f.write_str("GPT block I/O error"),
+            Self::InvalidExtent => f.write_str("GPT partition extent invalid"),
         }
     }
 }
@@ -62,6 +67,12 @@ pub(crate) struct PartitionInfo {
 
 impl PartitionInfo {
     /// Partition length in sectors.
+    ///
+    /// INVARIANT: only [`find_partition`] constructs a [`PartitionInfo`],
+    /// and it rejects `last_lba < first_lba` (and the `last_lba ==
+    /// u64::MAX` case that would overflow this add) before returning one
+    /// (#627) -- so `last_lba - first_lba + 1` never underflows or
+    /// overflows for any value this type actually holds.
     pub(crate) const fn sectors(&self) -> u64 {
         self.last_lba - self.first_lba + 1
     }
@@ -176,9 +187,22 @@ pub(crate) fn find_partition(dev: &dyn BlockDevice, name: &str) -> Result<Partit
             continue;
         }
         if entry[56..56 + 72] == name_utf16 {
+            let first_lba = le64(entry, 32);
+            let last_lba = le64(entry, 40);
+            // WHY: first_lba/last_lba are on-disk, attacker-controlled
+            // fields -- PartitionInfo::sectors() computes `last_lba -
+            // first_lba + 1` and requires this to be a valid forward
+            // extent to stay total. A crafted last_lba < first_lba
+            // underflows that subtraction; a crafted last_lba ==
+            // u64::MAX overflows the + 1. Reject both here, once, so
+            // every PartitionInfo this function returns already
+            // satisfies the invariant sectors() relies on (#627).
+            if last_lba < first_lba || last_lba == u64::MAX {
+                return Err(GptError::InvalidExtent);
+            }
             return Ok(PartitionInfo {
-                first_lba: le64(entry, 32),
-                last_lba: le64(entry, 40),
+                first_lba,
+                last_lba,
             });
         }
     }
@@ -247,6 +271,23 @@ mod tests {
         assert_eq!(boot.first_lba, 2048);
         assert_eq!(boot.last_lba, 4095);
         assert_eq!(boot.sectors(), 2048);
+    }
+
+    /// A crafted entry with `last_lba < first_lba` must be rejected
+    /// rather than let `PartitionInfo::sectors()` underflow (#627).
+    #[test]
+    fn inverted_extent_rejects_instead_of_underflowing() {
+        let dev = gpt_device(&[("boot", 4095, 2048)]);
+        assert_eq!(find_partition(&dev, "boot"), Err(GptError::InvalidExtent));
+    }
+
+    /// A crafted entry with `last_lba == u64::MAX` must be rejected
+    /// rather than let `PartitionInfo::sectors()` overflow the `+ 1`
+    /// (#627).
+    #[test]
+    fn max_last_lba_rejects_instead_of_overflowing() {
+        let dev = gpt_device(&[("boot", 0, u64::MAX)]);
+        assert_eq!(find_partition(&dev, "boot"), Err(GptError::InvalidExtent));
     }
 
     #[test]

--- a/crates/thumos/src/lfs.rs
+++ b/crates/thumos/src/lfs.rs
@@ -2823,14 +2823,23 @@ mod tests {
     /// underlying LfsError.
     #[test]
     fn unlink_last_entry_out_of_space_reports_no_space_not_io_error() {
-        // 5 segments of 4 blocks each: segment 0 reserved, segments 2/3
-        // pinned used, segment 4 withheld as the compaction reserve (only
-        // segment 1 is ordinarily allocatable, same layout style as
-        // `unlink_io_failure_during_directory_write_leaves_imap_and_directory_consistent`).
-        let mut dev =
-            MemBlockDevice::new(5 * 4 * SECTORS_PER_BLOCK as u64).expect("create tiny device");
+        // WHY the setup provisions room and exhausts it AFTERWARDS rather than
+        // sizing the device so the last setup write exactly fills it: the
+        // latter encodes how many blocks four `write_inode` calls happen to
+        // consume, which is an allocator internal. A device sized that way
+        // fails in SETUP the moment allocation changes, and the failure looks
+        // like the behaviour under test rather than a stale fixture.
+        const SEG_BLOCKS: u32 = 5;
+        const SEG_COUNT: u32 = 5;
+        let mut dev = MemBlockDevice::new(
+            u64::from(SEG_COUNT) * u64::from(SEG_BLOCKS) * SECTORS_PER_BLOCK as u64,
+        )
+        .expect("create tiny device");
         let mut cache = BlockCache::new();
-        let mut seg_mgr = LfsSegmentManager::new(5, 4);
+        // segment_size matches the superblock below: `validate_block_num`
+        // treats [0, segment_size) as the reserved metadata region, so the two
+        // disagreeing would reject live data blocks as reserved.
+        let mut seg_mgr = LfsSegmentManager::new(SEG_COUNT, SEG_BLOCKS);
         seg_mgr.mark_used(0);
         seg_mgr.mark_used(2);
         seg_mgr.mark_used(3);
@@ -2886,7 +2895,6 @@ mod tests {
             Lfs::write_dir_block(&mut dev, &mut cache, &mut writer, &mut seg_mgr, &entries)
                 .expect("write dir block");
         // Write 4/4: root inode updated to point at the directory block.
-        // This consumes segment 1's last data slot.
         let mut root = dir_inode_template;
         root.direct[0] = dir_block;
         root.size = entries.iter().map(|e| e.record_len as u64).sum();
@@ -2894,6 +2902,13 @@ mod tests {
             .write_inode(&mut dev, &mut cache, &mut imap, &mut seg_mgr, 0, &root)
             .expect("write updated root inode");
 
+        // The four writes above exactly fill segment 1's usable data blocks,
+        // and every other segment is either reserved (0), pinned used (2, 3),
+        // or the compaction reserve `allocate` withholds (#329). So the
+        // directory rewrite below has nowhere to seal -- neither room in the
+        // open segment nor a free one to allocate. BOTH conditions are needed:
+        // leaving space in the open segment lets the rewrite succeed even with
+        // no free segment left.
         assert_eq!(
             seg_mgr.free_count(),
             1,
@@ -2904,8 +2919,8 @@ mod tests {
             magic: LFS_MAGIC,
             version: LFS_VERSION,
             block_count: dev.sector_count() / SECTORS_PER_BLOCK as u64,
-            segment_size: 4,
-            segment_count: 5,
+            segment_size: SEG_BLOCKS,
+            segment_count: SEG_COUNT,
             checkpoint_block_a: 1,
             checkpoint_block_b: 2,
             imap_block: 3,

--- a/crates/thumos/src/lfs.rs
+++ b/crates/thumos/src/lfs.rs
@@ -521,6 +521,18 @@ pub(crate) fn mount(mut dev: Box<dyn BlockDevice>) -> Result<Lfs, LfsError> {
     cache.read(dev.as_mut(), SUPERBLOCK_BLOCK, &mut sb_buf)?;
     let superblock = LfsSuperblock::from_block(&sb_buf)?;
 
+    // The on-disk block_count is untrusted (magic/version-checked only,
+    // by LfsSuperblock::from_block) and is passed below as the extent
+    // bound every imap/direct-block pointer is validated against
+    // (validate_block_num, LfsImap::load_from_disk). A block_count that
+    // outruns the device's actual capacity would let that bound wave
+    // through pointers into space the device does not physically have --
+    // reject it here, once, before it is trusted anywhere (#627).
+    let device_blocks = dev.sector_count() / SECTORS_PER_BLOCK as u64;
+    if superblock.block_count > device_blocks {
+        return Err(LfsError::Corrupt);
+    }
+
     // Pick the latest checkpoint.
     let (checkpoint, _slot_block) = lfs_checkpoint::pick_latest(
         dev.as_mut(),
@@ -2846,6 +2858,34 @@ mod tests {
         assert!(
             matches!(result, Err(LfsError::Corrupt)),
             "a self-consistent on-disk segment_size == 0 must be rejected, not mounted"
+        );
+    }
+
+    /// (SECURITY, #627): the on-disk superblock's block_count is passed
+    /// unvalidated as the extent bound every imap/direct-block pointer is
+    /// checked against after mount (validate_block_num,
+    /// LfsImap::load_from_disk) -- a crafted value exceeding the device's
+    /// real capacity must be rejected at mount instead of silently
+    /// trusted as that bound.
+    #[test]
+    fn mount_rejects_block_count_exceeding_device_capacity() {
+        let mut dev = block_device_for_lfs();
+        format(&mut dev).expect("format");
+
+        let device_blocks = dev.sector_count() / SECTORS_PER_BLOCK as u64;
+
+        let mut sb_buf = [0u8; BLOCK_SIZE];
+        block::read_block(&dev, SUPERBLOCK_BLOCK, &mut sb_buf).expect("read superblock");
+        let mut sb = LfsSuperblock::from_block(&sb_buf).expect("parse superblock");
+        sb.block_count = device_blocks + 1;
+        let corrupted_sb_block = sb.to_block();
+        block::write_block(&mut dev, SUPERBLOCK_BLOCK, &corrupted_sb_block)
+            .expect("write corrupted superblock");
+
+        let result = mount(Box::new(dev));
+        assert!(
+            matches!(result, Err(LfsError::Corrupt)),
+            "block_count exceeding the device's real capacity must be rejected at mount"
         );
     }
 

--- a/crates/thumos/src/lfs.rs
+++ b/crates/thumos/src/lfs.rs
@@ -1224,7 +1224,7 @@ impl Filesystem for Lfs {
                 inode_id,
                 &inode,
             )
-            .map_err(|_| VfsError::IoError)?;
+            .map_err(Self::map_write_data_block_err)?;
 
         drop(cache);
         drop(dev);
@@ -1305,7 +1305,7 @@ impl Filesystem for Lfs {
                 new_inode_id,
                 &new_inode,
             )
-            .map_err(|_| VfsError::NoSpace)?;
+            .map_err(Self::map_write_data_block_err)?;
 
         // Add directory entry to parent.
         let mut entries = existing;
@@ -1341,7 +1341,7 @@ impl Filesystem for Lfs {
         parent.direct[0] = dir_block;
         parent.size = entries.iter().map(|e| e.record_len as u64).sum();
 
-        match writer.write_inode(
+        if let Err(e) = writer.write_inode(
             dev.as_mut(),
             &mut cache,
             &mut self.imap,
@@ -1349,11 +1349,8 @@ impl Filesystem for Lfs {
             dir_inode,
             &parent,
         ) {
-            Ok(_) => {}
-            Err(_) => {
-                self.imap.remove(new_inode_id);
-                return Err(VfsError::IoError);
-            }
+            self.imap.remove(new_inode_id);
+            return Err(Self::map_write_data_block_err(e));
         }
 
         drop(cache);
@@ -1470,7 +1467,7 @@ impl Filesystem for Lfs {
                 dir_inode,
                 &parent,
             )
-            .map_err(|_| VfsError::IoError)?;
+            .map_err(Self::map_write_data_block_err)?;
 
         // Only now, after the directory entry removal is durable, retire
         // the target inode: drop it from the imap if this was the last
@@ -1487,7 +1484,7 @@ impl Filesystem for Lfs {
                     target_id,
                     &target_inode,
                 )
-                .map_err(|_| VfsError::IoError)?;
+                .map_err(Self::map_write_data_block_err)?;
         }
 
         drop(cache);
@@ -1634,7 +1631,10 @@ impl Filesystem for Lfs {
                 inode_id,
                 &inode,
             )
-            .map_err(|_| VfsError::IoError)?;
+            // Same map_write_data_block_err class fix as create()/write()/
+            // unlink() (#627): write_inode's LfsError must not collapse
+            // to a single hardcoded VfsError variant here either.
+            .map_err(Self::map_write_data_block_err)?;
 
         Ok(())
     }
@@ -2809,6 +2809,140 @@ mod tests {
         assert!(
             dir_entries.iter().any(|e| e.name == "victim"),
             "directory entry must remain after a failed unlink"
+        );
+    }
+
+    /// unlink() on the LAST entry in a directory skips write_dir_block()
+    /// entirely (the empty-directory branch just zeroes parent.direct[0]),
+    /// so writer.write_inode(dir_inode, &parent) is the ONLY log write
+    /// attempted -- isolating it from write_dir_block's write_data_block
+    /// call, which already routed through map_write_data_block_err. A
+    /// disk-full LfsError::NoFreeSegments here must map to
+    /// VfsError::NoSpace, not IoError -- before #627's fix this call site
+    /// hardcoded `.map_err(|_| VfsError::IoError)` regardless of the
+    /// underlying LfsError.
+    #[test]
+    fn unlink_last_entry_out_of_space_reports_no_space_not_io_error() {
+        // 5 segments of 4 blocks each: segment 0 reserved, segments 2/3
+        // pinned used, segment 4 withheld as the compaction reserve (only
+        // segment 1 is ordinarily allocatable, same layout style as
+        // `unlink_io_failure_during_directory_write_leaves_imap_and_directory_consistent`).
+        let mut dev =
+            MemBlockDevice::new(5 * 4 * SECTORS_PER_BLOCK as u64).expect("create tiny device");
+        let mut cache = BlockCache::new();
+        let mut seg_mgr = LfsSegmentManager::new(5, 4);
+        seg_mgr.mark_used(0);
+        seg_mgr.mark_used(2);
+        seg_mgr.mark_used(3);
+
+        let mut imap = LfsImap::new();
+        let mut writer = LfsWriter::new(&mut seg_mgr).expect("create writer");
+
+        let dir_inode_template = DiskInode {
+            inode_type: INODE_TYPE_DIR,
+            link_count: 1,
+            size: 0,
+            direct: [0u64; DIRECT_BLOCK_COUNT],
+            indirect: 0,
+        };
+        let file_inode_template = DiskInode {
+            inode_type: INODE_TYPE_FILE,
+            link_count: 1,
+            size: 0,
+            direct: [0u64; DIRECT_BLOCK_COUNT],
+            indirect: 0,
+        };
+
+        // Write 1/4: root placeholder.
+        writer
+            .write_inode(
+                &mut dev,
+                &mut cache,
+                &mut imap,
+                &mut seg_mgr,
+                0,
+                &dir_inode_template,
+            )
+            .expect("write root placeholder");
+        // Write 2/4: victim inode -- the directory's only entry.
+        writer
+            .write_inode(
+                &mut dev,
+                &mut cache,
+                &mut imap,
+                &mut seg_mgr,
+                1,
+                &file_inode_template,
+            )
+            .expect("write victim inode");
+        // Write 3/4: directory block listing only "victim".
+        let entries = alloc::vec![DiskDirEntry {
+            inode_id: 1,
+            name_len: 6,
+            record_len: ((DIR_ENTRY_HEADER_SIZE + 6 + 3) & !3) as u16,
+            name: String::from("victim"),
+        }];
+        let dir_block =
+            Lfs::write_dir_block(&mut dev, &mut cache, &mut writer, &mut seg_mgr, &entries)
+                .expect("write dir block");
+        // Write 4/4: root inode updated to point at the directory block.
+        // This consumes segment 1's last data slot.
+        let mut root = dir_inode_template;
+        root.direct[0] = dir_block;
+        root.size = entries.iter().map(|e| e.record_len as u64).sum();
+        writer
+            .write_inode(&mut dev, &mut cache, &mut imap, &mut seg_mgr, 0, &root)
+            .expect("write updated root inode");
+
+        assert_eq!(
+            seg_mgr.free_count(),
+            1,
+            "setup must exhaust every ordinarily-allocatable segment, leaving only the compaction reserve"
+        );
+
+        let superblock = LfsSuperblock {
+            magic: LFS_MAGIC,
+            version: LFS_VERSION,
+            block_count: dev.sector_count() / SECTORS_PER_BLOCK as u64,
+            segment_size: 4,
+            segment_count: 5,
+            checkpoint_block_a: 1,
+            checkpoint_block_b: 2,
+            imap_block: 3,
+            imap_block_count: 1,
+            root_inode: 0,
+            next_inode: 2,
+        };
+
+        let mut fs = Lfs {
+            dev: RefCell::new(Box::new(dev)),
+            cache: RefCell::new(cache),
+            imap,
+            segments: seg_mgr,
+            superblock,
+            next_sequence: writer.sequence(),
+            writer: Some(writer),
+            next_inode: 2,
+            checkpoint_sequence: 1,
+        };
+
+        // Removing "victim" empties the directory: unlink() takes the
+        // `remaining.is_empty()` branch (no write_dir_block call) and
+        // writer.write_inode(0, &parent) is the only write attempted --
+        // and there is no segment left for it to seal into.
+        let result = fs.unlink(0, "victim");
+        assert_eq!(
+            result,
+            Err(VfsError::NoSpace),
+            "a disk-full write_inode failure must report NoSpace, not IoError (#627)"
+        );
+
+        // The failed write must not have mutated imap state: the target
+        // inode must still be reachable (mirrors #301's rollback
+        // invariant already covered above).
+        assert!(
+            fs.stat(1).is_ok(),
+            "victim inode must remain in the imap after a failed unlink"
         );
     }
 

--- a/crates/thumos/src/lfs.rs
+++ b/crates/thumos/src/lfs.rs
@@ -583,16 +583,34 @@ pub(crate) fn mount(mut dev: Box<dyn BlockDevice>) -> Result<Lfs, LfsError> {
         superblock.block_count,
     )?;
 
+    // WHY checked_add: last_segment_sequence and sequence are on-disk,
+    // untrusted u64 fields -- a crafted or bit-flipped u64::MAX here
+    // would wrap the unchecked `+ 1` to 0. For checkpoint_sequence that
+    // is a silent, mount-surviving failure: a checkpoint written next
+    // with sequence 0 compares as older than every prior nonzero
+    // sequence, so pick_latest() (lfs_checkpoint.rs) would never select
+    // it again -- new checkpoints go durably to disk but are never
+    // picked up, freezing the filesystem's recoverable state at whatever
+    // checkpoint predated the wrap (#627). Fail closed at mount instead.
+    let next_sequence = checkpoint
+        .last_segment_sequence
+        .checked_add(1)
+        .ok_or(LfsError::Corrupt)?;
+    let checkpoint_sequence = checkpoint
+        .sequence
+        .checked_add(1)
+        .ok_or(LfsError::Corrupt)?;
+
     Ok(Lfs {
         dev: RefCell::new(dev),
         cache: RefCell::new(cache),
         imap,
         segments,
         superblock,
-        next_sequence: checkpoint.last_segment_sequence + 1,
+        next_sequence,
         writer: None,
         next_inode: checkpoint.next_inode,
-        checkpoint_sequence: checkpoint.sequence + 1,
+        checkpoint_sequence,
     })
 }
 
@@ -2886,6 +2904,54 @@ mod tests {
         assert!(
             matches!(result, Err(LfsError::Corrupt)),
             "block_count exceeding the device's real capacity must be rejected at mount"
+        );
+    }
+
+    /// (#627): checkpoint.sequence == u64::MAX must not silently wrap to
+    /// 0 through mount()'s `+ 1`. A checkpoint written next with
+    /// sequence 0 compares as older than every prior nonzero sequence,
+    /// so pick_latest() would never select it again -- freezing the
+    /// filesystem's recoverable state at whatever checkpoint predated
+    /// the wrap.
+    #[test]
+    fn mount_rejects_checkpoint_sequence_overflow() {
+        let mut dev = block_device_for_lfs();
+        format(&mut dev).expect("format");
+
+        let mut cache = BlockCache::new();
+        let mut header = lfs_checkpoint::read_checkpoint(&mut dev, &mut cache, CHECKPOINT_SLOT_A)
+            .expect("read initial checkpoint");
+        header.sequence = u64::MAX;
+        let header_buf = header.to_block();
+        block::write_block(&mut dev, CHECKPOINT_SLOT_A, &header_buf)
+            .expect("write corrupted checkpoint");
+
+        let result = mount(Box::new(dev));
+        assert!(
+            matches!(result, Err(LfsError::Corrupt)),
+            "checkpoint.sequence == u64::MAX must be rejected, not silently wrapped to 0"
+        );
+    }
+
+    /// Same defect as `mount_rejects_checkpoint_sequence_overflow`, on
+    /// the sibling field `last_segment_sequence` (#627).
+    #[test]
+    fn mount_rejects_last_segment_sequence_overflow() {
+        let mut dev = block_device_for_lfs();
+        format(&mut dev).expect("format");
+
+        let mut cache = BlockCache::new();
+        let mut header = lfs_checkpoint::read_checkpoint(&mut dev, &mut cache, CHECKPOINT_SLOT_A)
+            .expect("read initial checkpoint");
+        header.last_segment_sequence = u64::MAX;
+        let header_buf = header.to_block();
+        block::write_block(&mut dev, CHECKPOINT_SLOT_A, &header_buf)
+            .expect("write corrupted checkpoint");
+
+        let result = mount(Box::new(dev));
+        assert!(
+            matches!(result, Err(LfsError::Corrupt)),
+            "last_segment_sequence == u64::MAX must be rejected, not silently wrapped to 0"
         );
     }
 

--- a/crates/thumos/src/lfs.rs
+++ b/crates/thumos/src/lfs.rs
@@ -620,25 +620,33 @@ pub(crate) fn mount(mut dev: Box<dyn BlockDevice>) -> Result<Lfs, LfsError> {
 
 impl Lfs {
     /// Validate that an on-disk block pointer falls within the
-    /// filesystem's own block extent before it is used to address the
-    /// block cache.
+    /// filesystem's own allocatable block extent before it is used to
+    /// address the block cache.
     ///
     /// `inode.direct[]` entries are on-disk, untrusted data: a
     /// corrupted or maliciously crafted inode could set them to any
-    /// `u64`. Every block the filesystem itself allocates stays within
-    /// `[1, superblock.block_count)` (block 0 is the superblock, never
-    /// an allocatable data block), so any pointer outside that range is
-    /// corruption -- fail closed rather than let it reach the block
-    /// cache and read/write memory outside the filesystem's own
-    /// extent, even when that block number is still within the raw
-    /// block device's physical capacity.
+    /// `u64`. Segment 0 -- blocks `[0, superblock.segment_size)` -- is
+    /// permanently reserved for the superblock, both checkpoint slots,
+    /// the imap, and the segment bitmap (`LfsSegmentManager::new` marks
+    /// it used forever; the ordinary allocator never hands it out), so
+    /// every block the filesystem itself allocates for inode/data
+    /// content stays within `[superblock.segment_size,
+    /// superblock.block_count)`. A direct pointer inside segment 0 is
+    /// corruption -- without this bound it would let a crafted inode
+    /// alias a live checkpoint or imap block as ordinary file content,
+    /// serving (or overwriting) filesystem metadata as if it were file
+    /// data (#627). Fail closed rather than let it reach the block
+    /// cache, even when the block number is still within the raw block
+    /// device's physical capacity.
     ///
     /// # Errors
     ///
-    /// Returns [`VfsError::IoError`] if `block_num` is 0 or `>=
-    /// superblock.block_count`.
+    /// Returns [`VfsError::IoError`] if `block_num` is inside the
+    /// reserved segment 0 or `>= superblock.block_count`.
     fn validate_block_num(&self, block_num: u64) -> Result<(), VfsError> {
-        if block_num == 0 || block_num >= self.superblock.block_count {
+        if block_num < u64::from(self.superblock.segment_size)
+            || block_num >= self.superblock.block_count
+        {
             return Err(VfsError::IoError);
         }
         Ok(())
@@ -1139,6 +1147,7 @@ impl Filesystem for Lfs {
         // check inside the loop doesn't need a `&self` method call while
         // `self.writer` is exclusively borrowed.
         let block_count = self.superblock.block_count;
+        let reserved_blocks = u64::from(self.superblock.segment_size);
 
         let mut bytes_written = 0usize;
         let mut dev = self.dev.borrow_mut();
@@ -1169,12 +1178,14 @@ impl Filesystem for Lfs {
                 let existing_block = inode.direct[block_index];
                 if existing_block != 0 {
                     // WARNING: inode.direct[] is on-disk, untrusted data --
-                    // bound it to the filesystem's own extent before it
-                    // reaches the block cache (#security, mirrors read()'s
-                    // validate_block_num; inlined here because `writer`
-                    // already holds an exclusive borrow of `self.writer`,
-                    // so a `&self` method call is not available).
-                    if existing_block >= block_count {
+                    // bound it to the filesystem's own allocatable extent
+                    // before it reaches the block cache (#security, mirrors
+                    // read()'s validate_block_num, including its segment-0
+                    // reserved-metadata exclusion, #627; inlined here
+                    // because `writer` already holds an exclusive borrow
+                    // of `self.writer`, so a `&self` method call is not
+                    // available).
+                    if existing_block < reserved_blocks || existing_block >= block_count {
                         return Err(VfsError::IoError);
                     }
                     cache
@@ -1400,11 +1411,15 @@ impl Filesystem for Lfs {
             // WARNING: imap entries are on-disk, untrusted data -- the
             // same class as inode.direct[], which this file already
             // bounds before it reaches the block cache (#624,
-            // #security). Inlined here (rather than calling
-            // self.validate_block_num) because `writer` above already
-            // holds an exclusive borrow of `self.writer`, so a `&self`
-            // method call on the whole struct is not available.
-            if block_num == 0 || block_num >= self.superblock.block_count {
+            // #security), including the segment-0 reserved-metadata
+            // exclusion validate_block_num applies (#627). Inlined here
+            // (rather than calling self.validate_block_num) because
+            // `writer` above already holds an exclusive borrow of
+            // `self.writer`, so a `&self` method call on the whole
+            // struct is not available.
+            if block_num < u64::from(self.superblock.segment_size)
+                || block_num >= self.superblock.block_count
+            {
                 return Err(VfsError::IoError);
             }
             let mut buf = [0u8; BLOCK_SIZE];
@@ -1946,6 +1961,32 @@ mod tests {
         );
     }
 
+    /// (#627): validate_block_num previously excluded only block 0 (the
+    /// superblock), not the rest of reserved segment 0 -- blocks
+    /// `[1, segment_size)` hold the checkpoint slots, imap, and segment
+    /// bitmap. Block 1 (checkpoint slot A) is nonzero and well within
+    /// the raw device's capacity, so only the reserved-segment bound
+    /// this test targets catches a crafted pointer there.
+    #[test]
+    fn load_inode_rejects_imap_block_inside_reserved_segment_but_nonzero() {
+        let mut dev = block_device_for_lfs();
+        format(&mut dev).expect("format");
+        let mut fs = mount(Box::new(dev)).expect("mount");
+        let root = fs.root_inode();
+
+        let file_id = fs
+            .create(root, "f", InodeType::RegularFile)
+            .expect("create");
+
+        fs.imap.insert(file_id, 1); // checkpoint slot A -- live metadata, not block 0.
+
+        let result = fs.load_inode(file_id);
+        assert!(
+            matches!(result, Err(VfsError::IoError)),
+            "an imap entry inside the reserved metadata segment (but not block 0) must be rejected"
+        );
+    }
+
     #[test]
     fn create_file_then_read_back() {
         let mut dev = block_device_for_lfs();
@@ -2108,6 +2149,32 @@ mod tests {
         assert!(
             fs.lookup(root, "f").is_ok(),
             "a rejected unlink must not have mutated the parent directory"
+        );
+    }
+
+    /// (#627): the check above catches block 0, but unlink()'s inline
+    /// bound previously stopped there too -- blocks `[1, segment_size)`
+    /// (checkpoint slots, imap, segment bitmap) were left addressable.
+    /// Block 1 (checkpoint slot A) is nonzero and well within the raw
+    /// device's capacity, so only the reserved-segment bound this test
+    /// targets catches it.
+    #[test]
+    fn unlink_rejects_target_imap_block_inside_reserved_segment_but_nonzero() {
+        let mut dev = block_device_for_lfs();
+        format(&mut dev).expect("format");
+        let mut fs = mount(Box::new(dev)).expect("mount");
+        let root = fs.root_inode();
+
+        let file_id = fs
+            .create(root, "f", InodeType::RegularFile)
+            .expect("create");
+
+        fs.imap.insert(file_id, 1); // checkpoint slot A -- live metadata, not block 0.
+
+        let result = fs.unlink(root, "f");
+        assert!(
+            matches!(result, Err(VfsError::IoError)),
+            "unlink()'s inline imap-pointer bound must also exclude the reserved segment, not just block 0"
         );
     }
 

--- a/crates/thumos/src/lock_screen.rs
+++ b/crates/thumos/src/lock_screen.rs
@@ -430,7 +430,9 @@ impl LockScreen {
             // re-match after the window elapses (#388). Keeps throttle
             // recoverable and keeps all submit exits consistent.
             self.clear_input();
-            return UnlockResult::Throttled { wait_secs: wait };
+            let result = UnlockResult::Throttled { wait_secs: wait };
+            self.last_result = Some(result);
+            return result;
         }
 
         let entered = &self.passphrase_buffer[..self.passphrase_len as usize];
@@ -459,7 +461,9 @@ impl LockScreen {
             // never re-match — the same "locked out after throttle" failure
             // class #388 targets. Clearing keeps the throttle recoverable.
             self.clear_input();
-            return UnlockResult::Throttled { wait_secs: wait };
+            let result = UnlockResult::Throttled { wait_secs: wait };
+            self.last_result = Some(result);
+            return result;
         }
 
         // Require exactly REQUIRED_PIN_LEN digits.
@@ -1014,6 +1018,40 @@ mod tests {
             screen.passphrase_len(),
             0,
             "the throttled exit clears the buffer (#388)"
+        );
+        // last_result drives draw()'s "WAIT..." status line -- a throttled
+        // attempt that never records it leaves that UI branch unreachable
+        // (#627).
+        assert_eq!(
+            screen.last_result,
+            Some(UnlockResult::Throttled { wait_secs: 4 }),
+            "a throttled attempt must record last_result so draw() can show it"
+        );
+    }
+
+    /// Same coverage as `submit_passphrase_with_honors_the_throttle_window`
+    /// for the `submit_pin` throttle exit -- a separate call site with the
+    /// identical defect (#627).
+    #[test]
+    fn submit_pin_throttled_attempt_records_last_result() {
+        let mut screen = make_screen();
+        screen.set_mode(LockMode::PinUnlock);
+        for _ in 0..3 {
+            for &byte in b"999999" {
+                screen.push_pin_digit(byte);
+            }
+            let r = screen.submit_pin(100);
+            assert_eq!(r, UnlockResult::WrongPin);
+        }
+        for &byte in TEST_PIN {
+            screen.push_pin_digit(byte);
+        }
+        let r = screen.submit_pin(101);
+        assert_eq!(r, UnlockResult::Throttled { wait_secs: 4 });
+        assert_eq!(
+            screen.last_result,
+            Some(UnlockResult::Throttled { wait_secs: 4 }),
+            "a throttled PIN attempt must record last_result so draw() can show it"
         );
     }
 

--- a/crates/thumos/src/vfs.rs
+++ b/crates/thumos/src/vfs.rs
@@ -348,12 +348,26 @@ impl MountTable {
     ///
     /// # Errors
     ///
-    /// - `VfsError::InvalidPath` if the path does not start with `/`.
+    /// - `VfsError::InvalidPath` if the path does not start with `/`, or is
+    ///   a non-root path with a trailing `/`.
     /// - `VfsError::AlreadyExists` if the path is already mounted.
     /// - `VfsError::NoSpace` if all mount slots are occupied.
     #[must_use]
     pub(crate) fn mount(&mut self, path: &str, fs: Box<dyn Filesystem>) -> Result<(), VfsError> {
         if !path.starts_with('/') {
+            return Err(VfsError::InvalidPath);
+        }
+
+        // WHY: a non-root entry with a trailing slash (e.g. "/dev/") can
+        // never be the winning prefix in lookup()'s longest-prefix match
+        // -- an ordinary path like "/dev/tty" does not have "/dev/" as a
+        // `starts_with` prefix followed by another '/' (the next byte is
+        // 't', not '/'), so the entry would sit in the table matching
+        // nothing and silently shadow no requests while also never
+        // routing any (#627). Reject it at mount time instead of
+        // installing a dead entry. Root "/" is the sole trailing-slash
+        // path this table ever holds.
+        if path.len() > 1 && path.ends_with('/') {
             return Err(VfsError::InvalidPath);
         }
 
@@ -839,6 +853,41 @@ mod tests {
         mt.mount("/", Box::new(TestFs)).expect("first mount");
         let result = mt.mount("/", Box::new(TestFs));
         assert_eq!(result, Err(VfsError::AlreadyExists));
+    }
+
+    /// A non-root trailing-slash mount path can never win lookup()'s
+    /// longest-prefix match against an ordinary child path -- it would
+    /// sit in the table as a dead entry that matches nothing (#627).
+    /// Reject it at mount() instead of installing it.
+    #[test]
+    fn mount_rejects_trailing_slash() {
+        let mut mt = MountTable::new();
+        let result = mt.mount("/dev/", Box::new(TestFs));
+        assert_eq!(result, Err(VfsError::InvalidPath));
+    }
+
+    /// Root "/" is the one legitimate trailing-slash mount path.
+    #[test]
+    fn mount_accepts_bare_root() {
+        let mut mt = MountTable::new();
+        assert_eq!(mt.mount("/", Box::new(TestFs)), Ok(()));
+    }
+
+    /// Companion to `mount_rejects_trailing_slash`: proves what the
+    /// rejected form would have broken -- a correctly-mounted "/dev"
+    /// (no trailing slash) resolves an ordinary child path.
+    #[test]
+    fn mount_without_trailing_slash_resolves_children() {
+        let mut mt = MountTable::new();
+        mt.mount("/", Box::new(TestFs)).expect("mount root");
+        mt.mount("/dev", Box::new(TestFs)).expect("mount /dev");
+        let (idx, remaining) = mt.lookup("/dev/tty").expect("must resolve");
+        assert_eq!(remaining, "/tty");
+        assert_ne!(
+            idx,
+            mt.lookup("/").expect("root must resolve").0,
+            "/dev/tty must resolve against the /dev mount, not fall through to root"
+        );
     }
 
     #[test]

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -361,7 +361,7 @@ mechanism = "host"
 
 [[module]]
 name = "lock_screen"
-tests = 23
+tests = 24
 mechanism = "host"
 fidelity = "policy logic host-covered; boot-time passphrase input is #446"
 

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -691,7 +691,7 @@ fidelity = "MMIO/ISR paths are not exercised host-side; EP1 ring sync is #437 re
 
 [[module]]
 name = "vfs"
-tests = 16
+tests = 19
 mechanism = "host"
 
 [[module]]

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -55,7 +55,7 @@ mechanism = "host"
 
 [[module]]
 name = "gpt"
-tests = 6
+tests = 8
 mechanism = "host"
 fidelity = "parse logic proven on synthetic GPT images host-side; the live eMMC GPT read is the m7 boot path (hardware-gated)"
 

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -331,7 +331,7 @@ mechanism = "host"
 
 [[module]]
 name = "lfs"
-tests = 48
+tests = 49
 mechanism = "host"
 
 [[module]]

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -331,7 +331,7 @@ mechanism = "host"
 
 [[module]]
 name = "lfs"
-tests = 46
+tests = 48
 mechanism = "host"
 
 [[module]]

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -331,7 +331,7 @@ mechanism = "host"
 
 [[module]]
 name = "lfs"
-tests = 43
+tests = 44
 mechanism = "host"
 
 [[module]]

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -331,7 +331,7 @@ mechanism = "host"
 
 [[module]]
 name = "lfs"
-tests = 44
+tests = 46
 mechanism = "host"
 
 [[module]]


### PR DESCRIPTION
## Finding

All seven findings in the #627 rollup, one commit each. Every one was re-verified against current code before being fixed — `lfs.rs` changed substantially today (#620/#623/#624 and #625/#626 both landed), so several cited line numbers had moved.

| finding | disposition |
|---|---|
| `gpt.rs` `PartitionInfo::sectors()` | **real** — `last_lba - first_lba + 1` underflows on unvalidated on-disk LBAs |
| `lock_screen.rs` throttled submit | **real** — early return never set `last_result`, so the Throttled UI branch was unreachable |
| `lfs.rs` `mount()` sequence `+1` | **real** — wraps silently on a crafted `u64::MAX` |
| `lfs.rs` `mount()` `block_count` | **real** — never checked against real device capacity before being trusted as the pointer-validation bound |
| `vfs.rs` `MountTable::mount()` | **real** — trailing-slash paths accepted but can never win `lookup()`'s longest-prefix match, creating a dead entry |
| `validate_block_num` reserved segment | **real, citation stale** — see below |
| `lfs.rs` `write_inode` error mapping | **real, and wider than filed** — see below |

## Two findings that were not what the issue said

**The `lfs_segment.rs:50` citation is wrong.** No `validate_block_num` has ever existed in that file — `git log --all -S validate_block_num -- crates/thumos/src/lfs_segment.rs` returns zero commits. It has always been `Lfs::validate_block_num` in `lfs.rs`. The *claim* is real once traced to the actual site: it excluded only block 0, not the rest of reserved segment 0 `[0, segment_size)`, which holds both checkpoint slots, the imap, and the segment bitmap. Fixed there plus two inline duplicates in `write()` and `unlink()`.

The identical gap exists in `LfsImap::deserialize`/`load_from_disk`, filed as **#653** rather than folded in — distinct mechanism, a `pub(crate)` signature change, and ~10 test call sites.

**The `write_inode` mapping defect had a seventh site the issue didn't name.** Six production call sites hardcoded a single `VfsError` on `write_inode`'s `LfsError` result instead of using the existing `map_write_data_block_err` helper — collapsing `NoFreeSegments` into `IoError` at five, and collapsing everything including real I/O faults into `NoSpace` at one. `truncate()` has the same defect and was not listed; fixed anyway, per the standing rule to fix the class rather than the instance.

## Why this matters

Individually low. Together they are a consistent pattern: on-disk values from an untrusted medium reaching arithmetic or a bound without validation, and error variants collapsed such that a caller cannot distinguish "out of space" from "the device faulted".

The `validate_block_num` one is the sharpest — excluding only block 0 left the checkpoint slots, imap, and segment bitmap addressable by a crafted pointer, which is the metadata region the whole validation exists to protect.

## Desired correction

Each fix is scoped to its own commit with a WHY naming the untrusted-input class. Tests added at every host-reachable site (the ledger is updated accordingly and reconciles clean).

**Verification:** the four static checkers — target-test-ledger, board-seam, convergence, doc-inventory — all exit 0 on the rebased branch. The kernel suite is CI's to confirm; this lane was cut off before it could run it, and I am not claiming a run I did not watch.

Closes #627
