### PR TITLE
feat(usb): register the MUSB interrupt with the GIC

### DIFF
--- a/crates/thumos/src/board/m7.rs
+++ b/crates/thumos/src/board/m7.rs
@@ -72,10 +72,11 @@ pub(crate) const MUSB_BASE: usize = 0x1121_0000;
 /// `gic::enable_irq` and the IRQ-dispatch comparison in `exceptions.rs`
 /// both consume -- SPI number + 32, same convention as `timer::TIMER_IRQ`).
 ///
-/// `None` -- NOT hardware-confirmed (#666). Every MediaTek MT6739 vendor
-/// Android kernel DTS this driver's own history cites was re-checked while
-/// wiring this constant, and none of it resolves cleanly: two independently
-/// hosted copies of MediaTek's mt6739 vendor tree
+/// `None` -- NOT hardware-confirmed (#666, tracked to closure by #676).
+/// Every MediaTek MT6739 vendor Android kernel DTS this driver's own
+/// history cites was re-checked while wiring this constant, and none of it
+/// resolves cleanly: two independently hosted copies of MediaTek's mt6739
+/// vendor tree
 /// (github.com/fukehan/kernel-4.4, github.com/iscle/OrangePi_4G-IOT_Android_8.1_BSP)
 /// carry a `usb0@11200000` node -- `compatible = "mediatek,mt6739-usb20"`,
 /// `interrupts = <GIC_SPI 73 IRQ_TYPE_LEVEL_LOW>` (INTID 32+73 = 105) -- but
@@ -85,16 +86,16 @@ pub(crate) const MUSB_BASE: usize = 0x1121_0000;
 /// but neither cites a source beyond the other -- there is no artifact in
 /// this repo's history that independently confirms either address against
 /// real AGM M7 hardware or an authoritative MT6739 datasheet. Wiring a real
-/// GIC INTID into a live `enable_irq` call on that contested a foundation
+/// GIC INTID into a live `enable_irq` call on that contested foundation
 /// would be a fabricated fact wearing a hardware-verified constant's
 /// clothes, not an engineering shortcut -- so this stays `None` (a
-/// no-op at the `exceptions::init()` call site) until a follow-up closes
-/// the gap by hardware probe or a source that resolves the base-address
-/// conflict. Flipping this to `Some(105)` (the one researched candidate,
-/// unverified) is then the ENTIRE remaining step -- see `exceptions::init()`
-/// and `exceptions::irq_handler_body()`, both already written against this
+/// no-op at the `exceptions::init()` call site) until #676 closes the gap
+/// by hardware probe or a source that resolves the base-address conflict.
+/// Flipping this to `Some(105)` (the one researched candidate, unverified)
+/// is then the ENTIRE remaining step -- see `exceptions::init()` and
+/// `exceptions::irq_handler_body()`, both already written against this
 /// constant.
-/// TODO(#666)[deliberate-prudent]: confirm the AGM M7 MUSB GIC INTID (candidate:
+/// TODO(#676)[deliberate-prudent]: confirm the AGM M7 MUSB GIC INTID (candidate:
 /// 105) against real hardware or a source that resolves the MUSB_BASE
 /// 0x1121_0000-vs-0x1120_0000 conflict noted above, then set this to Some(n).
 pub(crate) const MUSB_IRQ: Option<u32> = None;

--- a/crates/thumos/src/board/m7.rs
+++ b/crates/thumos/src/board/m7.rs
@@ -68,6 +68,37 @@ pub(crate) const LFS_PREAMBLE_SECTORS: u64 = 1;
 /// for `musb-hdrc`; the DT node and the usb.rs driver agree on this value.
 pub(crate) const MUSB_BASE: usize = 0x1121_0000;
 
+/// MUSB OTG controller GIC interrupt (raw GIC INTID, the form
+/// `gic::enable_irq` and the IRQ-dispatch comparison in `exceptions.rs`
+/// both consume -- SPI number + 32, same convention as `timer::TIMER_IRQ`).
+///
+/// `None` -- NOT hardware-confirmed (#666). Every MediaTek MT6739 vendor
+/// Android kernel DTS this driver's own history cites was re-checked while
+/// wiring this constant, and none of it resolves cleanly: two independently
+/// hosted copies of MediaTek's mt6739 vendor tree
+/// (github.com/fukehan/kernel-4.4, github.com/iscle/OrangePi_4G-IOT_Android_8.1_BSP)
+/// carry a `usb0@11200000` node -- `compatible = "mediatek,mt6739-usb20"`,
+/// `interrupts = <GIC_SPI 73 IRQ_TYPE_LEVEL_LOW>` (INTID 32+73 = 105) -- but
+/// that node's `reg` base is `0x1120_0000`, not the `0x1121_0000` MUSB_BASE
+/// carries above. MUSB_BASE's own doc comment attributes `0x1121_0000` to
+/// "the DT node", and the #534 PR that moved it here repeats that claim,
+/// but neither cites a source beyond the other -- there is no artifact in
+/// this repo's history that independently confirms either address against
+/// real AGM M7 hardware or an authoritative MT6739 datasheet. Wiring a real
+/// GIC INTID into a live `enable_irq` call on that contested a foundation
+/// would be a fabricated fact wearing a hardware-verified constant's
+/// clothes, not an engineering shortcut -- so this stays `None` (a
+/// no-op at the `exceptions::init()` call site) until a follow-up closes
+/// the gap by hardware probe or a source that resolves the base-address
+/// conflict. Flipping this to `Some(105)` (the one researched candidate,
+/// unverified) is then the ENTIRE remaining step -- see `exceptions::init()`
+/// and `exceptions::irq_handler_body()`, both already written against this
+/// constant.
+/// TODO(#666)[deliberate-prudent]: confirm the AGM M7 MUSB GIC INTID (candidate:
+/// 105) against real hardware or a source that resolves the MUSB_BASE
+/// 0x1121_0000-vs-0x1120_0000 conflict noted above, then set this to Some(n).
+pub(crate) const MUSB_IRQ: Option<u32> = None;
+
 // ---------------------------------------------------------------------------
 // Display pipeline
 // ---------------------------------------------------------------------------
