### PR TITLE
pteron: ACL data path and L2CAP fixed-channel layer

### DIFF
--- a/crates/pteron/src/hci.rs
+++ b/crates/pteron/src/hci.rs
@@ -10,7 +10,12 @@ use snafu::Snafu;
 const BD_ADDR_LEN: usize = 6;
 
 const H4_COMMAND_TYPE: u8 = 0x01;
-const H4_EVENT_TYPE: u8 = 0x04;
+/// H4 packet type for HCI ACL Data (Vol 4 Part E §5.4.2). `pub(crate)` so
+/// `transport.rs`'s RX loop can dispatch on it without re-decoding.
+pub(crate) const H4_ACL_TYPE: u8 = 0x02;
+/// `pub(crate)` so `transport.rs`'s RX loop can dispatch on it without
+/// re-decoding (#635).
+pub(crate) const H4_EVENT_TYPE: u8 = 0x04;
 
 // OGF (Opcode Group Field)
 const OGF_LINK_CONTROL: u16 = 0x01;
@@ -52,6 +57,8 @@ const INQUIRY_ENTRY_CLOCK_OFFSET: usize = 12;
 
 // Minimum sizes
 const MIN_EVENT_PACKET: usize = 3; // H4 type + event_code + param_length
+// H4 type(1) + Connection_Handle/PB/BC(2) + Data_Total_Length(2)
+const MIN_ACL_PACKET: usize = 5;
 
 // ── Error type ─────────────────────────────────────────────────────────────────
 
@@ -101,6 +108,13 @@ pub(crate) enum Error {
     /// Event parameters are truncated or structurally invalid.
     #[snafu(display("malformed HCI event: {detail}"))]
     MalformedEvent {
+        /// Human-readable description of the problem.
+        detail: &'static str,
+    },
+
+    /// ACL Data packet fields are truncated or structurally invalid (#635).
+    #[snafu(display("malformed HCI ACL packet: {detail}"))]
+    MalformedAclPacket {
         /// Human-readable description of the problem.
         detail: &'static str,
     },
@@ -253,6 +267,55 @@ pub(crate) enum HciEvent {
         /// Individual advertising reports.
         reports: Vec<LeAdvReport>,
     },
+}
+
+/// `Packet_Boundary_Flag` values on an HCI ACL Data packet (Vol 4 Part E
+/// §5.4.2, Table 5.1) — where in an L2CAP PDU's fragmentation sequence this
+/// ACL packet falls (#635).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub(crate) enum PbFlag {
+    /// `0b00` — first fragment of a message, not automatically flushable.
+    FirstNonFlushable,
+    /// `0b01` — a continuing fragment of a higher-layer message.
+    Continuation,
+    /// `0b10` — first fragment of a message, automatically flushable.
+    FirstFlushable,
+    /// `0b11` — a complete L2CAP PDU, automatically flushable
+    /// (Controller-to-Host only).
+    CompleteFlushable,
+}
+
+impl PbFlag {
+    /// Decode the two-bit `Packet_Boundary_Flag` field.
+    const fn from_bits(bits: u8) -> Self {
+        match bits & 0b11 {
+            0b00 => Self::FirstNonFlushable,
+            0b01 => Self::Continuation,
+            0b10 => Self::FirstFlushable,
+            _ => Self::CompleteFlushable,
+        }
+    }
+}
+
+/// A decoded HCI ACL Data packet (H4 type `0x02`, Vol 4 Part E §5.4.2).
+///
+/// `data` borrows FROM the input buffer — every variant of
+/// [`Packet_Boundary_Flag`](PbFlag) still needs its bytes copied exactly
+/// once by the L2CAP reassembler (`l2cap.rs`, #635), so this decode step
+/// does not pay for a second copy first.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub(crate) struct AclDataPacket<'a> {
+    /// `Connection_Handle` (12 bits).
+    pub(crate) handle: u16,
+    /// `Packet_Boundary_Flag` (2 bits).
+    pub(crate) pb_flag: PbFlag,
+    /// `Broadcast_Flag` (2 bits). Always `0b00` (point-to-point) on LE-U;
+    /// classic BR/EDR broadcast values are decoded but unused by this driver.
+    pub(crate) bc_flag: u8,
+    /// The packet's `Data` field — one fragment of an L2CAP PDU.
+    pub(crate) data: &'a [u8],
 }
 
 // ── BdAddr impl ────────────────────────────────────────────────────────────────
@@ -457,6 +520,75 @@ pub(crate) fn decode_event(data: &[u8]) -> Result<HciEvent> {
         EVT_LE_META => decode_le_meta(params),
         code => Err(Error::UnknownEventCode { code }),
     }
