### PR TITLE
fix(metaxu): close 10 real kanon-lint defects, report 71 rule false-positives

### DIFF
--- a/crates/metaxu/src/envelope.rs
+++ b/crates/metaxu/src/envelope.rs
@@ -108,6 +108,17 @@ impl MessageKind {
         }
     }
 
+    /// This kind's wire value (the inverse of [`Self::from_u16`]).
+    const fn to_u16(self) -> u16 {
+        match self {
+            Self::TaskRequest => 1,
+            Self::TaskResponse => 2,
+            Self::SttEvent => 3,
+            Self::AuthenticatedRequest => 4,
+            Self::AuthenticatedResponse => 5,
+        }
+    }
+
     /// This kind's payload ceiling.
     const fn payload_ceiling(self) -> u32 {
         match self {
@@ -204,7 +215,7 @@ impl EnvelopeHeader {
         out[4..6].copy_from_slice(&SCHEMA_ID.to_le_bytes());
         out[6] = MAJOR;
         out[7] = MINOR;
-        out[8..10].copy_from_slice(&(self.kind as u16).to_le_bytes());
+        out[8..10].copy_from_slice(&self.kind.to_u16().to_le_bytes());
         out[10..18].copy_from_slice(&self.correlation_id.to_le_bytes());
         out[18..22].copy_from_slice(&self.payload_len.to_le_bytes());
         out
@@ -338,7 +349,13 @@ impl Envelope {
     /// is ceiling-checked BEFORE the payload is copied (#553).
     pub(crate) fn decode(bytes: &[u8]) -> Result<Self, EnvelopeError> {
         let header = EnvelopeHeader::parse(bytes)?;
-        let expected = HEADER_LEN + header.payload_len as usize;
+        let payload_len =
+            usize::try_from(header.payload_len).map_err(|_| EnvelopeError::FrameTooLarge {
+                kind: header.kind,
+                declared: header.payload_len,
+                ceiling: header.kind.payload_ceiling(),
+            })?;
+        let expected = HEADER_LEN + payload_len;
         if bytes.len() < expected {
             return Err(EnvelopeError::TruncatedFrame {
                 expected,

--- a/crates/metaxu/src/grants.rs
+++ b/crates/metaxu/src/grants.rs
@@ -73,14 +73,14 @@ pub struct SignedGrant {
 impl SignedGrant {
     /// Issue a grant: sign the postcard encoding with the issuer key.
     pub fn issue(grant: Grant, issuer_key: &SigningKey) -> Self {
-        let bytes = postcard::to_allocvec(&grant).unwrap_or_default();
+        let bytes = postcard::to_allocvec(&grant).unwrap_or_default(); // WHY: infallible -- Grant is fixed-size byte arrays, a bounded Vec<Capability>, and u64 fields; postcard cannot fail encoding it
         let signature: Signature = issuer_key.sign(&bytes);
         Self { grant, signature }
     }
 
     /// The signed payload bytes (what the signature covers).
     fn signed_bytes(&self) -> Vec<u8> {
-        postcard::to_allocvec(&self.grant).unwrap_or_default()
+        postcard::to_allocvec(&self.grant).unwrap_or_default() // WHY: infallible -- see SignedGrant::issue
     }
 
     /// Verify the grant against the expected device at `now_ms`.
@@ -126,10 +126,10 @@ pub(crate) fn hkdf_sha256(ikm: &[u8; 16], info: &[u8]) -> [u8; 32] {
     use sha2::Sha256;
     // extract: PRK = HMAC(salt=zero, IKM); expand: OKM = HMAC(PRK, info||0x01).
     let mut h =
-        <Hmac<Sha256> as Mac>::new_from_slice(&[0u8; 32]).unwrap_or_else(|_| unreachable!());
+        <Hmac<Sha256> as Mac>::new_from_slice(&[0u8; 32]).unwrap_or_else(|_| unreachable!()); // INVARIANT: RustCrypto hmac's new_from_slice never errs on any key
     h.update(ikm);
     let prk = h.finalize().into_bytes();
-    let mut e = <Hmac<Sha256> as Mac>::new_from_slice(&prk).unwrap_or_else(|_| unreachable!());
+    let mut e = <Hmac<Sha256> as Mac>::new_from_slice(&prk).unwrap_or_else(|_| unreachable!()); // INVARIANT: RustCrypto hmac's new_from_slice never errs on any key
     e.update(info);
     e.update(&[0x01]);
     e.finalize().into_bytes().into()
@@ -139,7 +139,7 @@ pub(crate) fn hkdf_sha256(ikm: &[u8; 16], info: &[u8]) -> [u8; 32] {
 pub fn response_mac(key: &[u8; 32], parts: &[&[u8]]) -> [u8; 32] {
     use hmac::{Hmac, Mac};
     use sha2::Sha256;
-    let mut h = <Hmac<Sha256> as Mac>::new_from_slice(key).unwrap_or_else(|_| unreachable!());
+    let mut h = <Hmac<Sha256> as Mac>::new_from_slice(key).unwrap_or_else(|_| unreachable!()); // INVARIANT: RustCrypto hmac's new_from_slice never errs on any key
     for part in parts {
         h.update(part);
     }

--- a/crates/metaxu/src/protocol.rs
+++ b/crates/metaxu/src/protocol.rs
@@ -3,11 +3,10 @@
 use compact_str::CompactString;
 use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
-use snafu::ResultExt as _;
+use snafu::{IntoError as _, ResultExt as _};
 use ulid::Ulid;
 
 use crate::error::{EncodeSnafu, Result};
-use snafu::IntoError as _;
 
 mod ulid_bytes {
     use serde::{Deserialize as _, Serialize as _, Serializer};

--- a/crates/metaxu/src/session.rs
+++ b/crates/metaxu/src/session.rs
@@ -50,14 +50,14 @@ impl AuthenticatedResponse {
     /// Build an authenticated response for `response` under `grant`'s
     /// response key.
     pub fn build(signed_grant: &SignedGrant, response: TaskResponse) -> Self {
-        let payload = postcard::to_allocvec(&response).unwrap_or_default();
+        let payload = postcard::to_allocvec(&response).unwrap_or_default(); // WHY: infallible -- TaskResponse is plain enums/structs over CompactString, Vec<ContactSummary>, and a fixed-size Ulid; postcard cannot fail encoding it
         let mac = crate::grants::response_mac(&signed_grant.response_key(), &[&payload]);
         Self { response, mac }
     }
 
     /// Verify the response MAC under `signed_grant`'s response key.
     pub fn verify(&self, signed_grant: &SignedGrant) -> bool {
-        let payload = postcard::to_allocvec(&self.response).unwrap_or_default();
+        let payload = postcard::to_allocvec(&self.response).unwrap_or_default(); // WHY: infallible -- see AuthenticatedResponse::build
         let expected = crate::grants::response_mac(&signed_grant.response_key(), &[&payload]);
         // Constant-time comparison for a 32-byte MAC.
         expected


### PR DESCRIPTION
## Finding

`kanon lint crates/metaxu --summary` reported 81 baseline violations on `main` (67 before #544 merged, matching #652's original count). Of those 81, only **10 were real code defects** — the other **71 are basanos rule-precision defects** (kanon#3088), not bugs in `metaxu`. Fixing the false positives with `.get()`/restructuring, as #652's own "Desired correction" originally suggested for several sites, would have made provably-correct code worse to satisfy a checker that can't see the proof. Per the "fixing a false positive is worse than leaving it" standard, those 71 are left as-is and reported to kanon#3088 with file:line evidence (items 7-8) instead.

## Evidence

**Real defects fixed (10):**

- `envelope.rs:218` — `self.kind as u16` on a `#[repr(u16)]` enum replaced with an explicit `to_u16()` match, mirroring the file's own existing `from_u16` reverse match. No `as` cast, no behavior change.
- `envelope.rs` (`Envelope::decode`) — `header.payload_len as usize` replaced with `usize::try_from(...)` returning the existing `EnvelopeError::FrameTooLarge` on the (currently unreachable, given the ceiling check in `EnvelopeHeader::parse`) overflow case, instead of silently truncating.
- `grants.rs:76,83` — `postcard::to_allocvec(&grant).unwrap_or_default()` masked a hypothetical serialization failure as an empty (signature-invalid) payload with no documentation of why that's safe. `Grant` is fixed-size byte arrays + a bounded `Vec<Capability>` + `u64` fields — postcard cannot fail encoding it. Added the same-line `// WHY: infallible --` comment `RUST/no-result-unwrap-or-default` requires (RUST.md's own canonical resolution for this exact class).
- `grants.rs:129,132,142` — three `Hmac::<Sha256>::new_from_slice(...).unwrap_or_else(|_| unreachable!())` calls, each with no `// INVARIANT:`/`// SAFETY:` marker. Verified against the vendored `hmac-0.12.1` crate source (`get_der_key`/`KeyInit::new_from_slice` in `optim.rs`): HMAC accepts a key of any length by design (short keys zero-padded, long keys hashed down), so this genuinely never errors. Added the same-line `// INVARIANT:` comment the rule's own skip pattern recognizes.
- `session.rs:53,60` — same `postcard::to_allocvec(...).unwrap_or_default()` pattern on `TaskResponse` (plain enums/structs over `CompactString`, `Vec<ContactSummary>`, and a fixed-size `Ulid`) — same fix.
- `protocol.rs:10` — `use snafu::IntoError as _;` was declared after the crate-local `use crate::error::{...}` import instead of grouped with the other external-crate imports above it. Moved into the external-imports group.

**Rule defects left unfixed, reported to kanon#3088 (71):**

- **52** — `witness.rs`, `pylon.rs`, `vectors.rs` are declared `#[cfg(test)] mod ...;` in `lib.rs` and never contain an internal `#[cfg(test)]` marker of their own, so basanos's per-file `cfg_test_line()` treats the entire file as production code (kanon#3088 item 1, already filed).
- **17** — `envelope.rs`'s `EnvelopeHeader::parse`/`Envelope::decode` index a `&[u8]` after an explicit `bytes.len() < HEADER_LEN` / two-sided `bytes.len() </> expected` guard; the bounds-guard regex in `RUST/indexing-slicing` only recognizes a numeric-literal bound (`([0-9]+)`), not a named `const` or local variable, so it never sees these guards even though they prove every flagged index safe (kanon#3088 item 7, filed with this PR).
- **2** — `envelope.rs::EnvelopeHeader::encode` (writing into a `[u8; HEADER_LEN]` stack array with literal-constant ranges) and `protocol.rs::correlation_of` (`bytes[..8]` on a ULID's fixed `[u8; 16]`) are exactly the case `RUST.md#type-safety`'s own documented exception carves out ("tuple and fixed-size array access where the index is a compile-time constant and the size is known"), which neither `RUST/indexing-slicing` nor `RUST/string-slice` implements (kanon#3088 item 8, filed with this PR). `RUST/string-slice` additionally mis-labels this a *string* (UTF-8 char boundary) risk on a `&[u8]`, which cannot apply.

## Why this matters

The dominant volume (52/81) was already tracked, but this crate is where it concentrates: `witness.rs`'s adversarial round-trip witness and `pylon.rs`'s reference endpoint double are the crate's entire security-verification surface, and every one of their `unreachable!()`/`as`-cast/`assert!()` sites is misgraded as production risk. The two new items add the crate's remaining wire-format code (`envelope.rs`, `protocol.rs`) as confirmed-safe, evidenced false positives rather than debt — so a future sweep doesn't re-spend budget "fixing" already-correct bounds-proven code.

## Desired correction

Landed in this PR for the 10 real defects. The 71 rule-defect violations are tracked at kanon#3088 (items 1, 7, 8) and close when basanos implements the corresponding carve-outs — not by further code changes in `metaxu`.

Closes #652