@@ -270,5 +301,22 @@ mod tests {
         assert_eq!(DSI0_CMD_FIFO, 0x1400_D200);
         assert_eq!(MCDI_CORE_EN, 0x1000_DC04);
         assert!(!BOARD_NAME.is_empty());
+    }
+
+    /// WHY (#666): MUSB_IRQ is `None` until hardware-confirmed (see its doc
+    /// comment). Guards the day it flips to `Some(n)` -- n must be a real
+    /// SPI (INTID >= 32; 0..31 are SGI/PPI, never a peripheral line), so a
+    /// typo during the eventual hardware-confirmed edit cannot silently
+    /// enable a reserved software/private interrupt line instead of a real
+    /// peripheral one.
+    #[test]
+    fn musb_irq_is_unset_or_a_valid_spi() {
+        match MUSB_IRQ {
+            None => {}
+            Some(n) => assert!(
+                n >= 32,
+                "MUSB_IRQ must be a real SPI (INTID >= 32, not an SGI/PPI slot), got {n}"
+            ),
+        }
     }
 }

--- a/crates/thumos/src/exceptions.rs
+++ b/crates/thumos/src/exceptions.rs
@@ -17,12 +17,16 @@
 
 use core::fmt::Write;
 
+#[cfg(not(feature = "qemu"))]
+use crate::board;
 use crate::csprng;
 use crate::gic;
 use crate::power;
 use crate::process;
 use crate::timer;
 use crate::uart::Uart;
+#[cfg(not(feature = "qemu"))]
+use crate::usb;
 use crate::watchdog;
 
 /// Tick counter incremented by the timer IRQ handler, split into
@@ -68,6 +72,25 @@ pub unsafe fn init() {
 
         // Set the first timer tick
         timer::set_ms(TICK_MS);
+
+        // Enable the MUSB serial RX IRQ in the GIC (#666), alongside the
+        // timer registration above -- same call site, same mechanism, no
+        // second registration path. board::m7::MUSB_IRQ is `None` until
+        // hardware-confirmed (see its doc comment), so this is a no-op on
+        // every build today; flipping the board constant to `Some(n)` is
+        // the entire remaining step. Safe to enable before
+        // usb::init_controller() runs later in kinit: a MUSB interrupt
+        // reaching the CPU here can only come from a genuine bus event
+        // (SOFTCONN, set inside init(), is what attaches D+/D- to the bus
+        // in the first place) or a stale latched condition surviving the
+        // bootloader handoff -- either way, usb::handle_musb_interrupt's
+        // own not-yet-ready gate turns a pre-init fire into a controlled
+        // no-op rather than dispatching into a partially-initialized
+        // controller.
+        #[cfg(not(feature = "qemu"))]
+        if let Some(musb_irq) = board::MUSB_IRQ {
+            gic::enable_irq(musb_irq);
+        }
     }
 }
 
@@ -370,6 +393,15 @@ fn irq_handler_body() {
         // gone. The delivery happens on every timer IRQ once the body has
         // done its scheduler work, so a handled signal lands in user context
         // at the next return.
+    }
+
+    // #666: MUSB serial RX. board::m7::MUSB_IRQ is `None` until
+    // hardware-confirmed, so `Some(irq) == board::MUSB_IRQ` is always false
+    // today and this branch never dispatches -- see MUSB_IRQ's doc comment
+    // and exceptions::init()'s registration above.
+    #[cfg(not(feature = "qemu"))]
+    if Some(irq) == board::MUSB_IRQ {
+        usb::handle_musb_interrupt();
     }
 }
 

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -69,7 +69,7 @@ use crate::uart::Uart;
 use crate::uart::boot_log;
 use crate::ui;
 #[cfg(not(feature = "qemu"))]
-use crate::usb::UsbController;
+use crate::usb;
 use crate::watchdog;
 
 // ---------------------------------------------------------------------------
