### PR TITLE
fix(pteron): compose bonded-IRK pairing with RPA resolution over real L2CAP dispatch

### DIFF
--- a/crates/pteron/src/hci.rs
+++ b/crates/pteron/src/hci.rs
@@ -296,6 +296,16 @@ impl PbFlag {
             _ => Self::CompleteFlushable,
         }
     }
+
+    /// Encode back to the two-bit wire value — the inverse of [`Self::from_bits`].
+    const fn to_bits(self) -> u8 {
+        match self {
+            Self::FirstNonFlushable => 0b00,
+            Self::Continuation => 0b01,
+            Self::FirstFlushable => 0b10,
+            Self::CompleteFlushable => 0b11,
+        }
+    }
 }
 
 /// A decoded HCI ACL Data packet (H4 type `0x02`, Vol 4 Part E §5.4.2).
@@ -589,6 +599,27 @@ pub(crate) fn decode_acl_data(data: &[u8]) -> Result<AclDataPacket<'_>> {
         bc_flag,
         data: payload,
     })
+}
+
+/// Encode an H4-framed HCI ACL Data packet (H4 type `0x02`) — the inverse
+/// of [`decode_acl_data`]: `[0x02, handle_lo, handle_hi|pb|bc, data_len_lo,
+/// data_len_hi, data...]`.
+///
+/// `handle` is masked to its 12 protocol bits and `bc_flag` to its 2 (Vol
+/// 4 Part E §5.4.2) — an out-of-range caller value is truncated rather
+/// than panicking, matching [`decode_acl_data`]'s own tolerance for the
+/// field's bit width.
+pub(crate) fn encode_acl_data(handle: u16, pb_flag: PbFlag, bc_flag: u8, data: &[u8]) -> Vec<u8> {
+    let handle_and_flags = (handle & 0x0FFF)
+        | (u16::from(pb_flag.to_bits()) << 12)
+        | (u16::from(bc_flag & 0b11) << 14);
+    let data_len = u16::try_from(data.len()).unwrap_or(u16::MAX);
+    let mut packet = Vec::with_capacity(5 + data.len());
+    packet.push(H4_ACL_TYPE);
+    packet.extend_from_slice(&handle_and_flags.to_le_bytes());
+    packet.extend_from_slice(&data_len.to_le_bytes());
+    packet.extend_from_slice(data);
+    packet
 }
 
 fn decode_command_complete(params: &[u8]) -> Result<HciEvent> {
@@ -1144,7 +1175,7 @@ mod tests {
         Ok(())
     }
 
-    // ── PbFlag::from_bits ──
+    // ── PbFlag::from_bits / to_bits ──
 
     #[test]
     fn pb_flag_from_bits_covers_all_four_values() {
@@ -1152,5 +1183,42 @@ mod tests {
         assert_eq!(PbFlag::from_bits(0b01), PbFlag::Continuation);
         assert_eq!(PbFlag::from_bits(0b10), PbFlag::FirstFlushable);
         assert_eq!(PbFlag::from_bits(0b11), PbFlag::CompleteFlushable);
+    }
+
+    #[test]
+    fn pb_flag_to_bits_is_the_inverse_of_from_bits() {
+        for bits in 0b00..=0b11 {
+            assert_eq!(
+                PbFlag::from_bits(bits).to_bits(),
+                bits,
+                "to_bits must invert from_bits for every two-bit value"
+            );
+        }
+    }
+
+    // ── encode_acl_data (#635/#455 stage 3 composition) ──
+
+    #[test]
+    fn encode_acl_data_round_trips_through_decode() -> Result<()> {
+        let encoded = encode_acl_data(0x0040, PbFlag::FirstFlushable, 0b00, &[0xAA, 0xBB, 0xCC]);
+        let pkt = decode_acl_data(&encoded)?;
+        assert_eq!(pkt.handle, 0x0040, "handle must round-trip");
+        assert_eq!(
+            pkt.pb_flag,
+            PbFlag::FirstFlushable,
+            "pb_flag must round-trip"
+        );
+        assert_eq!(pkt.bc_flag, 0b00, "bc_flag must round-trip");
+        assert_eq!(pkt.data, &[0xAA, 0xBB, 0xCC], "payload must round-trip");
+        Ok(())
+    }
+
+    #[test]
+    fn encode_acl_data_masks_handle_and_bc_flag_to_their_protocol_widths() -> Result<()> {
+        let encoded = encode_acl_data(0xFFFF, PbFlag::Continuation, 0xFF, &[]);
+        let pkt = decode_acl_data(&encoded)?;
+        assert_eq!(pkt.handle, 0x0FFF, "handle must be masked to 12 bits");
+        assert_eq!(pkt.bc_flag, 0b11, "bc_flag must be masked to 2 bits");
+        Ok(())
     }
 }

--- a/crates/pteron/src/l2cap.rs
+++ b/crates/pteron/src/l2cap.rs
@@ -109,6 +109,25 @@ pub(crate) enum Error {
 /// Result alias for this module.
 pub(crate) type Result<T> = std::result::Result<T, Error>;
 
+// ── PDU encoding ───────────────────────────────────────────────────────────────
+
+/// Frame `payload` for `cid` as a single-fragment L2CAP Basic-mode PDU:
+/// `[Length(2 LE)][CID(2 LE)][payload...]` (Vol 3 Part A §3.1) — the
+/// inverse of what [`AclReassembler`] reassembles.
+///
+/// Single-fragment only: every PDU this driver encodes today (SMP) fits
+/// well under one ACL packet, so there is no TX-side segmentation to model
+/// yet — that would additionally need the connection's negotiated ACL
+/// MTU, which this crate does not track.
+pub(crate) fn encode_pdu(cid: u16, payload: &[u8]) -> Vec<u8> {
+    let len = u16::try_from(payload.len()).unwrap_or(u16::MAX);
+    let mut out = Vec::with_capacity(L2CAP_HEADER_LEN + payload.len());
+    out.extend_from_slice(&len.to_le_bytes());
+    out.extend_from_slice(&cid.to_le_bytes());
+    out.extend_from_slice(payload);
+    out
+}
+
 // ── Types ──────────────────────────────────────────────────────────────────────
 
 /// A fully-reassembled L2CAP SDU delivered on a fixed channel.
@@ -308,6 +327,21 @@ mod tests {
             bc_flag: 0b00,
             data,
         }
+    }
+
+    // ── encode_pdu (#455 stage 3 / #636 composition) ──
+
+    #[test]
+    fn encode_pdu_is_consumable_by_the_real_reassembler() -> Result<()> {
+        let mut r = AclReassembler::new();
+        let framed = encode_pdu(CID_SMP, &[0x01, 0x02, 0x03]);
+        let pkt = acl(0x0001, PbFlag::FirstNonFlushable, &framed);
+        let Some(sdu) = r.feed(&pkt)? else {
+            unreachable!("a freshly encoded single-fragment PDU must complete immediately");
+        };
+        assert_eq!(sdu.cid, CID_SMP);
+        assert_eq!(sdu.payload, vec![0x01, 0x02, 0x03]);
+        Ok(())
     }
 
     // ── single-fragment PDUs ──

--- a/crates/pteron/src/smp/pairing.rs
+++ b/crates/pteron/src/smp/pairing.rs
@@ -1370,12 +1370,9 @@ mod tests {
             bob_addr.clone(),
             &alice_irk,
         );
-        let mut bob = PairingSession::new(
-            Role::Responder,
-            bob_addr.clone(),
-            alice_addr.clone(),
-            &bob_irk,
-        );
+        // Neither address is used again after this — move rather than
+        // clone (clippy::redundant_clone).
+        let mut bob = PairingSession::new(Role::Responder, bob_addr, alice_addr, &bob_irk);
         let mut rng_a = fixed_stream(0x03);
         let mut rng_b = fixed_stream(0x83);
 

--- a/crates/pteron/src/smp/pairing.rs
+++ b/crates/pteron/src/smp/pairing.rs
@@ -716,7 +716,10 @@ fn address_octets((address_type, address): (u8, BdAddr)) -> [u8; 7] {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::hci::{self, PbFlag};
+    use crate::l2cap::{self, CID_SMP, FixedChannel};
     use crate::smp::pdu::{AuthReq, IoCapability, KeyDistribution};
+    use crate::transport::{self, BtHciTransport};
 
     /// A small deterministic byte stream — enough entropy variety for
     /// ECDH key generation and nonces to differ from call to call and
@@ -1157,5 +1160,255 @@ mod tests {
         let mut bob = PairingSession::new(Role::Responder, test_addr(0x02), test_addr(0x01), &irk);
         assert_eq!(bob.initiate(), None);
         assert_eq!(bob.state(), PairingState::AwaitingPairingRequest);
+    }
+
+    // ── #635/#657 composition: pairing + RPA over the real L2CAP dispatch ──
+    //
+    // `full_handshake_bonds_both_directions` above proves the state
+    // machine correctly derives and exchanges IRKs, but it calls
+    // `handle_pdu` directly with each PDU's raw SMP bytes — it never
+    // touches `crate::l2cap`/`crate::transport`, so it does not prove SMP
+    // PDUs actually travel the CID 0x0006 fixed channel #635/#657 built.
+    // The helpers and tests below route the SAME handshake through the
+    // real STP -> HCI ACL -> L2CAP dispatch pipeline, and then close
+    // #455's "a bonded peer can resolve the address": the bonded IRK used
+    // to resolve an RPA is the one the handshake itself delivered, not a
+    // shared constant.
+
+    /// Deliver one SMP PDU to `receiver`'s RX path exactly as a real combo
+    /// chip forwarding an over-the-air SMP PDU would: L2CAP Basic-mode
+    /// framing (CID 0x0006) inside one HCI ACL Data H4 packet inside one
+    /// STP frame, pushed into the RX ring.
+    fn deliver_smp_pdu(receiver: &mut BtHciTransport, seq: u8, handle: u16, smp_payload: &[u8]) {
+        let l2cap_frame = l2cap::encode_pdu(CID_SMP, smp_payload);
+        let acl_frame = hci::encode_acl_data(handle, PbFlag::FirstNonFlushable, 0b00, &l2cap_frame);
+        let mut stp_buf = vec![0u8; acl_frame.len() + 16];
+        let Ok(written) = transport::stp_encode(seq, &acl_frame, &mut stp_buf) else {
+            unreachable!("a small SMP PDU always fits a buffer sized for it");
+        };
+        assert!(
+            receiver.push_rx(&stp_buf[..written]),
+            "test RX ring must have room for one small SMP PDU"
+        );
+    }
+
+    /// Drain the next SMP PDU FROM `receiver` via the real STP -> HCI ACL
+    /// -> L2CAP dispatch pipeline (`recv_l2cap_pdu`, #635/#657), asserting
+    /// it actually resolved to the SMP fixed channel rather than being
+    /// accepted off some other CID.
+    fn recv_smp_pdu(receiver: &mut BtHciTransport) -> Vec<u8> {
+        let Ok(Some(sdu)) = receiver.recv_l2cap_pdu() else {
+            unreachable!("a delivered single-fragment SMP PDU must reassemble immediately");
+        };
+        assert_eq!(
+            FixedChannel::from_cid(sdu.cid),
+            FixedChannel::Smp,
+            "an SMP PDU must dispatch via CID 0x0006, not be accepted off some other channel"
+        );
+        sdu.payload
+    }
+
+    /// Deliver every PDU in `outgoing` to `receiver` through the real
+    /// L2CAP dispatch, feed each through `receiver.handle_pdu`, and return
+    /// the concatenation of whatever that produces — the dispatch-routed
+    /// equivalent of `full_handshake_bonds_both_directions`'s `step`
+    /// helper above.
+    fn relay(
+        receiver: &mut PairingSession<'_>,
+        receiver_transport: &mut BtHciTransport,
+        handle: u16,
+        seq: &mut u8,
+        outgoing: &[Vec<u8>],
+        random: &mut dyn FnMut(&mut [u8]),
+    ) -> Outbound {
+        let mut produced = Vec::new();
+        for pdu in outgoing {
+            deliver_smp_pdu(receiver_transport, *seq, handle, pdu);
+            *seq = seq.wrapping_add(1) & 0x0F;
+            let payload = recv_smp_pdu(receiver_transport);
+            produced.extend(receiver.handle_pdu(&payload, &mut *random));
+        }
+        produced
+    }
+
+    /// Run the full LE Secure Connections handshake between `alice`
+    /// (initiator) and `bob` (responder) with every PDU routed through the
+    /// real L2CAP dispatch pipeline rather than a direct `handle_pdu`
+    /// call. Leaves both sessions `Complete` with a populated
+    /// `bonding_record`, mirroring `full_handshake_bonds_both_directions`.
+    fn run_handshake_via_l2cap(
+        alice: &mut PairingSession<'_>,
+        bob: &mut PairingSession<'_>,
+        rng_a: &mut dyn FnMut(&mut [u8]),
+        rng_b: &mut dyn FnMut(&mut [u8]),
+    ) {
+        let mut alice_transport = BtHciTransport::new();
+        let mut bob_transport = BtHciTransport::new();
+        let (alice_handle, bob_handle) = (0x0040u16, 0x0041u16);
+        let (mut seq_to_alice, mut seq_to_bob) = (0u8, 0u8);
+
+        let Some(request) = alice.initiate() else {
+            unreachable!("a fresh initiator session must produce a Pairing Request");
+        };
+
+        // Phase 1-2: alternate delivery until a side's handle_pdu produces
+        // nothing further to send. That happens exactly once, right after
+        // alice accepts bob's verified DHKey Check — mirrors the fixed
+        // step sequence `full_handshake_bonds_both_directions` walks
+        // through manually.
+        let mut pending = vec![request];
+        let mut next_is_bob = true;
+        loop {
+            pending = if next_is_bob {
+                relay(
+                    bob,
+                    &mut bob_transport,
+                    bob_handle,
+                    &mut seq_to_bob,
+                    &pending,
+                    rng_b,
+                )
+            } else {
+                relay(
+                    alice,
+                    &mut alice_transport,
+                    alice_handle,
+                    &mut seq_to_alice,
+                    &pending,
+                    rng_a,
+                )
+            };
+            if pending.is_empty() {
+                break;
+            }
+            next_is_bob = !next_is_bob;
+        }
+        assert_eq!(alice.state(), PairingState::AwaitingEncryption);
+        assert_eq!(bob.state(), PairingState::AwaitingEncryption);
+
+        // Phase 3: gated on confirm_link_encrypted, then IdKey exchange —
+        // same shape as `full_handshake_bonds_both_directions`.
+        let alice_identity = alice.confirm_link_encrypted();
+        let bob_identity = bob.confirm_link_encrypted();
+        let to_bob = relay(
+            bob,
+            &mut bob_transport,
+            bob_handle,
+            &mut seq_to_bob,
+            &alice_identity,
+            rng_b,
+        );
+        assert!(
+            to_bob.is_empty(),
+            "receiving an identity PDU produces no reply PDU"
+        );
+        let to_alice = relay(
+            alice,
+            &mut alice_transport,
+            alice_handle,
+            &mut seq_to_alice,
+            &bob_identity,
+            rng_a,
+        );
+        assert!(to_alice.is_empty());
+
+        assert_eq!(alice.state(), PairingState::Complete);
+        assert_eq!(bob.state(), PairingState::Complete);
+    }
+
+    #[test]
+    fn full_handshake_bonds_both_directions_via_l2cap_dispatch() {
+        let alice_irk = fixed_irk(0x20);
+        let bob_irk = fixed_irk(0xA0);
+        let alice_addr = test_addr(0x11);
+        let bob_addr = test_addr(0x12);
+
+        let mut alice = PairingSession::new(
+            Role::Initiator,
+            alice_addr.clone(),
+            bob_addr.clone(),
+            &alice_irk,
+        );
+        let mut bob = PairingSession::new(
+            Role::Responder,
+            bob_addr.clone(),
+            alice_addr.clone(),
+            &bob_irk,
+        );
+        let mut rng_a = fixed_stream(0x02);
+        let mut rng_b = fixed_stream(0x82);
+
+        run_handshake_via_l2cap(&mut alice, &mut bob, &mut rng_a, &mut rng_b);
+
+        let Some(alice_bond) = alice.bonding_record() else {
+            unreachable!("alice must have bonded bob's identity over the L2CAP dispatch path");
+        };
+        assert_eq!(alice_bond.peer_identity_address, bob_addr);
+        assert_eq!(alice_bond.peer_irk.as_bytes(), bob_irk.as_bytes());
+
+        let Some(bob_bond) = bob.bonding_record() else {
+            unreachable!("bob must have bonded alice's identity over the L2CAP dispatch path");
+        };
+        assert_eq!(bob_bond.peer_identity_address, alice_addr);
+        assert_eq!(
+            bob_bond.peer_irk.as_bytes(),
+            alice_irk.as_bytes(),
+            "the IRK bob holds must be the one alice's session distributed, delivered through CID 0x0006 — not a copy handed over out of band"
+        );
+    }
+
+    #[test]
+    fn bonded_peer_resolves_an_rpa_generated_with_the_protocol_obtained_irk() {
+        let alice_irk = fixed_irk(0x30);
+        let bob_irk = fixed_irk(0xB0);
+        let alice_addr = test_addr(0x21);
+        let bob_addr = test_addr(0x22);
+
+        let mut alice = PairingSession::new(
+            Role::Initiator,
+            alice_addr.clone(),
+            bob_addr.clone(),
+            &alice_irk,
+        );
+        let mut bob = PairingSession::new(
+            Role::Responder,
+            bob_addr.clone(),
+            alice_addr.clone(),
+            &bob_irk,
+        );
+        let mut rng_a = fixed_stream(0x03);
+        let mut rng_b = fixed_stream(0x83);
+
+        run_handshake_via_l2cap(&mut alice, &mut bob, &mut rng_a, &mut rng_b);
+
+        let Some(bob_bond) = bob.bonding_record() else {
+            unreachable!("bob must hold alice's bonded IRK after the handshake");
+        };
+
+        // Alice generates an RPA with HER OWN IRK. `prand`'s top two bits
+        // are deliberately NOT already 0b01 (0x2C = 0b00101100) — proves
+        // generate_rpa hashes what actually lands in the address (#455
+        // fix), not whatever raw bits the caller passed.
+        let prand = [0x2C, 0x71, 0x9A];
+        let alice_rpa = transport::generate_rpa(alice_irk.as_bytes(), &prand);
+
+        // Peer B resolves using the IRK IT OBTAINED THROUGH THE HANDSHAKE
+        // — never `alice_irk` directly. This is #455's "a bonded peer can
+        // resolve the address," composed end to end: the IRK travelled
+        // through the pairing protocol over the real L2CAP dispatch, and
+        // is what actually resolves the address.
+        assert!(
+            transport::resolve_rpa(bob_bond.peer_irk.as_bytes(), &alice_rpa),
+            "bob must resolve alice's RPA using the IRK the pairing handshake gave him"
+        );
+
+        // Negative case: an unbonded/wrong IRK must NOT resolve it — a
+        // resolver that returns true for everything would pass the
+        // positive assertion above too.
+        let unbonded_irk = fixed_irk(0xE0);
+        assert!(
+            !transport::resolve_rpa(unbonded_irk.as_bytes(), &alice_rpa),
+            "an IRK that never bonded with alice must not resolve her RPA"
+        );
     }
 }

--- a/crates/pteron/src/transport.rs
+++ b/crates/pteron/src/transport.rs
@@ -498,14 +498,10 @@ pub(crate) fn generate_rpa(irk: &[u8; 16], prand: &[u8; 3]) -> BdAddr {
     let [p0, p1, p2] = *prand;
     // Force two MSBs to 0b01 in the most-significant byte (index 0 = display MSB)
     let b0 = (p0 & !RANDOM_ADDR_MSB_MASK) | RPA_MSB_BITS;
-    // WHY: ah() must hash the SAME 24 bits that end up stored in the
-    // address (b0, not the caller's raw p0) — a peer resolving against
-    // the transmitted address recomputes ah() over [b0, p1, p2], never
-    // over whatever top bits the caller's entropy happened to carry. Any
-    // caller passing a prand whose top two bits are not already 0b01
-    // would otherwise store an address that no bonded peer can resolve.
-    let masked_prand = [b0, p1, p2];
-    let hash = crate::smp::ah(irk, &masked_prand);
+    // FALSIFICATION: intentionally hash the caller's raw, unmasked prand
+    // again (the pre-fix defect) to prove the negative-case/CI wiring
+    // actually catches it. Revert before merge.
+    let hash = crate::smp::ah(irk, prand);
     BdAddr::from_bytes([b0, p1, p2, hash[0], hash[1], hash[2]])
 }
 

--- a/crates/pteron/src/transport.rs
+++ b/crates/pteron/src/transport.rs
@@ -498,8 +498,33 @@ pub(crate) fn generate_rpa(irk: &[u8; 16], prand: &[u8; 3]) -> BdAddr {
     let [p0, p1, p2] = *prand;
     // Force two MSBs to 0b01 in the most-significant byte (index 0 = display MSB)
     let b0 = (p0 & !RANDOM_ADDR_MSB_MASK) | RPA_MSB_BITS;
-    let hash = crate::smp::ah(irk, prand);
+    // WHY: ah() must hash the SAME 24 bits that end up stored in the
+    // address (b0, not the caller's raw p0) — a peer resolving against
+    // the transmitted address recomputes ah() over [b0, p1, p2], never
+    // over whatever top bits the caller's entropy happened to carry. Any
+    // caller passing a prand whose top two bits are not already 0b01
+    // would otherwise store an address that no bonded peer can resolve.
+    let masked_prand = [b0, p1, p2];
+    let hash = crate::smp::ah(irk, &masked_prand);
     BdAddr::from_bytes([b0, p1, p2, hash[0], hash[1], hash[2]])
+}
+
+/// Resolve a resolvable private address against a candidate IRK — the
+/// operation a bonded peer performs on every advertisement/connection to
+/// decide whether an RPA belongs to that IRK's owner: recompute
+/// `ah(irk, prand)` over the address's OWN transmitted `prand` field
+/// (bytes 0..3, type bits included per [`crate::smp::ah`]'s documented
+/// contract) and compare against its `hash` field (bytes 3..6).
+///
+/// This proves the cryptographic binding between an IRK and an RPA that
+/// IRK generated — `ah()` itself is verified against the Core Spec
+/// Appendix D.7 known-answer vector, and this runs the same primitive in
+/// the resolving direction. It proves nothing about resolution against
+/// real controller resolving-list hardware, real advertisement/connection
+/// timing, or interop with an independent BLE stack.
+pub(crate) fn resolve_rpa(irk: &[u8; 16], addr: &BdAddr) -> bool {
+    let [b0, b1, b2, b3, b4, b5] = *addr.as_bytes();
+    crate::smp::ah(irk, &[b0, b1, b2]) == [b3, b4, b5]
 }
 
 /// Build the `HCI_LE_Set_Random_Address` command packet (OGF=0x08, OCF=0x0005).
@@ -1250,17 +1275,31 @@ mod tests {
 
     #[test]
     fn rpa_resolution_round_trip() {
-        // A bonded peer resolves an RPA by recomputing ah(IRK, prand) and
-        // comparing the hash field — the contract #455 exists to provide.
+        // A bonded peer resolves an RPA by recomputing ah(IRK, prand) over
+        // the address's OWN transmitted prand bytes and comparing the hash
+        // field — the contract #455 exists to provide. `prand`'s top two
+        // bits are deliberately NOT already 0b01 (0x21 = 0b00100001):
+        // proves generate_rpa hashes what actually lands on the wire, not
+        // whatever raw top bits the caller's entropy happened to carry.
         let prand = [0x21, 0x43, 0x65];
         let addr = generate_rpa(&APPENDIX_D_IRK, &prand);
-        let bytes = addr.as_bytes();
-        let recovered_prand = [bytes[0] & !RANDOM_ADDR_MSB_MASK, bytes[1], bytes[2]];
-        let recomputed = crate::smp::ah(&APPENDIX_D_IRK, &recovered_prand);
-        assert_eq!(
-            &bytes[3..],
-            &recomputed,
-            "the hash field must resolve against the embedded prand"
+        assert!(
+            resolve_rpa(&APPENDIX_D_IRK, &addr),
+            "a bonded peer recomputing ah(IRK, prand) over the address's own prand bytes must resolve it"
+        );
+    }
+
+    #[test]
+    fn rpa_does_not_resolve_against_an_unrelated_irk() {
+        // The negative case: resolution must FAIL for an IRK that did not
+        // generate the address — a resolver that always returns true
+        // would pass `rpa_resolution_round_trip` too.
+        let prand = [0x21, 0x43, 0x65];
+        let addr = generate_rpa(&APPENDIX_D_IRK, &prand);
+        let unrelated_irk = [0x11u8; 16];
+        assert!(
+            !resolve_rpa(&unrelated_irk, &addr),
+            "an IRK that never generated this address must not resolve it"
         );
     }
 

--- a/crates/pteron/src/transport.rs
+++ b/crates/pteron/src/transport.rs
@@ -498,10 +498,14 @@ pub(crate) fn generate_rpa(irk: &[u8; 16], prand: &[u8; 3]) -> BdAddr {
     let [p0, p1, p2] = *prand;
     // Force two MSBs to 0b01 in the most-significant byte (index 0 = display MSB)
     let b0 = (p0 & !RANDOM_ADDR_MSB_MASK) | RPA_MSB_BITS;
-    // FALSIFICATION: intentionally hash the caller's raw, unmasked prand
-    // again (the pre-fix defect) to prove the negative-case/CI wiring
-    // actually catches it. Revert before merge.
-    let hash = crate::smp::ah(irk, prand);
+    // WHY: ah() must hash the SAME 24 bits that end up stored in the
+    // address (b0, not the caller's raw p0) — a peer resolving against
+    // the transmitted address recomputes ah() over [b0, p1, p2], never
+    // over whatever top bits the caller's entropy happened to carry. Any
+    // caller passing a prand whose top two bits are not already 0b01
+    // would otherwise store an address that no bonded peer can resolve.
+    let masked_prand = [b0, p1, p2];
+    let hash = crate::smp::ah(irk, &masked_prand);
     BdAddr::from_bytes([b0, p1, p2, hash[0], hash[1], hash[2]])
 }
 


### PR DESCRIPTION
## Already fixed, credited

- `ah(irk, prand)` (Vol 3 Part H §2.2.2), spec-vector-verified against Core Spec Appendix D.7 — `a82499a` / #606. `crates/pteron/src/smp/mod.rs:54-66`, test `ah_matches_appendix_d_7`.
- `generate_rpa` filling the hash field via `ah()` instead of raw entropy — same PR. `crates/pteron/src/transport.rs`.
- The full LE Secure Connections pairing state machine with IRK bonding — `ca7b06a` / #660. `crates/pteron/src/smp/pairing.rs`, test `full_handshake_bonds_both_directions` (`:762-880` pre-this-PR).
- The ACL data path + L2CAP fixed-channel layer, CID `0x0006` — #657. `crates/pteron/src/l2cap.rs`.

## What was never composed, and why it mattered

`git grep -n "generate_rpa"` showed it was only ever called with the hardcoded Appendix D.7 IRK — never one obtained through an actual handshake. Nothing demonstrated this issue's acceptance criterion: **a bonded peer can resolve the address**.

Separately, `full_handshake_bonds_both_directions` calls `PairingSession::handle_pdu` directly with raw SMP bytes. It never touches `crate::l2cap` or `crate::transport` — SMP is defined to travel on L2CAP CID `0x0006`, but nothing proved it actually did; the fixed-channel dispatch #635/#657 built had zero callers outside its own unit tests (`grep -rn "FixedChannel\|CID_SMP" crates/pteron/src/*.rs` matched nothing outside `l2cap.rs`'s own test module and raw test-helper byte literals).

## What this PR adds

**The composed test** (`crates/pteron/src/smp/pairing.rs`):

- `run_handshake_via_l2cap` replays the full LE Secure Connections handshake between two `PairingSession`s, but every PDU now travels through the real pipeline: `l2cap::encode_pdu` → `hci::encode_acl_data` → `transport::stp_encode` → `BtHciTransport::push_rx` → `BtHciTransport::recv_l2cap_pdu` → `FixedChannel::from_cid` (asserted `== Smp`) → `handle_pdu`. Two new small production functions closed the gap: `l2cap::encode_pdu` and `hci::encode_acl_data` (+ `PbFlag::to_bits`) are the TX-encode mirrors of the RX-decode path that already existed — only the receive direction had ever been exercised.
- `full_handshake_bonds_both_directions_via_l2cap_dispatch` proves the handshake still bonds both directions when routed this way.
- `bonded_peer_resolves_an_rpa_generated_with_the_protocol_obtained_irk` is the composition: peer A generates an RPA using **its own IRK as obtained by peer B through the handshake** (`bob_bond.peer_irk`, never `alice_irk` directly — the IRK travelled through the protocol, over the real L2CAP dispatch, not a copy handed over out of band). Peer B resolves it via the new `transport::resolve_rpa` (the resolution half of the feature — only generation was exposed before this PR). **Negative case included**: an unbonded IRK is asserted to fail resolution, so a resolver that returns `true` unconditionally would not pass this test.

**A real bug found and fixed along the way**: `generate_rpa` hashed the caller's *raw* `prand` argument instead of the version with the RPA type bits forced to `0b01` that actually gets stored in the address. For any `prand` whose top two bits weren't already `0b01` (i.e. most random `prand` values), the stored hash didn't match `ah(irk, stored_prand)` — a real bonded peer, which only ever sees the transmitted address bytes, would fail to resolve it. The existing `rpa_resolution_round_trip` test didn't catch this because it happened to strip the same bits back off before recomputing, canceling the bug out; it's rewritten to use `resolve_rpa` directly against the transmitted bytes, with a `prand` chosen specifically to *not* start at `0b01`, so it now actually exercises the fix.

## Deliverable 2 (route pairing through L2CAP): landed

Not infeasible — done in software, no hardware needed. See "What this PR adds" above.

## CI falsification

Pushed a commit that broke the binding (reverted `generate_rpa`'s masked-hash fix, so it once again hashes the caller's raw `prand` instead of the value actually stored in the address — the exact pre-fix defect), confirmed CI went red, then reverted (clean no-op diff against the pre-falsify commit) and confirmed green.

- RED: `workspace clippy + tests` FAILURE — `bonded_peer_resolves_an_rpa_generated_with_the_protocol_obtained_irk` panicked at `pairing.rs:1397:9` with `"bob must resolve alice's RPA using the IRK the pairing handshake gave him"`. Run: https://github.com/forkwright/thumos/actions/runs/31326997813
- GREEN (reverted): https://github.com/forkwright/thumos/actions/runs/31327084087

## What this does NOT prove

Pure host-side, software-only verification of the cryptographic binding (`ah()` derivation + resolution) and of PDU routing through this crate's own L2CAP/HCI/STP layers. It does **not** prove:

- Real controller timing or PDU sequencing (this crate's `HCI_LE_Start_Encryption` / `HCI_LE_Long_Term_Key_Request` round trip against real hardware still doesn't exist — `PairingSession::confirm_link_encrypted`'s doc comment already flags this as the actual gap standing between this module and a real peer).
- Interop with an independent BLE stack (BlueZ, a phone, etc.).

Filed as forkwright/thumos#671 rather than leaving it implied.

Closes #455
