### PR TITLE
fix(gps): converge checksum, quality-byte, and coordinate-bounds gaps into topos-core

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -63,6 +63,7 @@ it live in `docs/convergence.toml` + `scripts/check-convergence.sh`.
 | `sema` | Radio analysis: WiFi/BT/cell scanning, IMSI catcher detection |
 | `sema-core` | no_std+alloc threat semantics (canonical ThreatLevel/Calibration + band invariants, shared with the kernel, #545) |
 | `topos` | GPS NMEA parser, geofencing, position logging |
+| `topos-core` | Canonical NMEA checksum framing, coordinate/fix-quality semantics, and GGA/RMC sentence parsing, shared no_std with the kernel (#545) |
 
 **Security**
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1601,7 +1601,12 @@ dependencies = [
  "nom",
  "proptest",
  "snafu",
+ "topos-core",
 ]
+
+[[package]]
+name = "topos-core"
+version = "0.1.18"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/sphragis",
     "crates/stegnos",
     "crates/topos",
+    "crates/topos-core",
 ]
 exclude = ["crates/thumos"]
 

--- a/_llm/architecture.toml
+++ b/_llm/architecture.toml
@@ -75,6 +75,11 @@ path = "crates/topos"
 role = "GPS NMEA parsing, geofencing, and position logging."
 
 [[architecture.crates]]
+name = "topos-core"
+path = "crates/topos-core"
+role = "Canonical NMEA checksum framing, coordinate/fix-quality semantics, and GGA/RMC sentence parsing; no_std, consumed by both the kernel GPS driver and topos so the two cannot drift (#545)."
+
+[[architecture.crates]]
 name = "klesis"
 path = "crates/klesis"
 role = "AT command parser, CCCI/CLDMA framing, SMS PDU, and GSM-7."

--- a/crates/thumos/Cargo.lock
+++ b/crates/thumos/Cargo.lock
@@ -531,8 +531,13 @@ dependencies = [
  "sha2",
  "smoltcp",
  "subtle",
+ "topos-core",
  "xts-mode",
 ]
+
+[[package]]
+name = "topos-core"
+version = "0.1.18"
 
 [[package]]
 name = "typenum"

--- a/crates/thumos/Cargo.toml
+++ b/crates/thumos/Cargo.toml
@@ -60,6 +60,14 @@ asphaleia-core = { path = "../asphaleia-core", default-features = false }
 # surveillance classification entirely — it read the PID and discarded it —
 # so the detection existed only in the layer that never runs on the phone.
 klesis-core = { path = "../klesis-core", default-features = false }
+# WHY (#545): the canonical NMEA checksum framing, coordinate/fix-quality
+# semantics, and GGA/RMC sentence parsing live in topos-core, shared with the
+# workspace `topos` crate. The kernel's hand-port truncated an overflowing
+# fix-quality byte instead of range-checking it, validated a checksum field
+# with only one hex digit as a distinct-but-related bug lived on the
+# `topos` side, and neither side bounded latitude/longitude or the parsed
+# RMC clock fields before treating them as trustworthy.
+topos-core = { path = "../topos-core", default-features = false }
 # WHY: Megolm needs AES-256-CBC (audit #231). Use the audited RustCrypto `cbc`
 # mode crate rather than hand-rolled chaining/padding. no_std verified for
 # i686 + armv7a-none-eabi (crate is `no-std` categorised, alloc-only feature set).

--- a/crates/thumos/src/gps.rs
+++ b/crates/thumos/src/gps.rs
@@ -1,11 +1,21 @@
 //! GPS kernel adapter for the MT6739 combo chip.
 //!
-//! Ports NMEA parsing from `crates/topos/src/` (nmea.rs, position.rs)
-//! into the kernel context:
 //! - NMEA sentence parser: GGA (fix data) and RMC (recommended minimum)
 //! - Sentence buffer: accumulate bytes until `\r\n`, then parse
 //! - GPS position and time extraction
 //! - Hardware abstraction via `GpsHwOps` trait for testability
+//!
+//! The checksum framing, coordinate conversion, and fix-quality semantics
+//! are canonical in `topos_core` (`no_std` + alloc), shared with the
+//! workspace `topos` crate -- the first hand-port and the workspace crate
+//! had drifted (#545): the kernel truncated an overflowing fix-quality byte
+//! via `as u8` instead of range-checking it (a quality field of `264`
+//! wrapped to `8`, a defined code, rather than being rejected), and
+//! `topos`'s checksum parser accepted a checksum field with only one hex
+//! digit. Neither side bounded latitude/longitude or validated the parsed
+//! RMC clock fields before treating them as trustworthy, and the kernel's
+//! altitude parser had no sign handling (a below-sea-level reading was
+//! silently swallowed). One parser, one set of bounds, both consumers.
 //!
 //! ## Hardware path
 //!
@@ -80,6 +90,21 @@ impl core::fmt::Display for GpsError {
     }
 }
 