+}
+
+/// Decode an H4-framed HCI ACL Data packet (H4 type `0x02`, Vol 4 Part E
+/// §5.4.2).
+///
+/// Layout: `[0x02, handle_lo, handle_hi|pb|bc, data_len_lo, data_len_hi, data...]`
+/// — `Connection_Handle` (12 bits) and `PB_Flag`/`BC_Flag` (2 bits each)
+/// share a little-endian `u16`; `Data_Total_Length` is a second
+/// little-endian `u16` bounding the `Data` field that follows.
+///
+/// # Errors
+///
+/// Returns [`Error::PacketTooShort`] if `data` has fewer than 5 bytes.
+///
+/// Returns [`Error::UnexpectedPacketType`] if the first byte is not `0x02`.
+///
+/// Returns [`Error::MalformedAclPacket`] if `Data_Total_Length` exceeds the
+/// bytes actually present — mirrors [`decode_event`]'s `param_length` bound,
+/// so a truncated ACL packet is rejected rather than silently short-read.
+pub(crate) fn decode_acl_data(data: &[u8]) -> Result<AclDataPacket<'_>> {
+    if data.len() < MIN_ACL_PACKET {
+        return Err(Error::PacketTooShort {
+            min: MIN_ACL_PACKET,
+            actual: data.len(),
+        });
+    }
+
+    let h4_type = data.first().copied().unwrap_or_default();
+    if h4_type != H4_ACL_TYPE {
+        return Err(Error::UnexpectedPacketType {
+            expected: H4_ACL_TYPE,
+            actual: h4_type,
+        });
+    }
+
+    let mut cur = Cursor::new(data.get(1..).unwrap_or(&[]));
+    let handle_and_flags = cur.read_u16_le().ok_or(Error::MalformedAclPacket {
+        detail: "ACL: missing Connection_Handle/PB/BC field",
+    })?;
+    let handle = handle_and_flags & 0x0FFF;
+    // WHY: PB_Flag occupies bits [13:12] and BC_Flag bits [15:14] of the
+    // combined field (Table 5.1) — both above the 12-bit handle. Each is
+    // masked to 2 bits before the u16->u8 narrowing, so the cast never
+    // truncates a live bit (workspace lint cast_possible_truncation = allow).
+    let pb_flag = PbFlag::from_bits(((handle_and_flags >> 12) & 0b11) as u8);
+    let bc_flag = ((handle_and_flags >> 14) & 0b11) as u8;
+
+    let data_total_length = cur.read_u16_le().ok_or(Error::MalformedAclPacket {
+        detail: "ACL: missing Data_Total_Length field",
+    })?;
+    // WHY the slice comes from `data` and not from `cur`: the returned packet
+    // borrows for the caller's lifetime, and `cur` is local — reading the
+    // payload through the cursor would return a reference into a value dropped
+    // at the end of this function. The header is fixed-width (H4 type, then the
+    // handle/flags and length u16s), so the payload offset is known without it.
+    let payload_start = 1 + 2 + 2;
+    let payload = data
+        .get(payload_start..)
+        .and_then(|rest| rest.get(..usize::from(data_total_length)))
+        .ok_or(Error::MalformedAclPacket {
+            detail: "ACL: Data_Total_Length exceeds available bytes",
+        })?;
+
+    Ok(AclDataPacket {
+        handle,
+        pb_flag,
+        bc_flag,
+        data: payload,
+    })
 }
 
 fn decode_command_complete(params: &[u8]) -> Result<HciEvent> {
@@ -905,5 +1037,120 @@ mod tests {
             matches!(result, Err(Error::UnexpectedPacketType { .. })),
             "non-event H4 type should produce UnexpectedPacketType error"
         );
+    }
+
+    // ── decode_acl_data (#635) ──
+
+    #[test]
+    fn decode_acl_data_extracts_handle_flags_and_payload() -> Result<()> {
+        // handle=0x0040, PB=0b10 (FirstFlushable), BC=0b00 -> handle_and_flags
+        // = 0x0040 | (0b10 << 12) = 0x2040, LE bytes [0x40, 0x20].
+        // data_total_length=3, payload=[0xAA, 0xBB, 0xCC].
+        let data = [0x02, 0x40, 0x20, 0x03, 0x00, 0xAA, 0xBB, 0xCC];
+        let pkt = decode_acl_data(&data)?;
+        assert_eq!(pkt.handle, 0x0040, "handle should be the low 12 bits");
+        assert_eq!(
+            pkt.pb_flag,
+            PbFlag::FirstFlushable,
+            "PB bits 0b10 should decode to FirstFlushable"
+        );
+        assert_eq!(pkt.bc_flag, 0b00, "BC bits should be 0b00 (point-to-point)");
+        assert_eq!(
+            pkt.data,
+            &[0xAA, 0xBB, 0xCC],
+            "payload should match Data field"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn decode_acl_data_decodes_continuation_pb_flag() -> Result<()> {
+        // handle=0x0001, PB=0b01 (Continuation) -> 0x0001 | (0b01 << 12) = 0x1001.
+        let data = [0x02, 0x01, 0x10, 0x01, 0x00, 0xFF];
+        let pkt = decode_acl_data(&data)?;
+        assert_eq!(
+            pkt.pb_flag,
+            PbFlag::Continuation,
+            "PB bits 0b01 should decode to Continuation"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn decode_acl_data_masks_handle_to_twelve_bits() -> Result<()> {
+        // handle field bits set beyond 12 must not leak into the handle:
+        // handle_and_flags = 0xFFFF -> handle = 0x0FFF, PB=0b11, BC=0b11.
+        let data = [0x02, 0xFF, 0xFF, 0x00, 0x00];
+        let pkt = decode_acl_data(&data)?;
+        assert_eq!(pkt.handle, 0x0FFF, "handle must be masked to 12 bits");
+        assert_eq!(pkt.pb_flag, PbFlag::CompleteFlushable, "PB bits 0b11");
+        assert_eq!(pkt.bc_flag, 0b11, "BC bits 0b11");
+        Ok(())
+    }
+
+    #[test]
+    fn decode_acl_data_rejects_wrong_h4_type() {
+        // 0x04 = Event, not ACL.
+        let data = [0x04, 0x40, 0x00, 0x01, 0x00, 0xAA];
+        let result = decode_acl_data(&data);
+        assert!(
+            matches!(
+                result,
+                Err(Error::UnexpectedPacketType {
+                    expected: H4_ACL_TYPE,
+                    ..
+                })
+            ),
+            "non-ACL H4 type should produce UnexpectedPacketType error"
+        );
+    }
+
+    #[test]
+    fn decode_acl_data_rejects_packet_too_short() {
+        let data = [0x02, 0x40, 0x00, 0x00]; // only 4 bytes, need 5
+        let result = decode_acl_data(&data);
+        assert!(
+            matches!(
+                result,
+                Err(Error::PacketTooShort {
+                    min: MIN_ACL_PACKET,
+                    actual: 4
+                })
+            ),
+            "a 4-byte ACL packet should be rejected as too short"
+        );
+    }
+
+    #[test]
+    fn decode_acl_data_rejects_data_total_length_exceeding_available_bytes() {
+        // data_total_length declares 10 bytes but only 2 follow.
+        let data = [0x02, 0x40, 0x00, 0x0A, 0x00, 0xAA, 0xBB];
+        let result = decode_acl_data(&data);
+        assert!(
+            matches!(result, Err(Error::MalformedAclPacket { .. })),
+            "Data_Total_Length exceeding the actual buffer must be rejected, not silently truncated"
+        );
+    }
+
+    #[test]
+    fn decode_acl_data_accepts_empty_payload() -> Result<()> {
+        // data_total_length=0 is a valid (if unusual) ACL packet.
+        let data = [0x02, 0x40, 0x00, 0x00, 0x00];
+        let pkt = decode_acl_data(&data)?;
+        assert!(
+            pkt.data.is_empty(),
+            "zero-length Data field should decode to an empty slice"
+        );
+        Ok(())
+    }
+
+    // ── PbFlag::from_bits ──
+
+    #[test]
+    fn pb_flag_from_bits_covers_all_four_values() {
+        assert_eq!(PbFlag::from_bits(0b00), PbFlag::FirstNonFlushable);
+        assert_eq!(PbFlag::from_bits(0b01), PbFlag::Continuation);
+        assert_eq!(PbFlag::from_bits(0b10), PbFlag::FirstFlushable);
+        assert_eq!(PbFlag::from_bits(0b11), PbFlag::CompleteFlushable);
     }
 }

--- a/crates/pteron/src/l2cap.rs
+++ b/crates/pteron/src/l2cap.rs
@@ -1,0 +1,638 @@
+//! L2CAP fixed-channel framing and ACL fragment reassembly (#635).
+//!
+//! Basic L2CAP mode (Core Spec Vol 3, Part A §3.1) frames every PDU as
+//! `[Length(2 LE)][CID(2 LE)][payload...]` — the L2CAP Basic header — before
+//! handing it to the Controller for transmission. On the wire that PDU
+//! travels inside one or more HCI ACL Data packets
+//! ([`crate::hci::decode_acl_data`]); when a PDU is larger than one ACL
+//! packet can carry, the sender splits it using `PB_Flag`
+//! ([`crate::hci::PbFlag`]): the first fragment carries the L2CAP Basic
+//! header, later Continuation fragments carry only payload bytes (Vol 4
+//! Part E §5.4.2).
+//!
+//! [`AclReassembler`] reverses that split for received data, keyed by
+//! connection handle so multiple simultaneous LE links reassemble
+//! independently without cross-contaminating each other's buffers.
+//! [`FixedChannel::from_cid`] demuxes a reassembled SDU to the fixed
+//! channel it targets — today only CID `0x0006` (LE SMP) is routed; any
+//! other CID surfaces as [`FixedChannel::Unrouted`] rather than being
+//! silently misinterpreted as SMP.
+
+use std::collections::HashMap;
+
+use snafu::Snafu;
+
+use crate::hci::{AclDataPacket, PbFlag};
+
+// ── Constants ──────────────────────────────────────────────────────────────────
+
+/// L2CAP Basic header size: 2-byte Length + 2-byte CID (Vol 3 Part A §3.1).
+const L2CAP_HEADER_LEN: usize = 4;
+
+/// CID for the LE Security Manager Protocol fixed channel (Vol 3 Part A,
+/// Table 2.1) — the only channel this driver routes today. Consumed by the
+/// pairing state machine, forkwright/thumos#636.
+pub(crate) const CID_SMP: u16 = 0x0006;
+
+/// Upper bound on a reassembled L2CAP SDU this driver accepts.
+///
+/// WHY: the Basic header's 16-bit Length field allows up to 65535 bytes,
+/// but nothing this crate consumes today (SMP PDUs top out around 65 bytes)
+/// needs more than a small fraction of that. Capping reassembly bounds
+/// worst-case per-connection memory against a peer that declares an
+/// oversized PDU and only ever trickles continuation fragments.
+const MAX_L2CAP_SDU_LEN: usize = 2048;
+
+/// Maximum connection handles with an in-flight reassembly tracked at once.
+///
+/// WHY: bounds memory from a peer opening many spurious connection handles;
+/// pteron manages at most a handful of simultaneous LE links on this
+/// hardware.
+const MAX_CONCURRENT_REASSEMBLIES: usize = 4;
+
+// ── Error type ─────────────────────────────────────────────────────────────────
+
+/// Errors FROM L2CAP framing and ACL fragment reassembly.
+#[derive(Debug, Snafu)]
+#[non_exhaustive]
+pub(crate) enum Error {
+    /// A first/complete ACL fragment's payload was too short to hold the
+    /// 4-byte L2CAP Basic header.
+    #[snafu(display("L2CAP header truncated: need {min} bytes, got {actual}"))]
+    HeaderTruncated {
+        /// Minimum bytes required.
+        min: usize,
+        /// Actual bytes available.
+        actual: usize,
+    },
+
+    /// The L2CAP Length field declared a PDU larger than this driver accepts.
+    #[snafu(display("L2CAP PDU length {declared} exceeds accepted maximum {max}"))]
+    PduTooLarge {
+        /// Length the peer declared.
+        declared: usize,
+        /// The accepted ceiling ([`MAX_L2CAP_SDU_LEN`]).
+        max: usize,
+    },
+
+    /// A Continuation fragment (`PB_Flag = 0b01`) arrived for a connection
+    /// handle with no in-progress reassembly — either the start fragment
+    /// was lost, or the peer never sent one.
+    #[snafu(display("ACL continuation with no start fragment, handle 0x{handle:04X}"))]
+    OrphanContinuation {
+        /// The connection handle the orphan continuation named.
+        handle: u16,
+    },
+
+    /// A fragment pushed the accumulated payload past the L2CAP Length the
+    /// start fragment declared.
+    #[snafu(display(
+        "L2CAP reassembly overrun on handle 0x{handle:04X}: expected {expected}, got {actual}"
+    ))]
+    ReassemblyOverrun {
+        /// The connection handle.
+        handle: u16,
+        /// Bytes declared by the L2CAP Length field.
+        expected: usize,
+        /// Bytes actually accumulated when the overrun was detected.
+        actual: usize,
+    },
+
+    /// Too many connection handles already have an in-flight reassembly.
+    #[snafu(display("too many concurrent ACL reassemblies (max {max})"))]
+    TooManyReassemblies {
+        /// The concurrent-reassembly ceiling ([`MAX_CONCURRENT_REASSEMBLIES`]).
+        max: usize,
+    },
+}
+
+/// Result alias for this module.
+pub(crate) type Result<T> = std::result::Result<T, Error>;
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+/// A fully-reassembled L2CAP SDU delivered on a fixed channel.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub(crate) struct L2capSdu {
+    /// The connection handle it arrived on.
+    pub(crate) handle: u16,
+    /// The fixed-channel CID it targets.
+    pub(crate) cid: u16,
+    /// The reassembled payload — excludes the 4-byte L2CAP Basic header.
+    pub(crate) payload: Vec<u8>,
+}
+
+/// A fixed channel identified by CID (Vol 3 Part A §2.1, Table 2.1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub(crate) enum FixedChannel {
+    /// LE Security Manager Protocol, CID `0x0006` — the only channel this
+    /// driver routes today (#635; consumed by the pairing state machine,
+    /// forkwright/thumos#636).
+    Smp,
+    /// A CID this driver does not route anywhere yet.
+    Unrouted(u16),
+}
+
+impl FixedChannel {
+    /// Resolve a CID to the fixed channel it names.
+    pub(crate) const fn from_cid(cid: u16) -> Self {
+        match cid {
+            CID_SMP => Self::Smp,
+            other => Self::Unrouted(other),
+        }
+    }
+}
+
+/// State for one connection handle's in-progress L2CAP reassembly.
+struct PartialSdu {
+    cid: u16,
+    expected_len: usize,
+    buf: Vec<u8>,
+}
+
+/// Reassembles L2CAP Basic-mode SDUs FROM HCI ACL Data packet fragments,
+/// tracking one in-progress reassembly per connection handle.
+#[derive(Default)]
+pub(crate) struct AclReassembler {
+    partials: HashMap<u16, PartialSdu>,
+}
+
+impl AclReassembler {
+    /// Construct an empty reassembler.
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Feed one decoded ACL Data packet in.
+    ///
+    /// Returns `Ok(Some(sdu))` once `pkt`'s connection handle has a
+    /// complete L2CAP SDU (either a single-fragment PDU, or the fragment
+    /// that closes out a multi-fragment one). Returns `Ok(None)` while more
+    /// Continuation fragments are still expected.
+    ///
+    /// # Errors
+    ///
+    /// See the [`Error`] variants. Any error drops the in-progress
+    /// reassembly for `pkt.handle`, so a subsequent Continuation for the
+    /// same handle correctly surfaces [`Error::OrphanContinuation`] rather
+    /// than silently resuming a buffer that is already known-corrupt.
+    pub(crate) fn feed(&mut self, pkt: &AclDataPacket<'_>) -> Result<Option<L2capSdu>> {
+        if pkt.pb_flag == PbFlag::Continuation {
+            self.feed_continuation(pkt)
+        } else {
+            self.feed_start(pkt)
+        }
+    }
+
+    /// Handle a fragment that starts a new L2CAP PDU — any `PbFlag` other
+    /// than `Continuation` carries the 4-byte L2CAP Basic header first.
+    fn feed_start(&mut self, pkt: &AclDataPacket<'_>) -> Result<Option<L2capSdu>> {
+        if pkt.data.len() < L2CAP_HEADER_LEN {
+            // WHY: a stale in-progress reassembly for this handle, if any,
+            // cannot be trusted to resume correctly once a malformed start
+            // fragment has been seen on the same handle.
+            self.partials.remove(&pkt.handle);
+            return Err(Error::HeaderTruncated {
+                min: L2CAP_HEADER_LEN,
+                actual: pkt.data.len(),
+            });
+        }
+        let l2cap_len = usize::from(u16::from_le_bytes([
+            pkt.data.first().copied().unwrap_or_default(),
+            pkt.data.get(1).copied().unwrap_or_default(),
+        ]));
+        let cid = u16::from_le_bytes([
+            pkt.data.get(2).copied().unwrap_or_default(),
+            pkt.data.get(3).copied().unwrap_or_default(),
+        ]);
+
+        if l2cap_len > MAX_L2CAP_SDU_LEN {
+            self.partials.remove(&pkt.handle);
+            return Err(Error::PduTooLarge {
+                declared: l2cap_len,
+                max: MAX_L2CAP_SDU_LEN,
+            });
+        }
+
+        // WHY: a fresh start fragment always replaces any prior in-progress
+        // reassembly for this handle — receiving a new start can only mean
+        // the previous PDU (if any) was abandoned by the peer, and holding
+        // onto it would either leak memory or let stray continuation bytes
+        // splice onto the wrong PDU.
+        self.partials.remove(&pkt.handle);
+
+        let body = pkt.data.get(L2CAP_HEADER_LEN..).unwrap_or(&[]);
+        if body.len() > l2cap_len {
+            return Err(Error::ReassemblyOverrun {
+                handle: pkt.handle,
+                expected: l2cap_len,
+                actual: body.len(),
+            });
+        }
+        if body.len() == l2cap_len {
+            return Ok(Some(L2capSdu {
+                handle: pkt.handle,
+                cid,
+                payload: body.to_vec(),
+            }));
+        }
+
+        if self.partials.len() >= MAX_CONCURRENT_REASSEMBLIES {
+            return Err(Error::TooManyReassemblies {
+                max: MAX_CONCURRENT_REASSEMBLIES,
+            });
+        }
+        self.partials.insert(
+            pkt.handle,
+            PartialSdu {
+                cid,
+                expected_len: l2cap_len,
+                buf: body.to_vec(),
+            },
+        );
+        Ok(None)
+    }
+
+    /// Handle a Continuation fragment (`PbFlag::Continuation`) — raw
+    /// payload bytes with no L2CAP header, appended to the in-progress
+    /// buffer for this handle.
+    fn feed_continuation(&mut self, pkt: &AclDataPacket<'_>) -> Result<Option<L2capSdu>> {
+        let Some(partial) = self.partials.get_mut(&pkt.handle) else {
+            return Err(Error::OrphanContinuation { handle: pkt.handle });
+        };
+        partial.buf.extend_from_slice(pkt.data);
+
+        if partial.buf.len() > partial.expected_len {
+            let (expected, actual) = (partial.expected_len, partial.buf.len());
+            self.partials.remove(&pkt.handle);
+            return Err(Error::ReassemblyOverrun {
+                handle: pkt.handle,
+                expected,
+                actual,
+            });
+        }
+        if partial.buf.len() == partial.expected_len {
+            let Some(done) = self.partials.remove(&pkt.handle) else {
+                unreachable!("handle was just resolved via get_mut above");
+            };
+            return Ok(Some(L2capSdu {
+                handle: pkt.handle,
+                cid: done.cid,
+                payload: done.buf,
+            }));
+        }
+        Ok(None)
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn start_pkt(cid: u16, l2cap_len: u16, body: &[u8]) -> Vec<u8> {
+        let mut data = Vec::with_capacity(L2CAP_HEADER_LEN + body.len());
+        data.extend_from_slice(&l2cap_len.to_le_bytes());
+        data.extend_from_slice(&cid.to_le_bytes());
+        data.extend_from_slice(body);
+        data
+    }
+
+    fn acl(handle: u16, pb_flag: PbFlag, data: &[u8]) -> AclDataPacket<'_> {
+        AclDataPacket {
+            handle,
+            pb_flag,
+            bc_flag: 0b00,
+            data,
+        }
+    }
+
+    // ── single-fragment PDUs ──
+
+    #[test]
+    fn single_fragment_pdu_completes_immediately() -> Result<()> {
+        let mut r = AclReassembler::new();
+        let raw = start_pkt(CID_SMP, 3, &[0x01, 0x02, 0x03]);
+        let pkt = acl(0x0001, PbFlag::FirstNonFlushable, &raw);
+        let Some(sdu) = r.feed(&pkt)? else {
+            unreachable!("single-fragment PDU with matching length must complete immediately");
+        };
+        assert_eq!(sdu.handle, 0x0001);
+        assert_eq!(sdu.cid, CID_SMP);
+        assert_eq!(sdu.payload, vec![0x01, 0x02, 0x03]);
+        Ok(())
+    }
+
+    #[test]
+    fn complete_flushable_pb_flag_also_completes_in_one_fragment() -> Result<()> {
+        // PB=0b11 (CompleteFlushable, Controller-to-Host only) still carries
+        // the L2CAP header on its one and only fragment.
+        let mut r = AclReassembler::new();
+        let raw = start_pkt(CID_SMP, 2, &[0xAA, 0xBB]);
+        let pkt = acl(0x0002, PbFlag::CompleteFlushable, &raw);
+        let Some(sdu) = r.feed(&pkt)? else {
+            unreachable!("CompleteFlushable single fragment must complete immediately");
+        };
+        assert_eq!(sdu.payload, vec![0xAA, 0xBB]);
+        Ok(())
+    }
+
+    #[test]
+    fn empty_payload_pdu_completes_with_zero_length() -> Result<()> {
+        let mut r = AclReassembler::new();
+        let raw = start_pkt(CID_SMP, 0, &[]);
+        let pkt = acl(0x0001, PbFlag::FirstNonFlushable, &raw);
+        let Some(sdu) = r.feed(&pkt)? else {
+            unreachable!("a zero-length L2CAP PDU is a valid, immediately-complete SDU");
+        };
+        assert!(sdu.payload.is_empty());
+        Ok(())
+    }
+
+    // ── multi-fragment reassembly ──
+
+    #[test]
+    fn pdu_split_across_two_fragments_reassembles() -> Result<()> {
+        let mut r = AclReassembler::new();
+        // L2CAP length=5, but the start fragment only carries 2 payload bytes.
+        let start_raw = start_pkt(CID_SMP, 5, &[0x01, 0x02]);
+        let start = acl(0x0040, PbFlag::FirstNonFlushable, &start_raw);
+        assert_eq!(
+            r.feed(&start)?,
+            None,
+            "start fragment shorter than declared length must not complete yet"
+        );
+
+        let cont = acl(0x0040, PbFlag::Continuation, &[0x03, 0x04, 0x05]);
+        let Some(sdu) = r.feed(&cont)? else {
+            unreachable!("continuation completing the declared length must yield the SDU");
+        };
+        assert_eq!(sdu.handle, 0x0040);
+        assert_eq!(sdu.cid, CID_SMP);
+        assert_eq!(sdu.payload, vec![0x01, 0x02, 0x03, 0x04, 0x05]);
+        Ok(())
+    }
+
+    #[test]
+    fn pdu_split_across_three_fragments_reassembles_in_order() -> Result<()> {
+        let mut r = AclReassembler::new();
+        let start_raw = start_pkt(CID_SMP, 6, &[0xAA]);
+        let start = acl(0x0007, PbFlag::FirstFlushable, &start_raw);
+        assert_eq!(r.feed(&start)?, None);
+
+        let cont1 = acl(0x0007, PbFlag::Continuation, &[0xBB, 0xCC]);
+        assert_eq!(r.feed(&cont1)?, None, "still short of the declared length");
+
+        let cont2 = acl(0x0007, PbFlag::Continuation, &[0xDD, 0xEE, 0xFF]);
+        let Some(sdu) = r.feed(&cont2)? else {
+            unreachable!("third fragment completes the declared 6-byte length");
+        };
+        assert_eq!(sdu.payload, vec![0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]);
+        Ok(())
+    }
+
+    // ── the three required edge cases ──
+
+    #[test]
+    fn continuation_with_no_start_is_rejected() {
+        let mut r = AclReassembler::new();
+        let cont = acl(0x0099, PbFlag::Continuation, &[0x01, 0x02]);
+        let result = r.feed(&cont);
+        assert!(
+            matches!(result, Err(Error::OrphanContinuation { handle: 0x0099 })),
+            "a continuation fragment with no prior start must be rejected, not treated as a new PDU"
+        );
+    }
+
+    #[test]
+    fn over_long_l2cap_length_field_is_rejected() {
+        let mut r = AclReassembler::new();
+        // Declares a PDU far larger than MAX_L2CAP_SDU_LEN; body doesn't
+        // need to actually be that long since the check is on the declared
+        // field before any accumulation happens.
+        let start_raw = start_pkt(CID_SMP, 0xFFFF, &[0x00; 8]);
+        let start = acl(0x0001, PbFlag::FirstNonFlushable, &start_raw);
+        let result = r.feed(&start);
+        assert!(
+            matches!(
+                result,
+                Err(Error::PduTooLarge {
+                    declared: 0xFFFF,
+                    max: MAX_L2CAP_SDU_LEN
+                })
+            ),
+            "an L2CAP Length field beyond the accepted ceiling must be rejected up front"
+        );
+    }
+
+    #[test]
+    fn pdu_split_across_packets_edge_case_leaves_no_residual_state() -> Result<()> {
+        // Re-affirms the split-PDU case with an assertion on cleanup: after
+        // completion, the handle must not still be tracked as in-progress
+        // (a later continuation on the same handle must now be orphaned).
+        let mut r = AclReassembler::new();
+        let start_raw = start_pkt(CID_SMP, 4, &[0x01, 0x02]);
+        let start = acl(0x0010, PbFlag::FirstNonFlushable, &start_raw);
+        r.feed(&start)?;
+        let cont = acl(0x0010, PbFlag::Continuation, &[0x03, 0x04]);
+        assert!(r.feed(&cont)?.is_some(), "PDU should complete");
+
+        let stray = acl(0x0010, PbFlag::Continuation, &[0xFF]);
+        let result = r.feed(&stray);
+        assert!(
+            matches!(result, Err(Error::OrphanContinuation { handle: 0x0010 })),
+            "a completed reassembly must not leave residual state a stray continuation can attach to"
+        );
+        Ok(())
+    }
+
+    // ── additional robustness cases ──
+
+    #[test]
+    fn header_truncated_start_fragment_is_rejected() {
+        let mut r = AclReassembler::new();
+        // Only 3 bytes: not enough for the 4-byte L2CAP Basic header.
+        let start = acl(0x0001, PbFlag::FirstNonFlushable, &[0x01, 0x02, 0x03]);
+        let result = r.feed(&start);
+        assert!(
+            matches!(
+                result,
+                Err(Error::HeaderTruncated {
+                    min: L2CAP_HEADER_LEN,
+                    actual: 3
+                })
+            ),
+            "a start fragment too short for the L2CAP header must be rejected"
+        );
+    }
+
+    #[test]
+    fn single_fragment_body_exceeding_declared_length_is_rejected() {
+        let mut r = AclReassembler::new();
+        // Declares length=2 but carries 4 body bytes.
+        let raw = start_pkt(CID_SMP, 2, &[0x01, 0x02, 0x03, 0x04]);
+        let start = acl(0x0001, PbFlag::FirstNonFlushable, &raw);
+        let result = r.feed(&start);
+        assert!(
+            matches!(
+                result,
+                Err(Error::ReassemblyOverrun {
+                    handle: 0x0001,
+                    expected: 2,
+                    actual: 4
+                })
+            ),
+            "a first fragment carrying more body than its own declared length must be rejected"
+        );
+    }
+
+    #[test]
+    fn continuation_overrun_past_declared_length_is_rejected() -> Result<()> {
+        let mut r = AclReassembler::new();
+        let start_raw = start_pkt(CID_SMP, 3, &[0x01]);
+        let start = acl(0x0001, PbFlag::FirstNonFlushable, &start_raw);
+        r.feed(&start)?;
+
+        // Declared length is 3; this continuation alone brings the total to 5.
+        let cont = acl(0x0001, PbFlag::Continuation, &[0x02, 0x03, 0x04, 0x05]);
+        let result = r.feed(&cont);
+        assert!(
+            matches!(
+                result,
+                Err(Error::ReassemblyOverrun {
+                    handle: 0x0001,
+                    expected: 3,
+                    actual: 5
+                })
+            ),
+            "continuation bytes pushing total past the declared length must be rejected"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn fresh_start_fragment_discards_stale_partial_for_same_handle() -> Result<()> {
+        let mut r = AclReassembler::new();
+        // Begin a 5-byte PDU but never finish it.
+        let stale_raw = start_pkt(CID_SMP, 5, &[0x01, 0x02]);
+        let stale_start = acl(0x0001, PbFlag::FirstNonFlushable, &stale_raw);
+        r.feed(&stale_start)?;
+
+        // A new start fragment on the same handle replaces the abandoned one.
+        let fresh_raw = start_pkt(CID_SMP, 2, &[0xAA, 0xBB]);
+        let fresh_start = acl(0x0001, PbFlag::FirstNonFlushable, &fresh_raw);
+        let Some(sdu) = r.feed(&fresh_start)? else {
+            unreachable!("fresh start with matching length must complete immediately");
+        };
+        assert_eq!(
+            sdu.payload,
+            vec![0xAA, 0xBB],
+            "the fresh PDU's bytes must win, not a splice with the abandoned one"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn independent_connection_handles_do_not_cross_contaminate() -> Result<()> {
+        let mut r = AclReassembler::new();
+
+        let a_start_raw = start_pkt(CID_SMP, 4, &[0xA1, 0xA2]);
+        let a_start = acl(0x0001, PbFlag::FirstNonFlushable, &a_start_raw);
+        assert_eq!(r.feed(&a_start)?, None);
+
+        // Handle B completes fully while A is still in progress.
+        let b_raw = start_pkt(CID_SMP, 2, &[0xB1, 0xB2]);
+        let b_start = acl(0x0002, PbFlag::FirstNonFlushable, &b_raw);
+        let Some(b_sdu) = r.feed(&b_start)? else {
+            unreachable!("handle B's single-fragment PDU must complete on its own");
+        };
+        assert_eq!(b_sdu.handle, 0x0002);
+        assert_eq!(b_sdu.payload, vec![0xB1, 0xB2]);
+
+        // Handle A's continuation must still complete correctly afterward.
+        let a_cont = acl(0x0001, PbFlag::Continuation, &[0xA3, 0xA4]);
+        let Some(a_sdu) = r.feed(&a_cont)? else {
+            unreachable!("handle A's continuation must complete independently of B");
+        };
+        assert_eq!(a_sdu.handle, 0x0001);
+        assert_eq!(a_sdu.payload, vec![0xA1, 0xA2, 0xA3, 0xA4]);
+        Ok(())
+    }
+
+    #[test]
+    fn too_many_concurrent_reassemblies_is_rejected() -> Result<()> {
+        let mut r = AclReassembler::new();
+        // Open MAX_CONCURRENT_REASSEMBLIES distinct handles, each needing a
+        // continuation (so none complete immediately and all stay tracked).
+        for h in 0..u16::try_from(MAX_CONCURRENT_REASSEMBLIES).unwrap_or_default() {
+            let raw = start_pkt(CID_SMP, 2, &[0x01]);
+            let start = acl(h, PbFlag::FirstNonFlushable, &raw);
+            assert_eq!(
+                r.feed(&start)?,
+                None,
+                "handle {h} should need a continuation"
+            );
+        }
+
+        // One more distinct handle must be rejected: no room to track it.
+        let extra_handle = u16::try_from(MAX_CONCURRENT_REASSEMBLIES).unwrap_or_default();
+        let extra_raw = start_pkt(CID_SMP, 2, &[0x01]);
+        let extra_start = acl(extra_handle, PbFlag::FirstNonFlushable, &extra_raw);
+        let result = r.feed(&extra_start);
+        assert!(
+            matches!(
+                result,
+                Err(Error::TooManyReassemblies {
+                    max: MAX_CONCURRENT_REASSEMBLIES
+                })
+            ),
+            "a reassembly beyond the concurrent-handle ceiling must be rejected"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn completing_a_reassembly_frees_capacity_for_a_new_one() -> Result<()> {
+        let mut r = AclReassembler::new();
+        for h in 0..u16::try_from(MAX_CONCURRENT_REASSEMBLIES).unwrap_or_default() {
+            let raw = start_pkt(CID_SMP, 2, &[0x01]);
+            let start = acl(h, PbFlag::FirstNonFlushable, &raw);
+            r.feed(&start)?;
+        }
+
+        // Complete handle 0's reassembly, freeing a slot.
+        let cont = acl(0, PbFlag::Continuation, &[0x02]);
+        assert!(r.feed(&cont)?.is_some());
+
+        // A brand-new handle should now fit.
+        let new_handle = u16::try_from(MAX_CONCURRENT_REASSEMBLIES).unwrap_or_default();
+        let raw = start_pkt(CID_SMP, 2, &[0x01]);
+        let start = acl(new_handle, PbFlag::FirstNonFlushable, &raw);
+        assert_eq!(
+            r.feed(&start)?,
+            None,
+            "freed capacity should admit a new in-progress reassembly"
+        );
+        Ok(())
+    }
+
+    // ── FixedChannel demux ──
+
+    #[test]
+    fn fixed_channel_routes_smp_cid() {
+        assert_eq!(FixedChannel::from_cid(CID_SMP), FixedChannel::Smp);
+    }
+
+    #[test]
+    fn fixed_channel_reports_unrouted_cid() {
+        // CID 0x0004 is ATT — not routed by this driver yet (#635 scope is
+        // SMP only).
+        assert_eq!(
+            FixedChannel::from_cid(0x0004),
+            FixedChannel::Unrouted(0x0004)
+        );
+    }
+}

--- a/crates/pteron/src/lib.rs
+++ b/crates/pteron/src/lib.rs
@@ -15,5 +15,6 @@ pub mod ble;
 pub mod config;
 pub mod device;
 pub mod hci;
+pub mod l2cap;
 pub mod smp;
 pub mod transport;

--- a/crates/pteron/src/transport.rs
+++ b/crates/pteron/src/transport.rs
@@ -2,7 +2,12 @@
 //!
 //! BT uses STP function type 0. All HCI packets are wrapped in STP frames
 //! before transmission to the BTIF UART. Received STP frames are unwrapped
-//! and decoded as HCI events.
+//! and dispatched by H4 packet type: HCI Events decode directly
+//! ([`recv_event`](BtHciTransport::recv_event)); ACL Data packets
+//! reassemble through the L2CAP path (`crate::l2cap`, #635) into complete
+//! SDUs ([`recv_l2cap_pdu`](BtHciTransport::recv_l2cap_pdu)). The two
+//! never lose data to each other — a frame of the kind the caller didn't
+//! ask for is queued rather than discarded.
 //!
 //! Frame format (DRIVER-INTERFACES.md §2.7):
 //! ```text
@@ -15,10 +20,16 @@
 //! HDR3      = checksum (XOR of HDR0..HDR2)
 //! ```
 
+use std::collections::VecDeque;
+
 use snafu::Snafu;
 
 use crate::config::Config;
-use crate::hci::{BdAddr, HciCommand, HciEvent, decode_event, encode_command};
+use crate::hci::{
+    BdAddr, H4_ACL_TYPE, H4_EVENT_TYPE, HciCommand, HciEvent, decode_acl_data, decode_event,
+    encode_command,
+};
+use crate::l2cap::{AclReassembler, L2capSdu};
 
 // ── Constants ──────────────────────────────────────────────────────────────────
 
@@ -165,11 +176,27 @@ pub(crate) enum Error {
     #[snafu(display("STP receive buffer underrun: incomplete frame"))]
     RxUnderrun,
 
-    /// HCI event decoding failed.
+    /// HCI event or ACL data decoding failed.
     #[snafu(display("HCI decode error: {source}"))]
     HciDecode {
         /// Underlying HCI decode error.
         source: crate::hci::Error,
+    },
+
+    /// L2CAP reassembly of an ACL data fragment failed (#635).
+    #[snafu(display("L2CAP reassembly error: {source}"))]
+    L2capReassembly {
+        /// Underlying L2CAP reassembly error.
+        source: crate::l2cap::Error,
+    },
+
+    /// The RX loop decoded an STP frame whose H4 packet type is neither
+    /// Event (`0x04`) nor ACL Data (`0x02`) — the only two this transport
+    /// dispatches (#635).
+    #[snafu(display("unrouted H4 packet type on RX: 0x{actual:02X}"))]
+    UnroutedH4Type {
+        /// The unrecognized H4 type byte.
+        actual: u8,
     },
 
     /// The reset state machine is in an unexpected state for the requested
@@ -183,6 +210,25 @@ pub(crate) enum Error {
 
 /// Result alias for this module.
 pub(crate) type Result<T> = core::result::Result<T, Error>;
+
+// ── RX frame dispatch ──────────────────────────────────────────────────────────
+
+/// One STP frame decoded and dispatched by its H4 packet type (#635).
+///
+/// Internal to [`BtHciTransport::recv_frame`] — [`recv_event`] and
+/// [`recv_l2cap_pdu`] each unwrap the variant they want and queue the other.
+///
+/// [`recv_event`]: BtHciTransport::recv_event
+/// [`recv_l2cap_pdu`]: BtHciTransport::recv_l2cap_pdu
+enum RxFrame {
+    /// A decoded HCI Event.
+    Event(HciEvent),
+    /// A complete, reassembled L2CAP SDU.
+    L2cap(L2capSdu),
+    /// A frame was consumed but produced no complete higher-layer unit yet
+    /// — an ACL fragment still awaiting its Continuation(s).
+    Absorbed,
+}
 
 // ── Reset state ────────────────────────────────────────────────────────────────
 
@@ -511,6 +557,23 @@ pub(crate) struct BtHciTransport {
     /// WHY: stored per-instance so different transports (Daily vs. Sentinel
     /// mode) can use different rotation cadences without a global mutable.
     rotation_interval_secs: u64,
+
+    /// L2CAP reassembly state for ACL Data frames, keyed by connection
+    /// handle (#635).
+    acl_reassembler: AclReassembler,
+
+    /// Events decoded FROM the RX ring but not yet claimed by
+    /// [`recv_event`](Self::recv_event), because
+    /// [`recv_l2cap_pdu`](Self::recv_l2cap_pdu) drained past them while
+    /// looking for an L2CAP SDU. Keeps the shared RX stream non-lossy when
+    /// both packet kinds interleave (#635).
+    pending_events: VecDeque<HciEvent>,
+
+    /// L2CAP SDUs reassembled FROM the RX ring but not yet claimed by
+    /// [`recv_l2cap_pdu`](Self::recv_l2cap_pdu), because
+    /// [`recv_event`](Self::recv_event) drained past them while looking for
+    /// an event. Mirrors `pending_events` (#635).
+    pending_l2cap: VecDeque<L2capSdu>,
 }
 
 impl BtHciTransport {
@@ -536,6 +599,9 @@ impl BtHciTransport {
             current_random_addr: None,
             secs_since_rotation: 0,
             rotation_interval_secs: config.rotation_interval_secs(),
+            acl_reassembler: AclReassembler::new(),
+            pending_events: VecDeque::new(),
+            pending_l2cap: VecDeque::new(),
         }
     }
 
@@ -641,7 +707,8 @@ impl BtHciTransport {
 
     // ── RX path ────────────────────────────────────────────────────────────────
 
-    /// Push raw bytes FROM the hardware character device INTO the RX ring buffer.
+    /// Push raw bytes FROM the hardware character device INTO the RX ring
+    /// buffer.
     ///
     /// Returns `false` if the buffer does not have sufficient free space.
     pub(crate) fn push_rx(&mut self, data: &[u8]) -> bool {
@@ -650,18 +717,75 @@ impl BtHciTransport {
 
     /// Attempt to decode one HCI event FROM the front of the RX ring buffer.
     ///
-    /// This method checks whether the RX buffer contains enough bytes for a
-    /// complete STP frame (delimiter + header + payload), then decodes the
-    /// payload as an HCI event.
+    /// ACL Data frames encountered while draining toward the next event are
+    /// reassembled via the L2CAP path (#635) and queued for
+    /// [`recv_l2cap_pdu`](Self::recv_l2cap_pdu) instead of being discarded
+    /// or mis-decoded as an event — the RX ring carries both packet kinds
+    /// once a connection exists, so a caller that only wants events must
+    /// not silently destroy ACL data sitting ahead of the next one.
     ///
-    /// Returns `Ok(None)` when no complete frame is available yet.
+    /// Returns `Ok(None)` when no complete event is available yet — this
+    /// can mean the RX ring is empty, or that everything currently queued
+    /// is an in-progress ACL fragment.
     ///
     /// # Errors
     ///
     /// Returns [`Error::ChecksumMismatch`] on STP header corruption.
     /// Returns [`Error::FuncTypeMismatch`] if the frame is not BT function type 0.
-    /// Returns [`Error::HciDecode`] if the HCI payload is malformed.
+    /// Returns [`Error::HciDecode`] if the HCI or ACL payload is malformed.
+    /// Returns [`Error::L2capReassembly`] if an interleaved ACL fragment
+    /// fails L2CAP reassembly.
+    /// Returns [`Error::UnroutedH4Type`] if a frame is neither an Event nor
+    /// an ACL Data packet.
     pub(crate) fn recv_event(&mut self) -> Result<Option<HciEvent>> {
+        if let Some(evt) = self.pending_events.pop_front() {
+            return Ok(Some(evt));
+        }
+        loop {
+            match self.recv_frame()? {
+                None => return Ok(None),
+                Some(RxFrame::Absorbed) => {}
+                Some(RxFrame::Event(evt)) => return Ok(Some(evt)),
+                Some(RxFrame::L2cap(sdu)) => self.pending_l2cap.push_back(sdu),
+            }
+        }
+    }
+
+    /// Attempt to decode one complete, reassembled L2CAP SDU FROM the front
+    /// of the RX ring buffer (#635).
+    ///
+    /// HCI Event frames encountered while draining toward the next L2CAP
+    /// SDU are queued for [`recv_event`](Self::recv_event) instead of being
+    /// discarded, mirroring [`recv_event`]'s treatment of ACL frames —
+    /// calling one method never starves the other of a packet kind it
+    /// didn't ask for.
+    ///
+    /// Returns `Ok(None)` when no complete SDU is available yet.
+    ///
+    /// # Errors
+    ///
+    /// Same error set as [`recv_event`](Self::recv_event).
+    pub(crate) fn recv_l2cap_pdu(&mut self) -> Result<Option<L2capSdu>> {
+        if let Some(sdu) = self.pending_l2cap.pop_front() {
+            return Ok(Some(sdu));
+        }
+        loop {
+            match self.recv_frame()? {
+                None => return Ok(None),
+                Some(RxFrame::Absorbed) => {}
+                Some(RxFrame::L2cap(sdu)) => return Ok(Some(sdu)),
+                Some(RxFrame::Event(evt)) => self.pending_events.push_back(evt),
+            }
+        }
+    }
+
+    /// Decode exactly one STP frame FROM the RX ring buffer, if a complete
+    /// one is available, and dispatch it by its H4 packet type.
+    ///
+    /// A malformed frame is still consumed FROM the ring (matching the
+    /// pre-#635 single-purpose `recv_event`'s contract) so one bad frame
+    /// cannot jam every packet queued behind it.
+    fn recv_frame(&mut self) -> Result<Option<RxFrame>> {
         if self.rx.is_empty() {
             return Ok(None);
         }
@@ -687,8 +811,29 @@ impl BtHciTransport {
             Ok((payload, frame_len)) => {
                 // We have a complete frame  -  consume it FROM the ring buffer
                 self.rx.skip(frame_len);
-                let event = decode_event(payload).map_err(|source| Error::HciDecode { source })?;
-                Ok(Some(event))
+                let h4_type = payload.first().copied().unwrap_or_default();
+                match h4_type {
+                    H4_EVENT_TYPE => {
+                        let event =
+                            decode_event(payload).map_err(|source| Error::HciDecode { source })?;
+                        Ok(Some(RxFrame::Event(event)))
+                    }
+                    H4_ACL_TYPE => {
+                        let acl = decode_acl_data(payload)
+                            .map_err(|source| Error::HciDecode { source })?;
+                        // A fragment that does not complete an SDU is Absorbed:
+                        // the reassembler holds it and the caller gets a frame
+                        // back either way, so an incomplete PDU is never
+                        // mistaken for an idle transport.
+                        Ok(Some(
+                            self.acl_reassembler
+                                .feed(&acl)
+                                .map_err(|source| Error::L2capReassembly { source })?
+                                .map_or(RxFrame::Absorbed, RxFrame::L2cap),
+                        ))
+                    }
+                    actual => Err(Error::UnroutedH4Type { actual }),
+                }
             }
             Err(Error::RxUnderrun) => Ok(None),
             Err(e) => Err(e),
@@ -1328,5 +1473,183 @@ mod tests {
             "last address byte in the framed payload must be the MSB (0xAA)"
         );
         Ok(())
+    }
+
+    // ── ACL/L2CAP RX dispatch (#635) ──
+
+    /// Build the raw ACL Data H4 payload, matching `hci::decode_acl_data`'s
+    /// wire layout: handle/flags, then `Data_Total_Length`, then the data.
+    /// #635's scope is RX-only, so there is no `encode_acl_data` to reuse yet.
+    fn raw_acl_payload(handle: u16, pb_bits: u8, bc_bits: u8, data: &[u8]) -> Vec<u8> {
+        let handle_and_flags = (handle & 0x0FFF)
+            | (u16::from(pb_bits & 0b11) << 12)
+            | (u16::from(bc_bits & 0b11) << 14);
+        let [hf_lo, hf_hi] = handle_and_flags.to_le_bytes();
+        let data_len = u16::try_from(data.len()).unwrap_or(u16::MAX);
+        let [dl_lo, dl_hi] = data_len.to_le_bytes();
+        let mut pkt = vec![H4_ACL_TYPE, hf_lo, hf_hi, dl_lo, dl_hi];
+        pkt.extend_from_slice(data);
+        pkt
+    }
+
+    /// Build an L2CAP Basic-mode header+body: `[len_lo, len_hi, cid_lo, cid_hi, body...]`.
+    fn raw_l2cap_pdu(cid: u16, body: &[u8]) -> Vec<u8> {
+        let len = u16::try_from(body.len()).unwrap_or(u16::MAX);
+        let mut pkt = Vec::with_capacity(4 + body.len());
+        pkt.extend_from_slice(&len.to_le_bytes());
+        pkt.extend_from_slice(&cid.to_le_bytes());
+        pkt.extend_from_slice(body);
+        pkt
+    }
+
+    /// STP-frame `payload` and push it directly INTO `transport`'s RX ring,
+    /// mirroring how a real STP frame arrives FROM the hardware character
+    /// device (bypassing the TX path entirely).
+    fn push_stp_frame(transport: &mut BtHciTransport, seq: u8, payload: &[u8]) {
+        let mut buf = vec![0u8; STP_DELIMITER_LEN + STP_HEADER_LEN + payload.len()];
+        let Ok(written) = stp_encode(seq, payload, &mut buf) else {
+            unreachable!("test payload always fits the buffer sized for it");
+        };
+        assert!(
+            transport.push_rx(&buf[..written]),
+            "test RX ring should have room for one small frame"
+        );
+    }
+
+    #[test]
+    fn recv_l2cap_pdu_delivers_single_fragment_smp_pdu() {
+        let mut transport = BtHciTransport::new();
+        let l2cap = raw_l2cap_pdu(crate::l2cap::CID_SMP, &[0x01, 0x02, 0x03]);
+        let acl = raw_acl_payload(0x0001, 0b00, 0b00, &l2cap);
+        push_stp_frame(&mut transport, 0, &acl);
+
+        let Ok(Some(sdu)) = transport.recv_l2cap_pdu() else {
+            unreachable!("a complete single-fragment SMP PDU must decode successfully");
+        };
+        assert_eq!(sdu.handle, 0x0001);
+        assert_eq!(sdu.cid, crate::l2cap::CID_SMP);
+        assert_eq!(sdu.payload, vec![0x01, 0x02, 0x03]);
+    }
+
+    #[test]
+    fn recv_l2cap_pdu_reassembles_a_pdu_split_across_two_acl_packets() {
+        let mut transport = BtHciTransport::new();
+        // L2CAP length=5, but the start ACL fragment only carries 2 payload bytes.
+        let mut header_and_partial = Vec::new();
+        header_and_partial.extend_from_slice(&5u16.to_le_bytes());
+        header_and_partial.extend_from_slice(&crate::l2cap::CID_SMP.to_le_bytes());
+        header_and_partial.extend_from_slice(&[0x01, 0x02]);
+        let start = raw_acl_payload(0x0040, 0b00, 0b00, &header_and_partial);
+        push_stp_frame(&mut transport, 0, &start);
+
+        let Ok(none) = transport.recv_l2cap_pdu() else {
+            unreachable!("recv_l2cap_pdu should not error on an in-progress fragment");
+        };
+        assert_eq!(
+            none, None,
+            "the PDU must not be reported complete before its continuation arrives"
+        );
+
+        let cont = raw_acl_payload(0x0040, 0b01, 0b00, &[0x03, 0x04, 0x05]);
+        push_stp_frame(&mut transport, 1, &cont);
+
+        let Ok(Some(sdu)) = transport.recv_l2cap_pdu() else {
+            unreachable!("the continuation should complete the declared 5-byte PDU");
+        };
+        assert_eq!(sdu.payload, vec![0x01, 0x02, 0x03, 0x04, 0x05]);
+    }
+
+    #[test]
+    fn recv_event_skips_past_a_completed_acl_frame_without_losing_it() {
+        let mut transport = BtHciTransport::new();
+        // Queue an ACL frame that completes immediately, THEN an event frame.
+        let l2cap = raw_l2cap_pdu(crate::l2cap::CID_SMP, &[0xAA]);
+        let acl = raw_acl_payload(0x0001, 0b00, 0b00, &l2cap);
+        push_stp_frame(&mut transport, 0, &acl);
+
+        let event_payload = [0x04, 0x01, 0x01, 0x00]; // InquiryComplete, status=0
+        push_stp_frame(&mut transport, 1, &event_payload);
+
+        let Ok(Some(HciEvent::InquiryComplete { status: 0 })) = transport.recv_event() else {
+            unreachable!("recv_event must skip past the ACL frame and return the queued event");
+        };
+
+        // The ACL frame's SDU must not have been lost — it must now be
+        // retrievable FROM the pending queue.
+        let Ok(Some(sdu)) = transport.recv_l2cap_pdu() else {
+            unreachable!("the SDU skipped by recv_event must still be retrievable");
+        };
+        assert_eq!(sdu.payload, vec![0xAA]);
+    }
+
+    #[test]
+    fn recv_l2cap_pdu_skips_past_an_event_frame_without_losing_it() {
+        let mut transport = BtHciTransport::new();
+        // Queue an event frame, THEN an ACL frame that completes immediately.
+        let event_payload = [0x04, 0x01, 0x01, 0x00]; // InquiryComplete, status=0
+        push_stp_frame(&mut transport, 0, &event_payload);
+
+        let l2cap = raw_l2cap_pdu(crate::l2cap::CID_SMP, &[0xBB]);
+        let acl = raw_acl_payload(0x0002, 0b00, 0b00, &l2cap);
+        push_stp_frame(&mut transport, 1, &acl);
+
+        let Ok(Some(sdu)) = transport.recv_l2cap_pdu() else {
+            unreachable!("recv_l2cap_pdu must skip past the event frame and return the SDU");
+        };
+        assert_eq!(sdu.payload, vec![0xBB]);
+
+        let Ok(Some(HciEvent::InquiryComplete { status: 0 })) = transport.recv_event() else {
+            unreachable!("the event skipped by recv_l2cap_pdu must still be retrievable");
+        };
+    }
+
+    #[test]
+    fn recv_event_returns_none_after_absorbing_an_in_progress_acl_fragment() {
+        let mut transport = BtHciTransport::new();
+        // A start fragment declaring more length than it carries: needs a
+        // continuation that never arrives.
+        let mut header_and_partial = Vec::new();
+        header_and_partial.extend_from_slice(&10u16.to_le_bytes());
+        header_and_partial.extend_from_slice(&crate::l2cap::CID_SMP.to_le_bytes());
+        header_and_partial.extend_from_slice(&[0x01]);
+        let start = raw_acl_payload(0x0001, 0b00, 0b00, &header_and_partial);
+        push_stp_frame(&mut transport, 0, &start);
+
+        let Ok(none) = transport.recv_event() else {
+            unreachable!("an in-progress ACL fragment with no event behind it must not error");
+        };
+        assert_eq!(
+            none, None,
+            "recv_event must yield None (not Some/Err) when only an in-progress ACL fragment is queued"
+        );
+    }
+
+    #[test]
+    fn recv_event_surfaces_l2cap_reassembly_errors() {
+        let mut transport = BtHciTransport::new();
+        // A Continuation (PB=0b01) with no prior start on this handle.
+        let orphan = raw_acl_payload(0x0099, 0b01, 0b00, &[0x01, 0x02]);
+        push_stp_frame(&mut transport, 0, &orphan);
+
+        let result = transport.recv_event();
+        assert!(
+            matches!(result, Err(Error::L2capReassembly { .. })),
+            "an orphan continuation must surface as a L2capReassembly error, not be silently dropped"
+        );
+    }
+
+    #[test]
+    fn recv_event_surfaces_unrouted_h4_type() {
+        let mut transport = BtHciTransport::new();
+        // H4 type 0x01 (Command) never legitimately appears in the RX
+        // direction; the dispatcher must reject it rather than misroute it.
+        let bogus = [0x01u8, 0x03, 0x0C, 0x00];
+        push_stp_frame(&mut transport, 0, &bogus);
+
+        let result = transport.recv_event();
+        assert!(
+            matches!(result, Err(Error::UnroutedH4Type { actual: 0x01 })),
+            "an H4 type this transport does not route must surface as UnroutedH4Type"
+        );
     }
 }


### PR DESCRIPTION
## Finding

pteron had no ACL handling of any kind, so there was no channel an SMP PDU could travel over.

```
$ grep -n "ACL\|l2cap\|L2CAP" crates/pteron/src/*.rs
crates/pteron/src/hci.rs:902:    // ACL-typed (0x02) H4 byte is rejected by decode_event
```

One match, and it is a **test asserting ACL frames are rejected**.

## Why this matters

This is why #455 stalled rather than being merely unfinished. PR #606 landed spec-conformant `ah()` per Core Spec Vol 3 Part H §2.2.2 (verified against the Appendix D.7 vector) and a zeroize-on-drop `Irk`. Both have sat unreachable from any real pairing flow since, because SMP is an L2CAP protocol on fixed channel `0x0006` and there was no L2CAP.

The gap was not a missing function. It was a missing layer, which is the distinction that makes #455's remaining "stage 3" look small and behave large.

## Desired correction

- **H4 ACL packet type**, alongside the existing event path in `hci.rs`.
- **ACL fragmentation and reassembly.** An L2CAP PDU larger than the controller's ACL payload arrives split across packets with a start/continuation boundary flag, so the reassembler holds partial state per handle.
- **L2CAP fixed-channel layer** with CID `0x0006` (LE SMP) routable.

Reassembly is the part worth reviewing closely: it consumes attacker-influenced framing *before any pairing state exists*, so a continuation with no start, a declared length longer than what arrives, and an over-long length field are all rejected rather than accumulated. 17 tests cover those edges.

One correctness note on `decode_acl_data`: the payload slice is taken from the input buffer at a fixed header offset rather than through the local cursor. Reading it through the cursor returns a reference into a value dropped at the end of the function, which does not compile — and the fix is not to extend the cursor's life but to slice what the caller already owns.

**Verification:** `cargo clippy --workspace --all-targets -- -D warnings` → 0; `cargo nextest run --workspace` → **756 passed**; `cargo fmt --all --check` → 0. Rebased on current main.

## What remains for #636

This lands the transport beneath SMP, not SMP. #636 still needs the pairing state machine, STK/LTK generation, and key distribution — with an IRK exchange being the specific thing #455's "done when" requires before a bonded peer can resolve an address.

Closes #635