@@ -1340,10 +1340,12 @@ pub unsafe fn run() -> ! {
     serial.log(" Skipped (qemu: no MUSB model)\r\n");
     #[cfg(not(feature = "qemu"))]
     {
-        let mut usb = UsbController::new();
-        // SAFETY: usb.init() programs the MUSB MMIO registers at their known
-        // physical address (0x1121_0000). Called once after heap and GIC init.
-        match unsafe { usb.init() } {
+        // SAFETY: init_controller() programs the MUSB MMIO registers at
+        // their known physical address (0x1121_0000) on the shared static
+        // controller (#666, promoted off this stack frame so
+        // exceptions::irq_handler_body's ISR path can reach it). Called
+        // once, here, after heap and GIC init -- the sole init call site.
+        match unsafe { usb::init_controller() } {
             Ok(()) => {
                 serial.log(" USB ACM gadget connected\r\n");
                 devices.activate("musb-hdrc");

--- a/crates/thumos/src/usb.rs
+++ b/crates/thumos/src/usb.rs
@@ -828,7 +828,8 @@ static mut SERIAL_RX_RING: SerialRxRing = SerialRxRing::new();
 /// Run `f` on the serial RX ring under the IRQ-safe lock. Single accessor so
 /// the lock can never be bypassed by a future call site.
 fn with_serial_rx<R>(f: impl FnOnce(&mut SerialRxRing) -> R) -> R {
-    let _guard = SERIAL_RX_RING_LOCK.lock();
+    // FALSIFICATION (#666): lock bypassed on purpose to prove the
+    // contention test detects it. Revert before merge.
     // SAFETY: the lock serializes the ISR push path and the reader drain
     // path; this is the only accessor to the static ring.
     unsafe { f(&mut *core::ptr::addr_of_mut!(SERIAL_RX_RING)) }

--- a/crates/thumos/src/usb.rs
+++ b/crates/thumos/src/usb.rs
@@ -21,6 +21,8 @@
 // Base address
 // ---------------------------------------------------------------------------
 
+use core::sync::atomic::{AtomicBool, Ordering};
+
 use crate::irq;
 
 /// MUSB OTG controller base address on MT6739.
@@ -758,8 +760,11 @@ pub(crate) struct UsbController {
 /// (#437 remnant 2). The ISR path (`handle_ep1_rx`) and the reader path
 /// (`read_serial`) previously shared the controller's raw fields with
 /// nothing enforcing they could not interleave; the ring now lives behind
-/// an `irq::IrqSpinlock` (the ipc.rs/mmu.rs pattern), so when the MUSB IRQ
-/// is registered with the GIC the wiring is a one-line call-site change.
+/// an `irq::IrqSpinlock` (the ipc.rs/mmu.rs pattern). The MUSB IRQ is
+/// registered with the GIC as of #666 (`exceptions::init()`,
+/// `board::m7::MUSB_IRQ`) -- `handle_musb_interrupt` now dispatches into
+/// this ring's ISR-side push path for real, gated only on the real GIC
+/// INTID remaining unconfirmed (see `MUSB_IRQ`'s doc comment).
 struct SerialRxRing {
     /// Byte storage.
     buf: [u8; SERIAL_RX_BUF_LEN],
@@ -963,7 +968,10 @@ impl UsbController {
     ///
     /// # Safety
     ///
-    /// Caller must not call this concurrently with [`handle_interrupt`].
+    /// Caller must not call this concurrently with [`handle_interrupt`] --
+    /// guaranteed by construction when reached only through
+    /// [`with_usb_controller`] (#666), the sole accessor to the shared
+    /// controller instance.
     ///
     /// [`handle_interrupt`]: UsbController::handle_interrupt
     #[must_use]
@@ -1508,6 +1516,88 @@ impl UsbController {
 }
 
 // ---------------------------------------------------------------------------
+// Shared controller instance (#666)
+// ---------------------------------------------------------------------------
+
+/// WHY (#322/#331 class, same reasoning as SERIAL_RX_RING_LOCK above): an
+/// `irq::IrqSpinlock`, not bare single-core-cooperative reasoning -- once
+/// the MUSB IRQ is registered with the GIC (`board::m7::MUSB_IRQ`, `None`
+/// until hardware-confirmed), `handle_musb_interrupt` runs in interrupt
+/// context while `init_controller` and any future ordinary-context caller
+/// (`write_serial`) run in ordinary kernel code, and nothing previously
+/// enforced they could not interleave. `UsbController` was a `kinit` stack
+/// local before #666 for exactly this reason -- an ISR cannot reach a stack
+/// local at all, so the question of concurrent access never arose.
+static USB_CONTROLLER_LOCK: irq::IrqSpinlock = irq::IrqSpinlock::new();
+/// The one kernel-wide controller instance. Access ONLY through
+/// `with_usb_controller`.
+static mut USB_CONTROLLER: UsbController = UsbController::new();
+
+/// True once [`init_controller`] has run to completion. Gates
+/// [`handle_musb_interrupt`] against a MUSB interrupt reaching the CPU
+/// before the controller is configured -- `exceptions::init()` enables the
+/// MUSB IRQ at the GIC well before kinit's USB step runs
+/// `init_controller`, so a stale latched interrupt condition surviving the
+/// bootloader handoff could in principle fire in that window. Without this
+/// gate that would dispatch into a controller whose endpoints have never
+/// been configured; with it, a pre-ready fire is a controlled no-op.
+static USB_CONTROLLER_READY: AtomicBool = AtomicBool::new(false);
+
+/// Run `f` on the shared USB controller under the IRQ-safe lock. Single
+/// accessor so the lock can never be bypassed by a future call site -- the
+/// same pattern as [`with_serial_rx`], extended to the whole controller.
+pub(crate) fn with_usb_controller<R>(f: impl FnOnce(&mut UsbController) -> R) -> R {
+    let _guard = USB_CONTROLLER_LOCK.lock();
+    // SAFETY: the lock masks IRQ delivery for its entire hold
+    // (`irq::IrqSpinlock`), so `handle_musb_interrupt`'s ISR-context call
+    // literally cannot preempt an ordinary-context caller inside this
+    // closure, and vice versa -- this is the only accessor to the static
+    // controller.
+    unsafe { f(&mut *core::ptr::addr_of_mut!(USB_CONTROLLER)) }
+}
+
+/// Initialize the shared USB controller and mark it ready for interrupt
+/// dispatch. Must be called exactly once during kernel init, before
+/// anything else touches the MUSB hardware.
+///
+/// # Safety
+///
+/// Same contract as [`UsbController::init`]: the caller must ensure no
+/// concurrent access to MUSB registers outside this call -- satisfied by
+/// this being the sole `init` call site (kinit's USB step) and by every
+/// other accessor going through [`with_usb_controller`]'s lock.
+pub(crate) unsafe fn init_controller() -> Result<(), UsbInitError> {
+    let result = with_usb_controller(|usb| {
+        // SAFETY: propagated from this function's own contract; the lock
+        // held by with_usb_controller is the exclusivity guarantee.
+        unsafe { usb.init() }
+    });
+    if result.is_ok() {
+        USB_CONTROLLER_READY.store(true, Ordering::Release);
+    }
+    result
+}
+
+/// Route a MUSB GIC interrupt to [`UsbController::handle_interrupt`].
+///
+/// Called FROM `exceptions::irq_handler_body` when the acknowledged GIC IRQ
+/// ID matches `board::m7::MUSB_IRQ`. No-ops before [`init_controller`] has
+/// completed (see [`USB_CONTROLLER_READY`]).
+pub(crate) fn handle_musb_interrupt() {
+    if !USB_CONTROLLER_READY.load(Ordering::Acquire) {
+        return;
+    }
+    with_usb_controller(|usb| {
+        // SAFETY: called only FROM the GIC IRQ dispatch path
+        // (exceptions::irq_handler_body), which is interrupt context --
+        // the sole call site.
+        unsafe {
+            usb.handle_interrupt();
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -2032,5 +2122,113 @@ mod tests {
         // write_serial checks `configured` before any MMIO access.
         let n = unsafe { ctrl.write_serial(b"hello") };
         assert_eq!(n, 0, "write_serial must return 0 when not configured");
+    }
+
+    // --- Contention witness (#666): real concurrent ISR-push vs. reader-drain ---
+
+    /// WHY `extern crate std` HERE, scoped inside this test function rather
+    /// than at module or crate scope: the kernel crate is `#![no_std]` for
+    /// the armv7a target, but the i686 host test binary links a real
+    /// libstd in its sysroot regardless -- `#![no_std]` only suppresses the
+    /// IMPLICIT `extern crate std` + prelude, not std's availability.
+    /// `std::thread` is the only way to exercise `with_serial_rx`'s
+    /// `IrqSpinlock` under REAL concurrent access on host:
+    /// `IrqSpinlock::lock()`'s `AtomicBool::compare_exchange_weak` is a
+    /// genuine cross-thread mutex (not merely a single-core IRQ-mask
+    /// simulation), so two real OS threads racing on it faithfully tests
+    /// the lock itself, even though the ARM CPSR-masking half of its
+    /// contract (irq.rs's own `cfg(not(target_arch = "arm"))` mock) is
+    /// single-core-only and cannot be exercised this way. This function is
+    /// the ONLY place in the kernel crate that references `std`, and the
+    /// `extern crate` is function-scoped so it cannot leak into any other
+    /// item or the armv7a build.
+    ///
+    /// WHY this shape proves synchronization, not just correctness: a test
+    /// that calls the push path then the drain path sequentially proves
+    /// nothing about synchronization -- both paths would run under the SAME
+    /// execution context either way. This spawns a real OS thread as the
+    /// producer (standing in for the MUSB ISR's `ring_push` path) racing
+    /// the main thread as the reader (standing in for `read_serial`'s
+    /// `drain` path) against the SAME shared ring, many rounds, and checks
+    /// two properties that a torn/lost/duplicated/reordered ring slot would
+    /// break: exact count conservation, and strict per-round monotonicity
+    /// of what was drained. Unique byte values 0..PUSH_PER_ROUND per round
+    /// (kept under 256, so no value wraps) turn "the drained sequence must
+    /// be strictly increasing" into an unambiguous check. ROUNDS repeats
+    /// with a fresh ring each time -- real-world races are probabilistic,
+    /// so many short rounds give a lock bypass many independent chances to
+    /// manifest rather than relying on one long run's timing.
+    ///
+    /// Falsification (see the PR body for the CI run pair): with
+    /// `with_serial_rx`'s `SERIAL_RX_RING_LOCK.lock()` bypassed, this test
+    /// goes RED under real thread contention; restoring the lock turns it
+    /// GREEN again.
+    #[test]
+    fn serial_rx_ring_survives_real_concurrent_isr_and_reader_contention() {
+        extern crate std;
+        use std::thread;
+        use std::vec::Vec;
+
+        const PUSH_PER_ROUND: u8 = 200;
+        const ROUNDS: usize = 64;
+
+        for _round in 0..ROUNDS {
+            with_serial_rx(|r| *r = SerialRxRing::new());
+
+            let producer = thread::spawn(move || {
+                let mut accepted = 0usize;
+                for byte in 0..PUSH_PER_ROUND {
+                    if with_serial_rx(|r| r.push(byte)) {
+                        accepted += 1;
+                    }
+                }
+                accepted
+            });
+
+            // Drain concurrently while the producer is still pushing -- the
+            // real production scenario (ISR push vs. read_serial drain
+            // interleaving), not a sequential call-then-call.
+            let mut drained: Vec<u8> = Vec::with_capacity(usize::from(PUSH_PER_ROUND));
+            while !producer.is_finished() {
+                let mut chunk = [0u8; 32];
+                let n = with_serial_rx(|r| r.drain(&mut chunk));
+                drained.extend_from_slice(&chunk[..n]);
+            }
+            let Ok(accepted) = producer.join() else {
+                unreachable!("producer thread must not panic")
+            };
+            // Drain the remainder pushed between the last poll above and
+            // the producer's join.
+            loop {
+                let mut chunk = [0u8; 32];
+                let n = with_serial_rx(|r| r.drain(&mut chunk));
+                if n == 0 {
+                    break;
+                }
+                drained.extend_from_slice(&chunk[..n]);
+            }
+
+            let dropped = with_serial_rx(|r| r.dropped_bytes());
+            assert_eq!(
+                drained.len() + usize::try_from(dropped).unwrap_or(usize::MAX),
+                accepted,
+                "every byte push() reported accepted must be either drained or counted dropped -- a mismatch means the reader and pusher corrupted the shared head/tail indices"
+            );
+
+            let mut previous: Option<u8> = None;
+            for &b in &drained {
+                assert!(
+                    b < PUSH_PER_ROUND,
+                    "drained byte {b} is outside the pushed range 0..{PUSH_PER_ROUND} -- a corrupted ring slot"
+                );
+                if let Some(prev) = previous {
+                    assert!(
+                        b > prev,
+                        "drained byte {b} did not strictly increase past {prev} -- a duplicated or reordered ring slot"
+                    );
+                }
+                previous = Some(b);
+            }
+        }
     }
 }

--- a/crates/thumos/src/usb.rs
+++ b/crates/thumos/src/usb.rs
@@ -828,8 +828,7 @@ static mut SERIAL_RX_RING: SerialRxRing = SerialRxRing::new();
 /// Run `f` on the serial RX ring under the IRQ-safe lock. Single accessor so
 /// the lock can never be bypassed by a future call site.
 fn with_serial_rx<R>(f: impl FnOnce(&mut SerialRxRing) -> R) -> R {
-    // FALSIFICATION (#666): lock bypassed on purpose to prove the
-    // contention test detects it. Revert before merge.
+    let _guard = SERIAL_RX_RING_LOCK.lock();
     // SAFETY: the lock serializes the ISR push path and the reader drain
     // path; this is the only accessor to the static ring.
     unsafe { f(&mut *core::ptr::addr_of_mut!(SERIAL_RX_RING)) }
@@ -2147,18 +2146,40 @@ mod tests {
     /// WHY this shape proves synchronization, not just correctness: a test
     /// that calls the push path then the drain path sequentially proves
     /// nothing about synchronization -- both paths would run under the SAME
-    /// execution context either way. This spawns a real OS thread as the
-    /// producer (standing in for the MUSB ISR's `ring_push` path) racing
-    /// the main thread as the reader (standing in for `read_serial`'s
-    /// `drain` path) against the SAME shared ring, many rounds, and checks
-    /// two properties that a torn/lost/duplicated/reordered ring slot would
-    /// break: exact count conservation, and strict per-round monotonicity
-    /// of what was drained. Unique byte values 0..PUSH_PER_ROUND per round
-    /// (kept under 256, so no value wraps) turn "the drained sequence must
-    /// be strictly increasing" into an unambiguous check. ROUNDS repeats
-    /// with a fresh ring each time -- real-world races are probabilistic,
-    /// so many short rounds give a lock bypass many independent chances to
-    /// manifest rather than relying on one long run's timing.
+    /// execution context either way. This spawns TWO real OS threads as
+    /// producers (standing in for the MUSB ISR's `ring_push` path -- e.g. a
+    /// bus reset re-arming the ring while a prior packet's bytes are still
+    /// draining) racing each other AND the main thread as the reader
+    /// (standing in for `read_serial`'s `drain` path) against the SAME
+    /// shared ring, many rounds.
+    ///
+    /// WHY two producers, not one: an earlier version of this test used a
+    /// single producer racing the reader. Pushed to CI with
+    /// `SERIAL_RX_RING_LOCK` deliberately bypassed, it stayed GREEN --
+    /// x86's strong memory ordering (TSO) plus this crate's `SerialRxRing`
+    /// touching mostly-disjoint fields per role (the pusher's `head`/
+    /// `buf[head]` vs. the reader's `tail`/`buf[tail]`) makes a
+    /// single-producer/single-reader race a subtle memory-VISIBILITY
+    /// hazard that x86 hardware happens to mask often enough that it is
+    /// not a reliable witness. Two producers racing EACH OTHER on the SAME
+    /// `head` field is a classic read-modify-write "lost update": both
+    /// read the same `head`, both compute the same `next_head`, one
+    /// pusher's `buf[head]` write is silently overwritten by the other's,
+    /// and `head` only advances once despite two `push()` calls both
+    /// returning `accepted`. That is a genuine race on shared mutable
+    /// state, not a memory-ordering subtlety -- it does not depend on weak
+    /// ordering to manifest, which is what makes it a reliable witness
+    /// even on x86 CI hardware.
+    ///
+    /// Each producer pushes a disjoint value lane (0..PUSH_PER_LANE and
+    /// PUSH_PER_LANE..2*PUSH_PER_LANE) so the drained stream can still be
+    /// checked per-lane after interleaving. Two properties a
+    /// torn/lost/duplicated/reordered ring slot would break: exact count
+    /// conservation (every `push()` that reported `accepted` is either
+    /// drained or counted `dropped`), and strict per-lane monotonicity of
+    /// what was drained. ROUNDS repeats with a fresh ring each time --
+    /// races are probabilistic, so many short rounds give a lock bypass
+    /// many independent chances to manifest.
     ///
     /// Falsification (see the PR body for the CI run pair): with
     /// `with_serial_rx`'s `SERIAL_RX_RING_LOCK.lock()` bypassed, this test
@@ -2170,36 +2191,48 @@ mod tests {
         use std::thread;
         use std::vec::Vec;
 
-        const PUSH_PER_ROUND: u8 = 200;
+        const PUSH_PER_LANE: u8 = 100;
         const ROUNDS: usize = 64;
 
         for _round in 0..ROUNDS {
             with_serial_rx(|r| *r = SerialRxRing::new());
 
-            let producer = thread::spawn(move || {
+            let producer_a = thread::spawn(move || {
                 let mut accepted = 0usize;
-                for byte in 0..PUSH_PER_ROUND {
+                for byte in 0..PUSH_PER_LANE {
                     if with_serial_rx(|r| r.push(byte)) {
                         accepted += 1;
                     }
                 }
                 accepted
             });
+            let producer_b = thread::spawn(move || {
+                let mut accepted = 0usize;
+                for byte in 0..PUSH_PER_LANE {
+                    if with_serial_rx(|r| r.push(byte + PUSH_PER_LANE)) {
+                        accepted += 1;
+                    }
+                }
+                accepted
+            });
 
-            // Drain concurrently while the producer is still pushing -- the
-            // real production scenario (ISR push vs. read_serial drain
+            // Drain concurrently while both producers are still pushing --
+            // the real production scenario (ISR push vs. read_serial drain
             // interleaving), not a sequential call-then-call.
-            let mut drained: Vec<u8> = Vec::with_capacity(usize::from(PUSH_PER_ROUND));
-            while !producer.is_finished() {
+            let mut drained: Vec<u8> = Vec::with_capacity(2 * usize::from(PUSH_PER_LANE));
+            while !producer_a.is_finished() || !producer_b.is_finished() {
                 let mut chunk = [0u8; 32];
                 let n = with_serial_rx(|r| r.drain(&mut chunk));
                 drained.extend_from_slice(&chunk[..n]);
             }
-            let Ok(accepted) = producer.join() else {
-                unreachable!("producer thread must not panic")
+            let Ok(accepted_a) = producer_a.join() else {
+                unreachable!("producer_a thread must not panic")
+            };
+            let Ok(accepted_b) = producer_b.join() else {
+                unreachable!("producer_b thread must not panic")
             };
             // Drain the remainder pushed between the last poll above and
-            // the producer's join.
+            // the producers' join.
             loop {
                 let mut chunk = [0u8; 32];
                 let n = with_serial_rx(|r| r.drain(&mut chunk));
@@ -2212,23 +2245,35 @@ mod tests {
             let dropped = with_serial_rx(|r| r.dropped_bytes());
             assert_eq!(
                 drained.len() + usize::try_from(dropped).unwrap_or(usize::MAX),
-                accepted,
-                "every byte push() reported accepted must be either drained or counted dropped -- a mismatch means the reader and pusher corrupted the shared head/tail indices"
+                accepted_a + accepted_b,
+                "every byte push() reported accepted must be either drained or counted dropped -- a mismatch means the two producers (or a producer and the reader) corrupted the shared head/tail indices"
             );
 
-            let mut previous: Option<u8> = None;
+            let mut previous_a: Option<u8> = None;
+            let mut previous_b: Option<u8> = None;
             for &b in &drained {
-                assert!(
-                    b < PUSH_PER_ROUND,
-                    "drained byte {b} is outside the pushed range 0..{PUSH_PER_ROUND} -- a corrupted ring slot"
-                );
-                if let Some(prev) = previous {
-                    assert!(
-                        b > prev,
-                        "drained byte {b} did not strictly increase past {prev} -- a duplicated or reordered ring slot"
+                if b < PUSH_PER_LANE {
+                    if let Some(prev) = previous_a {
+                        assert!(
+                            b > prev,
+                            "lane-A byte {b} did not strictly increase past {prev} -- a duplicated or reordered ring slot"
+                        );
+                    }
+                    previous_a = Some(b);
+                } else if b < 2 * PUSH_PER_LANE {
+                    let lane_b_value = b - PUSH_PER_LANE;
+                    if let Some(prev) = previous_b {
+                        assert!(
+                            lane_b_value > prev,
+                            "lane-B byte {lane_b_value} did not strictly increase past {prev} -- a duplicated or reordered ring slot"
+                        );
+                    }
+                    previous_b = Some(lane_b_value);
+                } else {
+                    unreachable!(
+                        "drained byte {b} is outside both pushed lanes -- a corrupted ring slot"
                     );
                 }
-                previous = Some(b);
             }
         }
     }

--- a/crates/thumos/src/usb.rs
+++ b/crates/thumos/src/usb.rs
@@ -828,8 +828,7 @@ static mut SERIAL_RX_RING: SerialRxRing = SerialRxRing::new();
 /// Run `f` on the serial RX ring under the IRQ-safe lock. Single accessor so
 /// the lock can never be bypassed by a future call site.
 fn with_serial_rx<R>(f: impl FnOnce(&mut SerialRxRing) -> R) -> R {
-    // FALSIFICATION (#666): lock bypassed on purpose to prove the
-    // contention test detects it. Revert before merge.
+    let _guard = SERIAL_RX_RING_LOCK.lock();
     // SAFETY: the lock serializes the ISR push path and the reader drain
     // path; this is the only accessor to the static ring.
     unsafe { f(&mut *core::ptr::addr_of_mut!(SERIAL_RX_RING)) }

--- a/docs/capability-inventory.toml
+++ b/docs/capability-inventory.toml
@@ -133,7 +133,7 @@ notes = "No production call path from boot/loop. Owners: encryption #449/#446, n
 id = "hardware-support"
 modules = ["qemu", "console", "uart", "usb"]
 tier = "kernel-wired"
-notes = "console host-testability is #459; USB EP1 ISR/reader sync is #437 remnant 2."
+notes = "console host-testability is #459; USB EP1 ISR is registered with the GIC and reader/ISR sync is locked + concurrency-tested (#666), gated on board::m7::MUSB_IRQ pending hardware confirmation of the interrupt number."
 
 [[capability]]
 id = "board-platform"

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -141,7 +141,7 @@ fidelity = "shared memory-map tables pinned host-side; MMIO interaction is the m
 
 [[module]]
 name = "board/m7"
-tests = 2
+tests = 3
 mechanism = "host"
 fidelity = "address tables + registry population pinned host-side; MMIO interaction is the m7 boot path (hardware-gated)"
 
@@ -688,9 +688,9 @@ witness = "boot.sh"
 
 [[module]]
 name = "usb"
-tests = 31
+tests = 32
 mechanism = "host"
-fidelity = "MMIO/ISR paths are not exercised host-side; EP1 ring sync is #437 remnant 2"
+fidelity = "MMIO/GIC dispatch is not exercised host-side (no real MUSB IRQ fires until board::m7::MUSB_IRQ is hardware-confirmed, #666); the SERIAL_RX_RING_LOCK contention it depends on IS exercised host-side, under real OS-thread concurrency, not single-core simulation"
 
 [[module]]
 name = "vfs"


### PR DESCRIPTION
## What was already in place

- The serial RX ring (`SerialRxRing`) lived behind `SERIAL_RX_RING_LOCK` (an `irq::IrqSpinlock`) with a single accessor (`with_serial_rx`), shared by the ISR-side push path (`handle_ep1_rx`) and the reader-side drain path (`read_serial`).
- `board::m7::MUSB_BASE` existed for the MMIO base.
- `gic::enable_irq` had exactly one call site (the timer) in `exceptions::init()`.
- `UsbController` was a `kinit` stack local (`crates/thumos/src/kinit.rs:1343`), unreachable from an ISR by construction.

## What this PR wires

- **`UsbController` promoted off the kinit stack** to a static (`usb::USB_CONTROLLER`), guarded by a new `USB_CONTROLLER_LOCK` (`irq::IrqSpinlock`) behind a single accessor `with_usb_controller` — same pattern as the existing `SERIAL_RX_RING_LOCK`/`with_serial_rx`, not a second locking scheme. `kinit`'s USB step now calls `usb::init_controller()` instead of constructing a local `UsbController`.
- **MUSB IRQ registered with the GIC** alongside the timer, in `exceptions::init()`, using a new board constant `board::m7::MUSB_IRQ: Option<u32>` — no raw number at the call site.
- **ISR routed to `handle_ep1_rx`**: `exceptions::irq_handler_body()` dispatches a matching IRQ to `usb::handle_musb_interrupt()`, which calls `UsbController::handle_interrupt()` (which was already written to call `handle_ep1_rx` on an RX event) under `with_usb_controller`'s lock.
- **`USB_CONTROLLER_READY`** (`AtomicBool`) gates `handle_musb_interrupt` until `init_controller()` has completed, closing the "spurious interrupt before initialization" case explicitly (see SAFETY reasoning below).

## SAFETY reasoning for interrupt-context access

- `IrqSpinlock` is **not reentrant** (confirmed by reading `irq.rs`): a second `lock()` call from the SAME context while already held spins forever. The reason this doesn't deadlock the ISR-vs-ordinary-code case: `lock()` masks IRQ delivery (CPSR.I) **before** spinning for the flag. So the only way the ISR could ever observe the flag held is if it fired while masked — which is architecturally impossible (masked means it can't fire at all). Concretely: if ordinary code (e.g. `read_serial`) holds `USB_CONTROLLER_LOCK` or `SERIAL_RX_RING_LOCK`, IRQs are masked for the whole critical section, so `handle_musb_interrupt` cannot preempt it — it simply doesn't run until the lock is released and IRQs are unmasked again. This is why `IrqSpinlock`, not a bare atomic flag, is what actually makes this IRQ-safe (matches the existing `#322/#331` reasoning already documented on `SERIAL_RX_RING_LOCK`, extended to the whole controller).
- **Spurious interrupt before initialization**: `exceptions::init()` enables the MUSB IRQ at the GIC well before `kinit`'s USB step runs `init_controller()` (boot order: `... → GIC → process → exceptions/timer → ... → USB serial → ...`). In that window, a MUSB interrupt reaching the CPU would either be a genuine bus event (impossible — `SOFTCONN`, which physically attaches D+/D- to the bus, is only set inside `init()`) or a stale latched condition surviving the bootloader handoff. `USB_CONTROLLER_READY` (false until `init_controller()` completes) makes either case a controlled no-op instead of dispatching into a controller whose endpoints were never configured.
- Every new `unsafe` block carries a `SAFETY:` comment stating the invariant that makes it sound (lock-held exclusivity, sole call site, or propagated caller contract).

## The IRQ number, and how I established it (or didn't)

`board::m7::MUSB_IRQ` is `Option<u32> = None` — **not hardware-confirmed**. I looked for it in the three sources the issue named:

- **Existing code / repo history**: `MUSB_BASE`'s doc comment claims `0x1121_0000` is verified against "the DT node," and the #534 PR that placed it in `board/m7.rs` repeats that claim — but neither cites an actual artifact. Tracing back to the original commit that introduced `usb.rs` (`7e0375e`, April), there is no source cited at all beyond "MT6739 micro-USB port." There is nothing in this repo's history that independently verifies `MUSB_BASE`, let alone an IRQ number.
- **External research**: two independently-hosted copies of MediaTek's real mt6739 vendor Android kernel device tree (`github.com/fukehan/kernel-4.4`, `github.com/iscle/OrangePi_4G-IOT_Android_8.1_BSP`) carry a `usb0@11200000` node — `compatible = "mediatek,mt6739-usb20"`, `interrupts = <GIC_SPI 73 IRQ_TYPE_LEVEL_LOW>` (GIC INTID = 32+73 = 105). This node's `reg` base is `0x1120_0000`, **not** this repo's `0x1121_0000` — a real conflict, not a rounding/typo-level discrepancy.

Given that conflict, I judged the candidate (INTID 105) as **not established** per the issue's own bar ("existing code, datasheet constants already in the tree, or vendor device-tree values referenced elsewhere in the repo"). Rather than wire an unverified GIC INTID into a live `enable_irq` call on real hardware — which risks enabling the wrong interrupt line if the number is wrong — `MUSB_IRQ` stays `Option<u32> = None`, documented in full (with both citations and the conflict) in its doc comment, with a `TODO(#666)`-successor tag. The registration and dispatch code is fully written against it (`if let Some(n) = board::MUSB_IRQ { gic::enable_irq(n); }` / `if Some(irq) == board::MUSB_IRQ { ... }`), so setting the constant to `Some(105)` (or whatever a hardware probe confirms) is the entire remaining step — exactly the "one-line call-site change" the module's own header comment already promised.

I filed **#676** with the full research trail (both citations, the base-address conflict, and a proposed hardware-probe path) as the tracked follow-up.

## The contention test, and its CI falsification

`crates/thumos/src/usb.rs::tests::serial_rx_ring_survives_real_concurrent_isr_and_reader_contention` (final shape, after the iteration below) spawns TWO real OS threads (`std::thread`, function-scoped `extern crate std` — the i686 host test binary links libstd regardless of the kernel's `#![no_std]`) as producers racing EACH OTHER and the main thread as the reader (standing in for `read_serial`'s `drain` path) against the **same shared static ring**, over 64 independent rounds. Each producer pushes 100 distinct byte values in its own lane (0..100 and 100..200, kept under 256 so no value wraps) and the test asserts two properties a torn/lost/duplicated/reordered ring slot would break:
1. **Exact count conservation**: `drained.len() + dropped == accepted_a + accepted_b` (every byte either `push()` call reported accepted is either drained or counted dropped).
2. **Strict per-lane monotonicity**: each producer's own drained sub-sequence, filtered of drops, must strictly increase — a duplicate or reordering breaks this immediately.

This is a genuine multi-thread race, not a sequential call-then-call (`IrqSpinlock::lock()`'s `AtomicBool::compare_exchange_weak` is a real cross-thread mutex, not merely a single-core IRQ-mask simulation — that's the part of the lock this test can exercise on host; the ARM CPSR-masking half stays hardware/QEMU-only and is out of scope for a host test).

**Falsification** (three rounds, since the first design didn't hold up):

1. **Baseline** (lock held, single-producer test): GREEN — https://github.com/forkwright/thumos/actions/runs/31327654064/job/93280496571
2. **Falsification 1** (lock bypassed, single-producer test): stayed GREEN — https://github.com/forkwright/thumos/actions/runs/31327857131/job/93281079306. This is a genuine finding, not a false pass (confirmed from the raw log: the test executed and passed both feature passes, 2 rounds x 64). A single producer racing the reader on this specific ring (which touches mostly-disjoint fields per role -- the pusher's `head`/`buf[head]` vs. the reader's `tail`/`buf[tail]`) is a memory-visibility hazard subtle enough that x86's strong memory ordering masks it often enough on CI hardware to not be a reliable witness.
3. **Redesign**: replaced the single producer with two producer threads racing EACH OTHER (plus the reader) on the same `head` field -- a classic read-modify-write "lost update," which doesn't depend on weak memory ordering to manifest.
4. **New baseline** (lock held, two-producer test): GREEN — https://github.com/forkwright/thumos/actions/runs/31328148384/job/93281819410
5. **Falsification 2** (lock bypassed, two-producer test): RED — https://github.com/forkwright/thumos/actions/runs/31328321932/job/93282295428. `thread 'usb::tests::serial_rx_ring_survives_real_concurrent_isr_and_reader_contention' panicked at src/usb.rs:2247:13: assertion \`left == right\` failed: every byte push() reported accepted must be either drained or counted dropped -- a mismatch means the two producers (or a producer and the reader) corrupted the shared head/tail indices`. Failed on the `--features debug-console` pass, not the default-features pass -- probabilistic, as expected for a real race, but reliable within 64 rounds.
6. **Lock restored**: GREEN — https://github.com/forkwright/thumos/actions/runs/31328461496/job/93282664326

The test genuinely falsifies. The iteration itself is worth keeping visible: a single-producer/single-reader design looked like a faithful reproduction of the real MUSB-ISR-vs-`read_serial` hazard, and it is the shape most people would reach for first, but it did not reliably prove the lock does anything on this hardware. The two-producer design is a different (stronger) witness of the SAME underlying claim -- that `with_serial_rx`'s single-accessor + `IrqSpinlock` pattern is what prevents concurrent corruption of the ring, not an artifact of how the two paths happen to interleave.

## What remains unproven without real hardware

- The MUSB GIC INTID itself (see above) — `MUSB_IRQ` is `None`, so no real interrupt reaches `handle_ep1_rx` on any build today, including real M7 hardware. Tracked in #676.
- Whether `MUSB_BASE` (`0x1121_0000`) is itself correct — the same investigation surfaced doubt about this pre-existing constant too (see the follow-up issue). This PR does not touch `MUSB_BASE`.
- The single-core ARM CPSR-masking half of `IrqSpinlock`'s contract (the part that actually prevents an ISR from preempting a critical section on real hardware) has no host-test equivalent — it's covered by `irq.rs`'s own existing mock-flag tests and, ultimately, only provable by a real MUSB interrupt firing during a `read_serial` call on real silicon.
- GIC dispatch itself (`gic::acknowledge`/`end_of_interrupt`/`enable_irq` wired to a real MUSB line) is untested by CI — QEMU `virt` models no MUSB, so no witness in this PR exercises the real interrupt-delivery path end to end.

Closes #666
