### PR TITLE
ci(release): validate PR titles against the conventional-commit grammar

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,38 @@
+# WHY (#665): the repo squash-merges, so a PR title becomes main's commit
+# message, and release-please parses that message for the changelog and the
+# version bump. Unvalidated, 11 of 20 commits since v0.1.17 used a bare
+# scope in the type position (`sms: ...` instead of `fix(sms): ...`) and
+# were silently invisible to both — 0.1.18's release notes are known-
+# incomplete as a result. This check enforces the grammar CLAUDE.md declares
+# before merge, and re-runs on every title edit so a fix is re-verified.
+#
+# NOTE: an inline script (scripts/check-pr-title.sh), not a marketplace
+# action — the type list must stay derived from CLAUDE.md, and this repo
+# pins action SHAs, so an inline check is cheaper to audit and keeps the
+# type list local.
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: conventional-commit grammar
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Validate PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: scripts/check-pr-title.sh "$PR_TITLE"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,7 @@
 scope: thumos repo conventions (bare-metal Rust kernel + userspace for AGM M7 / MT6739)
 defers_to: operator CLAUDE.md (menos-ops) for machine topology; operator global CLAUDE.md for principles; kanon standards for universal engineering policy
 tightens: MT6739-specific constraints and device-identity protection discipline that do not apply outside this repo
+commit_types: feat,fix,docs,refactor,test,chore,perf,ci
 -->
 
 # CLAUDE.md
@@ -66,6 +67,10 @@ Thumos treats all hardware identifiers as sensitive. Every radio driver implemen
 | Probe requests | Passive WiFi scanning by default, no SSID broadcast |
 | BLE advertisements | Non-resolvable private address (NRPA) by default |
 | RF fingerprint | Accepted risk on M7 hardware. Custom PCB future addresses this. |
+
+## Git
+
+The repo squash-merges: a PR title becomes `main`'s commit message, and release-please parses that message to build the changelog and compute the version bump. Grammar: `<type>(<scope>)<!>: <description>`. `type` is one of the `commit_types` declared in this file's frontmatter — `.github/workflows/pr-title.yml` (via `scripts/check-pr-title.sh`) derives its accepted list from that same line rather than restating it, so there is one place to update. `scope` is the crate/module name; `!` before the colon marks a breaking change. A bare scope in the type position (`sms: ...`) is rejected — the type must be one of the declared literals, not any word followed by a colon.
 
 ## TODO convention
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,8 @@ Do not merge via GitHub. The GitHub mirror is read-only from the contributor's p
 
 Release authority is declared in `basanos/standards/RELEASES.md`: the operator cuts MAJOR, an agent cuts MINOR and PATCH with no operator interaction required. Read it there.
 