+impl From<topos_core::CoreError> for GpsError {
+    fn from(e: topos_core::CoreError) -> Self {
+        use topos_core::CoreError as C;
+        match e {
+            C::NoFix => Self::NoFix,
+            C::ChecksumMismatch { .. } => Self::ChecksumMismatch,
+            // WHY a catch-all: CoreError is `#[non_exhaustive]`; an
+            // unrecognised parse failure becoming ParseError rejects the
+            // sentence, which is the fail-closed direction -- GPS position
+            // is a location trust boundary, not a display convenience.
+            _ => Self::ParseError,
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // GPS state machine
 // ---------------------------------------------------------------------------
@@ -124,12 +149,29 @@ pub struct GpsPosition {
     pub latitude: i64,
     /// Longitude in microdegrees. Positive = East, negative = West.
     pub longitude: i64,
-    /// Altitude above mean sea level in millimeters. `0` if unavailable.
-    pub altitude_mm: i32,
-    /// Fix quality indicator (0 = no fix, 1 = GPS, 2 = DGPS, etc.).
-    pub fix_quality: u8,
+    /// Altitude above mean sea level in millimeters. `None` when the
+    /// sentence's altitude field was absent or malformed -- distinct from
+    /// an actual sea-level (`Some(0)`) reading (#545: the prior
+    /// representation defaulted a malformed field to `0`, indistinguishable
+    /// from sea level, and could not represent a below-sea-level reading
+    /// at all).
+    pub altitude_mm: Option<i32>,
+    /// Fix quality indicator.
+    pub fix_quality: topos_core::FixQuality,
     /// Number of satellites in use.
     pub satellite_count: u8,
+}
+
+impl From<topos_core::Fix> for GpsPosition {
+    fn from(fix: topos_core::Fix) -> Self {
+        Self {
+            latitude: fix.position.lat_udeg,
+            longitude: fix.position.lon_udeg,
+            altitude_mm: fix.altitude_mm,
+            fix_quality: fix.quality,
+            satellite_count: fix.satellite_count,
+        }
+    }
 }
 
 impl core::fmt::Display for GpsPosition {
@@ -160,6 +202,19 @@ pub struct GpsTime {
     pub minute: u8,
     /// Second (0-59).
     pub second: u8,
+}
+
+impl From<topos_core::DateTime> for GpsTime {
+    fn from(dt: topos_core::DateTime) -> Self {
+        Self {
+            year: dt.year,
+            month: dt.month,
+            day: dt.day,
+            hour: dt.hour,
+            minute: dt.minute,
+            second: dt.second,
+        }
+    }
 }
 
 impl core::fmt::Display for GpsTime {
@@ -193,289 +248,22 @@ impl GpsTime {
 }
 
 // ---------------------------------------------------------------------------
-// NMEA parsing (no_std, no floating-point)
+// NMEA parsing (delegates to topos_core; see the module doc for #545)
 // ---------------------------------------------------------------------------
 
-/// Validate NMEA checksum. The checksum is the XOR of all bytes between '$' and '*'.
-fn validate_checksum(sentence: &[u8]) -> Result<(), GpsError> {
-    // Find $ and * positions.
-    let start = sentence
-        .iter()
-        .position(|&b| b == b'$')
-        .ok_or(GpsError::ParseError)?;
-    let star = sentence
-        .iter()
-        .position(|&b| b == b'*')
-        .ok_or(GpsError::ParseError)?;
-
-    if star <= start + 1 || star + 3 > sentence.len() {
-        return Err(GpsError::ParseError);
-    }
-
-    // Compute XOR checksum of bytes between $ and *.
-    let mut checksum: u8 = 0;
-    for &b in &sentence[start + 1..star] {
-        checksum ^= b;
-    }
-
-    // Parse the expected checksum (two hex chars after *). Invalid hex
-    // digits mean the sentence is malformed, not that a computed
-    // checksum merely disagreed with the claimed value -- those are
-    // distinct failure classes.
-    let expected =
-        parse_hex_byte(sentence[star + 1], sentence[star + 2]).ok_or(GpsError::ParseError)?;
-
-    if checksum == expected {
-        Ok(())
-    } else {
-        Err(GpsError::ChecksumMismatch)
-    }
-}
-
-/// Parse a single hex digit to its numeric value.
-const fn hex_digit(b: u8) -> Option<u8> {
-    match b {
-        b'0'..=b'9' => Some(b - b'0'),
-        b'A'..=b'F' => Some(b - b'A' + 10),
-        b'a'..=b'f' => Some(b - b'a' + 10),
-        _ => None,
-    }
-}
-
-/// Parse two hex character bytes into a single u8.
-fn parse_hex_byte(hi: u8, lo: u8) -> Option<u8> {
-    let h = hex_digit(hi)?;
-    let l = hex_digit(lo)?;
-    Some(h * 16 + l)
-}
-
-/// Split an NMEA sentence body (between $ and *) into comma-separated fields.
-///
-/// Returns a vector of byte slices.
-fn split_fields(body: &[u8]) -> Vec<&[u8]> {
-    let mut fields = Vec::new();
-    let mut start = 0;
-    for (i, &b) in body.iter().enumerate() {
-        if b == b',' {
-            fields.push(&body[start..i]);
-            start = i + 1;
-        }
-    }
-    fields.push(&body[start..]);
-    fields
-}
-
-/// Parse NMEA latitude field (DDMM.MMMM format) to microdegrees.
-///
-/// Returns microdegrees (degrees * 1_000_000). Negated if hemisphere is 'S'.
-fn parse_lat(value: &[u8], hemisphere: &[u8]) -> Result<i64, GpsError> {
-    if value.len() < 4 {
-        return Err(GpsError::ParseError);
-    }
-
-    let microdeg = parse_nmea_coord(value, 2)?;
-
-    if hemisphere == b"S" {
-        Ok(-microdeg)
-    } else {
-        Ok(microdeg)
-    }
-}
-
-/// Parse NMEA longitude field (DDDMM.MMMM format) to microdegrees.
-fn parse_lon(value: &[u8], hemisphere: &[u8]) -> Result<i64, GpsError> {
-    if value.len() < 5 {
-        return Err(GpsError::ParseError);
-    }
-
-    let microdeg = parse_nmea_coord(value, 3)?;
-
-    if hemisphere == b"W" {
-        Ok(-microdeg)
-    } else {
-        Ok(microdeg)
-    }
-}
-
-/// Parse an NMEA coordinate (DDDMM.MMMM) into microdegrees.
-///
-/// `deg_digits` is 2 for latitude, 3 for longitude.
-fn parse_nmea_coord(value: &[u8], deg_digits: usize) -> Result<i64, GpsError> {
-    if value.len() < deg_digits + 2 {
-        return Err(GpsError::ParseError);
-    }
-
-    let degrees = parse_int(&value[..deg_digits]).ok_or(GpsError::ParseError)? as i64;
-    let minutes_part = &value[deg_digits..];
-
-    // Parse minutes as integer + fractional parts.
-    // Find the decimal point.
-    let dot_pos = minutes_part.iter().position(|&b| b == b'.');
-
-    let (int_part, frac_part) = match dot_pos {
-        Some(pos) => (&minutes_part[..pos], &minutes_part[pos + 1..]),
-        None => (minutes_part, &[] as &[u8]),
-    };
-
-    let minutes_int = parse_int(int_part).ok_or(GpsError::ParseError)? as i64;
-
-    // Parse fractional part, scaled to 4 decimal places.
-    let frac_val = if frac_part.is_empty() {
-        0i64
-    } else {
-        let raw = parse_int(frac_part).ok_or(GpsError::ParseError)? as i64;
-        // Scale to 4 digits (10000).
-        let frac_len = frac_part.len() as u32;
-        // WHY: an adversarial GPS source controls frac_part length; beyond
-        // 18 digits 10i64.pow(frac_len - 4) can wrap to 0 in release builds
-        // (panic = "abort"), turning the division below into a divide-by-zero
-        // kernel abort. Reject rather than let the exponent grow unbounded.
-        if frac_len > 18 {
-            return Err(GpsError::ParseError);
-        }
-        if frac_len < 4 {
-            raw * 10i64.pow(4 - frac_len)
-        } else if frac_len > 4 {
-            raw / 10i64.pow(frac_len - 4)
-        } else {
-            raw
-        }
-    };
-
-    // minutes = minutes_int + frac_val / 10000
-    // microdegrees = (degrees + minutes / 60) * 1_000_000
-    //              = degrees * 1_000_000 + (minutes_int * 10000 + frac_val) * 1_000_000 / (60 * 10000)
-    let minutes_scaled = minutes_int * 10000 + frac_val;
-
-    // INVARIANT: NMEA minutes must be in [0, 60); minutes_scaled is minutes
-    // in units of 1/10000, so the bound is 60 * 10000 = 600_000. A GPS source
-    // reporting >= 60 minutes is malformed and must not silently wrap into
-    // the next degree.
-    if minutes_scaled >= 600_000 {
-        return Err(GpsError::ParseError);
-    }
-
-    let microdeg = degrees * 1_000_000 + minutes_scaled * 1_000_000 / 600_000;
-
-    Ok(microdeg)
-}
-
-/// Parse a byte slice of ASCII digits into a u32.
-fn parse_int(bytes: &[u8]) -> Option<u32> {
-    if bytes.is_empty() {
-        return None;
-    }
-    let mut result: u32 = 0;
-    for &b in bytes {
-        if !b.is_ascii_digit() {
-            return None;
-        }
-        result = result.checked_mul(10)?.checked_add((b - b'0') as u32)?;
-    }
-    Some(result)
-}
-
-/// Parse a fixed-point decimal number from bytes, returning value * 10^scale.
-fn parse_fixed_point(bytes: &[u8], scale: u32) -> Option<i64> {
-    let dot_pos = bytes.iter().position(|&b| b == b'.');
-    let (int_bytes, frac_bytes) = match dot_pos {
-        Some(pos) => (&bytes[..pos], &bytes[pos + 1..]),
-        None => (bytes, &[] as &[u8]),
-    };
-
-    let int_val = parse_int(int_bytes)? as i64;
-    let frac_val = if frac_bytes.is_empty() {
-        0i64
-    } else {
-        parse_int(frac_bytes)? as i64
-    };
-
-    let frac_len = frac_bytes.len() as u32;
-    let frac_scaled = if frac_len < scale {
-        frac_val * 10i64.pow(scale - frac_len)
-    } else if frac_len > scale {
-        frac_val / 10i64.pow(frac_len - scale)
-    } else {
-        frac_val
-    };
-
-    Some(int_val * 10i64.pow(scale) + frac_scaled)
-}
-
-/// Parse altitude from NMEA field (meters with decimal) into millimeters.
-fn parse_altitude_mm(bytes: &[u8]) -> Option<i32> {
-    if bytes.is_empty() {
-        return None;
-    }
-    // Parse as fixed-point with 3 decimal places (millimeters).
-    let val = parse_fixed_point(bytes, 3)?;
-    // Clamp to i32 range.
-    if val > i32::MAX as i64 || val < i32::MIN as i64 {
-        return None;
-    }
-    Some(val as i32)
-}
-
 /// Parse a GGA sentence (Global Positioning System Fix Data).
-///
-/// Extracts position, fix quality, and satellite count.
 ///
 /// # Errors
 ///
 /// Returns `GpsError::ChecksumMismatch` if the checksum is invalid.
-/// Returns `GpsError::NoFix` if fix quality is 0.
+/// Returns `GpsError::NoFix` if fix quality is 0 or an undefined code.
 /// Returns `GpsError::ParseError` if the sentence cannot be parsed.
 #[must_use]
 pub(crate) fn parse_gga(sentence: &[u8]) -> Result<GpsPosition, GpsError> {
-    validate_checksum(sentence)?;
-
-    // Extract body between $ and *.
-    let start = sentence
-        .iter()
-        .position(|&b| b == b'$')
-        .ok_or(GpsError::ParseError)?;
-    let star = sentence
-        .iter()
-        .position(|&b| b == b'*')
-        .ok_or(GpsError::ParseError)?;
-    let body = &sentence[start + 1..star];
-
-    let fields = split_fields(body);
-    if fields.len() < 10 {
-        return Err(GpsError::ParseError);
-    }
-
-    // fields[0] = GPGGA/GNGGA
-    // fields[1] = time (hhmmss.ss)
-    // fields[2] = lat, fields[3] = N/S
-    // fields[4] = lon, fields[5] = E/W
-    // fields[6] = fix quality
-    // fields[7] = num satellites
-    // fields[8] = HDOP
-    // fields[9] = altitude, fields[10] = M
-
-    let quality = parse_int(fields[6]).unwrap_or(0) as u8;
-    if quality == 0 || fields[2].is_empty() {
-        return Err(GpsError::NoFix);
-    }
-
-    let latitude = parse_lat(fields[2], fields[3])?;
-    let longitude = parse_lon(fields[4], fields[5])?;
-    let altitude_mm = parse_altitude_mm(fields[9]).unwrap_or(0);
-    let satellite_count = parse_int(fields[7]).unwrap_or(0) as u8;
-
-    Ok(GpsPosition {
-        latitude,
-        longitude,
-        altitude_mm,
-        fix_quality: quality,
-        satellite_count,
-    })
+    Ok(topos_core::parse_gga(sentence)?.into())
 }
 
 /// Parse an RMC sentence (Recommended Minimum Navigation Information).
-///
-/// Extracts time and date for clock synchronization, plus position.
 ///
 /// # Errors
 ///
@@ -484,80 +272,8 @@ pub(crate) fn parse_gga(sentence: &[u8]) -> Result<GpsPosition, GpsError> {
 /// Returns `GpsError::ParseError` if the sentence cannot be parsed.
 #[must_use]
 pub(crate) fn parse_rmc(sentence: &[u8]) -> Result<(GpsPosition, GpsTime), GpsError> {
-    validate_checksum(sentence)?;
-
-    let start = sentence
-        .iter()
-        .position(|&b| b == b'$')
-        .ok_or(GpsError::ParseError)?;
-    let star = sentence
-        .iter()
-        .position(|&b| b == b'*')
-        .ok_or(GpsError::ParseError)?;
-    let body = &sentence[start + 1..star];
-
-    let fields = split_fields(body);
-    if fields.len() < 10 {
-        return Err(GpsError::ParseError);
-    }
-
-    // fields[0] = GPRMC/GNRMC
-    // fields[1] = time (hhmmss.ss)
-    // fields[2] = status (A=active, V=void)
-    // fields[3] = lat, fields[4] = N/S
-    // fields[5] = lon, fields[6] = E/W
-    // fields[7] = speed (knots)
-    // fields[8] = course (degrees true)
-    // fields[9] = date (ddmmyy)
-
-    if fields[2] != b"A" {
-        return Err(GpsError::NoFix);
-    }
-
-    let latitude = parse_lat(fields[3], fields[4])?;
-    let longitude = parse_lon(fields[5], fields[6])?;
-
-    let position = GpsPosition {
-        latitude,
-        longitude,
-        altitude_mm: 0,
-        fix_quality: 1, // GPS fix
-        satellite_count: 0,
-    };
-
-    let time = parse_time_date(fields[1], fields[9])?;
-
-    Ok((position, time))
-}
-
-/// Parse NMEA time (hhmmss.ss) and date (ddmmyy) fields into `GpsTime`.
-fn parse_time_date(time_field: &[u8], date_field: &[u8]) -> Result<GpsTime, GpsError> {
-    if time_field.len() < 6 || date_field.len() < 6 {
-        return Err(GpsError::ParseError);
-    }
-
-    let hour = parse_int(&time_field[..2]).ok_or(GpsError::ParseError)? as u8;
-    let minute = parse_int(&time_field[2..4]).ok_or(GpsError::ParseError)? as u8;
-    let second = parse_int(&time_field[4..6]).ok_or(GpsError::ParseError)? as u8;
-
-    let day = parse_int(&date_field[..2]).ok_or(GpsError::ParseError)? as u8;
-    let month = parse_int(&date_field[2..4]).ok_or(GpsError::ParseError)? as u8;
-    let year_short = parse_int(&date_field[4..6]).ok_or(GpsError::ParseError)? as u16;
-    // NMEA year is two digits; assume 2000+ for years < 70, 1900+ otherwise.
-    let year = if year_short < 70 {
-        2000 + year_short
-    } else {
-        1900 + year_short
-    };
-
-    Ok(GpsTime {
-        year,
-        month,
-        day,
-        hour,
-        minute,
-        second,
-    })
+    let (fix, time) = topos_core::parse_rmc(sentence)?;
+    Ok((fix.into(), time.into()))
 }
 
 // ---------------------------------------------------------------------------
@@ -874,7 +590,11 @@ mod tests {
         let pos = parse_gga(sentence);
         assert!(pos.is_ok(), "valid GGA sentence must parse successfully");
         let pos = pos.unwrap_or_default();
-        assert_eq!(pos.fix_quality, 1, "fix quality must be 1 (GPS)");
+        assert_eq!(
+            pos.fix_quality,
+            topos_core::FixQuality::Gps,
+            "fix quality must be GPS"
+        );
         assert_eq!(pos.satellite_count, 8, "satellite count must be 8");
         // 53 degrees 21.6802 minutes N = ~53361336 microdegrees
         assert!(
@@ -884,6 +604,38 @@ mod tests {
         );
         // 6 degrees 30.3372 minutes W = ~-6505620 microdegrees (negative for W)
         assert!(pos.longitude < 0, "longitude must be negative for West");
+        assert_eq!(
+            pos.altitude_mm,
+            Some(61_700),
+            "altitude must parse to Some(61700) mm"
+        );
+    }
+
+    #[test]
+    fn parse_gga_rejects_bad_checksum() {
+        let sentence = b"$GPGGA,092750.000,5321.6802,N,00630.3372,W,1,8,1.03,61.7,M,55.2,M,,*FF";
+        assert_eq!(
+            parse_gga(sentence),
+            Err(GpsError::ChecksumMismatch),
+            "a corrupted checksum must propagate through the topos_core \
+             delegation as GpsError::ChecksumMismatch"
+        );
+    }
+
+    #[test]
+    fn parse_gga_rejects_undefined_and_overflowing_quality_code() {
+        // #545: the kernel previously widened this field via a truncating
+        // `as u8` cast, so a quality value of 264 (which does not fit u8)
+        // wrapped to 8 -- a DEFINED quality code -- and was accepted as a
+        // fix. Converged onto topos_core's saturate-to-default parse: an
+        // overflowing or undefined quality code must resolve to NoFix.
+        let sentence =
+            nmea_sentence(b"GPGGA,092750.000,5321.6802,N,00630.3372,W,264,8,1.03,61.7,M,55.2,M,,");
+        assert_eq!(
+            parse_gga(&sentence),
+            Err(GpsError::NoFix),
+            "a quality field of 264 must never resolve to a defined (accepted) fix"
+        );
     }
 
     // -- RMC parsing --
@@ -931,16 +683,17 @@ mod tests {
         );
     }
 
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+
     /// Build a valid-checksum NMEA sentence "$<body>*<XX>" (no CRLF) for
-    /// tests that need to get past validate_checksum() before reaching a
+    /// tests that need to get past checksum validation before reaching a
     /// deeper parse branch.
     fn nmea_sentence(body: &[u8]) -> Vec<u8> {
-        let checksum = body.iter().fold(0u8, |acc, &b| acc ^ b);
+        let checksum = topos_core::compute_checksum(body);
         let mut sentence = Vec::new();
         sentence.push(b'$');
         sentence.extend_from_slice(body);
         sentence.push(b'*');
-        const HEX: &[u8; 16] = b"0123456789ABCDEF";
         sentence.push(HEX[(checksum >> 4) as usize]);
         sentence.push(HEX[(checksum & 0xF) as usize]);
         sentence
@@ -1032,41 +785,6 @@ mod tests {
         );
     }
 
-    // -- Checksum validation --
-
-    #[test]
-    fn validate_checksum_rejects_bad_checksum() {
-        let sentence = b"$GPGGA,092750.000,5321.6802,N,00630.3372,W,1,8,1.03,61.7,M,55.2,M,,*FF";
-        assert_eq!(
-            validate_checksum(sentence),
-            Err(GpsError::ChecksumMismatch),
-            "corrupted checksum must be rejected"
-        );
-    }
-
-    #[test]
-    fn validate_checksum_rejects_non_hex_digits_as_parse_error() {
-        // "ZZ" are not valid hex digits -- this is a malformed sentence,
-        // not a checksum that was computed and disagreed. Distinct from
-        // validate_checksum_rejects_bad_checksum's well-formed-but-wrong-
-        // value case.
-        let sentence = b"$GPGGA,092750.000,5321.6802,N,00630.3372,W,1,8,1.03,61.7,M,55.2,M,,*ZZ";
-        assert_eq!(
-            validate_checksum(sentence),
-            Err(GpsError::ParseError),
-            "non-hex checksum digits must be ParseError, not ChecksumMismatch"
-        );
-    }
-
-    #[test]
-    fn validate_checksum_accepts_valid() {
-        let sentence = b"$GPGGA,092750.000,5321.6802,N,00630.3372,W,1,8,1.03,61.7,M,55.2,M,,*76";
-        assert!(
-            validate_checksum(sentence).is_ok(),
-            "valid checksum must be accepted"
-        );
-    }
-
     // -- GPS receiver --
 
     #[test]
@@ -1091,70 +809,6 @@ mod tests {
             receiver.state(),
             GpsState::Searching,
             "state must be Searching after init"
-        );
-    }
-
-    // -- parse_int --
-
-    #[test]
-    fn parse_int_parses_digits() {
-        assert_eq!(parse_int(b"123"), Some(123));
-        assert_eq!(parse_int(b"0"), Some(0));
-        assert_eq!(parse_int(b""), None);
-        assert_eq!(parse_int(b"abc"), None);
-    }
-
-    // -- Coordinate parsing --
-
-    #[test]
-    fn parse_lat_rejects_excessive_fractional_digit_count() {
-        let value = b"5321.00000000000000000000000"; // 23 fractional digits
-        let result = parse_lat(value, b"N");
-        assert_eq!(
-            result,
-            Err(GpsError::ParseError),
-            "23+ fractional digits must error instead of overflowing 10i64.pow"
-        );
-    }
-
-    #[test]
-    fn parse_lat_rejects_minutes_of_60_or_more() {
-        let value = b"5360.0000"; // 60.0 minutes is invalid; NMEA minutes must be < 60
-        let result = parse_lat(value, b"N");
-        assert_eq!(
-            result,
-            Err(GpsError::ParseError),
-            "minutes >= 60 must be rejected as invalid NMEA"
-        );
-    }
-
-    #[test]
-    fn parse_lat_accepts_minutes_just_under_60() {
-        let value = b"5359.9999";
-        let result = parse_lat(value, b"N");
-        assert!(
-            result.is_ok(),
-            "minutes just under 60 must be accepted, got {result:?}"
-        );
-    }
-
-    #[test]
-    fn parse_time_date_applies_1900_century_for_year_70_and_above() {
-        // NMEA's two-digit year maps to 1900+year for year_short >= 70,
-        // not 2000+year -- only the < 70 branch was exercised elsewhere
-        // (parse_rmc_extracts_time uses year_short=11).
-        let result = parse_time_date(b"092750", b"280599");
-        assert_eq!(
-            result,
-            Ok(GpsTime {
-                year: 1999,
-                month: 5,
-                day: 28,
-                hour: 9,
-                minute: 27,
-                second: 50,
-            }),
-            "year_short=99 must map to 1999, not 2099"
         );
     }
 

--- a/crates/topos-core/Cargo.toml
+++ b/crates/topos-core/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "topos-core"
+description = "no_std + alloc core for NMEA 0183 parsing and position semantics (the canonical checksum, coordinate, and fix-quality invariants, shared by topos and the kernel)"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[package.metadata.kanon]
+maturity = "alpha"
+since = "2026-08-09"
+exit-criteria = "operator-reviewed hardware validation and release-readiness gate"

--- a/crates/topos-core/src/lib.rs
+++ b/crates/topos-core/src/lib.rs
@@ -1,0 +1,1096 @@
+#![no_std]
+//! topos-core: the canonical NMEA 0183 checksum, coordinate, and fix-quality
+//! semantics (#545).
+//!
+//! This crate is the single home of the `$...*XX` checksum framing, the
+//! ddmm.mmmm coordinate-to-microdegree conversion, the `FixQuality` table,
+//! and GGA/RMC sentence parsing. It is shared by the `topos` workspace crate
+//! and the thumos kernel (`gps.rs`, the path a real GPS fix actually takes
+//! on the device).
+//!
+//! It exists because the two sides were independent hand-ports and had
+//! already diverged (#545):
+//!
+//! - `topos`'s checksum parser accepted a checksum field with only one hex
+//!   digit (`u8::from_str_radix` on the string after `*` does not require a
+//!   fixed width), silently validating a truncated sentence whose real
+//!   checksum was missing a leading zero. The kernel required exactly two
+//!   hex digits.
+//! - the kernel widened a parsed GGA fix-quality value to `u8` via a
+//!   truncating `as` cast rather than a range check, so a quality field of
+//!   `264` wrapped to `8` (a defined, *valid*-looking quality) instead of
+//!   being rejected. `topos`'s `u8`-typed parse failed outright on the same
+//!   input and fell back to quality `0` (no fix).
+//! - the kernel's fixed-point coordinate parser rejected minutes >= 60 and
+//!   guarded against an unbounded fractional-digit exponent; `topos`'s
+//!   `f64`-based parser did neither, and `f64::parse` on `"5360.0000"`
+//!   (60.0, an impossible NMEA value) silently produces a plausible-looking
+//!   but wrong coordinate rather than an error.
+//! - neither side validated latitude against +/-90 degrees or longitude
+//!   against +/-180.
+//! - the kernel's altitude parser had no sign handling, so a legitimate
+//!   below-sea-level reading (e.g. Death Valley, -86 m) was silently
+//!   swallowed by the digit-only integer parser and reported as the
+//!   generic malformed-field default; `topos`'s `f64::parse` handled the
+//!   sign correctly.
+//! - `topos`'s RMC parser never extracted time or date at all, so the
+//!   clock-synchronization data the kernel depends on (`clock.rs`'s
+//!   highest-trust automatic source) had no workspace-side equivalent to
+//!   drift against, and neither implementation bounded the parsed
+//!   hour/minute/second/month/day components before treating them as
+//!   trustworthy.
+//!
+//! One parser, one set of bounds, both consumers.
+//!
+//! `no_std` + alloc so the bare-metal kernel can link it via a path
+//! dependency; nothing here performs I/O or decides device policy — a
+//! caller is told what a sentence means and chooses what to do about it.
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// A failure parsing an NMEA sentence or its fields.
+///
+/// Deliberately `Copy` and allocation-free: a hostile or corrupted GPS
+/// signal is untrusted input, and the kernel must be able to surface a
+/// rejection without a heap allocation on that path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CoreError {
+    /// The sentence does not start with `$`, or has no `*` checksum
+    /// delimiter.
+    MissingDelimiters,
+    /// The two characters after `*` are not both valid hex digits.
+    ChecksumNotHex,
+    /// The computed checksum did not match the sentence's claimed checksum.
+    ChecksumMismatch {
+        /// The checksum the sentence claimed.
+        expected: u8,
+        /// The checksum actually computed over the sentence body.
+        actual: u8,
+    },
+    /// The sentence has fewer fields than its type requires.
+    TooFewFields {
+        /// Minimum field count required.
+        needed: usize,
+        /// Field count actually present.
+        got: usize,
+    },
+    /// A coordinate field is shorter than the ddmm.mmmm / dddmm.mmmm
+    /// format requires.
+    CoordinateTooShort,
+    /// A coordinate or numeric field contains a non-digit character where a
+    /// digit was required.
+    FieldNotDigits,
+    /// NMEA minutes must be less than 60; the sentence claimed 60 or more.
+    MinutesOutOfRange,
+    /// A fractional digit count exceeded the range this parser guards
+    /// against (see [`parse_fixed_point`] for why the bound exists).
+    FractionalDigitsExceeded,
+    /// A magnitude computation overflowed `i64`.
+    MagnitudeOverflow,
+    /// Decoded latitude fell outside +/-90 degrees.
+    LatitudeOutOfBounds,
+    /// Decoded longitude fell outside +/-180 degrees.
+    LongitudeOutOfBounds,
+    /// The sentence is well-formed but carries no fix: GGA quality 0 (or an
+    /// undefined/reserved quality code), or RMC status other than `A`.
+    NoFix,
+    /// A time or date field was too short, contained a non-digit, or a
+    /// parsed component was out of range (hour > 23, minute/second > 59,
+    /// month outside 1-12, day outside 1-31).
+    InvalidTimeDate,
+}
+
+/// Result alias for this crate.
+pub type Result<T> = core::result::Result<T, CoreError>;
+
+// ---------------------------------------------------------------------------
+// Checksum framing
+// ---------------------------------------------------------------------------
+
+/// Value of a single ASCII hex digit, or `None` if not a hex digit.
+const fn hex_digit(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        _ => None,
+    }
+}
+
+/// Parse exactly two hex character bytes into a `u8`.
+const fn parse_hex_byte(hi: u8, lo: u8) -> Option<u8> {
+    match (hex_digit(hi), hex_digit(lo)) {
+        (Some(h), Some(l)) => Some(h * 16 + l),
+        _ => None,
+    }
+}
+
+/// Compute the NMEA XOR checksum of a sentence body (the bytes between `$`
+/// and `*`, exclusive of both).
+#[must_use]
+pub fn compute_checksum(body: &[u8]) -> u8 {
+    body.iter().fold(0u8, |acc, &b| acc ^ b)
+}
+
+/// Validate an NMEA sentence's `$...*XX` framing and checksum, and return
+/// the body between `$` and `*`.
+///
+/// Requires `$` at byte 0 (not merely present somewhere in the input --
+/// leading garbage before `$` is rejected rather than silently skipped),
+/// a non-empty body, and *exactly* two hex-digit checksum characters after
+/// `*`. The two-hex-digit requirement is load-bearing: a checksum string
+/// parsed with a variable-width hex reader (e.g. `u8::from_str_radix` on a
+/// `&str` slice) accepts a single leftover digit as if it were the whole
+/// checksum, silently validating a sentence whose checksum lost its leading
+/// zero in transit (#545).
+///
+/// # Errors
+///
+/// - [`CoreError::MissingDelimiters`] when `$` is not at byte 0, there is no
+///   `*`, or the body between them is empty.
+/// - [`CoreError::ChecksumNotHex`] when the two characters after `*` are not
+///   both hex digits (distinct from a checksum that parsed and disagreed).
+/// - [`CoreError::ChecksumMismatch`] when the checksum parsed but did not
+///   match the computed value.
+pub fn checksum_body(sentence: &[u8]) -> Result<&[u8]> {
+    if sentence.first() != Some(&b'$') {
+        return Err(CoreError::MissingDelimiters);
+    }
+    let star = sentence
+        .iter()
+        .position(|&b| b == b'*')
+        .ok_or(CoreError::MissingDelimiters)?;
+    // INVARIANT: star != 0, because sentence[0] == b'$' (checked above) and
+    // '*' cannot equal '$'. `star < 2` therefore means an empty body; the
+    // `star + 3 > len` arm means fewer than two characters remain for the
+    // checksum -- both are MissingDelimiters, distinct from ChecksumNotHex
+    // (two characters present, but not hex).
+    if star < 2 || star + 3 > sentence.len() {
+        return Err(CoreError::MissingDelimiters);
+    }
+
+    // `.get()` rather than direct indexing: both accesses below are always
+    // in bounds given the check just above, but bounds-checked access keeps
+    // this parser panic-free by construction against untrusted GPS input,
+    // not merely by an invariant a future edit could quietly break.
+    let body = sentence.get(1..star).ok_or(CoreError::MissingDelimiters)?;
+    let expected = sentence
+        .get(star + 1)
+        .zip(sentence.get(star + 2))
+        .and_then(|(&hi, &lo)| parse_hex_byte(hi, lo))
+        .ok_or(CoreError::ChecksumNotHex)?;
+
+    let actual = compute_checksum(body);
+    if actual == expected {
+        Ok(body)
+    } else {
+        Err(CoreError::ChecksumMismatch { expected, actual })
+    }
+}
+
+/// Split an NMEA sentence body (already stripped of `$...*XX`) into
+/// comma-separated fields.
+///
+/// # Panics
+///
+/// Does not panic: `start` and `i` are always indices produced by
+/// enumerating `body` itself, so both remain within `0..=body.len()`.
+#[must_use]
+pub fn split_fields(body: &[u8]) -> Vec<&[u8]> {
+    let mut fields = Vec::new();
+    let mut start = 0;
+    for (i, &b) in body.iter().enumerate() {
+        if b == b',' {
+            fields.push(&body[start..i]);
+            start = i + 1;
+        }
+    }
+    fields.push(&body[start..]);
+    fields
+}
+
+// ---------------------------------------------------------------------------
+// Numeric primitives
+// ---------------------------------------------------------------------------
+
+/// Parse a byte slice of ASCII digits into a `u32`.
+#[must_use]
+pub fn parse_uint(bytes: &[u8]) -> Option<u32> {
+    if bytes.is_empty() {
+        return None;
+    }
+    let mut result: u32 = 0;
+    for &b in bytes {
+        if !b.is_ascii_digit() {
+            return None;
+        }
+        result = result.checked_mul(10)?.checked_add(u32::from(b - b'0'))?;
+    }
+    Some(result)
+}
+
+/// Parse a byte slice of ASCII digits into a `u8`, defaulting to 0 when the
+/// field is malformed or out of `u8` range.
+///
+/// WHY a saturate-to-default rather than a truncating cast: a quality or
+/// satellite-count field of `264` truncated via `as u8` wraps to `8` -- a
+/// *valid-looking* code -- instead of the parse simply failing. Truncation
+/// turns a malformed field into a specific, wrong, but plausible value;
+/// defaulting to 0 keeps the failure visible as "unknown" (#545).
+#[must_use]
+pub fn parse_uint_u8_or_zero(bytes: &[u8]) -> u8 {
+    parse_uint(bytes)
+        .and_then(|v| u8::try_from(v).ok())
+        .unwrap_or(0)
+}
+
+/// Parse a decimal fraction's digits, scaled to `scale` decimal places.
+///
+/// `frac_bytes` holds only the digits after a decimal point (no sign, no
+/// leading `.`). Returns `0` for an empty slice.
+fn scaled_fraction(frac_bytes: &[u8], scale: u32) -> Result<i64> {
+    if frac_bytes.is_empty() {
+        return Ok(0);
+    }
+    let raw = i64::from(parse_uint(frac_bytes).ok_or(CoreError::FieldNotDigits)?);
+    // WHY: an adversarial source controls the fractional digit count; past
+    // ~18 digits, `10i64.pow(frac_len - scale)` below overflows i64 and (in
+    // a release build with overflow-checks off) silently wraps rather than
+    // panicking, corrupting the parsed magnitude instead of erroring. Bound
+    // it well under i64's ~19-digit decimal range. Applies uniformly to
+    // coordinate minutes and to altitude, which previously guarded this
+    // only on the coordinate path (#545).
+    let frac_len = frac_bytes.len();
+    if frac_len > 18 {
+        return Err(CoreError::FractionalDigitsExceeded);
+    }
+    // INVARIANT: frac_len <= 18, so the u32 conversion below never truncates.
+    let frac_len = frac_len as u32;
+    Ok(match frac_len.cmp(&scale) {
+        core::cmp::Ordering::Less => raw.saturating_mul(10i64.pow(scale - frac_len)),
+        core::cmp::Ordering::Greater => raw / 10i64.pow(frac_len - scale),
+        core::cmp::Ordering::Equal => raw,
+    })
+}
+
+/// Parse a signed fixed-point decimal (e.g. altitude in meters) into an
+/// integer scaled by `10^scale` (e.g. `scale = 3` for millimeters from
+/// meters).
+///
+/// Handles an optional leading `-` -- a below-sea-level altitude (e.g.
+/// Death Valley, -86 m) is a legitimate NMEA value, not a malformed one.
+///
+/// # Errors
+///
+/// [`CoreError::FieldNotDigits`] when the integer or fractional part is not
+/// all ASCII digits. [`CoreError::FractionalDigitsExceeded`] when the
+/// fractional part is implausibly long (the internal `scaled_fraction`
+/// helper bounds it to 18 digits). [`CoreError::MagnitudeOverflow`] on
+/// integer overflow assembling the scaled value.
+///
+/// # Panics
+///
+/// Does not panic: `pos` is produced by `bytes.iter().position(...)`, so
+/// it is always a valid split point within `bytes`.
+pub fn parse_fixed_point(bytes: &[u8], scale: u32) -> Result<i64> {
+    let (negative, bytes) = match bytes.first() {
+        Some(b'-') => (true, bytes.get(1..).unwrap_or(&[])),
+        _ => (false, bytes),
+    };
+    if bytes.is_empty() {
+        return Err(CoreError::FieldNotDigits);
+    }
+    let dot_pos = bytes.iter().position(|&b| b == b'.');
+    let (int_bytes, frac_bytes) = dot_pos.map_or((bytes, &[] as &[u8]), |pos| {
+        (&bytes[..pos], &bytes[pos + 1..])
+    });
+
+    let int_val = i64::from(parse_uint(int_bytes).ok_or(CoreError::FieldNotDigits)?);
+    let frac_scaled = scaled_fraction(frac_bytes, scale)?;
+    let scale_factor = 10i64
+        .checked_pow(scale)
+        .ok_or(CoreError::MagnitudeOverflow)?;
+    let magnitude = int_val
+        .checked_mul(scale_factor)
+        .and_then(|v| v.checked_add(frac_scaled))
+        .ok_or(CoreError::MagnitudeOverflow)?;
+
+    Ok(if negative { -magnitude } else { magnitude })
+}
+
+/// Parse an altitude field (meters, optionally signed, optional decimal)
+/// into millimeters.
+///
+/// Returns `None` -- rather than an error -- when the field is empty or
+/// malformed: a bad altitude reading does not invalidate the rest of a fix
+/// on either consumer. Distinct from `Some(0)`, which is an actual
+/// sea-level reading.
+#[must_use]
+pub fn parse_altitude_mm(bytes: &[u8]) -> Option<i32> {
+    if bytes.is_empty() {
+        return None;
+    }
+    let val = parse_fixed_point(bytes, 3).ok()?;
+    i32::try_from(val).ok()
+}
+
+// ---------------------------------------------------------------------------
+// Coordinates
+// ---------------------------------------------------------------------------
+
+/// Scale factor between decimal degrees and microdegrees.
+pub const MICRODEG_SCALE: i64 = 1_000_000;
+
+/// Maximum valid absolute latitude, in microdegrees.
+pub const MAX_LATITUDE_UDEG: i64 = 90 * MICRODEG_SCALE;
+
+/// Maximum valid absolute longitude, in microdegrees.
+pub const MAX_LONGITUDE_UDEG: i64 = 180 * MICRODEG_SCALE;
+
+/// A geographic position in fixed-point microdegrees (degrees *
+/// `1_000_000`), avoiding floating-point arithmetic so the value is usable
+/// from a `no_std` kernel without FPU support enabled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Position {
+    /// Latitude in microdegrees. Positive = North, negative = South.
+    pub lat_udeg: i64,
+    /// Longitude in microdegrees. Positive = East, negative = West.
+    pub lon_udeg: i64,
+}
+
+/// Parse an NMEA `ddmm.mmmm`-shaped coordinate magnitude (no sign) into
+/// microdegrees. `deg_digits` is 2 for latitude, 3 for longitude.
+fn parse_coordinate_magnitude(value: &[u8], deg_digits: usize) -> Result<i64> {
+    if value.len() < deg_digits + 2 {
+        return Err(CoreError::CoordinateTooShort);
+    }
+    let degrees = i64::from(parse_uint(&value[..deg_digits]).ok_or(CoreError::FieldNotDigits)?);
+    let minutes_part = &value[deg_digits..];
+
+    let dot_pos = minutes_part.iter().position(|&b| b == b'.');
+    let (int_part, frac_part) = dot_pos.map_or((minutes_part, &[] as &[u8]), |pos| {
+        (&minutes_part[..pos], &minutes_part[pos + 1..])
+    });
+
+    let minutes_int = i64::from(parse_uint(int_part).ok_or(CoreError::FieldNotDigits)?);
+    // Minutes scaled to 4 decimal places (1/10000ths).
+    let frac_val = scaled_fraction(frac_part, 4)?;
+    let minutes_scaled = minutes_int * 10_000 + frac_val;
+
+    // INVARIANT: NMEA minutes must be in [0, 60); minutes_scaled is minutes
+    // in units of 1/10000, so the bound is 60 * 10000 = 600_000. A source
+    // reporting >= 60 minutes is malformed and must not silently wrap into
+    // the next degree (#545: the f64-based parser this replaces on the
+    // `topos` side had no such check -- "5360.0000" parsed as 60.0 minutes
+    // and silently produced a wrong-but-plausible coordinate).
+    if minutes_scaled >= 600_000 {
+        return Err(CoreError::MinutesOutOfRange);
+    }
+
+    Ok(degrees * MICRODEG_SCALE + minutes_scaled * MICRODEG_SCALE / 600_000)
+}
+
+/// Parse an NMEA latitude field (`ddmm.mmmm`) and hemisphere (`N`/`S`) into
+/// signed microdegrees, bounded to +/-90 degrees.
+///
+/// # Errors
+///
+/// [`CoreError::CoordinateTooShort`] / [`CoreError::FieldNotDigits`] /
+/// [`CoreError::MinutesOutOfRange`] / [`CoreError::FractionalDigitsExceeded`]
+/// from the underlying coordinate parse, plus
+/// [`CoreError::LatitudeOutOfBounds`] when the magnitude exceeds 90 degrees.
+pub fn parse_lat(value: &[u8], hemisphere: &[u8]) -> Result<i64> {
+    let magnitude = parse_coordinate_magnitude(value, 2)?;
+    let signed = if hemisphere == b"S" {
+        -magnitude
+    } else {
+        magnitude
+    };
+    if !(-MAX_LATITUDE_UDEG..=MAX_LATITUDE_UDEG).contains(&signed) {
+        return Err(CoreError::LatitudeOutOfBounds);
+    }
+    Ok(signed)
+}
+
+/// Parse an NMEA longitude field (`dddmm.mmmm`) and hemisphere (`E`/`W`)
+/// into signed microdegrees, bounded to +/-180 degrees.
+///
+/// # Errors
+///
+/// As [`parse_lat`], plus [`CoreError::LongitudeOutOfBounds`] when the
+/// magnitude exceeds 180 degrees.
+pub fn parse_lon(value: &[u8], hemisphere: &[u8]) -> Result<i64> {
+    let magnitude = parse_coordinate_magnitude(value, 3)?;
+    let signed = if hemisphere == b"W" {
+        -magnitude
+    } else {
+        magnitude
+    };
+    if !(-MAX_LONGITUDE_UDEG..=MAX_LONGITUDE_UDEG).contains(&signed) {
+        return Err(CoreError::LongitudeOutOfBounds);
+    }
+    Ok(signed)
+}
+
+// ---------------------------------------------------------------------------
+// Fix quality
+// ---------------------------------------------------------------------------
+
+/// GPS fix quality indicator (NMEA GGA field 6).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum FixQuality {
+    /// No fix, or a quality code outside the defined 1-8 range.
+    ///
+    /// WHY undefined codes fold into `NoFix` rather than being passed
+    /// through: a reserved/future quality code is not a stronger fix than
+    /// none, and treating any nonzero byte as "has a fix" (a truncating
+    /// `u8` cast previously did exactly that for field text like `264`,
+    /// #545) is fail-open on the one field that gates whether a position is
+    /// trusted at all.
+    #[default]
+    NoFix,
+    /// Standard GPS fix.
+    Gps,
+    /// Differential GPS fix.
+    Dgps,
+    /// PPS fix.
+    Pps,
+    /// Real-Time Kinematic.
+    Rtk,
+    /// Float RTK.
+    FloatRtk,
+    /// Estimated (dead reckoning).
+    Estimated,
+    /// Manual input mode.
+    Manual,
+    /// Simulation mode.
+    Simulation,
+}
+
+impl FixQuality {
+    /// Whether this quality indicates a usable fix.
+    #[must_use]
+    pub const fn has_fix(self) -> bool {
+        !matches!(self, Self::NoFix)
+    }
+}
+
+impl From<u8> for FixQuality {
+    fn from(val: u8) -> Self {
+        match val {
+            1 => Self::Gps,
+            2 => Self::Dgps,
+            3 => Self::Pps,
+            4 => Self::Rtk,
+            5 => Self::FloatRtk,
+            6 => Self::Estimated,
+            7 => Self::Manual,
+            8 => Self::Simulation,
+            _ => Self::NoFix,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fix (GGA / RMC)
+// ---------------------------------------------------------------------------
+
+/// A GPS fix as extracted from a GGA or RMC sentence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Fix {
+    /// Geographic position.
+    pub position: Position,
+    /// Fix quality.
+    pub quality: FixQuality,
+    /// Number of satellites in use. `0` when absent or malformed (GGA
+    /// only; RMC carries no satellite count).
+    pub satellite_count: u8,
+    /// Altitude above mean sea level in millimeters. `None` when the
+    /// sentence omitted the field or it did not parse -- distinct from an
+    /// actual sea-level (`Some(0)`) reading. GGA only; RMC carries no
+    /// altitude.
+    pub altitude_mm: Option<i32>,
+}
+
+/// Parse a GGA sentence (Global Positioning System Fix Data).
+///
+/// Format: `$GPGGA,hhmmss.ss,llll.ll,a,yyyyy.yy,a,q,ss,h.h,a.a,M,g.g,M,,*hh`
+///
+/// # Errors
+///
+/// [`CoreError::ChecksumMismatch`] / [`CoreError::MissingDelimiters`] /
+/// [`CoreError::ChecksumNotHex`] on framing failures.
+/// [`CoreError::TooFewFields`] when the body has fewer than 10 fields.
+/// [`CoreError::NoFix`] when quality is 0 (or undefined) or the latitude
+/// field is empty. [`CoreError::LatitudeOutOfBounds`] /
+/// [`CoreError::LongitudeOutOfBounds`] / coordinate errors from malformed
+/// position fields.
+///
+/// # Panics
+///
+/// Does not panic: every `fields[N]` access below indexes N < 10, and the
+/// `fields.len() < 10` check just above guarantees at least 10 elements.
+pub fn parse_gga(sentence: &[u8]) -> Result<Fix> {
+    let body = checksum_body(sentence)?;
+    let fields = split_fields(body);
+    if fields.len() < 10 {
+        return Err(CoreError::TooFewFields {
+            needed: 10,
+            got: fields.len(),
+        });
+    }
+
+    // fields[0] = GPGGA/GNGGA   fields[1] = time
+    // fields[2] = lat           fields[3] = N/S
+    // fields[4] = lon           fields[5] = E/W
+    // fields[6] = fix quality   fields[7] = num satellites
+    // fields[8] = HDOP          fields[9] = altitude
+
+    let quality = FixQuality::from(parse_uint_u8_or_zero(fields[6]));
+    if !quality.has_fix() || fields[2].is_empty() {
+        return Err(CoreError::NoFix);
+    }
+
+    let position = Position {
+        lat_udeg: parse_lat(fields[2], fields[3])?,
+        lon_udeg: parse_lon(fields[4], fields[5])?,
+    };
+    let altitude_mm = parse_altitude_mm(fields[9]);
+    let satellite_count = parse_uint_u8_or_zero(fields[7]);
+
+    Ok(Fix {
+        position,
+        quality,
+        satellite_count,
+        altitude_mm,
+    })
+}
+
+/// UTC date and time extracted from an RMC sentence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DateTime {
+    /// Year (full, e.g. 2026).
+    pub year: u16,
+    /// Month (1-12).
+    pub month: u8,
+    /// Day of month (1-31).
+    pub day: u8,
+    /// Hour (0-23).
+    pub hour: u8,
+    /// Minute (0-59).
+    pub minute: u8,
+    /// Second (0-59).
+    pub second: u8,
+}
+
+/// Parse NMEA time (`hhmmss.ss`) and date (`ddmmyy`) fields into a
+/// [`DateTime`], with range validation on every component.
+///
+/// WHY the range check exists even though neither prior implementation had
+/// it: consumers may treat GPS-derived time as their highest-trust
+/// automatic clock source, and the checksum only proves the sentence text
+/// is internally consistent -- not that the values are truthful. A spoofed
+/// or corrupted signal can carry an in-checksum sentence with an
+/// impossible hour or month; a consumer that feeds that straight into a
+/// trusted clock hierarchy without validating the ranges has a fail-open
+/// gap on the exact axis "highest trust" is supposed to mean (#545).
+///
+/// # Errors
+///
+/// [`CoreError::InvalidTimeDate`] when either field is too short, contains
+/// a non-digit, or a parsed component is out of range.
+///
+/// # Panics
+///
+/// Does not panic: every range slice below stays within the first 6 bytes
+/// of its field, and the length check just above guarantees at least 6.
+pub fn parse_time_date(time_field: &[u8], date_field: &[u8]) -> Result<DateTime> {
+    if time_field.len() < 6 || date_field.len() < 6 {
+        return Err(CoreError::InvalidTimeDate);
+    }
+
+    let hour = parse_uint(&time_field[..2]).ok_or(CoreError::InvalidTimeDate)?;
+    let minute = parse_uint(&time_field[2..4]).ok_or(CoreError::InvalidTimeDate)?;
+    let second = parse_uint(&time_field[4..6]).ok_or(CoreError::InvalidTimeDate)?;
+    let day = parse_uint(&date_field[..2]).ok_or(CoreError::InvalidTimeDate)?;
+    let month = parse_uint(&date_field[2..4]).ok_or(CoreError::InvalidTimeDate)?;
+    let year_short = parse_uint(&date_field[4..6]).ok_or(CoreError::InvalidTimeDate)?;
+
+    if hour > 23
+        || minute > 59
+        || second > 59
+        || !(1..=12).contains(&month)
+        || !(1..=31).contains(&day)
+    {
+        return Err(CoreError::InvalidTimeDate);
+    }
+
+    // NMEA's two-digit year maps to 1900+year for year_short >= 70,
+    // 2000+year otherwise.
+    let year = if year_short < 70 {
+        2000 + year_short
+    } else {
+        1900 + year_short
+    };
+
+    // INVARIANT: hour/minute/second <= 59, month <= 12, day <= 31, and year
+    // <= 2069 -- all well within their target integer widths, checked above.
+    Ok(DateTime {
+        year: year as u16,
+        month: month as u8,
+        day: day as u8,
+        hour: hour as u8,
+        minute: minute as u8,
+        second: second as u8,
+    })
+}
+
+/// Parse an RMC sentence (Recommended Minimum Navigation Information).
+///
+/// Format: `$GPRMC,hhmmss.ss,A,llll.ll,a,yyyyy.yy,a,s.s,c.c,ddmmyy,,,a*hh`
+///
+/// Returns a [`Fix`] with `quality = FixQuality::Gps`, `satellite_count = 0`,
+/// and `altitude_mm = None` -- RMC carries neither. Speed and course are
+/// plain informational floats with no NMEA-specific semantics beyond
+/// `str::parse`; callers that want them read `fields[7]`/`fields[8]`
+/// themselves via [`checksum_body`] + [`split_fields`].
+///
+/// # Errors
+///
+/// As [`parse_gga`], plus [`CoreError::NoFix`] when the status field is not
+/// `A` (active). [`CoreError::InvalidTimeDate`] from [`parse_time_date`].
+///
+/// # Panics
+///
+/// Does not panic: every `fields[N]` access below indexes N < 10, and the
+/// `fields.len() < 10` check just above guarantees at least 10 elements.
+pub fn parse_rmc(sentence: &[u8]) -> Result<(Fix, DateTime)> {
+    let body = checksum_body(sentence)?;
+    let fields = split_fields(body);
+    if fields.len() < 10 {
+        return Err(CoreError::TooFewFields {
+            needed: 10,
+            got: fields.len(),
+        });
+    }
+
+    // fields[0] = GPRMC/GNRMC   fields[1] = time
+    // fields[2] = status (A/V) fields[3] = lat   fields[4] = N/S
+    // fields[5] = lon          fields[6] = E/W
+    // fields[7] = speed(kn)    fields[8] = course   fields[9] = date
+
+    if fields[2] != b"A" {
+        return Err(CoreError::NoFix);
+    }
+
+    let position = Position {
+        lat_udeg: parse_lat(fields[3], fields[4])?,
+        lon_udeg: parse_lon(fields[5], fields[6])?,
+    };
+    let fix = Fix {
+        position,
+        quality: FixQuality::Gps,
+        satellite_count: 0,
+        altitude_mm: None,
+    };
+    let time = parse_time_date(fields[1], fields[9])?;
+
+    Ok((fix, time))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ok<T>(r: Result<T>) -> T {
+        match r {
+            Ok(v) => v,
+            Err(e) => unreachable!("expected Ok, got {e:?}"),
+        }
+    }
+
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+
+    /// Build a valid-checksum NMEA sentence "$<body>*<XX>" for tests that
+    /// need to get past `checksum_body` before reaching a deeper branch.
+    fn nmea_sentence(body: &[u8]) -> alloc::vec::Vec<u8> {
+        let checksum = compute_checksum(body);
+        let mut sentence = alloc::vec::Vec::new();
+        sentence.push(b'$');
+        sentence.extend_from_slice(body);
+        sentence.push(b'*');
+        sentence.push(HEX[usize::from(checksum >> 4)]);
+        sentence.push(HEX[usize::from(checksum & 0xF)]);
+        sentence
+    }
+
+    // -- checksum framing --
+
+    #[test]
+    fn checksum_body_accepts_valid_sentence() {
+        let sentence = b"$GPGGA,092750.000,5321.6802,N,00630.3372,W,1,8,1.03,61.7,M,55.2,M,,*76";
+        assert!(
+            checksum_body(sentence).is_ok(),
+            "a valid checksum must be accepted"
+        );
+    }
+
+    #[test]
+    fn checksum_body_rejects_bad_checksum() {
+        let sentence = b"$GPGGA,092750.000,5321.6802,N,00630.3372,W,1,8,1.03,61.7,M,55.2,M,,*FF";
+        assert_eq!(
+            checksum_body(sentence),
+            Err(CoreError::ChecksumMismatch {
+                expected: 0xFF,
+                actual: 0x76
+            }),
+            "a corrupted checksum byte must be rejected with the mismatched values"
+        );
+    }
+
+    #[test]
+    fn checksum_body_rejects_non_hex_digits_as_distinct_from_mismatch() {
+        let sentence = b"$GPGGA,092750.000,5321.6802,N,00630.3372,W,1,8,1.03,61.7,M,55.2,M,,*ZZ";
+        assert_eq!(
+            checksum_body(sentence),
+            Err(CoreError::ChecksumNotHex),
+            "non-hex checksum characters are a distinct failure from a hex checksum that disagreed"
+        );
+    }
+
+    #[test]
+    fn checksum_body_rejects_a_truncated_single_digit_checksum() {
+        // #545: "$00*0" -- body "00" (XOR checksum 0x00), followed by a
+        // checksum field with only ONE hex character. A width-flexible hex
+        // parser (`u8::from_str_radix` on the trailing string, which is
+        // what `topos`'s original parser used) reads "0" as 0x00 and
+        // validates it, silently accepting a sentence whose checksum lost
+        // its leading zero. Exactly two hex digits must be required.
+        let sentence = b"$00*0";
+        assert_eq!(
+            checksum_body(sentence),
+            Err(CoreError::MissingDelimiters),
+            "a checksum field with only one hex digit must be rejected, not \
+             read as a valid one-digit checksum"
+        );
+    }
+
+    #[test]
+    fn checksum_body_requires_dollar_at_byte_zero() {
+        // Leading bytes before `$` must not be silently skipped -- their
+        // presence means the "sentence" was not cleanly framed.
+        let sentence = b"XX$GPGGA,1,2*00";
+        assert_eq!(
+            checksum_body(sentence),
+            Err(CoreError::MissingDelimiters),
+            "a sentence must start with $ at byte 0, not merely contain one"
+        );
+    }
+
+    #[test]
+    fn checksum_body_rejects_empty_body() {
+        let sentence = b"$*76";
+        assert_eq!(
+            checksum_body(sentence),
+            Err(CoreError::MissingDelimiters),
+            "an empty body between $ and * must be rejected"
+        );
+    }
+
+    // -- fix quality: truncating-cast divergence --
+
+    #[test]
+    fn quality_264_is_rejected_not_wrapped_to_a_valid_code() {
+        // #545: the kernel's original `parse_int(...).unwrap_or(0) as u8`
+        // wrapped 264 -> 8 (Simulation, a DEFINED quality) via truncation.
+        // `topos`'s `str::parse::<u8>()` failed outright on "264" and fell
+        // back to 0. Neither wrapping-to-a-valid-code nor "reject the
+        // sentence outright" is quite right for a field this permissive
+        // elsewhere -- the converged behavior treats a field this
+        // malformed as if it were absent (0 -> NoFix), matching `topos`'s
+        // fail-closed direction without hard-failing the whole sentence.
+        assert_eq!(
+            parse_uint_u8_or_zero(b"264"),
+            0,
+            "a quality value that overflows u8 must default to 0, not wrap"
+        );
+        assert_eq!(
+            FixQuality::from(parse_uint_u8_or_zero(b"264")),
+            FixQuality::NoFix,
+            "an overflowing quality field must never resolve to a defined \
+             (accepted) quality code"
+        );
+    }
+
+    #[test]
+    fn quality_9_undefined_code_is_no_fix() {
+        // Values 9+ are reserved/undefined by NMEA 0183. The kernel's
+        // original check was `quality == 0`, which let ANY nonzero byte
+        // (including 9, 50, 200) through as "has a fix". `topos` already
+        // rejected undefined codes via `FixQuality::from`; this converges
+        // the kernel onto that stricter behavior.
+        assert_eq!(
+            FixQuality::from(9),
+            FixQuality::NoFix,
+            "an undefined quality code must not be treated as a valid fix"
+        );
+        assert!(!FixQuality::from(9).has_fix());
+    }
+
+    #[test]
+    fn quality_1_through_8_are_defined_fixes() {
+        for q in 1u8..=8 {
+            assert!(
+                FixQuality::from(q).has_fix(),
+                "quality code {q} is defined by NMEA 0183 and must report has_fix()"
+            );
+        }
+    }
+
+    // -- coordinate bounds --
+
+    #[test]
+    fn parse_lat_rejects_minutes_of_60_or_more() {
+        // "5360.0000" is 53 degrees, 60.0 minutes -- impossible NMEA. The
+        // f64 parser `topos` used before convergence had no such check and
+        // would have silently computed 53 + 60.0/60.0 = 54.0 degrees, a
+        // plausible-looking but wrong coordinate.
+        assert_eq!(
+            parse_lat(b"5360.0000", b"N"),
+            Err(CoreError::MinutesOutOfRange),
+            "minutes >= 60 must be rejected, not silently carried into the next degree"
+        );
+    }
+
+    #[test]
+    fn parse_lat_accepts_minutes_just_under_60() {
+        assert!(
+            parse_lat(b"5359.9999", b"N").is_ok(),
+            "minutes just under 60 must be accepted"
+        );
+    }
+
+    #[test]
+    fn parse_lat_rejects_out_of_bounds_latitude() {
+        // 95 degrees north does not exist. Neither implementation checked
+        // this before convergence.
+        assert_eq!(
+            parse_lat(b"9500.0000", b"N"),
+            Err(CoreError::LatitudeOutOfBounds),
+            "a latitude magnitude exceeding 90 degrees must be rejected"
+        );
+    }
+
+    #[test]
+    fn parse_lat_accepts_exactly_90_degrees() {
+        assert!(
+            parse_lat(b"9000.0000", b"N").is_ok(),
+            "exactly 90 degrees (the pole) is a valid boundary value"
+        );
+    }
+
+    #[test]
+    fn parse_lon_rejects_out_of_bounds_longitude() {
+        assert_eq!(
+            parse_lon(b"20000.0000", b"E"),
+            Err(CoreError::LongitudeOutOfBounds),
+            "a longitude magnitude exceeding 180 degrees must be rejected"
+        );
+    }
+
+    #[test]
+    fn parse_lat_rejects_excessive_fractional_digit_count() {
+        let value = b"5321.00000000000000000000000"; // 23 fractional digits
+        assert_eq!(
+            parse_lat(value, b"N"),
+            Err(CoreError::FractionalDigitsExceeded),
+            "23+ fractional digits must error instead of overflowing 10i64.pow"
+        );
+    }
+
+    #[test]
+    fn parse_lat_converts_hemisphere_sign() {
+        let north = ok(parse_lat(b"3348.5410", b"N"));
+        let south = ok(parse_lat(b"3348.5410", b"S"));
+        assert!(north > 0, "N must be positive");
+        assert_eq!(south, -north, "S must be the exact negation of N");
+    }
+
+    // -- altitude: sign handling --
+
+    #[test]
+    fn parse_altitude_mm_handles_negative_altitude() {
+        // Death Valley is about -86 m. The kernel's original digit-only
+        // integer parser had no sign handling and silently fell through to
+        // the generic malformed-field default; `topos`'s f64 parser
+        // handled the sign correctly.
+        assert_eq!(
+            parse_altitude_mm(b"-86.0"),
+            Some(-86_000),
+            "a negative altitude must parse to a negative millimeter value, \
+             not fall back to the malformed-field default"
+        );
+    }
+
+    #[test]
+    fn parse_altitude_mm_positive_and_absent() {
+        assert_eq!(parse_altitude_mm(b"61.7"), Some(61_700));
+        assert_eq!(
+            parse_altitude_mm(b""),
+            None,
+            "an empty altitude field must be None (unknown), not Some(0)"
+        );
+    }
+
+    #[test]
+    fn parse_fixed_point_rejects_excessive_fractional_digits() {
+        // The same unbounded-exponent guard applied to coordinates must
+        // also apply here -- it previously did not (#545): the kernel's
+        // altitude parser had no equivalent bound.
+        let garbage = b"1.000000000000000000000"; // > 18 fractional digits
+        assert_eq!(
+            parse_fixed_point(garbage, 3),
+            Err(CoreError::FractionalDigitsExceeded),
+            "an implausibly long fractional part must error, not risk an \
+             overflowing pow() in the scale computation"
+        );
+    }
+
+    // -- GGA --
+
+    #[test]
+    fn parse_gga_extracts_position_quality_and_satellites() {
+        let sentence = b"$GPGGA,092750.000,5321.6802,N,00630.3372,W,1,8,1.03,61.7,M,55.2,M,,*76";
+        let fix = ok(parse_gga(sentence));
+        assert_eq!(
+            fix.quality,
+            FixQuality::Gps,
+            "fix quality must be GPS for quality indicator 1"
+        );
+        assert_eq!(fix.satellite_count, 8, "satellite count must match field 7");
+        assert!(
+            (fix.position.lat_udeg - 53_361_336).abs() < 100,
+            "latitude must be ~53361336 microdegrees, got {}",
+            fix.position.lat_udeg
+        );
+        assert!(
+            fix.position.lon_udeg < 0,
+            "longitude must be negative for West"
+        );
+        assert_eq!(
+            fix.altitude_mm,
+            Some(61_700),
+            "altitude must parse to 61700 mm"
+        );
+    }
+
+    #[test]
+    fn parse_gga_returns_no_fix_on_quality_zero() {
+        let sentence = nmea_sentence(b"GPGGA,092750.000,,,,,,0,0,,,,,,,");
+        assert_eq!(
+            parse_gga(&sentence),
+            Err(CoreError::NoFix),
+            "GGA with fix quality 0 must return NoFix"
+        );
+    }
+
+    #[test]
+    fn parse_gga_rejects_fewer_than_ten_fields() {
+        let sentence = nmea_sentence(b"GPGGA,1,2,3");
+        assert_eq!(
+            parse_gga(&sentence),
+            Err(CoreError::TooFewFields { needed: 10, got: 4 }),
+            "a GGA sentence with fewer than 10 fields must be rejected"
+        );
+    }
+
+    // -- RMC --
+
+    #[test]
+    fn parse_rmc_extracts_position_and_time() {
+        let sentence = b"$GPRMC,092750.000,A,5321.6802,N,00630.3372,W,0.02,31.66,280511,,,A*43";
+        let (fix, time) = ok(parse_rmc(sentence));
+        assert_eq!(fix.quality, FixQuality::Gps);
+        assert_eq!(
+            time,
+            DateTime {
+                year: 2011,
+                month: 5,
+                day: 28,
+                hour: 9,
+                minute: 27,
+                second: 50,
+            },
+            "RMC time/date fields must be extracted -- a capability the \
+             workspace side never had before convergence (#545)"
+        );
+    }
+
+    #[test]
+    fn parse_rmc_void_status_returns_no_fix() {
+        let sentence =
+            nmea_sentence(b"GPRMC,092750.000,V,5321.6802,N,00630.3372,W,0.02,31.66,280511,,,A");
+        assert_eq!(
+            parse_rmc(&sentence),
+            Err(CoreError::NoFix),
+            "RMC status 'V' (void) must return NoFix even though every \
+             other field is well-formed"
+        );
+    }
+
+    #[test]
+    fn parse_rmc_rejects_fewer_than_ten_fields() {
+        let sentence = nmea_sentence(b"GPRMC,1,A,2");
+        assert_eq!(
+            parse_rmc(&sentence),
+            Err(CoreError::TooFewFields { needed: 10, got: 4 }),
+        );
+    }
+
+    // -- time/date bounds --
+
+    #[test]
+    fn parse_time_date_rejects_impossible_hour() {
+        // Neither implementation validated this before convergence.
+        // clock.rs treats GPS as its highest-trust automatic clock source.
+        assert_eq!(
+            parse_time_date(b"992750", b"280511"),
+            Err(CoreError::InvalidTimeDate),
+            "an hour of 99 must be rejected before it can reach a trusted clock"
+        );
+    }
+
+    #[test]
+    fn parse_time_date_rejects_impossible_month() {
+        assert_eq!(
+            parse_time_date(b"092750", b"289911"),
+            Err(CoreError::InvalidTimeDate),
+            "a month of 99 must be rejected"
+        );
+    }
+
+    #[test]
+    fn parse_time_date_applies_1900_century_for_year_70_and_above() {
+        let dt = ok(parse_time_date(b"092750", b"280599"));
+        assert_eq!(
+            dt,
+            DateTime {
+                year: 1999,
+                month: 5,
+                day: 28,
+                hour: 9,
+                minute: 27,
+                second: 50,
+            },
+            "year_short=99 must map to 1999, not 2099"
+        );
+    }
+}

--- a/crates/topos/Cargo.toml
+++ b/crates/topos/Cargo.toml
@@ -8,6 +8,7 @@ publish.workspace = true
 repository.workspace = true
 
 [dependencies]
+topos-core = { path = "../topos-core" }
 nom = { workspace = true }
 jiff = { workspace = true }
 snafu = { workspace = true }

--- a/crates/topos/src/error.rs
+++ b/crates/topos/src/error.rs
@@ -3,7 +3,7 @@
 use snafu::Snafu;
 
 /// Errors from GPS operations.
-#[derive(Debug, Snafu)]
+#[derive(Debug, PartialEq, Snafu)]
 #[non_exhaustive]
 pub(crate) enum Error {
     /// NMEA sentence failed checksum validation.
@@ -29,6 +29,56 @@ pub(crate) enum Error {
     /// No fix available.
     #[snafu(display("no GPS fix"))]
     NoFix,
+}
+
+impl From<topos_core::CoreError> for Error {
+    fn from(e: topos_core::CoreError) -> Self {
+        use topos_core::CoreError as C;
+        match e {
+            C::NoFix => Self::NoFix,
+            C::ChecksumMismatch { expected, actual } => Self::ChecksumMismatch { expected, actual },
+            C::MissingDelimiters => Self::Parse {
+                message: "missing $ prefix or * checksum delimiter".to_owned(),
+            },
+            C::ChecksumNotHex => Self::Parse {
+                message: "checksum is not two hex digits".to_owned(),
+            },
+            C::TooFewFields { needed, got } => Self::Parse {
+                message: format!("sentence needs {needed}+ fields, got {got}"),
+            },
+            C::CoordinateTooShort => Self::Parse {
+                message: "coordinate field is shorter than the format requires".to_owned(),
+            },
+            C::FieldNotDigits => Self::Parse {
+                message: "field contains a non-digit character where a digit was required"
+                    .to_owned(),
+            },
+            C::MinutesOutOfRange => Self::Parse {
+                message: "NMEA minutes must be less than 60".to_owned(),
+            },
+            C::FractionalDigitsExceeded => Self::Parse {
+                message: "fractional digit count exceeds the supported range".to_owned(),
+            },
+            C::MagnitudeOverflow => Self::Parse {
+                message: "parsed magnitude overflowed the fixed-point range".to_owned(),
+            },
+            C::LatitudeOutOfBounds => Self::Parse {
+                message: "latitude outside +/-90 degrees".to_owned(),
+            },
+            C::LongitudeOutOfBounds => Self::Parse {
+                message: "longitude outside +/-180 degrees".to_owned(),
+            },
+            C::InvalidTimeDate => Self::Parse {
+                message: "time or date field is malformed or out of range".to_owned(),
+            },
+            // WHY a catch-all: CoreError is `#[non_exhaustive]`; an
+            // unrecognised parse failure becoming Error::Parse rejects the
+            // sentence, which is the fail-closed direction.
+            _ => Self::Parse {
+                message: "unrecognised NMEA parse failure".to_owned(),
+            },
+        }
+    }
 }
 
 /// Result type for GPS operations.

--- a/crates/topos/src/lib.rs
+++ b/crates/topos/src/lib.rs
@@ -6,8 +6,11 @@
 #![allow(unfulfilled_lint_expectations)]
 //! GPS driver and position service for the MT6739 combo chip.
 //!
-//! `NMEA` sentence parsing, coordinate logging, geofence evaluation,
-//! track recording. GPS data arrives via `CCCI` channel or UART.
+//! `NMEA` sentence parsing (GGA fix data, RMC recommended minimum),
+//! coordinate logging, geofence evaluation, track recording. GPS data
+//! arrives via `CCCI` channel or UART. The checksum, coordinate, and
+//! fix-quality invariants are canonical in `topos_core`, shared with the
+//! kernel's GPS driver (#545).
 
 pub mod error;
 pub mod nmea;

--- a/crates/topos/src/nmea.rs
+++ b/crates/topos/src/nmea.rs
@@ -1,111 +1,42 @@
 //! NMEA 0183 sentence parser.
 //!
-//! Parses standard GPS sentences: GGA (fix data), RMC (recommended minimum),
-//! GSA (DOP and active satellites), GSV (satellites in view).
+//! Parses the sentence types this crate has an implementation for: GGA
+//! (fix data) and RMC (recommended minimum). Checksum framing, coordinate
+//! conversion, fix-quality classification, and the GGA/RMC field layout are
+//! canonical in [`topos_core`] (#545), shared with the kernel's GPS driver.
 
-use crate::error::{self, Error};
-use crate::position::{Fix, FixQuality, Position};
+use crate::error;
+use crate::position::{Fix, Position};
 
-/// Validate NMEA checksum and return the sentence body (between '$' and '*').
+/// Extract field `index` from a checksummed sentence.
 ///
-/// Callers can use the returned `&str` to avoid re-parsing the sentence boundary.
-pub(crate) fn validate_checksum(sentence: &str) -> Result<&str, Error> {
-    let inner = sentence
-        .strip_prefix('$')
-        .and_then(|s| s.split('*').next())
-        .ok_or_else(|| Error::Parse {
-            message: "missing $ prefix or * checksum delimiter".to_owned(),
-        })?;
-
-    let expected_str = sentence
-        .split('*')
-        .nth(1)
-        .map(str::trim)
-        .ok_or_else(|| Error::Parse {
-            message: "missing checksum after *".to_owned(),
-        })?;
-
-    let expected = u8::from_str_radix(expected_str, 16).map_err(|_| Error::Parse {
-        message: format!("invalid checksum hex: {expected_str}"),
-    })?;
-
-    let actual = inner.bytes().fold(0u8, |acc, b| acc ^ b);
-
-    if actual == expected {
-        Ok(inner)
-    } else {
-        Err(Error::ChecksumMismatch { expected, actual })
-    }
-}
-
-/// Compute NMEA checksum for a sentence body (without $ and *).
-pub(crate) fn compute_checksum(body: &str) -> u8 {
-    body.bytes().fold(0u8, |acc, b| acc ^ b)
+/// HDOP, speed, and course carry no NMEA-specific parsing beyond
+/// `str::parse` -- there is no protocol invariant here worth sharing with
+/// the kernel, which does not read any of the three. WHY re-tokenizing
+/// rather than threading these out of [`topos_core::parse_gga`] /
+/// [`topos_core::parse_rmc`]: those functions return the position/fix
+/// invariants both consumers care about; bolting three kernel-unused
+/// floats onto that shared type would widen the surface the kernel has to
+/// ignore for no shared benefit.
+fn field(sentence: &str, index: usize) -> Option<&str> {
+    let body = topos_core::checksum_body(sentence.as_bytes()).ok()?;
+    let raw = topos_core::split_fields(body).get(index).copied()?;
+    std::str::from_utf8(raw).ok()
 }
 
 /// Parse a GGA sentence (Global Positioning System Fix Data).
 ///
 /// Format: `$GPGGA,hhmmss.ss,llll.ll,a,yyyyy.yy,a,x,xx,x.x,x.x,M,x.x,M,x.x,xxxx*hh`
 pub(crate) fn parse_gga(sentence: &str) -> error::Result<Fix> {
-    validate_checksum(sentence)?;
-
-    let body = sentence
-        .strip_prefix('$')
-        .and_then(|s| s.split('*').next())
-        .ok_or_else(|| Error::Parse {
-            message: "invalid GGA sentence".to_owned(),
-        })?;
-
-    let fields: Vec<&str> = body.split(',').collect();
-    if fields.len() < 10 {
-        return Err(Error::Parse {
-            message: format!("GGA needs 10+ fields, got {}", fields.len()),
-        });
-    }
-
-    // fields[0] = GPGGA/GNGGA
-    // fields[1] = time (hhmmss.ss)
-    // fields[2] = lat, fields[3] = N/S
-    // fields[4] = lon, fields[5] = E/W
-    // fields[6] = fix quality
-    // fields[7] = num satellites
-    // fields[8] = HDOP
-    // fields[9] = altitude, fields[10] = M
-
-    let quality_val: u8 = fields
-        .get(6)
-        .copied()
-        .unwrap_or_default()
-        .parse()
-        .unwrap_or(0);
-    let quality = FixQuality::from(quality_val);
-
-    if quality == FixQuality::NoFix || fields.get(2).copied().unwrap_or_default().is_empty() {
-        return Err(Error::NoFix);
-    }
-
-    let lat = parse_lat_field(
-        fields.get(2).copied().unwrap_or_default(),
-        fields.get(3).copied().unwrap_or_default(),
-    )?;
-    let lon = parse_lon_field(
-        fields.get(4).copied().unwrap_or_default(),
-        fields.get(5).copied().unwrap_or_default(),
-    )?;
-    let alt = fields.get(9).and_then(|s| s.parse::<f64>().ok());
-    let satellites: u8 = fields
-        .get(7)
-        .copied()
-        .unwrap_or_default()
-        .parse()
-        .unwrap_or(0);
-    let hdop = fields.get(8).and_then(|s| s.parse::<f64>().ok());
+    let core_fix = topos_core::parse_gga(sentence.as_bytes())?;
+    let mut position = Position::from(core_fix.position);
+    position.alt = core_fix.altitude_mm.map(|mm| f64::from(mm) / 1000.0);
 
     Ok(Fix {
-        position: Position { lat, lon, alt },
-        quality,
-        satellites,
-        hdop,
+        position,
+        quality: core_fix.quality,
+        satellites: core_fix.satellite_count,
+        hdop: field(sentence, 8).and_then(|s| s.parse::<f64>().ok()),
         speed_knots: None,
         course: None,
     })
@@ -114,141 +45,35 @@ pub(crate) fn parse_gga(sentence: &str) -> error::Result<Fix> {
 /// Parse a RMC sentence (Recommended Minimum Navigation Information).
 ///
 /// Format: `$GPRMC,hhmmss.ss,A,llll.ll,a,yyyyy.yy,a,x.x,x.x,ddmmyy,x.x,a*hh`
-pub(crate) fn parse_rmc(sentence: &str) -> error::Result<Fix> {
-    validate_checksum(sentence)?;
+///
+/// Returns the fix alongside the extracted UTC date/time -- a capability
+/// this crate did not have before #545 converged it with the kernel's GPS
+/// driver, which uses RMC time for clock synchronization.
+pub(crate) fn parse_rmc(sentence: &str) -> error::Result<(Fix, topos_core::DateTime)> {
+    let (core_fix, time) = topos_core::parse_rmc(sentence.as_bytes())?;
 
-    let body = sentence
-        .strip_prefix('$')
-        .and_then(|s| s.split('*').next())
-        .ok_or_else(|| Error::Parse {
-            message: "invalid RMC sentence".to_owned(),
-        })?;
-
-    let fields: Vec<&str> = body.split(',').collect();
-    if fields.len() < 10 {
-        return Err(Error::Parse {
-            message: format!("RMC needs 10+ fields, got {}", fields.len()),
-        });
-    }
-
-    // fields[0] = GPRMC/GNRMC
-    // fields[1] = time
-    // fields[2] = status (A=active, V=void)
-    // fields[3] = lat, fields[4] = N/S
-    // fields[5] = lon, fields[6] = E/W
-    // fields[7] = speed (knots)
-    // fields[8] = course (degrees true)
-    // fields[9] = date (ddmmyy)
-
-    if fields.get(2).copied().unwrap_or_default() != "A" {
-        return Err(Error::NoFix);
-    }
-
-    let lat = parse_lat_field(
-        fields.get(3).copied().unwrap_or_default(),
-        fields.get(4).copied().unwrap_or_default(),
-    )?;
-    let lon = parse_lon_field(
-        fields.get(5).copied().unwrap_or_default(),
-        fields.get(6).copied().unwrap_or_default(),
-    )?;
-    let speed_knots = fields.get(7).and_then(|s| s.parse::<f64>().ok());
-    let course = fields.get(8).and_then(|s| s.parse::<f64>().ok());
-
-    Ok(Fix {
-        position: Position {
-            lat,
-            lon,
-            alt: None,
-        },
-        quality: FixQuality::Gps,
-        satellites: 0,
+    let fix = Fix {
+        position: Position::from(core_fix.position),
+        quality: core_fix.quality,
+        satellites: core_fix.satellite_count,
         hdop: None,
-        speed_knots,
-        course,
-    })
-}
-
-/// Parse latitude FROM split fields (value, hemisphere).
-fn parse_lat_field(value: &str, hemisphere: &str) -> error::Result<f64> {
-    // WHY: NMEA fields are wire-ASCII; a non-ASCII field means the fixed
-    // byte offsets below could land inside a multi-byte UTF-8 sequence and
-    // panic on a &str byte-range slice. Reject non-ASCII input up front so
-    // every subsequent slice index is guaranteed to be a char boundary.
-    if value.len() < 4 || !value.is_ascii() {
-        return Err(Error::Parse {
-            message: format!("invalid latitude field: {value}"),
-        });
-    }
-    let degrees: f64 = value[..2].parse().map_err(|_| Error::Parse {
-        message: format!("invalid latitude degrees: {value}"),
-    })?;
-    let minutes: f64 = value[2..].parse().map_err(|_| Error::Parse {
-        message: format!("invalid latitude minutes: {value}"),
-    })?;
-    let mut lat = degrees + minutes / 60.0;
-    if hemisphere == "S" {
-        lat = -lat;
-    }
-    Ok(lat)
-}
-
-/// Parse longitude FROM split fields (value, hemisphere).
-fn parse_lon_field(value: &str, hemisphere: &str) -> error::Result<f64> {
-    // WHY: NMEA fields are wire-ASCII; a non-ASCII field means the fixed
-    // byte offsets below could land inside a multi-byte UTF-8 sequence and
-    // panic on a &str byte-range slice. Reject non-ASCII input up front so
-    // every subsequent slice index is guaranteed to be a char boundary.
-    if value.len() < 5 || !value.is_ascii() {
-        return Err(Error::Parse {
-            message: format!("invalid longitude field: {value}"),
-        });
-    }
-    let degrees: f64 = value[..3].parse().map_err(|_| Error::Parse {
-        message: format!("invalid longitude degrees: {value}"),
-    })?;
-    let minutes: f64 = value[3..].parse().map_err(|_| Error::Parse {
-        message: format!("invalid longitude minutes: {value}"),
-    })?;
-    let mut lon = degrees + minutes / 60.0;
-    if hemisphere == "W" {
-        lon = -lon;
-    }
-    Ok(lon)
+        speed_knots: field(sentence, 7).and_then(|s| s.parse::<f64>().ok()),
+        course: field(sentence, 8).and_then(|s| s.parse::<f64>().ok()),
+    };
+    Ok((fix, time))
 }
 
 #[cfg(test)]
 #[expect(clippy::expect_used, reason = "test assertions")]
 mod tests {
     use super::*;
+    use crate::error::Error;
     use crate::position::FixQuality;
 
-    #[test]
-    fn validate_checksum_accepts_valid_sentence() {
-        let sentence = "$GPGGA,092750.000,5321.6802,N,00630.3372,W,1,8,1.03,61.7,M,55.2,M,,*76";
-        assert!(
-            validate_checksum(sentence).is_ok(),
-            "valid GGA checksum must be accepted"
-        );
-    }
-
-    #[test]
-    fn validate_checksum_rejects_bad_checksum() {
-        let sentence = "$GPGGA,092750.000,5321.6802,N,00630.3372,W,1,8,1.03,61.7,M,55.2,M,,*FF";
-        assert!(
-            validate_checksum(sentence).is_err(),
-            "corrupted checksum byte must be rejected"
-        );
-    }
-
-    #[test]
-    fn compute_checksum_produces_correct_value_for_gga() {
-        let body = "GPGGA,092750.000,5321.6802,N,00630.3372,W,1,8,1.03,61.7,M,55.2,M,,";
-        assert_eq!(
-            compute_checksum(body),
-            0x76,
-            "XOR checksum of known GGA body must be 0x76"
-        );
+    /// Build a valid-checksum NMEA sentence "$<body>*<XX>" for tests.
+    fn nmea_sentence(body: &str) -> String {
+        let checksum = topos_core::compute_checksum(body.as_bytes());
+        format!("${body}*{checksum:02X}")
     }
 
     #[test]
@@ -261,7 +86,7 @@ mod tests {
             "fix quality must be GPS for quality indicator 1"
         );
         assert_eq!(fix.satellites, 8, "satellite count must match GGA field 7");
-        // 53 degrees 21.6802 minutes N = 53.36133... degrees
+        // 53 degrees 21.6802 minutes N = 53.36134... degrees
         assert!(
             (fix.position.lat - 53.36134).abs() < 0.001,
             "latitude must parse to ~53.361 decimal degrees"
@@ -275,22 +100,33 @@ mod tests {
             (fix.position.alt.unwrap_or_default() - 61.7).abs() < 0.1,
             "altitude must parse to ~61.7 m"
         );
+        assert!(
+            (fix.hdop.unwrap_or_default() - 1.03).abs() < 0.001,
+            "HDOP must parse to ~1.03"
+        );
     }
 
     #[test]
     fn parse_gga_returns_error_when_no_fix() {
-        let sentence = "$GPGGA,092750.000,,,,,,0,0,,,,,,,*47";
-        assert!(
-            parse_gga(sentence).is_err(),
-            "GGA with fix quality 0 must return an error"
+        // WHY the computed-checksum helper rather than a literal: the
+        // fixture this replaced hardcoded "*47" for this exact body text,
+        // whose real XOR checksum is 0x6D. The test still passed, but for
+        // the wrong reason -- it exercised the checksum-mismatch path, not
+        // the quality-zero path it claimed to cover. Found while comparing
+        // this fixture against the kernel's equivalent, which used the
+        // correct checksum (#545).
+        let sentence = nmea_sentence("GPGGA,092750.000,,,,,,0,0,,,,,,,");
+        assert_eq!(
+            parse_gga(&sentence),
+            Err(Error::NoFix),
+            "GGA with fix quality 0 must return Error::NoFix specifically, \
+             not merely any error"
         );
     }
 
     #[test]
     fn parse_gga_returns_error_when_too_few_fields() {
-        let body = "GPGGA,092750.000,5321.6802,N";
-        let checksum = compute_checksum(body);
-        let sentence = format!("${body}*{checksum:02X}");
+        let sentence = nmea_sentence("GPGGA,092750.000,5321.6802,N");
         let result = parse_gga(&sentence);
         assert!(
             matches!(result, Err(Error::Parse { .. })),
@@ -301,7 +137,7 @@ mod tests {
     #[test]
     fn parse_rmc_extracts_position_speed_and_course() {
         let sentence = "$GPRMC,092750.000,A,5321.6802,N,00630.3372,W,0.02,31.66,280511,,,A*43";
-        let fix = parse_rmc(sentence).expect("valid RMC sentence should parse");
+        let (fix, _time) = parse_rmc(sentence).expect("valid RMC sentence should parse");
         assert!(
             (fix.position.lat - 53.36134).abs() < 0.001,
             "latitude must parse to ~53.361 decimal degrees"
@@ -317,19 +153,39 @@ mod tests {
     }
 
     #[test]
+    fn parse_rmc_extracts_time() {
+        // Before #545 this crate never extracted RMC time/date at all --
+        // there was nothing here to compare against the kernel's
+        // equivalent. Converging onto the shared core gains the capability.
+        let sentence = "$GPRMC,092750.000,A,5321.6802,N,00630.3372,W,0.02,31.66,280511,,,A*43";
+        let (_fix, time) = parse_rmc(sentence).expect("valid RMC sentence should parse");
+        assert_eq!(
+            time,
+            topos_core::DateTime {
+                year: 2011,
+                month: 5,
+                day: 28,
+                hour: 9,
+                minute: 27,
+                second: 50,
+            },
+            "RMC time/date fields must be extracted, matching the kernel's equivalent"
+        );
+    }
+
+    #[test]
     fn parse_rmc_returns_error_when_status_void() {
-        let sentence = "$GPRMC,092750.000,V,,,,,,,280511,,,N*4C";
-        assert!(
-            parse_rmc(sentence).is_err(),
-            "RMC with status V (void) must return an error"
+        let sentence = nmea_sentence("GPRMC,092750.000,V,5321.6802,N,00630.3372,W,,,280511,,,A");
+        assert_eq!(
+            parse_rmc(&sentence),
+            Err(Error::NoFix),
+            "RMC with status V (void) must return Error::NoFix"
         );
     }
 
     #[test]
     fn parse_rmc_returns_error_when_too_few_fields() {
-        let body = "GPRMC,092750.000,A,5321.6802,N";
-        let checksum = compute_checksum(body);
-        let sentence = format!("${body}*{checksum:02X}");
+        let sentence = nmea_sentence("GPRMC,092750.000,A,5321.6802,N");
         let result = parse_rmc(&sentence);
         assert!(
             matches!(result, Err(Error::Parse { .. })),
@@ -337,73 +193,14 @@ mod tests {
         );
     }
 
-    #[test]
-    fn parse_lat_field_converts_north_to_positive_decimal_degrees() {
-        let lat = parse_lat_field("5321.6802", "N").unwrap_or_default();
-        assert!(
-            (lat - 53.36134).abs() < 0.001,
-            "North latitude must convert to positive decimal degrees"
-        );
-    }
-
-    #[test]
-    fn parse_lat_field_converts_south_to_negative_decimal_degrees() {
-        let lat = parse_lat_field("3348.5410", "S").unwrap_or_default();
-        assert!(lat < 0.0, "South hemisphere must produce negative latitude");
-        assert!(
-            (lat - (-33.80902)).abs() < 0.001,
-            "South latitude must convert correctly to negative decimal degrees"
-        );
-    }
-
-    #[test]
-    fn parse_lon_field_converts_west_to_negative_decimal_degrees() {
-        let lon = parse_lon_field("00630.3372", "W").unwrap_or_default();
-        assert!(lon < 0.0, "West hemisphere must produce negative longitude");
-    }
-
-    #[test]
-    fn parse_lon_field_converts_east_to_positive_decimal_degrees() {
-        let lon = parse_lon_field("15145.3478", "E").unwrap_or_default();
-        assert!(lon > 0.0, "East hemisphere must produce positive longitude");
-        assert!(
-            (lon - 151.75580).abs() < 0.001,
-            "East longitude must convert correctly to decimal degrees"
-        );
-    }
-
-    #[test]
-    fn parse_lat_field_rejects_non_ascii_instead_of_panicking() {
-        let result = parse_lat_field("\u{4e00}21.6802", "N");
-        assert!(
-            matches!(result, Err(Error::Parse { .. })),
-            "non-ASCII latitude field must return Error::Parse, not panic"
-        );
-    }
-
-    #[test]
-    fn parse_lon_field_rejects_non_ascii_instead_of_panicking() {
-        let result = parse_lon_field("\u{4e00}030.3372", "E");
-        assert!(
-            matches!(result, Err(Error::Parse { .. })),
-            "non-ASCII longitude field must return Error::Parse, not panic"
-        );
-    }
-
-    #[test]
-    fn parse_gga_never_panics_on_valid_checksum_non_ascii_coordinate() {
-        let body = "GPGGA,092750.000,\u{4e00}21.6802,N,00630.3372,W,1,8,1.03,61.7,M,55.2,M,,";
-        let checksum = compute_checksum(body);
-        let sentence = format!("${body}*{checksum:02X}");
-        let result = parse_gga(&sentence);
-        assert!(
-            matches!(result, Err(Error::Parse { .. })),
-            "a valid-checksum sentence with a non-ASCII latitude field must error, not panic"
-        );
-    }
-
-    // -- Proptest: fuzz the NMEA parser to verify no panics on arbitrary input --
-
+    // -- Proptest: fuzz the parser to verify no panics on arbitrary input --
+    //
+    // Byte-oriented parsing in topos_core removes the char-boundary panic
+    // risk that motivated the old ASCII-only guards in this crate's
+    // str-slicing parser (a non-ASCII coordinate field could land a `&str`
+    // byte-range slice inside a multi-byte sequence). These properties
+    // confirm arbitrary Unicode input -- not just arbitrary ASCII -- still
+    // never panics through the delegating wrapper.
     mod proptest_fuzz {
         use proptest::prelude::*;
 
@@ -412,7 +209,6 @@ mod tests {
         proptest! {
             #[test]
             fn parse_gga_never_panics(data in "\\PC{0,200}") {
-                // Arbitrary strings must never cause a panic — only Ok or Err.
                 let result = parse_gga(&data);
                 prop_assert!(result.is_ok() || result.is_err());
             }
@@ -424,8 +220,8 @@ mod tests {
             }
 
             #[test]
-            fn validate_checksum_never_panics(data in "\\PC{0,200}") {
-                let result = validate_checksum(&data);
+            fn checksum_body_never_panics(data in "\\PC{0,200}") {
+                let result = topos_core::checksum_body(data.as_bytes());
                 prop_assert!(result.is_ok() || result.is_err());
             }
 
@@ -435,8 +231,7 @@ mod tests {
                 // before reaching the slice, so they never exercise a
                 // valid-checksum sentence with a multi-byte coordinate field.
                 let body = format!("GPGGA,092750.000,{c}21.6802,N,00630.3372,W,1,8,1.03,61.7,M,55.2,M,,");
-                let checksum = compute_checksum(&body);
-                let sentence = format!("${body}*{checksum:02X}");
+                let sentence = nmea_sentence(&body);
                 let result = parse_gga(&sentence);
                 prop_assert!(result.is_ok() || result.is_err());
             }

--- a/crates/topos/src/position.rs
+++ b/crates/topos/src/position.rs
@@ -1,5 +1,7 @@
 //! Geographic position types.
 
+pub(crate) use topos_core::FixQuality;
+
 /// A geographic coordinate with latitude, longitude, and optional altitude.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) struct Position {
@@ -11,42 +13,21 @@ pub(crate) struct Position {
     pub(crate) alt: Option<f64>,
 }
 
-/// GPS fix quality indicator.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
-pub(crate) enum FixQuality {
-    /// No fix.
-    NoFix,
-    /// Standard GPS fix.
-    Gps,
-    /// Differential GPS fix.
-    Dgps,
-    /// PPS fix.
-    Pps,
-    /// Real-Time Kinematic.
-    Rtk,
-    /// Float RTK.
-    FloatRtk,
-    /// Estimated (dead reckoning).
-    Estimated,
-    /// Manual input mode.
-    Manual,
-    /// Simulation mode.
-    Simulation,
-}
-
-impl From<u8> for FixQuality {
-    fn from(val: u8) -> Self {
-        match val {
-            1 => Self::Gps,
-            2 => Self::Dgps,
-            3 => Self::Pps,
-            4 => Self::Rtk,
-            5 => Self::FloatRtk,
-            6 => Self::Estimated,
-            7 => Self::Manual,
-            8 => Self::Simulation,
-            _ => Self::NoFix,
+impl From<topos_core::Position> for Position {
+    // WHY: topos_core::Position stores microdegrees as i64 (bounded to
+    // +/-180 * 1_000_000 by topos_core's own range checks -- nowhere near
+    // f64's 53-bit exact-integer range), so the i64 -> f64 widening below
+    // never loses precision in practice; `cast_precision_loss` cannot see
+    // that value-range invariant, only the types.
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "microdegrees are bounded to +/-180_000_000, far inside f64's exact range"
+    )]
+    fn from(p: topos_core::Position) -> Self {
+        Self {
+            lat: p.lat_udeg as f64 / topos_core::MICRODEG_SCALE as f64,
+            lon: p.lon_udeg as f64 / topos_core::MICRODEG_SCALE as f64,
+            alt: None,
         }
     }
 }

--- a/docs/convergence.toml
+++ b/docs/convergence.toml
@@ -37,12 +37,12 @@ notes = "The kernel boot reader reports confirmed presses only (no queue, no rel
 
 [[pair]]
 name = "gps"
-kernel = "gps.rs (ported from topos)"
+kernel = "gps.rs (checksum framing, coordinate/fix-quality, GGA/RMC parsing converged)"
 workspace = "topos"
-disposition = "extract-core"
-canonical = "pending: topos-core (coordinate/geo types + parse) when the GPS NMEA path lands (#129 family)"
-owner = "unscheduled"
-notes = "gps.rs:3 doc header records the port. Not user-facing until the combo-chip GPS path lands."
+disposition = "converged"
+canonical = "topos-core (no_std+alloc; kernel links via path dep, topos re-exports FixQuality and converts Position/Fix)"
+owner = "#545 (this PR)"
+notes = "Converged: $...*XX checksum framing, ddmm.mmmm coordinate conversion, FixQuality, and full GGA/RMC sentence parsing. Five divergences found and resolved on the way -- (1) topos's checksum parser accepted a checksum field with only one hex digit (a width-flexible hex reader validated a truncated sentence missing its leading zero); the kernel required exactly two and topos now does too. (2) the kernel widened a parsed GGA quality byte via a truncating `as u8` cast, so a quality field of 264 wrapped to 8 (a DEFINED code) instead of being rejected; converged onto a saturate-to-default parse. (3) the kernel's fixed-point coordinate parser rejected minutes >= 60 and guarded an unbounded fractional-digit exponent; topos's f64 parser did neither -- both now share the guarded parser. (4) neither side bounded latitude to +/-90 or longitude to +/-180; both now do. (5) the kernel's altitude parser had no sign handling and silently swallowed a legitimate below-sea-level reading; topos's f64 parser handled it correctly and the kernel now does too. Also found: topos's RMC parser never extracted time/date at all (no prior implementation to compare against; both sides now share it, with range validation on hour/minute/second/month/day that neither side had, since clock.rs treats GPS as its highest-trust automatic time source); and topos's own `parse_gga_returns_error_when_no_fix` test carried a hardcoded checksum that did not match its body text, so it passed for the wrong reason (exercising the checksum-mismatch path, not the no-fix path it claimed to cover) -- fixed to compute the checksum. NOT converged: the WMT/CCCI hardware transport (SentenceBuffer, GpsHwOps, GpsHw) and the SentenceBuffer/GpsReceiver lifecycle state machine, which are genuinely kernel-device-specific; topos's own HDOP/speed/course extraction, which is plain `str::parse` with no NMEA-specific invariant worth sharing and which the kernel never reads."
 
 [[pair]]
 name = "wifi"

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -245,7 +245,7 @@ fidelity = "register interaction is not exercised host-side; the PL0 probes cove
 
 [[module]]
 name = "gps"
-tests = 25
+tests = 19
 mechanism = "host"
 
 [[module]]


### PR DESCRIPTION
## Finding

The kernel's `crates/thumos/src/gps.rs` (NMEA parsing, position/fix types, checksum validation) and the workspace `crates/topos` crate (`nmea.rs`, `position.rs`) independently hand-parsed the same GGA/RMC sentences. `gps.rs`'s module doc carried a provenance note recording the port. Both sides compiled and passed their own tests while diverging on how the same NMEA bytes are interpreted.

## Divergences found, with values

**1. Checksum: `topos` accepted a truncated (1-digit) checksum field.**
`crates/topos/src/nmea.rs` (pre-fix) parsed the trailing checksum with `u8::from_str_radix(expected_str, 16)` on a `str` slice of variable width. `crates/thumos/src/gps.rs` (pre-fix) required exactly two characters (`star + 3 > sentence.len()`).
Proof, not assertion: sentence `"$00*0"` — body `"00"`, XOR checksum `0x30 ^ 0x30 = 0x00`. The kernel's rule rejects it (only one hex char after `*`, needs two). The old `topos` parser reads `"0"` via `from_str_radix` → `Ok(0)`, matches the computed `0x00`, and returns `Ok` — validating a sentence whose checksum lost its leading zero in transit. This is exactly the "spoofing/truncation acceptance surface" called out in the brief. Test: `topos_core::tests::checksum_body_rejects_a_truncated_single_digit_checksum` (CI-green).

**2. Fix quality: the kernel's truncating cast accepted an out-of-range value as a defined quality.**
`crates/thumos/src/gps.rs` (pre-fix): `let quality = parse_int(fields[6]).unwrap_or(0) as u8;` then only checked `quality == 0`. `parse_int` parses the full `u32` first (`"264"` → `264u32`, no overflow at that width), then `as u8` truncates `264 % 256 = 8` — **a DEFINED quality code (Simulation)**. `crates/topos/src/nmea.rs` (pre-fix) used `str::parse::<u8>()` directly, which fails outright on `"264"` and falls back to `0` (`unwrap_or(0)`) → correctly `NoFix`. Same field value, opposite outcomes: kernel accepts a bogus 264 as a valid "Simulation" fix; `topos` rejects it. Converged onto a saturate-to-default parse (`topos_core::parse_uint_u8_or_zero`) so an overflowing/undefined code always resolves to `NoFix`. Separately: `topos`'s own `FixQuality::from` already rejected undefined codes 9+ (reserved/future); the kernel's `quality == 0` check let *any* nonzero byte through, including 9, 50, 200 — converged onto `topos`'s stricter rule. Tests: `quality_264_is_rejected_not_wrapped_to_a_valid_code`, `quality_9_undefined_code_is_no_fix`; kernel-level regression: `gps.rs::tests::parse_gga_rejects_undefined_and_overflowing_quality_code` (CI-green).

**3. Coordinate minutes: `topos`'s `f64` parser accepted minutes ≥ 60.**
`crates/thumos/src/gps.rs` (pre-fix) rejected `minutes_scaled >= 600_000` (60.0 minutes). `crates/topos/src/nmea.rs` (pre-fix) computed `degrees + minutes / 60.0` via plain `f64::parse`, with no such check: field `"5360.0000"` (53°, 60.0′ — impossible NMEA) silently produces `53 + 1.0 = 54.0` degrees, a wrong-but-plausible coordinate, not an error. Converged onto the guarded fixed-point parser for both. Test: `parse_lat_rejects_minutes_of_60_or_more` (CI-green).

**4. Latitude/longitude bounds: neither side validated ±90/±180.**
Confirmed by reading both parsers end to end — neither had a bound check. A crafted `"9500.0000,N"` (95° N, nonexistent) parsed "successfully" on both sides before this PR. Added `LatitudeOutOfBounds`/`LongitudeOutOfBounds` to the shared core. Tests: `parse_lat_rejects_out_of_bounds_latitude`, `parse_lat_accepts_exactly_90_degrees` (boundary), `parse_lon_rejects_out_of_bounds_longitude` (CI-green).

**5. Altitude sign: the kernel's integer parser silently dropped negative altitudes.**
`crates/thumos/src/gps.rs`'s `parse_int` (pre-fix) only accepted `is_ascii_digit()` bytes — no `-` handling. A legitimate below-sea-level reading (e.g. Death Valley, `"-86.0"`) fails to parse as an int, so `parse_altitude_mm` returns `None`, and the caller's `.unwrap_or(0)` reports it as `0` mm — **indistinguishable from an actual sea-level reading**, and simply wrong for a real negative value. `crates/topos/src/nmea.rs` used `f64::parse`, which handles `-` correctly. Converged: `topos_core::parse_fixed_point` now handles an optional leading `-`. Also converged the *representation*: `GpsPosition.altitude_mm` is now `Option<i32>` instead of `i32` defaulting to `0`. Test: `parse_altitude_mm_handles_negative_altitude` (asserts `Some(-86_000)`, CI-green).

**Also found, not a kernel/topos divergence but a real gap: RMC time/date was never bounds-checked on either side. This is the finding that matters most.**
`clock.rs` documents GPS as its **highest-trust automatic time source**. Neither implementation validated the parsed hour/minute/second/month/day before treating an RMC sentence as trustworthy — a spoofed or corrupted (but checksum-internally-consistent) sentence with `hour=99` or `month=88` would have been accepted into the clock hierarchy. `topos` never extracted RMC time/date at all (nothing to diverge against). Added range validation (`hour<24`, `minute/second<60`, `month` 1-12, `day` 1-31) in the shared `parse_time_date`, and `topos`'s `parse_rmc` now returns the extracted time too — a capability it never had. Tests: `parse_time_date_rejects_impossible_hour`, `parse_time_date_rejects_impossible_month` — **falsified via CI** (see below).

**Also found: `topos`'s own no-fix regression test had a checksum that didn't match its body.**
`crates/topos/src/nmea.rs`'s `parse_gga_returns_error_when_no_fix` hardcoded checksum `"*47"` for body `"GPGGA,092750.000,,,,,,0,0,,,,,,,"`. The real XOR checksum of that body is `0x6D` (verified independently with Python and matches the kernel's own equivalent fixture, which correctly used `*6D`). The test asserted only `.is_err()`, so it kept "passing" — but it was silently exercising the checksum-mismatch path, not the quality-zero/no-fix path it claimed to cover. Fixed to compute the checksum and to assert the specific `Error::NoFix` variant.

**Checked and found NOT to differ (stated explicitly, not left implicit):** both sides already validated the checksum before this PR (fail-closed on both — no accept-unchecksummed-sentence gap); both already rejected fewer-than-10-field sentences; both already rejected RMC status other than `'A'`; both support only GGA and RMC (nothing implements GSA/GSV/VTG/GLL on either side — `nmea.rs`'s module doc claimed GSA/GSV support it never had; fixed the doc). `split_fields`/`compute_checksum` logic was byte-identical in intent, differing only in `&str`-vs-`&[u8]` spelling — verified semantically, not by superficial diff, per the brief's own caution about the `'£'`/`'\u{00A3}'` false-positive class.

## What converged, and on which side

`topos-core` (`#![no_std]` + `extern crate alloc`) is the new single home of: `$...*XX` checksum framing (`checksum_body`), NMEA field splitting, the guarded fixed-point coordinate parser (`parse_lat`/`parse_lon`, now bounds- and minutes-checked), `parse_fixed_point`/`parse_altitude_mm` (now sign-aware and overflow-guarded), `FixQuality` (moved from `topos`, now the single enum both sides use), and full `parse_gga`/`parse_rmc` sentence parsing including the new `parse_time_date` range validation. Every divergence above converged onto the **stricter/fail-closed** side. Both `crates/topos` and `crates/thumos/src/gps.rs` now consume it by path dependency, and both **import and call it** — `crates/thumos/src/gps.rs`'s `parse_gga`/`parse_rmc` delegate directly to `topos_core::parse_gga`/`topos_core::parse_rmc` (the exact wiring gap that caught PR #661).

`crates/topos/src/error.rs` gained `impl From<topos_core::CoreError> for Error` (same pattern as `crates/klesis/src/error.rs`). `crates/thumos/src/gps.rs`'s `GpsError` gained the same conversion. `GpsPosition.fix_quality` changed from a raw `u8` to `topos_core::FixQuality`; `GpsPosition.altitude_mm` changed from `i32` to `Option<i32>` (see divergence 5). Neither field has any consumer outside `gps.rs` itself (verified by repo-wide grep before changing them).

## What did NOT converge, and why

- The WMT/CCCI hardware transport (`SentenceBuffer`, `GpsHwOps`, `GpsHw`) and the `GpsReceiver` lifecycle state machine — genuinely kernel-device-specific, no workspace equivalent exists or should.
- `topos`'s HDOP/speed/course extraction stays local to `topos::nmea` — it's plain `str::parse::<f64>()` with no NMEA-specific invariant worth sharing, and the kernel's `GpsPosition` never reads any of the three (verified by grep: no external consumer of those fields).
- `topos::Position`/`Fix` keep their own `f64`-based representation (geofencing math wants floats); `GpsPosition` keeps fixed-point microdegrees (the kernel has no FPU enabled) — both now *derive* from the same `topos_core::Position`/`Fix` via `From` impls rather than independently parsing.

## Verification

CI-exact gate, confirmed **fully green** on the landed commit (`8c758eb`):

```
cargo fmt --all --check                                     → pass (rustfmt check)
cargo fmt --manifest-path crates/thumos/Cargo.toml --check   → pass (rustfmt check, kernel crate)
cargo check --workspace --all-targets                        → pass (gate / full-gate-build)
cargo clippy --workspace --all-targets -- -D warnings         → pass (workspace clippy + tests)
cargo nextest run --workspace                                 → pass, 861/861 (workspace clippy + tests)
Kernel host tests (i686)                                      → pass (kernel job)
Target-test ledger check (scripts/check-target-test-ledger.sh) → pass (kernel job) -- confirms the
  hand-derived gps=19 count in docs/target-test-ledger.toml matches cargo nextest list exactly
Board-seam invariant check (scripts/check-board-seam.sh)       → pass (kernel job)
Convergence ratchet check (scripts/check-convergence.sh)       → pass (kernel job)
Kernel cross-compile (armv7a) + zero-warning gate              → pass (kernel job)
Trust-anchor build guard                                       → pass (kernel job)
Kernel QEMU boot + full behavioral matrix (fork/exec/signals/
  fault-halt/PID-0 supervisor/witness-extraction, 10 steps)     → all pass (kernel job)
cargo audit / cargo deny / osv-scanner                          → pass
```

GitHub PR checks against `8c758eb` (the landed commit) -- confirmed green twice: once before the falsification detour, once again after dropping the falsification commit and re-pushing the identical SHA:
- https://github.com/forkwright/thumos/actions/runs/31327799072 (rustfmt, workspace clippy + tests, kernel i686+armv7a -- post-restoration confirmation run)
- https://github.com/forkwright/thumos/actions/runs/31327799318 (gate / full-gate-build, gate / gate -- post-restoration confirmation run)

`scripts/check-doc-inventory.sh` is not wired into GitHub Actions (kanon-native, `.kanon-ci.toml` only) — verified locally, exit 0: `doc inventory: 19 crates (18 workspace + 1 kernel) verified across ARCHITECTURE.md + _llm/architecture.toml, 17 docs/ files verified against MANIFEST.toml`.

Getting to this green took several real iterations, reported honestly rather than smoothed over: this box's `vgate` core budget was saturated for the whole session (another session's stalled build; load hit 49.77 at one point), so the workspace clippy/nextest/kernel builds could not be run locally at all -- a scoped `cargo check -p topos-core` was attempted and killed by its own 2-minute timeout without completing, never admitted rather than failing. Iterating against CI directly caught three classes of mistake a local run would have caught immediately: two `clippy::doc_markdown` / `clippy::manual_range_contains` lints, one `clippy::items_after_statements` (a `const` declared after statements in a test helper, in both `topos-core` and the kernel's mirrored helper), one unused `Error` import in `topos/src/nmea.rs` (used only inside `#[cfg(test)]`, invisible to a plain `cargo build`), and **one genuine test-authoring bug of my own**: `parse_gga_rejects_fewer_than_ten_fields` asserted `got: 3` for body `"GPGGA,1,2,3"`, which actually splits into 4 fields (`GPGGA` counts). All fixed; final state is the CI-confirmed green above.

### Falsification

For each of the five divergences the fix addresses, the fix was reasoned through against a reverted version of the code to confirm the corresponding test would go red:

- **Checksum**: reverting `checksum_body`'s two-hex-digit requirement to accept any parseable width makes `checksum_body_rejects_a_truncated_single_digit_checksum` fail (asserts `Err(MissingDelimiters)`, would observe `Ok(_)`). Not re-run through a live CI cycle (the revert requires restructuring the tail-parsing logic, not a single-line change); the positive case is CI-green and the divergence is proven by the standalone Python XOR computation in the finding above.
- **Quality truncation**: reverting `parse_uint_u8_or_zero` to `parse_uint(bytes).unwrap_or(0) as u8` (the literal pre-convergence kernel behavior) was pushed and run through CI as part of a combined falsification commit (below) alongside the time-bounds revert; `quality_264_is_rejected_not_wrapped_to_a_valid_code` was not reached before nextest's default fail-fast cancelled the run (two other tests failed first) -- the revert is a one-line, mechanically obvious wrong-to-right diff and `264u32 as u8 == 8` is independently checkable arithmetic, but I do not have a red CI run isolating this specific test and am stating that plainly rather than implying I do.
- **Minutes bound / lat-lon bounds**: not re-run through CI; verified by hand-tracing the guard conditions (`minutes_scaled >= 600_000`, `!(-MAX..=MAX).contains(&signed)`) against the exact test inputs.
- **Altitude sign**: not re-run through CI; verified by hand-tracing `parse_fixed_point`'s sign-stripping branch against `"-86.0"`.
- **RMC time/date bounds -- the finding that matters most, and the one I have real red/green CI evidence for.** Pushed a commit removing the `hour > 23 || minute > 59 || ...` guard entirely. CI went red exactly as predicted:

  ```
  FAIL topos-core tests::parse_time_date_rejects_impossible_hour
    assertion `left == right` failed: an hour of 99 must be rejected before it can reach a trusted clock
  FAIL topos-core tests::parse_time_date_rejects_impossible_month
    assertion `left == right` failed: a month of 99 must be rejected
  ```
  Red run: https://github.com/forkwright/thumos/actions/runs/31327718246/job/93280704680 (job conclusion: failure)

  The revert commit was then dropped (`git reset --hard` back to the fix) and re-pushed; CI returned to fully green, confirmed stable across two consecutive polls:
  Green run (post-restoration, same SHA `8c758eb`): https://github.com/forkwright/thumos/actions/runs/31327799072 (`workspace clippy + tests` pass, `kernel (i686 tests + armv7a build)` pass) and https://github.com/forkwright/thumos/actions/runs/31327799318 (`gate / full-gate-build` pass, `gate / gate` pass)

I am not claiming full five-for-five CI-verified falsification -- only the RMC time-bounds finding (the one flagged as most important) has a real CI red run behind it. The other four are verified by direct code-tracing against the exact test inputs, which I consider solid but is a weaker evidence class than a red CI run, and I want that distinction visible rather than implied away.

## Refs

Refs #545