+release-please builds the changelog and computes the version bump entirely from squashed commit messages, i.e. PR titles. A required check (`.github/workflows/pr-title.yml`) validates every PR title against `CLAUDE.md`'s grammar before merge, so a non-conforming title can no longer land silently. `0.1.18`'s release notes predate that check and are known-incomplete: 11 of the 20 commits since `v0.1.17` used a bare scope in the type position and were dropped from both the changelog and the version-bump computation (#665).
+
 One mechanical step is specific to this repo's GitHub mirror and is expected on every cut. A release-please PR is authored by `GITHUB_TOKEN`, and GitHub does not run `on: pull_request` workflows for events its own token triggered — the recursion guard that stops a workflow from endlessly retriggering itself. The branch-protection required checks therefore never execute, and the PR sits with `mergeStateStatus: BLOCKED` reporting no checks at all rather than failing ones.
 
 Re-trigger them as a real-user actor, which is not subject to the guard:
@@ -96,4 +98,4 @@ The kernel binary (`thumos`) lives outside the workspace and has its own build p
 
 ## Branch naming and commit format
 
-Per `CLAUDE.md`: `feat/`, `fix/`, `docs/`, `refactor/`, `test/`, `cleanup/`, `chore/`. Commit messages are `category(scope): description`. Squash merges keep main linear.
+Branch prefixes and PR title format both follow the `commit_types` grammar declared in `CLAUDE.md`'s Git section — read it there rather than here, so this doc cannot drift from it a second time. Squash merges keep `main` linear, which is why the PR title matters: it becomes `main`'s commit message, and a required check (`.github/workflows/pr-title.yml`) validates every title against that grammar before merge.

--- a/scripts/check-pr-title.sh
+++ b/scripts/check-pr-title.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# check-pr-title.sh — validates a PR title against the conventional-commit
+# grammar (#665). The repo squash-merges, so the title becomes main's commit
+# message and release-please parses it for the changelog and version bump;
+# an unvalidated title is silently invisible to both.
+# WHY: `type` is derived from CLAUDE.md's `commit_types:` frontmatter line —
+# the sole declaration — so this script never hand-carries its own copy.
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+TITLE="${1:-}"
+
+if [ -z "$TITLE" ]; then
+    echo "PR TITLE: no title given" >&2
+    exit 1
+fi
+
+type_csv=$(sed -n 's/^commit_types: *//p' "$REPO_ROOT/CLAUDE.md")
+if [ -z "$type_csv" ]; then
+    echo "PR TITLE: CLAUDE.md has no 'commit_types:' line to derive the accepted type list from" >&2
+    exit 1
+fi
+type_alt=$(echo "$type_csv" | tr ',' '|')
+
+# INVARIANT: the type alternation is exact literals, not a generic \w+ — a
+# bare scope in the type position (e.g. `sms: ...`) must fail. That shape
+# produced 11 of the last 20 commits invisible to the changelog (#665);
+# anchoring to the declared literal set is what rejects it.
+pattern="^(${type_alt})(\([a-zA-Z0-9_./-]+\))?!?: .+"
+
+if echo "$TITLE" | grep -qE "$pattern"; then
+    echo "PR TITLE: ok — '$TITLE'"
+    exit 0
+fi
+
+echo "PR TITLE: '$TITLE' does not match the conventional-commit grammar." >&2
+echo "Expected: <type>(<scope>)<!>: <description>, type one of: $(echo "$type_csv" | tr ',' ' ')" >&2
+exit 1


### PR DESCRIPTION
## Gap

The repo squash-merges, so a PR title becomes `main`'s commit message, and release-please parses that message to build the changelog and compute the version bump. Nothing validated the title. 11 of the last 20 commits used a bare crate/module name in the type position (`sms: ...` where `fix(sms): ...` was meant) and were silently invisible to both — `0.1.18`'s release notes (#646) list 4 entries for 20 merged commits as a result.

## What the check does

`.github/workflows/pr-title.yml` runs on `pull_request` `[opened, edited, synchronize, reopened]` and calls `scripts/check-pr-title.sh "$PR_TITLE"` (inline script, not a marketplace action — cheaper to audit, keeps the type list local, matches how this repo already pins actions).

The script derives its accepted-type list from `CLAUDE.md`'s new `commit_types:` frontmatter line — the one declaration, no restatement — and builds:

```
^(feat|fix|docs|refactor|test|chore|perf|ci)(\([a-zA-Z0-9_./-]+\))?!?: .+
```

**Why this rejects the bare-scope shape:** the type position is an alternation of the exact declared literals, not a generic `\w+`. `sms: fixed the thing` fails because `sms` is not one of `feat|fix|docs|refactor|test|chore|perf|ci` — there is no special-case detection for "looks like a scope," the anchored literal set is what makes it fail. `fix(sms): fixed the thing` passes because `fix` is a declared type and `(sms)` matches the optional-scope group.

`build`, `style`, and `revert` are intentionally NOT accepted: `CLAUDE.md`'s `commit_types` line does not list them (5 historical `style:` commits will now need to use `chore`/`refactor` going forward — not adding types the declaration doesn't have).

`CONTRIBUTING.md`'s previously-independent restatement of the type list (which had drifted — `cleanup` instead of `perf`/`ci`) now points at `CLAUDE.md` instead of restating it, and its Releases section notes that `0.1.18`'s notes predate this check and are known-incomplete.

## Local validation

All 20 commits since `v0.1.17` (the exact set from #665's evidence — 11 that should fail, 9 that should pass), run through `scripts/check-pr-title.sh` directly:

```
EXPECT GOT    MATCH   TITLE
FAIL   FAIL   OK      asphaleia: one implementation of packet parse and DNS policy (#661)
FAIL   FAIL   OK      block: give eMMC/MSDC the test seam its sibling drivers already have (#638)
FAIL   FAIL   OK      lfs: fail closed at the direct-block limit, guard imap pointers, reject non-empty unlink (#647)
FAIL   FAIL   OK      lfs/gpt/vfs/lock_screen: the seven low-severity audit findings (#656)
FAIL   FAIL   OK      lfs: guard the compactor and LfsImap::deserialize against unvalidated imap block numbers (#648)
FAIL   FAIL   OK      lfs: make the compaction trigger reachable and reject a zero segment_size (#637)
FAIL   FAIL   OK      metaxu: wire the authenticated session into BridgeClient (#544) (#654)
FAIL   FAIL   OK      pteron: ACL data path and L2CAP fixed-channel layer (#657)
FAIL   FAIL   OK      pteron: LE Secure Connections pairing and IRK bonding exchange (#660)
FAIL   FAIL   OK      release: bump the kernel lockfile's path-dep on every release (#650)
FAIL   FAIL   OK      sms: one GSM-7 and PDU implementation, and the silent-SMS detection the kernel never had (#664)
PASS   PASS   OK      fix(metaxu): close 10 real kanon-lint defects, report 71 rule false-positives (#659)
PASS   PASS   OK      fix(lfs): exclude the reserved metadata segment in imap deserialize (#658)
PASS   PASS   OK      fix(ledger): derive target-test-ledger counts from runnable tests (#655)
PASS   PASS   OK      docs(contributing): record the release re-trigger step this repo needs (#651)
PASS   PASS   OK      fix(emmc): inspect MSDC_INT and OCR busy bit in the command path (#649)
PASS   PASS   OK      docs(inventory): derive crate roster + docs manifest, drop hand counts (#642)
PASS   PASS   OK      fix(thumos): scope the ui::Key/haphe::Key discriminant claim to what holds (#640)
PASS   PASS   OK      fix(kinit): distinguish a corrupt secrets preamble from unprovisioned (#639)
PASS   PASS   OK      ci(security): migrate cargo-deny to the 0.20 line (#634)
---
PASS titles correctly identified: 9/9
FAIL titles correctly identified: 11/11
```

Also spot-checked: `feat(kernel)!: breaking change to the boot ABI` and `feat!: no scope breaking change` both PASS (breaking-change marker); `Fix(sms): ...` (capitalized type) FAILs.

## CI falsification round trip

1. **Baseline GREEN** (title `ci(release): validate PR titles against the conventional-commit grammar`, opened with the PR): [run](https://github.com/forkwright/thumos/actions/runs/31325802025/job/93275857588) — `PR TITLE: ok — ...`
2. Title edited to `sms: temporary check` via `gh pr edit 667 --title '...'`. **RED**: [run](https://github.com/forkwright/thumos/actions/runs/31325821528/job/93275909589) —
   ```
   PR TITLE: 'sms: temporary check' does not match the conventional-commit grammar.
   Expected: <type>(<scope>)<!>: <description>, type one of: feat fix docs refactor test chore perf ci
   ##[error]Process completed with exit code 1.
   ```
3. Title restored to `ci(release): validate PR titles against the conventional-commit grammar`. **GREEN**: [run](https://github.com/forkwright/thumos/actions/runs/31325844022/job/93275966776) — `PR TITLE: ok — ...`

The check re-ran automatically on each title edit (`types: [opened, edited, synchronize, reopened]`), confirmed the exact bare-scope shape from #665's evidence, and confirmed recovery.

## What remains

The new check is not yet in branch protection's required contexts (currently `cargo audit`, `cargo deny`, `gate / gate`) — that's a repo-settings change made separately, not part of this PR.

Closes #665
