### PR TITLE
fix(kernel): scope unwrap/expect denial to production, fix doc backticks + literals

### DIFF
--- a/crates/thumos/src/audio.rs
+++ b/crates/thumos/src/audio.rs
@@ -474,13 +474,13 @@ impl<C: AudioCodecOps> AudioManager<C> {
     /// Return a mutable reference to the underlying codec.
     ///
     /// WHY test-only: production code must reach the codec ONLY through
-    /// the auditable session lifecycle (open_session/close_session/
-    /// set_route/set_volume) -- this raw accessor bypasses that entirely,
-    /// letting a caller flip enable_mic_bias()/enable_adc() with no
-    /// AudioSession ever recorded, defeating the "all mic activity is
+    /// the auditable session lifecycle (`open_session/close_session`/
+    /// `set_route/set_volume`) -- this raw accessor bypasses that entirely,
+    /// letting a caller flip `enable_mic_bias()/enable_adc()` with no
+    /// `AudioSession` ever recorded, defeating the "all mic activity is
     /// auditable via the session log" invariant documented at the top of
     /// this module. Grepped: every call site in the tree is this file's
-    /// own `#[cfg(test)] mod tests` (fault injection on MockCodec); no
+    /// own `#[cfg(test)] mod tests` (fault injection on `MockCodec`); no
     /// production caller exists (#397).
     #[cfg(test)]
     pub(crate) fn codec_mut(&mut self) -> &mut C {

--- a/crates/thumos/src/audio_codec.rs
+++ b/crates/thumos/src/audio_codec.rs
@@ -7,25 +7,25 @@
 //! ## Hardware path
 //!
 //! The MT6357 PMIC is accessed via the PMIC wrapper bus (PWRAP) on the
-//! MT6739 SoC.  Register writes go through PWRAP MMIO at `0x1000_D000`,
+//! MT6739 `SoC`.  Register writes go through PWRAP MMIO at `0x1000_D000`,
 //! which bridges to the PMIC I2C/SPI bus.
 //!
 //! ## PMIC audio register map (MT6357)
 //!
 //! | Register           | Offset   | Purpose                              |
 //! |--------------------|----------|--------------------------------------|
-//! | AUD_TOP_CON0       | 0x2000   | Audio top-level power control        |
-//! | AFE_UL_DL_CON0     | 0x2004   | UL/DL path enable                   |
-//! | AFE_DL_CON0        | 0x2008   | Downlink (DAC) control               |
-//! | AFE_UL_CON0        | 0x200C   | Uplink (ADC) control                 |
-//! | AFE_DL_GAIN        | 0x2010   | DAC digital gain (volume)            |
-//! | AFE_UL_GAIN        | 0x2014   | ADC digital gain                     |
-//! | AUDDEC_ANA_CON0    | 0x2080   | Decoder analog control 0 (HPL/HPR)   |
-//! | AUDDEC_ANA_CON1    | 0x2084   | Decoder analog control 1 (earpiece)  |
-//! | AUDDEC_ANA_CON6    | 0x2098   | Decoder analog control 6 (speaker)   |
-//! | AUDENC_ANA_CON0    | 0x20C0   | Encoder analog control (mic preamp)  |
-//! | AUDENC_ANA_CON9    | 0x20E4   | Mic bias voltage control             |
-//! | AUD_TOP_LDO_CON0   | 0x2100   | Audio LDO enable                    |
+//! | `AUD_TOP_CON0`       | 0x2000   | Audio top-level power control        |
+//! | `AFE_UL_DL_CON0`     | 0x2004   | UL/DL path enable                   |
+//! | `AFE_DL_CON0`        | 0x2008   | Downlink (DAC) control               |
+//! | `AFE_UL_CON0`        | 0x200C   | Uplink (ADC) control                 |
+//! | `AFE_DL_GAIN`        | 0x2010   | DAC digital gain (volume)            |
+//! | `AFE_UL_GAIN`        | 0x2014   | ADC digital gain                     |
+//! | `AUDDEC_ANA_CON0`    | 0x2080   | Decoder analog control 0 (HPL/HPR)   |
+//! | `AUDDEC_ANA_CON1`    | 0x2084   | Decoder analog control 1 (earpiece)  |
+//! | `AUDDEC_ANA_CON6`    | 0x2098   | Decoder analog control 6 (speaker)   |
+//! | `AUDENC_ANA_CON0`    | 0x20C0   | Encoder analog control (mic preamp)  |
+//! | `AUDENC_ANA_CON9`    | 0x20E4   | Mic bias voltage control             |
+//! | `AUD_TOP_LDO_CON0`   | 0x2100   | Audio LDO enable                    |
 //!
 //! These offsets are within the PMIC register space; actual access goes
 //! through PWRAP at `PWRAP_BASE + offset`.
@@ -96,40 +96,40 @@ const AUD_TOP_LDO_CON0: u16 = 0x2100;
 // Register bit definitions
 // ---------------------------------------------------------------------------
 
-/// AUD_TOP_CON0: audio subsystem power-on bit.
+/// `AUD_TOP_CON0`: audio subsystem power-on bit.
 const AUD_TOP_POWER_ON: u32 = 1 << 0;
 
-/// AUD_TOP_LDO_CON0: audio LDO enable bit.
+/// `AUD_TOP_LDO_CON0`: audio LDO enable bit.
 const AUD_LDO_ENABLE: u32 = 1 << 0;
 
-/// AFE_UL_DL_CON0: downlink path enable.
+/// `AFE_UL_DL_CON0`: downlink path enable.
 const AFE_DL_EN: u32 = 1 << 0;
 
-/// AFE_UL_DL_CON0: uplink path enable.
+/// `AFE_UL_DL_CON0`: uplink path enable.
 const AFE_UL_EN: u32 = 1 << 1;
 
-/// AFE_DL_CON0: DAC enable bit.
+/// `AFE_DL_CON0`: DAC enable bit.
 const DAC_ENABLE: u32 = 1 << 0;
 
-/// AFE_UL_CON0: ADC enable bit.
+/// `AFE_UL_CON0`: ADC enable bit.
 const ADC_ENABLE: u32 = 1 << 0;
 
-/// AUDDEC_ANA_CON0: headphone left amplifier enable.
+/// `AUDDEC_ANA_CON0`: headphone left amplifier enable.
 const HPL_AMP_EN: u32 = 1 << 0;
 
-/// AUDDEC_ANA_CON0: headphone right amplifier enable.
+/// `AUDDEC_ANA_CON0`: headphone right amplifier enable.
 const HPR_AMP_EN: u32 = 1 << 1;
 
-/// AUDDEC_ANA_CON1: earpiece receiver amplifier enable.
+/// `AUDDEC_ANA_CON1`: earpiece receiver amplifier enable.
 const EARPIECE_AMP_EN: u32 = 1 << 0;
 
-/// AUDDEC_ANA_CON6: loudspeaker amplifier enable.
+/// `AUDDEC_ANA_CON6`: loudspeaker amplifier enable.
 const SPEAKER_AMP_EN: u32 = 1 << 0;
 
-/// AUDENC_ANA_CON0: mic preamp enable.
+/// `AUDENC_ANA_CON0`: mic preamp enable.
 const MIC_PREAMP_EN: u32 = 1 << 0;
 
-/// AUDENC_ANA_CON9: mic bias voltage enable.
+/// `AUDENC_ANA_CON9`: mic bias voltage enable.
 const MIC_BIAS_EN: u32 = 1 << 0;
 
 /// Maximum hardware volume level (4-bit, 0-15).
@@ -137,7 +137,7 @@ const MAX_VOLUME: u8 = 15;
 
 /// Volume step in hardware gain units.
 ///
-/// Each step is approximately 1 dB.  The MT6357 AFE_DL_GAIN register
+/// Each step is approximately 1 dB.  The MT6357 `AFE_DL_GAIN` register
 /// uses a 16-bit value; we map 0-15 linearly into the usable range.
 const VOLUME_STEP: u32 = 0x0800;
 
@@ -658,8 +658,8 @@ pub struct MockCodec {
     /// If set, `disable_dac` returns this error.
     pub fail_disable_dac: Option<AudioError>,
     /// If set, `disable_adc` returns this error (#397) -- exercises the
-    /// power_down_mic partial-teardown path (disable_mic_bias succeeds,
-    /// disable_adc fails).
+    /// `power_down_mic` partial-teardown path (`disable_mic_bias` succeeds,
+    /// `disable_adc` fails).
     pub fail_disable_adc: Option<AudioError>,
     /// If set, `power_off` returns this error.
     pub fail_power_off: Option<AudioError>,
@@ -855,7 +855,7 @@ impl AudioCodecOps for MockCodec {
 
 /// A no-op audio codec for qemu (#399). The MT6357 PMIC/PWRAP MMIO is unmodeled
 /// on -machine virt, so the real `Mt6357Codec`'s register writes would
-/// data-abort. `NullCodec` tracks the power/enable/route state the AudioManager
+/// data-abort. `NullCodec` tracks the power/enable/route state the `AudioManager`
 /// session logic reads, but touches no hardware -- so the session / priority /
 /// route state machine runs in emulation. Distinct from the test-only
 /// `MockCodec` (which carries fail-injection knobs).
@@ -948,7 +948,7 @@ impl AudioCodecOps for NullCodec {
     }
 }
 
-/// The codec the booted kernel wires into its AudioManager (#399): the no-op
+/// The codec the booted kernel wires into its `AudioManager` (#399): the no-op
 /// `NullCodec` under qemu/test (no PMIC model on -machine virt), the real
 /// `Mt6357Codec` on device.
 #[cfg(any(feature = "qemu", test))]

--- a/crates/thumos/src/audio_route.rs
+++ b/crates/thumos/src/audio_route.rs
@@ -83,7 +83,7 @@ impl core::fmt::Display for AudioRoute {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum SessionKind {
-    /// Duplex voice call (cellular or VoIP).
+    /// Duplex voice call (cellular or `VoIP`).
     VoiceCall,
     /// Incoming call ringtone.
     Ringtone,

--- a/crates/thumos/src/audit.rs
+++ b/crates/thumos/src/audit.rs
@@ -37,11 +37,11 @@
 //!
 //! ## Integration points
 //!
-//! - `capability.rs` — CapDeny events
-//! - `firewall.rs` — PacketDeny events
-//! - `lock_screen.rs` — AuthFail, DuressAttempt events
-//! - `security_mode.rs` — ModeChange, PanicTrigger events
-//! - `secure_boot.rs` (Wave 6) — BootVerify events
+//! - `capability.rs` — `CapDeny` events
+//! - `firewall.rs` — `PacketDeny` events
+//! - `lock_screen.rs` — `AuthFail`, `DuressAttempt` events
+//! - `security_mode.rs` — `ModeChange`, `PanicTrigger` events
+//! - `secure_boot.rs` (Wave 6) — `BootVerify` events
 
 use core::fmt;
 
@@ -153,7 +153,7 @@ pub struct AuditEntry {
     pub detail: [u8; DETAIL_LEN],
     /// Number of valid bytes in `detail`.
     pub detail_len: u8,
-    /// HMAC-SHA256 covering (timestamp || event_type || pid || detail || prev_hmac).
+    /// HMAC-SHA256 covering (timestamp || `event_type` || pid || detail || `prev_hmac`).
     pub hmac: [u8; SHA256_DIGEST_LEN],
 }
 
@@ -167,7 +167,7 @@ impl AuditEntry {
     /// Serialize the entry content (excluding the HMAC itself) into a
     /// buffer suitable for HMAC computation.
     ///
-    /// Layout: timestamp (8 LE) || event_type (1) || pid (4 LE) || detail (64) || prev_hmac (32)
+    /// Layout: timestamp (8 LE) || `event_type` (1) || pid (4 LE) || detail (64) || `prev_hmac` (32)
     ///
     /// Returns the number of bytes written.
     fn serialize_for_hmac(
@@ -313,7 +313,7 @@ pub(crate) struct AuditLog {
     entries: Box<[AuditEntry]>,
     /// Index of the next write position in the ring.
     head: usize,
-    /// Number of live entries (0..=MAX_ENTRIES).
+    /// Number of live entries (`0..=MAX_ENTRIES`).
     count: usize,
     /// HMAC of the most recently appended entry (chains the next append).
     last_hmac: [u8; SHA256_DIGEST_LEN],

--- a/crates/thumos/src/battery.rs
+++ b/crates/thumos/src/battery.rs
@@ -1,11 +1,11 @@
-//! Battery monitoring for LiPo cells.
+//! Battery monitoring for `LiPo` cells.
 //!
 //! Provides [`BatteryInfo`] snapshots and a [`BatteryMonitor`] that polls
 //! hardware via the [`BatteryHwOps`] trait. Voltage-to-percentage conversion
-//! uses a piecewise-linear lookup table matching typical 3.7V LiPo discharge
+//! uses a piecewise-linear lookup table matching typical 3.7V `LiPo` discharge
 //! curves.
 //!
-//! ## Voltage table (3.7V single-cell LiPo)
+//! ## Voltage table (3.7V single-cell `LiPo`)
 //!
 //! | Voltage (mV) | Percentage |
 //! |--------------|------------|
@@ -43,7 +43,7 @@ struct LookupEntry {
     percentage: u8,
 }
 
-/// LiPo discharge curve lookup table.
+/// `LiPo` discharge curve lookup table.
 ///
 /// Sorted descending by voltage. Linear interpolation is used between
 /// adjacent entries.
@@ -95,7 +95,7 @@ pub(crate) const POLL_INTERVAL_SECS: u64 = 60;
 /// Snapshot of battery state at a point in time.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct BatteryInfo {
-    /// Battery voltage in millivolts (3000-4200 typical LiPo).
+    /// Battery voltage in millivolts (3000-4200 typical `LiPo`).
     pub voltage_mv: u16,
     /// Estimated charge percentage (0-100).
     pub percentage: u8,

--- a/crates/thumos/src/bfu_timer.rs
+++ b/crates/thumos/src/bfu_timer.rs
@@ -141,7 +141,7 @@ pub(crate) struct BfuTimer {
     fired: bool,
     /// Ticks elapsed since the current pause began. Reset whenever the
     /// timer leaves the Paused state (resume, reset, or the
-    /// MAX_PAUSE_TICKS force-resume in `tick`).
+    /// `MAX_PAUSE_TICKS` force-resume in `tick`).
     paused_ticks: u64,
 }
 

--- a/crates/thumos/src/bluetooth.rs
+++ b/crates/thumos/src/bluetooth.rs
@@ -10,7 +10,7 @@
 //! ## Hardware path
 //!
 //! The MT6739 Bluetooth hardware is accessed through the WMT combo chip:
-//! - `board::CONSYS_BASE = 0x1800_0000` (combo-chip base, board::m7 #534)
+//! - `board::CONSYS_BASE = 0x1800_0000` (combo-chip base, `board::m7` #534)
 //! - Data path goes through WMT STP framing (kelyphos handles the transport)
 //!
 //! ## Integration
@@ -30,7 +30,7 @@ use crate::csprng;
 
 /// WMT STP channel identifier for Bluetooth.
 ///
-/// The combo chip multiplexes WiFi, BT, GPS, and FM over a single transport.
+/// The combo chip multiplexes `WiFi`, BT, GPS, and FM over a single transport.
 /// Each subsystem is identified by a channel byte in the STP header.
 const WMT_BT_CHANNEL: u8 = 0x01;
 
@@ -441,7 +441,7 @@ impl BtHwOps for BtHw {
 /// MMIO is unmodeled on -machine virt, so the real `BtHw` STP transport would
 /// data-abort. `NullBtHw` lets the A2DP profile's local state machine + SBC
 /// framing run in emulation; it acknowledges commands without a controller
-/// (recv_event yields nothing, so no connection ever completes).
+/// (`recv_event` yields nothing, so no connection ever completes).
 #[cfg(any(feature = "qemu", test))]
 pub(crate) struct NullBtHw;
 
@@ -694,9 +694,9 @@ pub struct MockBtHw {
     pub sent_commands: Vec<Vec<u8>>,
     /// ACL data sent via `send_acl_data`.
     pub sent_acl_data: Vec<Vec<u8>>,
-    /// Whether power_on succeeds.
+    /// Whether `power_on` succeeds.
     pub power_on_ok: bool,
-    /// Whether send_command succeeds.
+    /// Whether `send_command` succeeds.
     pub send_ok: bool,
     /// Number of `send_command` calls observed so far.
     pub send_calls: usize,

--- a/crates/thumos/src/board/m7.rs
+++ b/crates/thumos/src/board/m7.rs
@@ -1,4 +1,4 @@
-//! The AGM M7 field board (MT6739 SoC) — every MT6739-specific fact in the
+//! The AGM M7 field board (MT6739 `SoC`) — every MT6739-specific fact in the
 //! kernel lives HERE and nowhere else (#534's standing invariant, enforced
 //! by `scripts/check-board-seam.sh`).
 //!
@@ -7,9 +7,9 @@
 //! structs by design — two real boards want no device-tree parser (#534
 //! explicitly retires the old "Phase 04+ DT" ambition).
 //!
-//! WHY cfg_attr(not(test)) on some expects (#528 shape): this module
+//! WHY `cfg_attr(not(test))` on some expects (#528 shape): this module
 //! compiles on the host test target, where this file's own tests reference
-//! the consts — a blanket expect(dead_code) would be UNFULFILLED there,
+//! the consts — a blanket `expect(dead_code)` would be UNFULFILLED there,
 //! while on armv7a a const with no runtime consumer is genuinely dead.
 
 use crate::device::DeviceRegistry;
@@ -45,13 +45,13 @@ pub(crate) const MSDC0_BASE: usize = 0x1123_0000;
 /// ~2.6 GB. LFS uses the userdata region starting at sector 0x50C000
 /// (~2.6 GB offset). Value from the GPT dump of the MT6739 eMMC
 /// (printgpt: userdata partition).
-pub(crate) const LFS_PARTITION_START: u64 = 0x50C000;
+pub(crate) const LFS_PARTITION_START: u64 = 0x0050_C000;
 
 /// Size of the LFS partition in sectors.
 /// WHY: ~3 GB of the 8 GB eMMC is available for user data. Rounded down
 /// from the actual userdata partition length (0x97BFDF sectors) to a clean
 /// segment-aligned boundary.
-pub(crate) const LFS_PARTITION_SIZE: u64 = 0x600000;
+pub(crate) const LFS_PARTITION_SIZE: u64 = 0x0060_0000;
 
 /// Sectors reserved at the userdata partition head for the plaintext
 /// secrets preamble (#449). The encrypted LFS payload starts this many
@@ -73,15 +73,15 @@ pub(crate) const MUSB_BASE: usize = 0x1121_0000;
 /// both consume -- SPI number + 32, same convention as `timer::TIMER_IRQ`).
 ///
 /// `None` -- NOT hardware-confirmed (#666, tracked to closure by #676).
-/// Every MediaTek MT6739 vendor Android kernel DTS this driver's own
+/// Every `MediaTek` MT6739 vendor Android kernel DTS this driver's own
 /// history cites was re-checked while wiring this constant, and none of it
-/// resolves cleanly: two independently hosted copies of MediaTek's mt6739
+/// resolves cleanly: two independently hosted copies of `MediaTek`'s mt6739
 /// vendor tree
 /// (github.com/fukehan/kernel-4.4, github.com/iscle/OrangePi_4G-IOT_Android_8.1_BSP)
 /// carry a `usb0@11200000` node -- `compatible = "mediatek,mt6739-usb20"`,
 /// `interrupts = <GIC_SPI 73 IRQ_TYPE_LEVEL_LOW>` (INTID 32+73 = 105) -- but
-/// that node's `reg` base is `0x1120_0000`, not the `0x1121_0000` MUSB_BASE
-/// carries above. MUSB_BASE's own doc comment attributes `0x1121_0000` to
+/// that node's `reg` base is `0x1120_0000`, not the `0x1121_0000` `MUSB_BASE`
+/// carries above. `MUSB_BASE`'s own doc comment attributes `0x1121_0000` to
 /// "the DT node", and the #534 PR that moved it here repeats that claim,
 /// but neither cites a source beyond the other -- there is no artifact in
 /// this repo's history that independently confirms either address against
@@ -96,7 +96,7 @@ pub(crate) const MUSB_BASE: usize = 0x1121_0000;
 /// `exceptions::irq_handler_body()`, both already written against this
 /// constant.
 /// TODO(#676)[deliberate-prudent]: confirm the AGM M7 MUSB GIC INTID (candidate:
-/// 105) against real hardware or a source that resolves the MUSB_BASE
+/// 105) against real hardware or a source that resolves the `MUSB_BASE`
 /// 0x1121_0000-vs-0x1120_0000 conflict noted above, then set this to Some(n).
 pub(crate) const MUSB_IRQ: Option<u32> = None;
 
@@ -141,9 +141,9 @@ pub(crate) const KPD_EN: usize = 0x00;
 /// KPD debounce register offset.
 pub(crate) const KPD_DEBOUNCE: usize = 0x18;
 
-/// GPIO controller MMIO base (MT67xx standard bank base).
+/// GPIO controller MMIO base (`MT67xx` standard bank base).
 ///
-/// NOTE: standard MT67xx base — verify against the MT6739 TRM GPIO section.
+/// NOTE: standard `MT67xx` base — verify against the MT6739 TRM GPIO section.
 /// Mirrors haphe's `GPIO_BASE` (crates/haphe/src/gpio.rs); the #446 boot
 /// keypad reader scans the matrix through these registers because the KPD
 /// hardware block has no verified read-out register map.
@@ -184,7 +184,7 @@ pub(crate) const KEYPAD_COL_PINS: [u8; 3] = [44, 45, 46];
 /// WMT combo-chip (CONSYS) MMIO base.
 pub(crate) const CONSYS_BASE: usize = 0x1800_0000;
 
-/// WiFi (WLAN) MMIO base.
+/// `WiFi` (WLAN) MMIO base.
 pub(crate) const WLAN_BASE: usize = 0x180F_0000;
 
 // ---------------------------------------------------------------------------
@@ -260,7 +260,7 @@ mod tests {
     use super::*;
 
     /// The registered device set must pin to the module's canonical consts —
-    /// this replaces kinit_plan's pre-#534 address test, which pinned the
+    /// this replaces `kinit_plan`'s pre-#534 address test, which pinned the
     /// consts the OLD device.rs carried (including the GIC aliases that
     /// silently resolved to QEMU addresses under --features qemu).
     #[test]
@@ -304,7 +304,7 @@ mod tests {
         assert!(!BOARD_NAME.is_empty());
     }
 
-    /// WHY (#666): MUSB_IRQ is `None` until hardware-confirmed (see its doc
+    /// WHY (#666): `MUSB_IRQ` is `None` until hardware-confirmed (see its doc
     /// comment). Guards the day it flips to `Some(n)` -- n must be a real
     /// SPI (INTID >= 32; 0..31 are SGI/PPI, never a peripheral line), so a
     /// typo during the eventual hardware-confirmed edit cannot silently

--- a/crates/thumos/src/board/mod.rs
+++ b/crates/thumos/src/board/mod.rs
@@ -2,7 +2,7 @@
 //! thumos boots on (#534).
 //!
 //! thumos is a two-board OS:
-//! - **m7** — the AGM M7 feature phone (MT6739 SoC), the field board;
+//! - **m7** — the AGM M7 feature phone (MT6739 `SoC`), the field board;
 //! - **virt** — QEMU `-machine virt` (armv7a), the dev board every CI
 //!   witness boots on (selected by `--features qemu`).
 //!
@@ -17,7 +17,7 @@
 //! base so the memory map is one truth), not per-board facts.
 //!
 //! OUT OF SCOPE by design (recognition-not-induction, #534): no device-tree
-//! parsing, no runtime board detection, no second SoC port, no mega-HAL —
+//! parsing, no runtime board detection, no second `SoC` port, no mega-HAL —
 //! the per-subsystem `HwOps` traits stay the driver seam; this module is
 //! only the *board* seam.
 
@@ -46,15 +46,15 @@ pub(crate) const KERNEL_LOAD: usize = 0x4000_8000;
 
 /// Kernel reserved size (992 KB).
 /// WHY: kernel image + reserved region spans `0x4000_8000..0x400F_FFFF`
-/// (see the memory map in `memguard.rs`), so KERNEL_END lands on the
-/// 0x4010_0000 page boundary rather than a full 1 MB past KERNEL_LOAD.
+/// (see the memory map in `memguard.rs`), so `KERNEL_END` lands on the
+/// `0x4010_0000` page boundary rather than a full 1 MB past `KERNEL_LOAD`.
 pub(crate) const KERNEL_RESERVED: usize = 0xF_8000;
 
 /// Kernel end address (load + reserved).
 pub(crate) const KERNEL_END: usize = KERNEL_LOAD + KERNEL_RESERVED;
 
 /// Userspace text region base (#474/#482): the top 1 MB of DRAM
-/// (0x7FF0_0000..0x8000_0000), the fixed identity load address for the
+/// (`0x7FF0_0000..0x8000_0000`), the fixed identity load address for the
 /// image-resident /init. EXCLUDED from the page allocator (kinit passes this
 /// as the allocator's upper bound) so an allocation never collides with the
 /// loaded image. In the KERNEL address space it is plain RAM + execute-never

--- a/crates/thumos/src/bt_audio.rs
+++ b/crates/thumos/src/bt_audio.rs
@@ -67,7 +67,7 @@ pub enum BtAudioError {
     AvdtpError,
     /// SBC encoding error (e.g., invalid parameters).
     SbcError,
-    /// The Connecting state exceeded BT_CONNECT_TIMEOUT_MS without reaching
+    /// The Connecting state exceeded `BT_CONNECT_TIMEOUT_MS` without reaching
     /// Connected — the peer never finished AVDTP signaling (#442).
     Timeout,
     /// The peer does not support SBC (mandatory codec).
@@ -163,13 +163,13 @@ pub(crate) struct A2dpProfile<H: BtHwOps> {
     /// Local stream endpoint ID.
     local_seid: u8,
     /// AVDTP signal ID whose response is currently awaited during the
-    /// Connecting sequence (Discover -> GetCapabilities ->
-    /// SetConfiguration -> Open -> Start) or during resume(). `None`
+    /// Connecting sequence (Discover -> `GetCapabilities` ->
+    /// `SetConfiguration` -> Open -> Start) or during `resume()`. `None`
     /// when no signaling response is outstanding.
     pending_signal: Option<u8>,
     /// Tick-ms when Connecting began (#442). `Some` only in the Connecting
     /// state; a peer that never finishes signaling transitions to
-    /// Error(Timeout) at BT_CONNECT_TIMEOUT_MS via check_timeout().
+    /// Error(Timeout) at `BT_CONNECT_TIMEOUT_MS` via `check_timeout()`.
     connecting_since: Option<u64>,
     /// Bluetooth hardware backend.
     hw: H,
@@ -307,7 +307,7 @@ impl<H: BtHwOps> A2dpProfile<H> {
     /// Enforce the Connecting-state deadline (#442). `now_ms` comes from the
     /// caller's own clock (kardia's IRQ-tick base in production, a fake
     /// clock in tests — the profile never reads a clock directly). A peer
-    /// that has been Connecting for BT_CONNECT_TIMEOUT_MS without reaching
+    /// that has been Connecting for `BT_CONNECT_TIMEOUT_MS` without reaching
     /// Connected is moved to Error(Timeout) and its pending signal cleared.
     pub(crate) fn check_timeout(&mut self, now_ms: u64) {
         if let (A2dpState::Connecting, Some(since)) = (self.state, self.connecting_since) {

--- a/crates/thumos/src/capability.rs
+++ b/crates/thumos/src/capability.rs
@@ -8,9 +8,9 @@
 //!
 //! - kinit (PID 0) holds `Capabilities::ALL` at boot.
 //! - Forked children receive a subset defined by kinit policy. The default
-//!   policy strips MODEM, AUDIT, and IPC_INIT so that generic userspace
+//!   policy strips MODEM, AUDIT, and `IPC_INIT` so that generic userspace
 //!   cannot access the baseband, read the audit log, or message PID 0's
-//!   inbox (#371 -- mirrors the CAP_KILL precedent for protecting PID 0
+//!   inbox (#371 -- mirrors the `CAP_KILL` precedent for protecting PID 0
 //!   as a signal target, #269).
 //! - Syscalls that access sensitive resources call `check(required)` at entry.
 //!   On failure the syscall returns EPERM; on success execution continues.
@@ -44,11 +44,11 @@ impl Capabilities {
     pub(crate) const KILL: u32 = 1 << 2;
     /// Access kernel CSPRNG and key material.
     pub(crate) const CRYPTO: u32 = 1 << 3;
-    /// WiFi / BT / GPS radio control.
+    /// `WiFi` / BT / GPS radio control.
     pub(crate) const RADIO: u32 = 1 << 4;
     /// Read audit log.
     pub(crate) const AUDIT: u32 = 1 << 5;
-    /// Send an IPC message to PID 0 (kinit). Mirrors the CAP_KILL precedent
+    /// Send an IPC message to PID 0 (kinit). Mirrors the `CAP_KILL` precedent
     /// (#269/REQ-09) of protecting PID 0 -- the fault supervisor and
     /// IPC-trust anchor -- with a dedicated capability rather than leaving
     /// it reachable by any process holding a generic "can do IPC" bit
@@ -59,7 +59,7 @@ impl Capabilities {
 
     /// Default capability set for forked children.
     ///
-    /// WHY: strips MODEM, AUDIT, and IPC_INIT from ALL. Generic userspace
+    /// WHY: strips MODEM, AUDIT, and `IPC_INIT` from ALL. Generic userspace
     /// processes have no legitimate need to speak AT commands to the
     /// baseband, read the audit log, or message kinit's inbox directly
     /// (#371). All other capabilities remain available; the policy can be

--- a/crates/thumos/src/ccci.rs
+++ b/crates/thumos/src/ccci.rs
@@ -1,7 +1,7 @@
 //! CCCI (Cross-Core Communication Interface) kernel driver.
 //!
 //! Manages the AP↔modem link on the MT6739. The modem (MD 6293) is a separate
-//! ARM core running opaque MediaTek firmware. This driver is the kernel boundary
+//! ARM core running opaque `MediaTek` firmware. This driver is the kernel boundary
 //! between the trusted AP and the hostile modem — every byte from the modem is
 //! untrusted.
 //!
@@ -80,7 +80,7 @@ mod cldma_pd {
     // Source: `eccci/mt6739/cldma_reg.h:69–133`
 
     /// PD base — TX/RX DMA control registers.
-    /// On MT6739 the PD registers share the CLDMA_AP aperture.
+    /// On MT6739 the PD registers share the `CLDMA_AP` aperture.
     const PD_BASE: usize = super::CLDMA_AP_BASE;
 
     // TX (UL = uplink = AP→MD) registers
@@ -173,7 +173,7 @@ const CLDMA_AO_RST_MASK: u32 = 1 << 6;
 const CLDMA_PD_RST_MASK: u32 = 1 << 2;
 /// CLDMA IP busy mask (bit 1).
 const CLDMA_IP_BUSY_MASK: u32 = 1 << 1;
-/// Bit 12 in MD_GLOBAL_CON0 enables CLDMA.
+/// Bit 12 in `MD_GLOBAL_CON0` enables CLDMA.
 const MD_GLOBAL_CON0_CLDMA_EN: u32 = 1 << 12;
 
 // ---------------------------------------------------------------------------
@@ -631,7 +631,7 @@ pub(crate) enum BootStep {
     MapHardware,
     /// Step 4: Write MD boot vector, release reset, poll status.
     ReleaseMd,
-    /// Step 5: Send runtime data via CCIF H2D_SRAM (channel 15).
+    /// Step 5: Send runtime data via CCIF `H2D_SRAM` (channel 15).
     SendRuntime,
     /// Step 6: Wait for MD acknowledge.
     WaitAck,
@@ -754,7 +754,7 @@ impl CldmaGpd {
     /// Set hardware ownership (give to DMA engine).
     ///
     /// WHY: this is the release half of the ownership handoff (issue
-    /// #262) -- the barrier ensures data_ptr/data_len/recv_len writes the
+    /// #262) -- the barrier ensures `data_ptr/data_len/recv_len` writes the
     /// caller made before this call are visible to the CLDMA engine before
     /// it can observe HWO set.
     pub(crate) fn set_hw_owned(&mut self) {
@@ -904,9 +904,9 @@ pub(crate) struct RxRing {
     head: usize,
     /// Number of descriptors currently owned by hardware.
     hw_count: usize,
-    /// Active ring length -- may be less than RX_RING_SIZE if fewer buffer
+    /// Active ring length -- may be less than `RX_RING_SIZE` if fewer buffer
     /// addresses were supplied to `init_chain` (e.g. a boot-time allocation
-    /// shortfall). `head` must wrap by this, not RX_RING_SIZE, or it walks
+    /// shortfall). `head` must wrap by this, not `RX_RING_SIZE`, or it walks
     /// into descriptors HW never chained into the ring (issue #282 finding 4).
     count: usize,
 }
@@ -1052,7 +1052,7 @@ pub(crate) enum NonCacheableRegion {
     CcismShare,
     /// CCB (Credit Control Buffer) for network flow control.
     CcbShare,
-    /// DHLogger raw.
+    /// `DHLogger` raw.
     DhlRawShare,
     /// Modem-consys shared.
     MdConsysShare,

--- a/crates/thumos/src/ccci_logger.rs
+++ b/crates/thumos/src/ccci_logger.rs
@@ -23,7 +23,7 @@
 //!
 //! ## Security
 //!
-//! All structures are fixed-size, no_std, no heap allocation.  The firewall
+//! All structures are fixed-size, `no_std`, no heap allocation.  The firewall
 //! evaluates *before* packet dispatch -- non-allowlisted channels never reach
 //! higher layers.
 
@@ -37,7 +37,7 @@ use crate::ccci::{CCCI_MAGIC, CCCI_MTU, CcciChannel};
 
 /// Logger ring buffer capacity in entries.
 ///
-/// 4 KB budget / size_of::<CcciLogEntry>() -- each entry is 28 bytes,
+/// 4 KB budget / `size_of::`<CcciLogEntry>() -- each entry is 28 bytes,
 /// giving 146 entries.  We round down to 128 (power of 2) for efficient
 /// modular arithmetic.
 const LOG_CAPACITY: usize = 128;
@@ -95,7 +95,7 @@ pub struct CcciLogEntry {
     pub channel: u32,
     /// Packet direction.
     pub direction: PacketDirection,
-    /// Header data0 field (length for data packets, CCCI_MAGIC for control).
+    /// Header data0 field (length for data packets, `CCCI_MAGIC` for control).
     pub data0: u32,
     /// Header data1 field (offset/index on some channels).
     pub data1: u32,
@@ -127,7 +127,7 @@ pub(crate) struct CcciLogger {
     entries: [CcciLogEntry; LOG_CAPACITY],
     /// Next write index.
     head: usize,
-    /// Number of live entries (0..=LOG_CAPACITY).
+    /// Number of live entries (`0..=LOG_CAPACITY`).
     count: usize,
 }
 
@@ -308,7 +308,7 @@ impl fmt::Display for ChannelStats {
 #[derive(Debug, Clone)]
 #[must_use]
 pub struct ModemBaseline {
-    /// Per-channel statistics (indexed by channel number 0..CHANNEL_COUNT).
+    /// Per-channel statistics (indexed by channel number `0..CHANNEL_COUNT`).
     pub channels: [ChannelStats; CHANNEL_COUNT],
     /// Start timestamp of the baseline window.
     pub window_start: u64,
@@ -522,7 +522,7 @@ const MAX_ANOMALIES: usize = 16;
 /// Returns an array of up to [`MAX_ANOMALIES`] anomalies, the count, and
 /// whether more anomalies were detected than the array could hold (issue
 /// #282 finding 5 -- the old 2-tuple gave no way to distinguish "exactly
-/// MAX_ANOMALIES occurred" from "more occurred and were dropped").
+/// `MAX_ANOMALIES` occurred" from "more occurred and were dropped").
 #[must_use]
 pub(crate) fn detect_anomalies(
     log: &CcciLogger,
@@ -844,12 +844,12 @@ impl fmt::Display for CcciFirewall {
 /// physically removes power from the modem -- a hard kill that software
 /// on the modem side cannot prevent or recover from.
 ///
-/// Source: MT6357 PMIC datasheet, VMODEM_CON0 register.
+/// Source: MT6357 PMIC datasheet, `VMODEM_CON0` register.
 /// Derived from the board's PWRAP base (#534) — one MMIO truth.
 #[cfg(not(feature = "qemu"))]
 const PMIC_VMODEM_CON0: usize = crate::board::PWRAP_BASE + 0x0C00;
 
-/// VMODEM enable bit (bit 0 of VMODEM_CON0).
+/// VMODEM enable bit (bit 0 of `VMODEM_CON0`).
 #[cfg(not(feature = "qemu"))]
 const VMODEM_EN_BIT: u32 = 1 << 0;
 

--- a/crates/thumos/src/clock.rs
+++ b/crates/thumos/src/clock.rs
@@ -16,7 +16,7 @@
 //!
 //! ## NTP client
 //!
-//! Minimal UDP NTP exchange: sends a single NTPv4 request to a configured
+//! Minimal UDP NTP exchange: sends a single `NTPv4` request to a configured
 //! server, parses the response for server transmit timestamp, and computes
 //! the clock offset. Uses the socket syscall layer (Wave 4) for UDP.
 
@@ -280,9 +280,9 @@ impl ClockManager {
 // NTP client (minimal UDP exchange)
 // ---------------------------------------------------------------------------
 
-/// Build a minimal NTPv4 client request packet (48 bytes).
+/// Build a minimal `NTPv4` client request packet (48 bytes).
 ///
-/// Sets LI=0 (no warning), VN=4 (NTPv4), Mode=3 (client).
+/// Sets LI=0 (no warning), VN=4 (`NTPv4`), Mode=3 (client).
 /// All timestamp fields are zeroed; the server will fill in its transmit time.
 #[must_use]
 pub(crate) fn build_ntp_request() -> [u8; NTP_PACKET_SIZE] {
@@ -350,7 +350,7 @@ pub(crate) fn parse_ntp_response(packet: &[u8]) -> Option<u64> {
 /// and the server's transmit timestamp (Unix epoch seconds), computes the
 /// offset to add to the local monotonic clock to get wall time.
 ///
-/// offset = server_time - local_send_time
+/// offset = `server_time` - `local_send_time`
 ///
 /// This is a simplified single-exchange offset. A production NTP client
 /// would use the four-timestamp algorithm (T1, T2, T3, T4) with RTT

--- a/crates/thumos/src/csprng.rs
+++ b/crates/thumos/src/csprng.rs
@@ -1,15 +1,15 @@
-//! Kernel CSPRNG — RustCrypto `ChaCha20Rng`, seeded from ARM generic timer jitter.
+//! Kernel CSPRNG — `RustCrypto` `ChaCha20Rng`, seeded from ARM generic timer jitter.
 //!
 //! Architecture mirrors Linux kernel random.c:
-//!   entropy pool (256 bits) → ChaCha20 key → keystream output
+//!   entropy pool (256 bits) → `ChaCha20` key → keystream output
 //!
-//! The DRBG core is `rand_chacha::ChaCha20Rng` (RustCrypto). This module owns
+//! The DRBG core is `rand_chacha::ChaCha20Rng` (`RustCrypto`). This module owns
 //! only the kernel-specific parts: entropy sourcing, the seededness gate, the
 //! reseed-after-N-bytes policy, and the fail-closed `kernel_random_bytes`
-//! interface. It does NOT hand-roll ChaCha20.
+//! interface. It does NOT hand-roll `ChaCha20`.
 //!
 //! Entropy sources:
-//!   (a) ARM generic timer (CNTPCT_EL0 / mrrc p15,0,…,c14) low word sampled
+//!   (a) ARM generic timer (`CNTPCT_EL0` / mrrc p15,0,…,c14) low word sampled
 //!       at every timer interrupt entry.
 //!   (b) Interrupt arrival timing jitter from source (a) — the *variation*
 //!       between successive samples, which is what earns entropy credit.
@@ -37,7 +37,7 @@
 //!
 //! All mutable globals are `static mut`. Access is restricted to:
 //!   - `collect_timer_entropy` / `add_entropy`: called only from the IRQ handler
-//!     (non-reentrant on single-core ARMv7, IRQ disabled during execution).
+//!     (non-reentrant on single-core `ARMv7`, IRQ disabled during execution).
 //!   - `init`: called once from kinit, before any code reads the CSPRNG.
 //!   - `kernel_random_bytes`: callable from kernel context after `init()`; not
 //!     called concurrently on this single-core kernel.
@@ -87,7 +87,7 @@ pub enum CsprngError {
 // DRBG wrapper
 // ---------------------------------------------------------------------------
 
-/// Kernel DRBG: a RustCrypto `ChaCha20Rng` plus the reseed accounting the
+/// Kernel DRBG: a `RustCrypto` `ChaCha20Rng` plus the reseed accounting the
 /// kernel policy needs.
 struct Csprng {
     rng: ChaCha20Rng,
@@ -188,7 +188,7 @@ static mut CSPRNG: Option<Csprng> = None;
 /// Global entropy accumulator. Written only from the IRQ handler.
 ///
 /// SAFETY: all writes are from `irq_handler_rust` (non-reentrant on single-core
-/// ARMv7 with IRQs disabled during handler execution). `init()` reads it once
+/// `ARMv7` with IRQs disabled during handler execution). `init()` reads it once
 /// after sufficient mixing; no concurrent read/write is possible.
 static mut ENTROPY: EntropyPool = EntropyPool::new();
 
@@ -424,7 +424,7 @@ pub fn kernel_random_bytes(buf: &mut [u8]) -> Result<(), CsprngError> {
 ///
 /// Only available in `#[cfg(test)]` builds. Seeds the DRBG deterministically so
 /// test vectors are reproducible without platform hardware. `nonce` sets the
-/// ChaCha20 stream and `counter` the block position (both zero for most callers).
+/// `ChaCha20` stream and `counter` the block position (both zero for most callers).
 #[cfg(test)]
 pub fn seed_for_test(key: &[u8; 32], nonce: &[u8; 8], counter: u64) {
     let mut rng = ChaCha20Rng::from_seed(*key);

--- a/crates/thumos/src/devfs.rs
+++ b/crates/thumos/src/devfs.rs
@@ -5,13 +5,13 @@
 //! | Inode | Name      | Type        | Behavior                              |
 //! |-------|-----------|-------------|---------------------------------------|
 //! | 0     | (root)    | Directory   | Contains all device entries            |
-//! | 1     | `null`    | CharDevice  | Write discards, read returns EOF      |
-//! | 2     | `zero`    | CharDevice  | Write discards, read fills with 0x00  |
-//! | 3     | `urandom` | CharDevice  | Write discards, read returns PRNG     |
-//! | 4     | `ttyMT0`  | CharDevice  | Stub: read/write return Ok(0)         |
-//! | 5     | `fb0`     | CharDevice  | Stub: read/write return Ok(0)         |
-//! | 6     | `bt0`     | CharDevice  | BT control (ioctl for scan)           |
-//! | 7     | `gps0`    | CharDevice  | GPS data (read returns position)      |
+//! | 1     | `null`    | `CharDevice`  | Write discards, read returns EOF      |
+//! | 2     | `zero`    | `CharDevice`  | Write discards, read fills with 0x00  |
+//! | 3     | `urandom` | `CharDevice`  | Write discards, read returns PRNG     |
+//! | 4     | `ttyMT0`  | `CharDevice`  | Stub: read/write return Ok(0)         |
+//! | 5     | `fb0`     | `CharDevice`  | Stub: read/write return Ok(0)         |
+//! | 6     | `bt0`     | `CharDevice`  | BT control (ioctl for scan)           |
+//! | 7     | `gps0`    | `CharDevice`  | GPS data (read returns position)      |
 //!
 //! No dynamic device registration. The devfs is read-only: `create`, `unlink`,
 //! and `truncate` always return `PermissionDenied`.

--- a/crates/thumos/src/device.rs
+++ b/crates/thumos/src/device.rs
@@ -5,7 +5,7 @@
 //! holds all known devices and initializes them in dependency order.
 //!
 //! This is the framework that connects the kernel to UART, display,
-//! keypad, touch, modem, WiFi, BT, GPS, FM, USB, and eMMC.
+//! keypad, touch, modem, `WiFi`, BT, GPS, FM, USB, and eMMC.
 //!
 //! The DEVICE SET and every MMIO base address are board facts — they live
 //! in `crate::board` (#534): `board::m7::register_devices` populates the

--- a/crates/thumos/src/dhcp.rs
+++ b/crates/thumos/src/dhcp.rs
@@ -1,4 +1,4 @@
-//! DHCP client wrapping smoltcp's built-in DHCPv4 socket.
+//! DHCP client wrapping smoltcp's built-in `DHCPv4` socket.
 //!
 //! smoltcp provides [`dhcpv4::Socket`] which handles the full DHCP state
 //! machine (Discover -> Offer -> Request -> Ack). This module wraps it
@@ -77,13 +77,13 @@ impl core::fmt::Display for DhcpConfig {
     }
 }
 
-/// DHCP client that wraps a smoltcp DHCPv4 socket.
+/// DHCP client that wraps a smoltcp `DHCPv4` socket.
 ///
 /// Owns a socket handle into the [`NetworkStack`]'s socket set. On each
 /// [`poll`](Self::poll) call, it checks for DHCP events and applies the
 /// resulting configuration (IP address, gateway) to the network interface.
 pub(crate) struct DhcpClient {
-    /// Handle to the smoltcp DHCPv4 socket in the network stack's socket set.
+    /// Handle to the smoltcp `DHCPv4` socket in the network stack's socket set.
     socket_handle: SocketHandle,
     /// Whether the interface currently has a DHCP-provided configuration.
     configured: bool,
@@ -97,7 +97,7 @@ pub(crate) struct DhcpClient {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum DhcpError {
-    /// The socket set is full; cannot add the DHCPv4 socket.
+    /// The socket set is full; cannot add the `DHCPv4` socket.
     SocketSetFull,
     /// Failed to apply the gateway route.
     RouteTableFull,

--- a/crates/thumos/src/display.rs
+++ b/crates/thumos/src/display.rs
@@ -1,6 +1,6 @@
 //! Display Data Path (DDP) driver for the MT6739.
 //!
-//! Implements the MediaTek display pipeline: OVL0 → RDMA0 → DSI0 → LCM.
+//! Implements the `MediaTek` display pipeline: OVL0 → RDMA0 → DSI0 → LCM.
 //! The [`DisplayDriver`] orchestrates the 10-step hardware init sequence
 //! and provides framebuffer UPDATE via RDMA0 memory mode.
 //!
@@ -64,13 +64,13 @@ mod mmsys {
     pub(crate) const CG0_DISP_ALL: u32 = (1 << 0) | (1 << 3) | (1 << 5) | (1 << 24);
 
     /// Bit mask: display pipeline clocks in CG1.
-    /// DSI0_DIGITAL(bit 0) | DSI0_ENGINE(bit 1).
+    /// `DSI0_DIGITAL(bit` 0) | `DSI0_ENGINE(bit` 1).
     pub(crate) const CG1_DISP_ALL: u32 = (1 << 0) | (1 << 1);
 
-    /// Full release mask for SW0_RST_B.
+    /// Full release mask for `SW0_RST_B`.
     pub(crate) const SW0_RST_RELEASE: u32 = 0xFFFF_FFFF;
 
-    /// Full release mask for SW1_RST_B.
+    /// Full release mask for `SW1_RST_B`.
     pub(crate) const SW1_RST_RELEASE: u32 = 0xFFFF_FFFF;
 
     /// LCM reset release (bit 0).
@@ -90,9 +90,9 @@ mod ovl {
     pub(crate) const INTEN: usize = crate::board::OVL0_BASE + 0x004;
     /// Interrupt status.
     pub(crate) const INTSTA: usize = crate::board::OVL0_BASE + 0x008;
-    /// Enable; bit 0 = OVL_EN, bit 8 = CK_ON.
+    /// Enable; bit 0 = `OVL_EN`, bit 8 = `CK_ON`.
     pub(crate) const EN: usize = crate::board::OVL0_BASE + 0x00C;
-    /// Trigger; bit 0 = SW_TRIG.
+    /// Trigger; bit 0 = `SW_TRIG`.
     pub(crate) const TRIG: usize = crate::board::OVL0_BASE + 0x010;
     /// Reset.
     pub(crate) const RST: usize = crate::board::OVL0_BASE + 0x014;
@@ -107,13 +107,13 @@ mod ovl {
     /// Layer 0 control (alpha, flip, format).
     pub(crate) const L0_CON: usize = crate::board::OVL0_BASE + 0x030;
 
-    /// OVL_EN bit.
+    /// `OVL_EN` bit.
     pub(crate) const EN_BIT: u32 = 1 << 0;
-    /// CK_ON bit (force clock on).
+    /// `CK_ON` bit (force clock on).
     pub(crate) const CK_ON_BIT: u32 = 1 << 8;
-    /// SW_TRIG bit.
+    /// `SW_TRIG` bit.
     pub(crate) const SW_TRIG_BIT: u32 = 1 << 0;
-    /// Layer 0 enable bit in SRC_CON.
+    /// Layer 0 enable bit in `SRC_CON`.
     pub(crate) const LAYER0_EN: u32 = 1 << 0;
 
     /// Frame complete interrupt enable.
@@ -133,7 +133,7 @@ mod ovl {
 /// RDMA0 register block.
 mod rdma {
 
-    /// Global control; bit 0 = ENGINE_EN, bit 1 = MODE_SEL (1=memory).
+    /// Global control; bit 0 = `ENGINE_EN`, bit 1 = `MODE_SEL` (1=memory).
     pub(crate) const GLOBAL_CON: usize = crate::board::RDMA0_BASE;
     /// Output frame width.
     pub(crate) const SIZE_CON_0: usize = crate::board::RDMA0_BASE + 0x014;
@@ -146,12 +146,12 @@ mod rdma {
     /// Framebuffer start address (physical).
     pub(crate) const MEM_START_ADDR: usize = crate::board::RDMA0_BASE + 0x0F0;
 
-    /// ENGINE_EN bit.
+    /// `ENGINE_EN` bit.
     pub(crate) const ENGINE_EN: u32 = 1 << 0;
-    /// MODE_SEL bit (1 = memory mode).
+    /// `MODE_SEL` bit (1 = memory mode).
     pub(crate) const MODE_MEMORY: u32 = 1 << 1;
 
-    /// RGB565 input format in MEM_CON.
+    /// RGB565 input format in `MEM_CON`.
     pub(crate) const FMT_RGB565: u32 = 0;
 }
 
@@ -204,15 +204,15 @@ mod dsi {
     /// Rack (read-ack) register — write 1 to acknowledge completed command.
     pub(crate) const RACK: usize = crate::board::DSI0_BASE + 0x084;
 
-    /// DSI_START bit.
+    /// `DSI_START` bit.
     pub(crate) const START_BIT: u32 = 1;
     /// Video mode sync pulse.
     pub(crate) const MODE_SYNC_PULSE: u32 = 1;
-    /// 1 data lane in TXRX_CTRL bits [3:2].
+    /// 1 data lane in `TXRX_CTRL` bits [3:2].
     pub(crate) const LANE_1: u32 = 0b00 << 2;
-    /// Clock lane enable in PHY_LCCON.
+    /// Clock lane enable in `PHY_LCCON`.
     pub(crate) const LC_HS_TX_EN: u32 = 1 << 0;
-    /// Data lane 0 enable in PHY_LD0CON.
+    /// Data lane 0 enable in `PHY_LD0CON`.
     pub(crate) const LD0_HS_TX_EN: u32 = 1 << 0;
 
     // WHY: CMDQ word format for DCS short writes (the only type we use):
@@ -778,7 +778,7 @@ pub enum DisplayState {
 // Pure helper functions (testable without hardware)
 // ---------------------------------------------------------------------------
 
-/// Encode width and height INTO OVL_ROI_SIZE register format.
+/// Encode width and height INTO `OVL_ROI_SIZE` register format.
 ///
 /// Format: bits [12:0] = width, bits [28:16] = height.
 pub const fn encode_roi_size(width: u16, height: u16) -> u32 {

--- a/crates/thumos/src/dns.rs
+++ b/crates/thumos/src/dns.rs
@@ -1,6 +1,6 @@
 //! DNS resolver with caching and split-horizon routing.
 //!
-//! Queries for `*.lan` hostnames are routed to a local AdGuard DNS
+//! Queries for `*.lan` hostnames are routed to a local `AdGuard` DNS
 //! instance, which resolves internal LAN services. All other queries
 //! go to Mullvad DNS (`194.242.2.2`) for privacy. ISP DNS is never
 //! used.
@@ -452,8 +452,8 @@ fn skip_dns_name(data: &[u8], mut offset: usize) -> Result<usize, DnsError> {
 ///
 /// When `use_dot` is enabled, non-LAN queries are routed through
 /// DNS-over-TLS (port 853) instead of plain UDP (port 53). LAN queries
-/// (`*.lan`) always use plain UDP to the local AdGuard instance regardless
-/// of the DoT setting. See [`dns_tls`](crate::dns_tls) for the DoT
+/// (`*.lan`) always use plain UDP to the local `AdGuard` instance regardless
+/// of the `DoT` setting. See [`dns_tls`](crate::dns_tls) for the `DoT`
 /// framing layer.
 pub(crate) struct DnsResolver {
     /// Local DNS cache.
@@ -466,7 +466,7 @@ pub(crate) struct DnsResolver {
     ///
     /// When true, the resolver signals that queries for non-LAN hostnames
     /// should be dispatched via a `dns_tls::DotClient` instead of plain UDP.
-    /// The actual DoT transport is managed externally; this flag controls
+    /// The actual `DoT` transport is managed externally; this flag controls
     /// routing decisions only.
     use_dot: bool,
 }
@@ -503,8 +503,8 @@ impl DnsResolver {
 
     /// Check whether a given hostname should use DNS-over-TLS.
     ///
-    /// Returns `true` if DoT is enabled and the hostname is not a LAN
-    /// hostname. LAN queries always bypass DoT.
+    /// Returns `true` if `DoT` is enabled and the hostname is not a LAN
+    /// hostname. LAN queries always bypass `DoT`.
     pub(crate) fn should_use_dot(&self, hostname: &str) -> bool {
         self.use_dot && !is_lan_hostname(hostname)
     }

--- a/crates/thumos/src/dns_tls.rs
+++ b/crates/thumos/src/dns_tls.rs
@@ -1,6 +1,6 @@
-//! DNS-over-TLS (DoT) framing layer.
+//! DNS-over-TLS (`DoT`) framing layer.
 //!
-//! Wraps DNS queries in the DoT wire format (RFC 7858): a 2-byte length
+//! Wraps DNS queries in the `DoT` wire format (RFC 7858): a 2-byte length
 //! prefix followed by the DNS message, transmitted over a TLS 1.3 connection
 //! to port 853. The actual TLS handshake is abstracted behind the
 //! [`TlsTransport`] trait, allowing the kernel to plug in any TLS backend
@@ -11,7 +11,7 @@
 //! The client stores the SHA-256 hash of the server's Subject Public Key
 //! Info (SPKI). During the TLS handshake callback, the received SPKI is
 //! checked against `pinned_spki_hash`. A mismatch causes the connection
-//! to be rejected. No plaintext fallback: DoT failure = DNS failure.
+//! to be rejected. No plaintext fallback: `DoT` failure = DNS failure.
 //!
 //! ## Wire format
 //!
@@ -30,8 +30,8 @@
 //!
 //! The `dns.rs` resolver can be wired to use a `DotClient` as transport
 //! instead of plain UDP by setting `DnsResolver::use_dot` (added by this
-//! module). LAN queries (`*.lan`) bypass DoT and use plain UDP to the
-//! local AdGuard instance.
+//! module). LAN queries (`*.lan`) bypass `DoT` and use plain UDP to the
+//! local `AdGuard` instance.
 
 // WHY: DNS-over-TLS created in Phase 08 Wave 7, integration pending.
 #![expect(
@@ -53,12 +53,12 @@ use crate::csprng;
 /// Standard DNS-over-TLS port (RFC 7858).
 pub(crate) const DOT_PORT: u16 = 853;
 
-/// Maximum DNS message size for DoT framing (RFC 7858 section 3.3).
+/// Maximum DNS message size for `DoT` framing (RFC 7858 section 3.3).
 /// TCP/TLS DNS messages can be up to 65535 bytes, but practical queries
 /// are much smaller. We cap at 4096 to prevent memory exhaustion.
 const MAX_DNS_MESSAGE_SIZE: usize = 4096;
 
-/// DoT frame header size: 2-byte big-endian length prefix.
+/// `DoT` frame header size: 2-byte big-endian length prefix.
 const DOT_FRAME_HEADER_SIZE: usize = 2;
 
 /// Maximum total frame size (header + message).
@@ -67,7 +67,7 @@ const MAX_FRAME_SIZE: usize = DOT_FRAME_HEADER_SIZE + MAX_DNS_MESSAGE_SIZE;
 /// SHA-256 hash length for SPKI pinning.
 const SPKI_HASH_LEN: usize = 32;
 
-/// Quad9 DNS server address (primary DoT target).
+/// Quad9 DNS server address (primary `DoT` target).
 pub(crate) const QUAD9_DNS: Ipv4Address = Ipv4Address::new(9, 9, 9, 9);
 
 /// DNS record type A (IPv4 address).
@@ -165,7 +165,7 @@ pub(crate) trait TlsTransport {
 // DoT framing
 // ---------------------------------------------------------------------------
 
-/// Wrap a DNS message in a DoT frame (2-byte big-endian length prefix).
+/// Wrap a DNS message in a `DoT` frame (2-byte big-endian length prefix).
 ///
 /// Returns the framed message or `DotError::MessageTooLarge` if the
 /// DNS message exceeds `MAX_DNS_MESSAGE_SIZE`.
@@ -182,7 +182,7 @@ pub(crate) fn frame_dns_message(dns_message: &[u8]) -> Result<Vec<u8>, DotError>
     Ok(frame)
 }
 
-/// Extract the DNS message length from a DoT frame header.
+/// Extract the DNS message length from a `DoT` frame header.
 ///
 /// Reads the first 2 bytes as a big-endian u16 length value.
 #[must_use]
@@ -190,7 +190,7 @@ pub(crate) fn parse_frame_length(header: &[u8; 2]) -> u16 {
     u16::from_be_bytes(*header)
 }
 
-/// Read a complete DoT frame from a TLS transport.
+/// Read a complete `DoT` frame from a TLS transport.
 ///
 /// Reads the 2-byte length prefix, then reads the DNS message body.
 /// Returns the DNS message payload (without the length prefix).
@@ -404,7 +404,7 @@ fn random_txid() -> u16 {
 }
 
 impl<T: TlsTransport> DotClient<T> {
-    /// Create a new DoT client with the given transport and SPKI pin.
+    /// Create a new `DoT` client with the given transport and SPKI pin.
     ///
     /// The `pinned_spki_hash` is the SHA-256 digest of the server's
     /// Subject Public Key Info, used for certificate pinning during
@@ -449,7 +449,7 @@ impl<T: TlsTransport> DotClient<T> {
 
     /// Send a DNS query for the given hostname (A record).
     ///
-    /// Builds a DNS A query, wraps it in a DoT frame, sends it over
+    /// Builds a DNS A query, wraps it in a `DoT` frame, sends it over
     /// the TLS transport, reads the response frame, and returns the
     /// raw DNS response message.
     #[must_use]
@@ -494,7 +494,7 @@ impl<T: TlsTransport> DotClient<T> {
         Ok(response)
     }
 
-    /// Send a raw DNS message over DoT and return the raw response.
+    /// Send a raw DNS message over `DoT` and return the raw response.
     ///
     /// The caller is responsible for building and parsing the DNS message.
     #[must_use]
@@ -522,21 +522,21 @@ impl<T: TlsTransport> DotClient<T> {
 /// Configuration for DNS-over-TLS integration with the DNS resolver.
 ///
 /// When `enabled` is true, the resolver routes non-LAN queries through
-/// a DoT client instead of plain UDP. LAN queries (`*.lan`) always use
-/// plain UDP to the local AdGuard instance.
+/// a `DoT` client instead of plain UDP. LAN queries (`*.lan`) always use
+/// plain UDP to the local `AdGuard` instance.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct DotConfig {
-    /// Whether DoT is enabled for non-LAN queries.
+    /// Whether `DoT` is enabled for non-LAN queries.
     pub enabled: bool,
-    /// DoT server address (e.g., Quad9 9.9.9.9).
+    /// `DoT` server address (e.g., Quad9 9.9.9.9).
     pub server_addr: Ipv4Address,
-    /// SHA-256 SPKI pin for the DoT server.
+    /// SHA-256 SPKI pin for the `DoT` server.
     pub pinned_spki_hash: [u8; SPKI_HASH_LEN],
 }
 
 impl DotConfig {
-    /// Create a new DoT configuration.
+    /// Create a new `DoT` configuration.
     pub(crate) fn new(server_addr: Ipv4Address, pinned_spki_hash: [u8; SPKI_HASH_LEN]) -> Self {
         Self {
             enabled: true,
@@ -545,7 +545,7 @@ impl DotConfig {
         }
     }
 
-    /// Create a disabled DoT configuration.
+    /// Create a disabled `DoT` configuration.
     pub(crate) fn disabled() -> Self {
         Self {
             enabled: false,
@@ -577,7 +577,7 @@ mod tests {
 
     // -- Mock TLS transport ---------------------------------------------------
 
-    /// Mock TLS transport for testing DoT framing and query flow.
+    /// Mock TLS transport for testing `DoT` framing and query flow.
     ///
     /// Stores sent data and returns preconfigured responses.
     struct MockTlsTransport {
@@ -617,7 +617,7 @@ mod tests {
 
         /// Script a transport whose clock advances `per_recv` tick-ms on
         /// every recv (#442): a recv that lands after the deadline must
-        /// return DotError::Timeout.
+        /// return `DotError::Timeout`.
         fn with_clock_advance(responses: Vec<Vec<u8>>, per_recv: u64) -> Self {
             Self {
                 sent: Vec::new(),

--- a/crates/thumos/src/ekphrasis.rs
+++ b/crates/thumos/src/ekphrasis.rs
@@ -1106,7 +1106,7 @@ impl fmt::Display for Ekphrasis {
 #[must_use]
 #[non_exhaustive]
 pub struct ActionProposal {
-    /// The action identifier (e.g., "open_dialer", "draft_sms").
+    /// The action identifier (e.g., "`open_dialer`", "`draft_sms`").
     pub action: String,
     /// Key-value parameters for the action.
     pub params: Vec<(String, String)>,
@@ -1164,13 +1164,13 @@ pub(crate) mod action_types {
     pub(crate) const ADD_CALENDAR_EVENT: &str = "add_calendar_event";
     /// Toggle security mode (Sentinel, Covert, etc.).
     pub(crate) const TOGGLE_MODE: &str = "toggle_mode";
-    /// Toggle a specific radio (WiFi, cellular, Bluetooth).
+    /// Toggle a specific radio (`WiFi`, cellular, Bluetooth).
     pub(crate) const TOGGLE_RADIO: &str = "toggle_radio";
     /// Navigate to a thumos function/screen.
     pub(crate) const OPEN_FEATURE: &str = "open_feature";
     /// Initiate a security scan (Phase 10).
     pub(crate) const SCAN_START: &str = "scan_start";
-    /// Add the current WiFi network to safe networks.
+    /// Add the current `WiFi` network to safe networks.
     pub(crate) const ADD_SAFE_NETWORK: &str = "add_safe_network";
 
     /// All known action type strings, for validation.
@@ -1247,7 +1247,7 @@ fn find_fenced_block(message: &str) -> Option<(&str, usize)> {
 }
 
 /// Try to find a fenced block with the given delimiters. `end_marker` must
-/// already include its leading newline (see FENCE_END / FENCE_END_ALT).
+/// already include its leading newline (see `FENCE_END` / `FENCE_END_ALT`).
 fn try_find_fence<'a>(
     message: &'a str,
     start_marker: &str,

--- a/crates/thumos/src/elf.rs
+++ b/crates/thumos/src/elf.rs
@@ -1,6 +1,6 @@
 //! Minimal ELF loader for userspace binaries.
 //!
-//! Parses ELF32 headers and loads PT_LOAD segments INTO memory.
+//! Parses ELF32 headers and loads `PT_LOAD` segments INTO memory.
 //! Only supports statically-linked ARM ELF binaries (what our userspace
 //! crates compile to with `armv7-unknown-linux-musleabihf` target).
 //!
@@ -26,7 +26,7 @@ const EM_ARM: u16 = 40;
 /// Program header type: loadable segment
 const PT_LOAD: u32 = 1;
 
-/// PT_LOAD segment permission flags (ELF32 program header `p_flags`).
+/// `PT_LOAD` segment permission flags (ELF32 program header `p_flags`).
 const PF_X: u32 = 0x1;
 const PF_W: u32 = 0x2;
 const PF_R: u32 = 0x4;
@@ -34,7 +34,7 @@ const PF_R: u32 = 0x4;
 /// Translate ELF `p_flags` to POSIX prot bits for `mmu::prot_to_l2_flags`
 /// (#482), so a spawned process's segments get W^X user page permissions
 /// (text RX, rodata RO, data/bss RW+XN; a W|X segment degrades to RW+XN
-/// because `prot_to_l2_flags` forces XN whenever PROT_WRITE is set).
+/// because `prot_to_l2_flags` forces XN whenever `PROT_WRITE` is set).
 pub(crate) fn flags_to_prot(p_flags: u32) -> u32 {
     let mut prot = 0;
     if p_flags & PF_R != 0 {
@@ -89,14 +89,14 @@ struct Elf32Phdr {
 
 /// Size of an on-disk `Elf32Phdr`: eight `u32` fields = 32 bytes.
 ///
-/// WHY size_of, not the header-declared `e_phentsize` (#317): the phdr read
+/// WHY `size_of`, not the header-declared `e_phentsize` (#317): the phdr read
 /// in `validate()` always consumes exactly this many bytes regardless of
 /// what the attacker-controlled `e_phentsize` claims, so both the entsize
 /// floor and the per-header bounds check must be pinned to the type's
 /// actual size.
 const PHDR_SIZE: usize = core::mem::size_of::<Elf32Phdr>();
 
-/// Maximum total PT_LOAD segment memory, in pages, a single ELF image may
+/// Maximum total `PT_LOAD` segment memory, in pages, a single ELF image may
 /// declare (#327).
 ///
 /// WHY 2048 (8 MB): generous headroom for a statically-linked ARM musl
@@ -113,7 +113,7 @@ pub(crate) struct LoadedElf {
     /// Number of pages written (#328: no longer a count of
     /// `page::alloc_page()` reservations — see `load()`'s doc comment).
     pub pages_used: usize,
-    /// `(vaddr, memsz, p_flags)` per PT_LOAD segment (#482), so `spawn_user`
+    /// `(vaddr, memsz, p_flags)` per `PT_LOAD` segment (#482), so `spawn_user`
     /// can map each segment PL0-accessible with W^X permissions derived from
     /// `p_flags`. The link address is `vaddr`; the LOAD address is
     /// `image_phys + (vaddr - image_lo)` (#502, no longer identity).
@@ -134,7 +134,7 @@ pub(crate) struct LoadedElf {
 }
 
 impl LoadedElf {
-    /// The loaded PT_LOAD segments as `(vaddr, memsz, p_flags)` (#482).
+    /// The loaded `PT_LOAD` segments as `(vaddr, memsz, p_flags)` (#482).
     pub(crate) fn segments(&self) -> &[(usize, usize, u32)] {
         &self.segments[..self.seg_count]
     }
@@ -184,7 +184,7 @@ pub enum ElfError {
 /// Performs all header validation (magic, class, endianness, machine type)
 /// and verifies that each program header is within `data` bounds.
 /// Returns the entry point, program header metadata, and validated segment
-/// descriptors for each PT_LOAD segment.
+/// descriptors for each `PT_LOAD` segment.
 ///
 /// This function is pure (no page allocation or memory writes) and is
 /// therefore safe to call in test builds.
@@ -347,7 +347,7 @@ fn validate(data: &[u8]) -> Result<(usize, ValidatedElf), ElfError> {
 /// Validated ELF segment descriptors (output of header validation).
 #[derive(Debug)]
 struct ValidatedElf {
-    /// `(vaddr, memsz, filesz, file_offset, p_flags)` for each PT_LOAD segment.
+    /// `(vaddr, memsz, filesz, file_offset, p_flags)` for each `PT_LOAD` segment.
     segments: [(usize, usize, usize, usize, u32); 16],
     /// Number of valid entries in `segments`.
     count: usize,
@@ -360,7 +360,7 @@ struct ValidatedElf {
 
 /// Load an ELF binary FROM a byte slice INTO memory.
 ///
-/// Writes each PT_LOAD segment directly to its identity-mapped `vaddr`
+/// Writes each `PT_LOAD` segment directly to its identity-mapped `vaddr`
 /// (validated by `validate()`'s load-region check, #318), zeroing BSS.
 /// Returns the entry point for process creation. #328: does not call
 /// `page::alloc_page()` per segment page — nothing would ever free such a
@@ -378,13 +378,13 @@ pub(crate) fn load(data: &[u8]) -> Result<LoadedElf, ElfError> {
     load_impl(data, None)
 }
 
-/// `load()`, but reject any PT_LOAD segment outside `[lo, hi)` -- the reserved
+/// `load()`, but reject any `PT_LOAD` segment outside `[lo, hi)` -- the reserved
 /// user-image window (#489) -- BEFORE writing a byte, and (#502) load into a
 /// freshly-allocated per-process image frame rather than the identity vaddr.
 /// A single `validate()` pass gates both format and placement, so a boot/exec
 /// image can never write into page-allocator RAM or escape the exec revocation
 /// surface, and fail-before-destroy holds. Every authored image links at
-/// USER_TEXT_BASE (init.ld). The returned `LoadedElf` carries the image frame
+/// `USER_TEXT_BASE` (init.ld). The returned `LoadedElf` carries the image frame
 /// base (`image_phys`/`image_lo`/`image_pages`) for `map_user_image` + teardown.
 ///
 /// # Safety
@@ -408,7 +408,7 @@ pub(crate) unsafe fn load_confined(
 /// the contiguous per-process image frame. Returns `(image_phys, image_lo)`.
 ///
 /// WHY its own `#[inline(never)]` function: see the call site in `load_impl` --
-/// keeping this out of load_impl's frame is what prevents the armv7 exec-path
+/// keeping this out of `load_impl`'s frame is what prevents the armv7 exec-path
 /// codegen from corrupting the returned `ValidatedElf`.
 #[inline(never)]
 fn plan_confined_image(
@@ -695,7 +695,7 @@ mod tests {
         assert_eq!(validate(&h).unwrap_err(), ElfError::InvalidSegment);
     }
 
-    /// #316: e_phoff chosen so `phoff + i*phentsize` would wrap a 32-bit
+    /// #316: `e_phoff` chosen so `phoff + i*phentsize` would wrap a 32-bit
     /// usize (this crate's host tests run on i686, so the wrap reproduces
     /// without a target-width mock) and bypass the bounds guard.
     #[test]
@@ -707,7 +707,7 @@ mod tests {
         assert_eq!(validate(&h).unwrap_err(), ElfError::InvalidSegment);
     }
 
-    /// #316: p_offset/p_filesz chosen so `file_offset + filesz` would wrap
+    /// #316: `p_offset/p_filesz` chosen so `file_offset + filesz` would wrap
     /// a 32-bit usize, attempting to smuggle a bogus segment past the
     /// file-extent bounds guard.
     #[test]
@@ -728,7 +728,7 @@ mod tests {
         assert_eq!(validate(&buf).unwrap_err(), ElfError::InvalidSegment);
     }
 
-    /// #317: e_phentsize smaller than size_of::<Elf32Phdr>() must be
+    /// #317: `e_phentsize` smaller than `size_of::`<Elf32Phdr>() must be
     /// rejected before any phdr is read, not admitted by a bounds check
     /// that trusts the attacker-controlled stride.
     #[test]
@@ -740,7 +740,7 @@ mod tests {
         assert_eq!(validate(&h).unwrap_err(), ElfError::InvalidSegment);
     }
 
-    /// #318: a PT_LOAD segment whose p_vaddr lies outside the sanctioned
+    /// #318: a `PT_LOAD` segment whose `p_vaddr` lies outside the sanctioned
     /// user-accessible DRAM load region must be rejected before any byte
     /// is written.
     #[test]
@@ -760,7 +760,7 @@ mod tests {
         assert_eq!(validate(&buf).unwrap_err(), ElfError::InvalidSegment);
     }
 
-    /// #327: a PT_LOAD segment declaring memory far beyond the configured
+    /// #327: a `PT_LOAD` segment declaring memory far beyond the configured
     /// per-image budget must be rejected before any page is allocated.
     #[test]
     fn parse_rejects_segment_memory_over_budget() {
@@ -781,7 +781,7 @@ mod tests {
         assert_eq!(validate(&buf).unwrap_err(), ElfError::InvalidSegment);
     }
 
-    /// finding 2: a 17th PT_LOAD segment must be rejected, not silently
+    /// finding 2: a 17th `PT_LOAD` segment must be rejected, not silently
     /// dropped from the fixed 16-slot `segments` array while `total_pages`
     /// still counted its budget -- the old behavior let `load()` report
     /// success while never writing that segment's bytes to memory.
@@ -843,11 +843,11 @@ mod tests {
 
     /// #501 regression: the exec-path mis-read (a segment's (vaddr, memsz)
     /// coming back field-shifted, e.g. (0x7ff00000, 0x40) -> (0x0, 0x7ff00000))
-    /// came from a SEPARATE pre-pass that re-parsed via a second validate()
-    /// "peek", now removed -- placement is folded into load()'s single write
+    /// came from a SEPARATE pre-pass that re-parsed via a second `validate()`
+    /// "peek", now removed -- placement is folded into `load()`'s single write
     /// loop. Guard both halves of the Done-when: (1) reading validated.segments
     /// in a standalone pre-pass yields the exact tuple values the write loop's
-    /// destructure yields (no field shift), and (2) a second validate() over
+    /// destructure yields (no field shift), and (2) a second `validate()` over
     /// the same bytes is idempotent (the peek scenario). Two distinct segments
     /// so any single-field shift is visible.
     #[test]
@@ -901,8 +901,8 @@ mod tests {
         }
     }
 
-    /// finding 49: e_entry outside every loaded PT_LOAD segment must be
-    /// rejected -- kinit.rs and syscall.rs's sys_execve both transmute this
+    /// finding 49: `e_entry` outside every loaded `PT_LOAD` segment must be
+    /// rejected -- kinit.rs and syscall.rs's `sys_execve` both transmute this
     /// address straight to a callable function pointer, so an unvalidated
     /// entry point is an arbitrary jump/code-execution primitive, not just
     /// a crash.
@@ -1062,7 +1062,7 @@ mod tests {
         assert!(unsafe { load_confined(&data, vaddr, vaddr.wrapping_add(0x1000)) }.is_ok());
     }
 
-    /// #328: when the free pool is smaller than the segment budget, load()
+    /// #328: when the free pool is smaller than the segment budget, `load()`
     /// must reject up front (before writing anything) rather than fail
     /// partway through — there is no partial state to roll back because no
     /// allocation happens until after this check passes.

--- a/crates/thumos/src/emmc.rs
+++ b/crates/thumos/src/emmc.rs
@@ -1,7 +1,7 @@
 //! eMMC block device driver for MT6739 MSDC controller.
 //!
-//! Implements PIO and DMA transfer paths for eMMC 5.1 on the MediaTek MSDC
-//! (MultiSlot Data Controller). Register offsets and interrupt definitions
+//! Implements PIO and DMA transfer paths for eMMC 5.1 on the `MediaTek` MSDC
+//! (`MultiSlot` Data Controller). Register offsets and interrupt definitions
 //! are derived FROM `docs/DRIVER-INTERFACES.md` section 8.
 //!
 //! # Architecture
@@ -212,7 +212,7 @@ const CMD_DTYPE_READ: u32 = 0b01 << 11;
 /// Data transfer direction: write (host → device).
 const CMD_DTYPE_WRITE: u32 = 0b10 << 11;
 
-/// Block length shift for SDC_CMD (bits [31:16] in some configs).
+/// Block length shift for `SDC_CMD` (bits [31:16] in some configs).
 #[expect(dead_code, reason = "block length SET via SDC_CFG on MT6739 (#145)")]
 const CMD_BLK_LEN_SHIFT: u32 = 16;
 
@@ -252,18 +252,18 @@ const FIFOCS_CLR: u32 = 1 << 0;
 ///
 /// WARNING: the exact bit position is taken from the issue's datasheet
 /// citation, not independently re-derived against the BSP header. The
-/// per-word poll is bounded by POLL_TIMEOUT so a wrong field position
-/// degrades to a DataTimeout (safe), but must be verified before silicon.
+/// per-word poll is bounded by `POLL_TIMEOUT` so a wrong field position
+/// degrades to a `DataTimeout` (safe), but must be verified before silicon.
 /// TODO(#293)[deliberate-prudent]: confirm FIFOCS RXCNT field position against the MT6739 BSP.
 const FIFOCS_RXCNT_SHIFT: u32 = 16;
 
 /// RX FIFO word-count field mask (8 bits at [23:16]).
 const FIFOCS_RXCNT_MASK: u32 = 0xFF << FIFOCS_RXCNT_SHIFT;
 
-/// True if the MSDC_FIFOCS RX word count is nonzero, i.e. at least one word
-/// is buffered and safe to read FROM MSDC_RXDATA.
+/// True if the `MSDC_FIFOCS` RX word count is nonzero, i.e. at least one word
+/// is buffered and safe to read FROM `MSDC_RXDATA`.
 ///
-/// WHY: STS_DATBUSY stays SET for the duration of an entire block transfer,
+/// WHY: `STS_DATBUSY` stays SET for the duration of an entire block transfer,
 /// so it cannot signal per-word FIFO readiness during a PIO read; the RX
 /// count field is the per-word-accurate signal (issue #293).
 fn fifo_rx_ready(fifocs: u32) -> bool {
@@ -363,56 +363,56 @@ fn classify_interrupt_status(status: u32) -> Option<MsdcError> {
 // eMMC command opcodes (MMC specification)
 // ---------------------------------------------------------------------------
 
-/// CMD0: GO_IDLE_STATE  -  reset card to idle.
+/// CMD0: `GO_IDLE_STATE`  -  reset card to idle.
 const CMD0_GO_IDLE: u32 = 0;
 
-/// CMD1: SEND_OP_COND  -  send operating conditions.
+/// CMD1: `SEND_OP_COND`  -  send operating conditions.
 const CMD1_SEND_OP_COND: u32 = 1;
 
-/// CMD2: ALL_SEND_CID  -  request card identification.
+/// CMD2: `ALL_SEND_CID`  -  request card identification.
 #[expect(dead_code, reason = "reserved for CID readback (#145)")]
 const CMD2_ALL_SEND_CID: u32 = 2;
 
-/// CMD3: SET_RELATIVE_ADDR  -  assign relative card address.
+/// CMD3: `SET_RELATIVE_ADDR`  -  assign relative card address.
 const CMD3_SET_RELATIVE_ADDR: u32 = 3;
 
-/// CMD7: SELECT_CARD  -  SELECT card for data transfer.
+/// CMD7: `SELECT_CARD`  -  SELECT card for data transfer.
 const CMD7_SELECT_CARD: u32 = 7;
 
-/// CMD8: SEND_EXT_CSD  -  read extended CSD register.
+/// CMD8: `SEND_EXT_CSD`  -  read extended CSD register.
 #[expect(dead_code, reason = "reserved for EXT_CSD readback (#145)")]
 const CMD8_SEND_EXT_CSD: u32 = 8;
 
-/// CMD13: SEND_STATUS  -  read card status register.
+/// CMD13: `SEND_STATUS`  -  read card status register.
 #[expect(dead_code, reason = "reserved for status polling (#145)")]
 const CMD13_SEND_STATUS: u32 = 13;
 
-/// CMD16: SET_BLOCKLEN  -  SET block length to 512 bytes.
+/// CMD16: `SET_BLOCKLEN`  -  SET block length to 512 bytes.
 const CMD16_SET_BLOCKLEN: u32 = 16;
 
-/// CMD17: READ_SINGLE_BLOCK.
+/// CMD17: `READ_SINGLE_BLOCK`.
 const CMD17_READ_SINGLE: u32 = 17;
 
-/// CMD18: READ_MULTIPLE_BLOCK.
+/// CMD18: `READ_MULTIPLE_BLOCK`.
 const CMD18_READ_MULTI: u32 = 18;
 
-/// CMD24: WRITE_SINGLE_BLOCK.
+/// CMD24: `WRITE_SINGLE_BLOCK`.
 const CMD24_WRITE_SINGLE: u32 = 24;
 
-/// CMD25: WRITE_MULTIPLE_BLOCK.
+/// CMD25: `WRITE_MULTIPLE_BLOCK`.
 const CMD25_WRITE_MULTI: u32 = 25;
 
 // ---------------------------------------------------------------------------
 // OCR (CMD1 SEND_OP_COND response) bit fields
 // ---------------------------------------------------------------------------
 
-/// OCR "power-up status" bit (bit 31) in the CMD1 (SEND_OP_COND) R3
+/// OCR "power-up status" bit (bit 31) in the CMD1 (`SEND_OP_COND`) R3
 /// response. 0 while the card is still completing power-up, 1 once ready.
 /// The eMMC spec requires CMD1 to be repeated until this bit is observed
 /// set (issue #622).
 const OCR_BUSY_BIT: u32 = 1 << 31;
 
-/// Maximum CMD1 (SEND_OP_COND) attempts during init before giving up.
+/// Maximum CMD1 (`SEND_OP_COND`) attempts during init before giving up.
 ///
 /// WHY: eMMC power-up on real hardware completes within a handful of
 /// attempts; an absent/dead card fails fast through `send_command`'s own
@@ -1144,7 +1144,7 @@ impl MsdcController {
         unsafe { self.check_and_clear_completion(INT_XFER_COMPL | INT_DXFER_DONE) }
     }
 
-    /// Read the 32-bit response FROM SDC_RESP0.
+    /// Read the 32-bit response FROM `SDC_RESP0`.
     ///
     /// # Safety
     ///
@@ -1154,7 +1154,7 @@ impl MsdcController {
         unsafe { self.read_reg(REG_SDC_RESP0) }
     }
 
-    /// Read the full 128-bit response FROM SDC_RESP0–3.
+    /// Read the full 128-bit response FROM `SDC_RESP0–3`.
     ///
     /// # Safety
     ///
@@ -1194,13 +1194,13 @@ impl MsdcController {
     /// Check for hardware error interrupts before clearing a transfer's
     /// completion bits.
     ///
-    /// Reads MSDC_INT; if any bit in [`INT_ERR_MASK`] is set, clears every
-    /// observed bit (MSDC_INT is write-1-to-clear) and returns
+    /// Reads `MSDC_INT`; if any bit in [`INT_ERR_MASK`] is set, clears every
+    /// observed bit (`MSDC_INT` is write-1-to-clear) and returns
     /// [`MsdcError::InterruptError`] carrying the error bits. Otherwise
     /// clears only `completion_bits` and returns `Ok(())`.
     ///
-    /// WHY: clearing a completion bit (e.g. INT_XFER_COMPL) without first
-    /// inspecting INT_ERR_MASK silently discards a hardware error that
+    /// WHY: clearing a completion bit (e.g. `INT_XFER_COMPL`) without first
+    /// inspecting `INT_ERR_MASK` silently discards a hardware error that
     /// coincided with completion (issue #286).
     ///
     /// # Safety
@@ -1393,7 +1393,7 @@ pub(crate) fn build_single_bd_chain(buf_phys: u32, len: u32) -> (Gpd, Bd) {
     (gpd, bd)
 }
 
-/// Build a multi-segment BD chain FROM an array of (phys_addr, len) pairs.
+/// Build a multi-segment BD chain FROM an array of (`phys_addr`, len) pairs.
 ///
 /// Returns a vector of BDs with next pointers SET to zero. The caller must
 /// fixup next pointers after placing BDs in contiguous physical memory.

--- a/crates/thumos/src/exceptions.rs
+++ b/crates/thumos/src/exceptions.rs
@@ -3,7 +3,7 @@
 //! The ARMv7-A (Cortex-A7) has 7 exception vectors at fixed offsets. We place
 //! the vector table at a known address and install handlers for IRQ (FROM GIC),
 //! SVC (syscalls), and the abort/undef traps. Abort/undef traps from PL0 kill
-//! the faulting process; from PL1 they halt the kernel (see handle_fault).
+//! the faulting process; from PL1 they halt the kernel (see `handle_fault`).
 //!
 //! Vector table layout (ARM ARM B1.8):
 //! Offset 0x00: Reset

--- a/crates/thumos/src/fd.rs
+++ b/crates/thumos/src/fd.rs
@@ -17,7 +17,7 @@
 //!
 //! WHY fixed-size: avoids heap allocation in the fd tables, keeps the
 //! structures predictable for a bare-metal kernel. 256 per-process fds and
-//! 256 system-wide OFDs suffice for a BusyBox shell + init + concurrent
+//! 256 system-wide OFDs suffice for a `BusyBox` shell + init + concurrent
 //! processes.
 
 extern crate alloc;
@@ -74,9 +74,9 @@ pub(crate) const ENOTTY: u32 = 0u32.wrapping_sub(25);
 
 /// Duplicate fd to lowest available >= arg.
 pub(crate) const F_DUPFD: u32 = 0;
-/// Get per-fd flags (FD_CLOEXEC).
+/// Get per-fd flags (`FD_CLOEXEC`).
 pub(crate) const F_GETFD: u32 = 1;
-/// Set per-fd flags (FD_CLOEXEC).
+/// Set per-fd flags (`FD_CLOEXEC`).
 pub(crate) const F_SETFD: u32 = 2;
 /// Get file descriptor flags.
 pub(crate) const F_GETFL: u32 = 3;
@@ -92,9 +92,9 @@ pub(crate) const O_APPEND: u32 = 0x400;
 /// Close-on-exec open flag (Linux ARM 0o2000000). Recorded on the per-fd
 /// entry and stripped from the OFD status flags at open (POSIX: it is an
 /// fd flag, not a file-status flag).
-pub(crate) const O_CLOEXEC: u32 = 0o2000000;
-/// Mask for access mode bits (O_RDONLY | O_WRONLY | O_RDWR).
-/// WHY: these bits are immutable after open; F_SETFL must not modify them.
+pub(crate) const O_CLOEXEC: u32 = 0o2_000_000;
+/// Mask for access mode bits (`O_RDONLY` | `O_WRONLY` | `O_RDWR`).
+/// WHY: these bits are immutable after open; `F_SETFL` must not modify them.
 pub(crate) const O_ACCMODE: u32 = 0o3;
 
 /// Seek whence constants (POSIX).
@@ -104,12 +104,12 @@ pub(crate) const SEEK_CUR: u32 = 1;
 /// Seek from end of file.
 pub(crate) const SEEK_END: u32 = 2;
 
-/// File type constants for StatBuf.
-pub(crate) const S_IFREG: u32 = 0o100000;
+/// File type constants for `StatBuf`.
+pub(crate) const S_IFREG: u32 = 0o100_000;
 /// Directory file type.
-pub(crate) const S_IFDIR: u32 = 0o040000;
+pub(crate) const S_IFDIR: u32 = 0o040_000;
 /// Character device file type.
-pub(crate) const S_IFCHR: u32 = 0o020000;
+pub(crate) const S_IFCHR: u32 = 0o020_000;
 
 /// Stat buffer written to userspace.
 ///
@@ -121,7 +121,7 @@ pub(crate) const S_IFCHR: u32 = 0o020000;
 pub struct StatBuf {
     /// File size in bytes.
     pub size: u32,
-    /// File type (S_IFREG, S_IFDIR, S_IFCHR).
+    /// File type (`S_IFREG`, `S_IFDIR`, `S_IFCHR`).
     pub file_type: u32,
 }
 
@@ -139,13 +139,13 @@ pub struct StatBuf {
 /// (see `pipe.rs`/`socket.rs`). `mount_idx` and `inode_id` are unused there.
 #[derive(Clone, Copy)]
 pub struct FileDescriptor {
-    /// Index into the global MountTable identifying the filesystem.
+    /// Index into the global `MountTable` identifying the filesystem.
     pub mount_idx: u8,
     /// Inode ID within the filesystem.
     pub inode_id: u32,
     /// Current read/write position within the file.
     pub offset: usize,
-    /// Open flags (O_RDONLY, O_WRONLY, O_RDWR, pipe encoding, etc.).
+    /// Open flags (`O_RDONLY`, `O_WRONLY`, `O_RDWR`, pipe encoding, etc.).
     pub flags: u32,
 }
 
@@ -195,7 +195,7 @@ impl FileDescriptor {
     }
 }
 
-/// One per-process fd slot: the OFD it names plus the per-fd FD_CLOEXEC
+/// One per-process fd slot: the OFD it names plus the per-fd `FD_CLOEXEC`
 /// flag.
 ///
 /// INVARIANT: `cloexec` lives on the fd entry, never on the shared OFD --
@@ -250,7 +250,7 @@ impl FdTable {
     }
 
     /// Allocate the lowest available file descriptor slot >= `min_fd`
-    /// (F_DUPFD). Returns the fd number, or None if no slot is available.
+    /// (`F_DUPFD`). Returns the fd number, or None if no slot is available.
     pub(crate) fn alloc_from(&mut self, min_fd: usize, entry: FdEntry) -> Option<usize> {
         if min_fd >= MAX_FDS {
             return None;
@@ -358,7 +358,7 @@ pub(crate) fn ofd_ref(idx: u16) {
 /// Drop one reference to an OFD; at zero, free the slot and run kind
 /// teardown (pipe EOF accounting, socket release).
 ///
-/// WHY teardown here and not in sys_close: with dup and fork a close no
+/// WHY teardown here and not in `sys_close`: with dup and fork a close no
 /// longer implies the description is dead -- pipe close-notification and
 /// socket release are correct only at refcount zero.
 pub(crate) fn ofd_unref(idx: u16) {
@@ -401,7 +401,7 @@ pub(crate) fn current_fd_flags(fd: usize) -> Option<u32> {
     ofds.get(usize::from(idx))?.as_ref().map(|o| o.desc.flags)
 }
 
-/// fork() (#267): copy a parent fd table for the child, bumping each
+/// `fork()` (#267): copy a parent fd table for the child, bumping each
 /// entry's OFD refcount. Each fd entry is one reference, so a dup'd pair
 /// in the parent bumps its OFD twice -- exactly matching the two entries
 /// the child receives.
@@ -426,7 +426,7 @@ pub(crate) fn close_all(table: &mut FdTable) {
     }
 }
 
-/// execve (#267): close every fd with FD_CLOEXEC set. Called only after
+/// execve (#267): close every fd with `FD_CLOEXEC` set. Called only after
 /// the last execve failure point (POSIX: fds close on SUCCESSFUL exec).
 pub(crate) fn close_cloexec(table: &mut FdTable) {
     for slot in table.entries.iter_mut() {
@@ -702,7 +702,7 @@ pub unsafe fn ramfs_find(path: &str) -> Option<&'static [u8]> {
 
 // -- Syscall implementation functions --
 
-/// SYS_open: open a file by path.
+/// `SYS_open`: open a file by path.
 ///
 /// # Arguments
 /// - `path_ptr`: userspace pointer to the path string
@@ -774,7 +774,7 @@ pub(crate) fn sys_open(path_ptr: u32, path_len: u32, flags: u32) -> u32 {
     }
 }
 
-/// SYS_read: read bytes from an open file descriptor.
+/// `SYS_read`: read bytes from an open file descriptor.
 ///
 /// # Arguments
 /// - `fd`: file descriptor number
@@ -846,7 +846,7 @@ pub(crate) fn sys_read(fd: u32, buf_ptr: u32, count: u32) -> u32 {
     }
 }
 
-/// SYS_write: write bytes to an open file descriptor.
+/// `SYS_write`: write bytes to an open file descriptor.
 ///
 /// # Arguments
 /// - `fd`: file descriptor number
@@ -915,7 +915,7 @@ pub(crate) fn sys_write(fd: u32, buf_ptr: u32, count: u32) -> u32 {
     }
 }
 
-/// SYS_close: close an open file descriptor.
+/// `SYS_close`: close an open file descriptor.
 ///
 /// # Arguments
 /// - `fd`: file descriptor number
@@ -936,12 +936,12 @@ pub(crate) fn sys_close(fd: u32) -> u32 {
     }
 }
 
-/// SYS_stat: get file status by path.
+/// `SYS_stat`: get file status by path.
 ///
 /// # Arguments
 /// - `path_ptr`: userspace pointer to the path string
 /// - `path_len`: length of the path string
-/// - `stat_buf_ptr`: userspace pointer to a StatBuf
+/// - `stat_buf_ptr`: userspace pointer to a `StatBuf`
 ///
 /// # Returns
 /// 0 on success, negative error code on failure.
@@ -1012,11 +1012,11 @@ pub(crate) fn sys_stat(path_ptr: u32, path_len: u32, stat_buf_ptr: u32) -> u32 {
     0
 }
 
-/// SYS_fstat: get file status by file descriptor.
+/// `SYS_fstat`: get file status by file descriptor.
 ///
 /// # Arguments
 /// - `fd`: file descriptor number
-/// - `stat_buf_ptr`: userspace pointer to a StatBuf
+/// - `stat_buf_ptr`: userspace pointer to a `StatBuf`
 ///
 /// # Returns
 /// 0 on success, negative error code on failure.
@@ -1110,12 +1110,12 @@ pub(crate) fn sys_fstat(fd: u32, stat_buf_ptr: u32) -> u32 {
     0
 }
 
-/// SYS_lseek: reposition the file offset.
+/// `SYS_lseek`: reposition the file offset.
 ///
 /// # Arguments
 /// - `fd`: file descriptor number
 /// - `offset`: offset value (interpreted based on whence)
-/// - `whence`: SEEK_SET (0), SEEK_CUR (1), or SEEK_END (2)
+/// - `whence`: `SEEK_SET` (0), `SEEK_CUR` (1), or `SEEK_END` (2)
 ///
 /// # Returns
 /// New file offset on success, negative error code on failure.
@@ -1172,7 +1172,7 @@ pub(crate) fn sys_lseek(fd: u32, offset: u32, whence: u32) -> u32 {
     new_pos_u32
 }
 
-/// SYS_dup: duplicate a file descriptor.
+/// `SYS_dup`: duplicate a file descriptor.
 ///
 /// # Arguments
 /// - `fd`: file descriptor to duplicate
@@ -1204,7 +1204,7 @@ pub(crate) fn sys_dup(fd: u32) -> u32 {
     }
 }
 
-/// SYS_dup2: duplicate a file descriptor to a specific number.
+/// `SYS_dup2`: duplicate a file descriptor to a specific number.
 ///
 /// # Arguments
 /// - `oldfd`: source file descriptor
@@ -1256,7 +1256,7 @@ pub(crate) fn sys_dup2(oldfd: u32, newfd: u32) -> u32 {
     }
 }
 
-/// SYS_fcntl: file descriptor control.
+/// `SYS_fcntl`: file descriptor control.
 ///
 /// Supports:
 /// - `F_GETFL` (3): return the fd's flags.
@@ -1266,7 +1266,7 @@ pub(crate) fn sys_dup2(oldfd: u32, newfd: u32) -> u32 {
 ///
 /// # Arguments
 /// - `fd`: file descriptor number
-/// - `cmd`: fcntl command (F_DUPFD, F_GETFL, F_SETFL)
+/// - `cmd`: fcntl command (`F_DUPFD`, `F_GETFL`, `F_SETFL`)
 /// - `arg`: command-specific argument
 ///
 /// # Returns
@@ -1352,7 +1352,7 @@ pub(crate) fn sys_fcntl(fd: u32, cmd: u32, arg: u32) -> u32 {
     }
 }
 
-/// SYS_ioctl: device-specific control operations.
+/// `SYS_ioctl`: device-specific control operations.
 ///
 /// Currently returns `ENOTTY` for all file descriptors. This establishes
 /// the dispatch path for future device-specific ioctl support.
@@ -1375,7 +1375,7 @@ pub(crate) fn sys_ioctl(fd: u32, _request: u32, _arg: u32) -> u32 {
     }
 }
 
-/// SYS_getcwd: get current working directory.
+/// `SYS_getcwd`: get current working directory.
 ///
 /// # Arguments
 /// - `buf_ptr`: userspace buffer
@@ -1418,7 +1418,7 @@ pub(crate) fn sys_getcwd(buf_ptr: u32, size: u32) -> u32 {
     0
 }
 
-/// SYS_mkdir: create a directory at the given path.
+/// `SYS_mkdir`: create a directory at the given path.
 ///
 /// Resolves the parent directory from the path, then calls
 /// `Filesystem::create()` with `InodeType::Directory`.
@@ -1486,7 +1486,7 @@ pub(crate) fn vfs_mkdir(path: &str) -> u32 {
     }
 }
 
-/// SYS_unlink: remove a file or directory entry.
+/// `SYS_unlink`: remove a file or directory entry.
 ///
 /// # Arguments
 /// - `path_ptr`: userspace pointer to the path string
@@ -1548,7 +1548,7 @@ pub(crate) fn vfs_unlink(path: &str) -> u32 {
     }
 }
 
-/// SYS_chdir: change the current working directory.
+/// `SYS_chdir`: change the current working directory.
 ///
 /// # Arguments
 /// - `path_ptr`: userspace pointer to the path string
@@ -1615,7 +1615,7 @@ pub(crate) fn vfs_chdir(path: &str) -> u32 {
     0
 }
 
-/// Split a path into (parent_path, final_component).
+/// Split a path into (`parent_path`, `final_component`).
 ///
 /// Returns `None` for paths without a valid split (empty, root-only).
 fn split_parent_name(path: &str) -> Option<(&str, &str)> {
@@ -1896,7 +1896,7 @@ mod tests {
         assert_eq!(fd, 0, "first open should return fd 0");
     }
 
-    /// #222: repeated ramfs_find on the same file must reuse the cached
+    /// #222: repeated `ramfs_find` on the same file must reuse the cached
     /// leak, not allocate a fresh copy on every call.
     #[test]
     fn ramfs_find_caches_repeated_lookups() {
@@ -2236,7 +2236,7 @@ mod tests {
         assert_eq!(result, EBADF);
     }
 
-    /// #249: a genuine fs.stat() failure (bogus inode) must propagate a
+    /// #249: a genuine `fs.stat()` failure (bogus inode) must propagate a
     /// non-zero errno, not a fabricated zeroed success stat.
     #[cfg(target_pointer_width = "32")]
     #[test]
@@ -2945,7 +2945,7 @@ mod tests {
         );
     }
 
-    /// FORK-SHARES-OFFSET: fork() copies the fd table, but the copied entry
+    /// FORK-SHARES-OFFSET: `fork()` copies the fd table, but the copied entry
     /// still names the SAME OFD as the parent -- one shared byte offset, per
     /// POSIX. A close in the parent must not affect the child's reference
     /// (the OFD lives until the LAST reference is gone).
@@ -3007,7 +3007,7 @@ mod tests {
         assert_eq!(&*buf3, b"s!");
     }
 
-    /// OPEN-AFTER-FORK-INDEPENDENT: a fresh open() in the child (even of the
+    /// OPEN-AFTER-FORK-INDEPENDENT: a fresh `open()` in the child (even of the
     /// SAME path) allocates a brand-new OFD at offset 0 -- it does not
     /// alias the parent's inherited, already-advanced descriptor.
     #[cfg(target_pointer_width = "32")]
@@ -3068,7 +3068,7 @@ mod tests {
 
     /// CWD-PER-PROCESS (#437): a chdir in one process never leaks into
     /// another, and fork inherits the parent's cwd (POSIX) — replacing the
-    /// old global CWD_BUF/CWD_LEN statics where every process shared one cwd.
+    /// old global `CWD_BUF/CWD_LEN` statics where every process shared one cwd.
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn chdir_is_per_process_and_fork_inherits() {
@@ -3111,7 +3111,7 @@ mod tests {
         crate::process::set_current_cwd("/");
     }
 
-    /// CWD-GETCWD-SYSCALL (#437): sys_getcwd reports the CURRENT process's
+    /// CWD-GETCWD-SYSCALL (#437): `sys_getcwd` reports the CURRENT process's
     /// cwd, not a shared global — after the child chdirs, parent and child
     /// read different paths from the same syscall.
     #[cfg(target_pointer_width = "32")]
@@ -3154,8 +3154,8 @@ mod tests {
         crate::process::set_current_cwd("/");
     }
 
-    /// CLOSE-ON-EXEC: `close_cloexec` sweeps ONLY fds marked FD_CLOEXEC
-    /// (whether set at open() via O_CLOEXEC or later via F_SETFD) and
+    /// CLOSE-ON-EXEC: `close_cloexec` sweeps ONLY fds marked `FD_CLOEXEC`
+    /// (whether set at `open()` via `O_CLOEXEC` or later via `F_SETFD`) and
     /// leaves plain fds untouched; a dup of a cloexec fd never inherits the
     /// flag (POSIX).
     #[cfg(target_pointer_width = "32")]
@@ -3267,7 +3267,7 @@ mod tests {
 
     /// DUP-SHARES-OFD: reading via the DUP advances the ORIGINAL's shared
     /// offset (the reverse direction from `dup_shares_offset_with_original`
-    /// above), and F_SETFL(O_APPEND) through one fd is visible through the
+    /// above), and `F_SETFL(O_APPEND)` through one fd is visible through the
     /// other -- both fds name one OFD's status flags, not a private copy.
     #[cfg(target_pointer_width = "32")]
     #[test]

--- a/crates/thumos/src/firewall.rs
+++ b/crates/thumos/src/firewall.rs
@@ -565,7 +565,7 @@ pub(crate) fn flush_packet_audit(
 }
 
 /// Format `"<count> <inbound|outbound> packet(s) denied"` into `buf`, returning
-/// the byte length written. A small no_std decimal formatter in the style of
+/// the byte length written. A small `no_std` decimal formatter in the style of
 /// the `format_*_into` helpers in `lock_screen`/`screen_fm`.
 fn format_deny_detail(count: u32, direction: Direction, buf: &mut [u8; DETAIL_LEN]) -> usize {
     let mut digits = [0u8; 10];

--- a/crates/thumos/src/fm_radio.rs
+++ b/crates/thumos/src/fm_radio.rs
@@ -8,7 +8,7 @@
 //! ## Hardware path
 //!
 //! FM radio is accessed through the WMT STP transport on the combo chip:
-//! - `board::CONSYS_BASE = 0x1800_0000` (combo-chip base, board::m7 #534)
+//! - `board::CONSYS_BASE = 0x1800_0000` (combo-chip base, `board::m7` #534)
 //! - WMT channel 0x04 for FM radio commands
 //! - FM register block at offset `0x6000` within the combo chip
 //!
@@ -346,15 +346,15 @@ pub(crate) type BootFmHw = FmHw;
 /// Mock FM hardware for unit testing.
 #[cfg(test)]
 pub struct MockFmHw {
-    /// Whether power_on succeeds.
+    /// Whether `power_on` succeeds.
     pub power_on_ok: bool,
-    /// Current tuned frequency (set by tune()).
+    /// Current tuned frequency (set by `tune()`).
     pub tuned_freq: u32,
     /// RSSI value to return.
     pub rssi: i8,
-    /// Frequency returned by seek_up (None = no station found).
+    /// Frequency returned by `seek_up` (None = no station found).
     pub seek_up_result: Option<u32>,
-    /// Frequency returned by seek_down (None = no station found).
+    /// Frequency returned by `seek_down` (None = no station found).
     pub seek_down_result: Option<u32>,
 }
 

--- a/crates/thumos/src/futex.rs
+++ b/crates/thumos/src/futex.rs
@@ -1,14 +1,14 @@
 //! Futex subsystem: fast userspace mutex kernel support.
 //!
-//! Provides FUTEX_WAIT and FUTEX_WAKE operations sufficient to implement
+//! Provides `FUTEX_WAIT` and `FUTEX_WAKE` operations sufficient to implement
 //! userspace mutexes and condition variables. This is the minimal kernel
 //! half of the Linux futex(2) interface.
 //!
 //! # Protocol
-//! - FUTEX_WAIT (op=0): atomically check `*addr == val` and, if equal,
+//! - `FUTEX_WAIT` (op=0): atomically check `*addr == val` and, if equal,
 //!   suspend the calling process. If `*addr != val`, return EAGAIN immediately
 //!   (the value changed before we could sleep — caller should retry).
-//! - FUTEX_WAKE (op=1): wake up to `val` processes waiting on `addr`.
+//! - `FUTEX_WAKE` (op=1): wake up to `val` processes waiting on `addr`.
 //!   Returns the number of processes woken.
 //!
 //! # Design constraints
@@ -19,7 +19,7 @@
 //! - Process suspension: set state to Blocked; the scheduler will not
 //!   reschedule a Blocked process. Wakeup sets it back to Ready.
 //!
-//! WHY 32 waiters: the maximum number of processes is 16 (MAX_PROCS), so 32
+//! WHY 32 waiters: the maximum number of processes is 16 (`MAX_PROCS`), so 32
 //! slots is 2× headroom in case a process waits on multiple futexes in sequence
 //! before the slots are reclaimed. Each slot is freed immediately on wakeup.
 
@@ -29,17 +29,17 @@ pub(crate) const EAGAIN: u32 = 0u32.wrapping_sub(11);
 /// ENOMEM — waiter table exhausted (two's complement -12, Linux ARM
 /// convention). Distinct from EAGAIN: a caller retrying on EAGAIN expects
 /// `*addr` to eventually change on its own, but a full waiter table will
-/// not free itself without a FUTEX_WAKE elsewhere -- conflating the two
+/// not free itself without a `FUTEX_WAKE` elsewhere -- conflating the two
 /// would make a retry loop on this specific failure spin forever.
 pub(crate) const ENOMEM: u32 = 0u32.wrapping_sub(12);
 
 /// EINVAL — unknown op (two's complement -22, Linux ARM convention).
 pub(crate) const EINVAL: u32 = 0u32.wrapping_sub(22);
 
-/// FUTEX_WAIT operation code.
+/// `FUTEX_WAIT` operation code.
 pub(crate) const FUTEX_WAIT: u32 = 0;
 
-/// FUTEX_WAKE operation code.
+/// `FUTEX_WAKE` operation code.
 pub(crate) const FUTEX_WAKE: u32 = 1;
 
 /// Maximum number of simultaneously sleeping futex waiters.
@@ -59,7 +59,7 @@ static mut FUTEX_WAITERS: [Option<FutexWaiter>; MAX_FUTEX_WAITERS] = {
     [NONE; MAX_FUTEX_WAITERS]
 };
 
-/// FUTEX_WAIT: if `*addr == val`, block the current process.
+/// `FUTEX_WAIT`: if `*addr == val`, block the current process.
 ///
 /// Returns 0 after being woken, EAGAIN if `*addr != val`, or EINVAL if
 /// `addr` does not lie within user-accessible DRAM (see
@@ -153,7 +153,7 @@ pub(crate) fn sys_futex_wait(addr: u32, val: u32) -> u32 {
     EAGAIN
 }
 
-/// FUTEX_WAKE: wake up to `max_wake` processes waiting on `addr`.
+/// `FUTEX_WAKE`: wake up to `max_wake` processes waiting on `addr`.
 ///
 /// Returns the number of processes woken.
 pub fn sys_futex_wake(addr: u32, max_wake: u32) -> u32 {
@@ -241,7 +241,7 @@ pub(crate) fn has_waiter_for_pid(pid: u32) -> bool {
 ///
 /// # Arguments
 /// - `addr`: userspace address of the futex word
-/// - `op`: FUTEX_WAIT (0) or FUTEX_WAKE (1)
+/// - `op`: `FUTEX_WAIT` (0) or `FUTEX_WAKE` (1)
 /// - `val`: for WAIT — expected value; for WAKE — max processes to wake
 ///
 /// # Returns

--- a/crates/thumos/src/gic.rs
+++ b/crates/thumos/src/gic.rs
@@ -1,6 +1,6 @@
 //! ARM GIC (Generic Interrupt Controller) driver for MT6739.
 //!
-//! The MT6739 uses a GICv2 with:
+//! The MT6739 uses a `GICv2` with:
 //! - Distributor (GICD) at 0x0C000000
 //! - CPU Interface (GICC) at 0x0C002000
 //!

--- a/crates/thumos/src/gps.rs
+++ b/crates/thumos/src/gps.rs
@@ -20,13 +20,13 @@
 //! ## Hardware path
 //!
 //! The MT6739 GPS hardware is accessed through the WMT combo chip:
-//! - `board::CONSYS_BASE = 0x1800_0000` (combo-chip base, board::m7 #534)
+//! - `board::CONSYS_BASE = 0x1800_0000` (combo-chip base, `board::m7` #534)
 //! - Data path goes through WMT STP framing (kelyphos handles the transport)
 //!
 //! ## Design
 //!
 //! No floating-point arithmetic: latitude and longitude are stored as
-//! fixed-point integers (degrees * 1_000_000) to avoid soft-float overhead
+//! fixed-point integers (degrees * `1_000_000`) to avoid soft-float overhead
 //! in a `#![no_std]` kernel without FPU support enabled.
 //!
 //! ## Integration
@@ -141,7 +141,7 @@ impl core::fmt::Display for GpsState {
 
 /// GPS position with fixed-point coordinates.
 ///
-/// Latitude and longitude are stored as microdegrees (degrees * 1_000_000)
+/// Latitude and longitude are stored as microdegrees (degrees * `1_000_000`)
 /// to avoid floating-point arithmetic in the kernel.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct GpsPosition {
@@ -535,7 +535,7 @@ impl<H: GpsHwOps> GpsReceiver<H> {
 pub struct MockGpsHw {
     /// Data to return from `read_data`.
     pub data_queue: Vec<u8>,
-    /// Whether power_on succeeds.
+    /// Whether `power_on` succeeds.
     pub power_on_ok: bool,
 }
 

--- a/crates/thumos/src/harmostes.rs
+++ b/crates/thumos/src/harmostes.rs
@@ -73,9 +73,9 @@ const MAX_MESSAGES_PER_ROOM: usize = 100;
 
 /// Maximum number of pending messages held in the outbox before
 /// `queue_message`/`send_message` reject further additions (#365). Each
-/// entry holds two heap Strings (room_id + body); bounding count bounds
-/// worst-case outbox memory on a 1 GB device the same way MAX_ROOMS and
-/// MAX_MESSAGES_PER_ROOM already bound room/timeline memory.
+/// entry holds two heap Strings (`room_id` + body); bounding count bounds
+/// worst-case outbox memory on a 1 GB device the same way `MAX_ROOMS` and
+/// `MAX_MESSAGES_PER_ROOM` already bound room/timeline memory.
 const MAX_OUTBOX_MESSAGES: usize = 256;
 
 /// Maximum bytes of a non-JSON server error body surfaced verbatim in

--- a/crates/thumos/src/heap_stub.rs
+++ b/crates/thumos/src/heap_stub.rs
@@ -7,7 +7,7 @@
 //!
 //! WHY(pattern): a gated-out hardware dependency is made test-visible by a
 //! parallel `#[cfg(test)] #[path = "..._stub.rs"] mod x;` binding in main.rs
-//! (see exceptions_stub.rs / timer_stub.rs / uart_stub.rs).
+//! (see `exceptions_stub.rs` / `timer_stub.rs` / `uart_stub.rs`).
 
 /// Return `(total_allocs, total_frees)` for leak detection.
 ///

--- a/crates/thumos/src/heorte.rs
+++ b/crates/thumos/src/heorte.rs
@@ -354,7 +354,7 @@ pub(crate) fn decompose_epoch(epoch: u64) -> (u8, u8, u16, u8, u8) {
 
 /// Convert days-since-Unix-epoch to a `(year, month, day)` civil date in
 /// O(1), replacing the year-by-year iteration that made `decompose_epoch`
-/// an O(years) DoS surface for an adversarial epoch -- up to ~11.7M
+/// an O(years) `DoS` surface for an adversarial epoch -- up to ~11.7M
 /// iterations for a large `days` value (#366).
 ///
 /// Closed-form Gregorian calendar algorithm (Howard Hinnant's

--- a/crates/thumos/src/http_client.rs
+++ b/crates/thumos/src/http_client.rs
@@ -539,10 +539,10 @@ fn find_header_end(data: &[u8]) -> Option<usize> {
     None
 }
 
-/// Parse the HTTP status line and return (status_code, bytes_consumed).
+/// Parse the HTTP status line and return (`status_code`, `bytes_consumed`).
 ///
 /// Expects: `HTTP/1.1 200 OK\r\n` (or similar).
-/// The bytes_consumed includes the trailing `\r\n`.
+/// The `bytes_consumed` includes the trailing `\r\n`.
 fn parse_status_line(header_block: &[u8]) -> Result<(u16, usize), HttpError> {
     // Find the first \r\n — that's the end of the status line.
     let line_end = find_crlf(header_block).ok_or(HttpError::MalformedStatusLine)?;
@@ -689,8 +689,8 @@ fn digit_value(b: u8) -> Option<u16> {
 }
 
 /// Write a usize as ASCII decimal digits into a byte buffer.
-/// WHY: no_std environment — we can't use format!() in the hot path
-/// of request serialization without pulling in alloc::format.
+/// WHY: `no_std` environment — we can't use format!() in the hot path
+/// of request serialization without pulling in `alloc::format`.
 fn write_usize_to_buf(buf: &mut Vec<u8>, mut n: usize) {
     if n == 0 {
         buf.push(b'0');

--- a/crates/thumos/src/kardia.rs
+++ b/crates/thumos/src/kardia.rs
@@ -1,4 +1,4 @@
-//! Kardia -- the kernel heartbeat: post-boot KernelState + service loop.
+//! Kardia -- the kernel heartbeat: post-boot `KernelState` + service loop.
 //!
 //! `kinit::run()` hands its fn-scope subsystem state to [`KernelState`], and
 //! the boot context (PID 0, the kernel/idle process created by
@@ -22,7 +22,7 @@
 //! (see [`service_loop`]) so a reflex IRQ that fires+retires in the check ->
 //! idle window cannot be lost. WHY `exceptions::ticks()`, not
 //! `timer::elapsed_ms()`, as the tick source (#461): the CNTPCT-backed
-//! elapsed_ms does not advance under qemu-virt, while the IRQ-incremented
+//! `elapsed_ms` does not advance under qemu-virt, while the IRQ-incremented
 //! tick counter does.
 
 use core::fmt::Write;
@@ -62,16 +62,16 @@ use crate::telephony::{BootModemTransport, RatGeneration, Telephony};
 use crate::uart::Uart;
 use crate::ui::{Screen, ScreenId, UiManager};
 
-/// Timer ticks per wall-clock second (exceptions.rs TICK_MS = 10).
+/// Timer ticks per wall-clock second (exceptions.rs `TICK_MS` = 10).
 const TICKS_PER_SECOND: u64 = 100;
 
-/// Milliseconds per timer tick (exceptions.rs TICK_MS). `ticks * TICK_MS` is the
-/// monotonic ms the ClockManager needs -- via the IRQ tick counter, which
+/// Milliseconds per timer tick (exceptions.rs `TICK_MS`). `ticks * TICK_MS` is the
+/// monotonic ms the `ClockManager` needs -- via the IRQ tick counter, which
 /// advances under qemu-virt (unlike CNTPCT, #461).
 const TICK_MS: u64 = 10;
 
-/// Boot wall-clock epoch (2025-01-01 UTC) -- matches time::REALTIME_OFFSET_SECS.
-/// Seeds ClockManager as a Manual (lowest-trust) source until a trusted source
+/// Boot wall-clock epoch (2025-01-01 UTC) -- matches `time::REALTIME_OFFSET_SECS`.
+/// Seeds `ClockManager` as a Manual (lowest-trust) source until a trusted source
 /// (GPS #129 / NTP / modem RTC #398) lands; on device the modem RTC replaces
 /// this at boot.
 const BOOT_WALL_EPOCH: u64 = 1_735_603_200;
@@ -147,7 +147,7 @@ pub(crate) struct KernelState {
     /// the screen stack; content comes from the heorte manager each render.
     calendar: CalendarScreen,
     /// FM radio controller + screen (#518): the `FmRadio<BootFmHw>` state
-    /// machine runs under emulation (NullFmHw) and feeds `fm_screen`; the real
+    /// machine runs under emulation (`NullFmHw`) and feeds `fm_screen`; the real
     /// WMT backend binds on device.
     fm: FmRadio<BootFmHw>,
     fm_screen: FmScreen,
@@ -175,7 +175,7 @@ pub(crate) struct KernelState {
     /// modem transport.
     sms: SmsManager,
     /// Audio session manager (#399): priority-preemptive sessions over the
-    /// codec (NullCodec under qemu, real MT6357 on device). Event-driven -- no
+    /// codec (`NullCodec` under qemu, real MT6357 on device). Event-driven -- no
     /// tick source; sessions open on ring/media/alarm events.
     audio: AudioManager<BootCodec>,
     /// Audio route arbitration (earpiece/speaker/BT/...) for the audio manager.
@@ -184,7 +184,7 @@ pub(crate) struct KernelState {
     /// recorded for the privacy dashboard.
     mic_audit: MicAuditLog,
     /// Bluetooth A2DP audio profile (#401): SBC-encoded stereo streaming over
-    /// the BT HCI transport (NullBtHw under qemu; real WMT/STP on device -- the
+    /// the BT HCI transport (`NullBtHw` under qemu; real WMT/STP on device -- the
     /// RF/HCI link is hardware-gated, so only the local profile state machine +
     /// SBC framing run in emulation).
     bt_audio: A2dpProfile<BootBtHw>,
@@ -197,7 +197,7 @@ pub(crate) struct KernelState {
     /// emitting Log/Deny audit events at the packet drop-site.
     ///
     /// INVARIANT-SAFE as a bare field: the device is synchronous/polled (the
-    /// loopback in-memory queue today; a polled WiFi adapter later) and is
+    /// loopback in-memory queue today; a polled `WiFi` adapter later) and is
     /// mutated only from loop context. If a future NIC becomes IRQ-fed (#129),
     /// its ISR MUST deposit frames into an `IrqSpinlock`/reflex ring that the
     /// loop drains -- this field never becomes IRQ-touched.
@@ -210,7 +210,7 @@ pub(crate) struct KernelState {
     /// `log_event` then fails closed (`NoKey`). Replaced by the key-hierarchy
     /// audit key when the passphrase flow lands (#217).
     audit_key: SecureKey<KEY_SIZE>,
-    /// Render target: the hardware framebuffer (FB_BASE) on device, a synthetic
+    /// Render target: the hardware framebuffer (`FB_BASE`) on device, a synthetic
     /// heap buffer under qemu (the virt machine models no display), or None when
     /// no display path exists. Wiring the render loop through this makes the UI
     /// surface CI-verifiable in emulation for the first time (#400).
@@ -421,7 +421,7 @@ impl KernelState {
     /// is no render target.
     ///
     /// The status badge + operating mode are read LIVE from the security-mode
-    /// manager (#404), and the wall-clock epoch from the ClockManager trust
+    /// manager (#404), and the wall-clock epoch from the `ClockManager` trust
     /// hierarchy (#402) -- both formerly hardcoded.
     pub(crate) fn render_if_dirty(&mut self) -> Option<usize> {
         // Computed before the fb borrow: status_network() reads &self as a whole

--- a/crates/thumos/src/key_manager.rs
+++ b/crates/thumos/src/key_manager.rs
@@ -39,7 +39,7 @@ const LABEL_SESSION: &[u8] = b"thumos-session-v1";
 /// HKDF info label for the boot passphrase verifier (#446).
 ///
 /// The verifier is not a key: it is stored plaintext in the secrets
-/// preamble (crate::secrets) so the boot gate can distinguish a correct
+/// preamble (`crate::secrets`) so the boot gate can distinguish a correct
 /// passphrase from a wrong one before mounting. Deriving it from the
 /// primary key keeps verification at PBKDF2 strength per guess.
 const LABEL_VERIFY: &[u8] = b"thumos-verify-v1";
@@ -299,7 +299,7 @@ impl KeyManager {
     /// Derive the boot passphrase verifier from a primary key (#446).
     ///
     /// The verifier is what first-boot setup stores in the secrets preamble
-    /// (crate::secrets, slot kind 4, plaintext) and what the boot passphrase
+    /// (`crate::secrets`, slot kind 4, plaintext) and what the boot passphrase
     /// gate compares against (constant-time) BEFORE any mount. It is an
     /// HKDF output over the primary key, so a stored verifier costs an
     /// attacker one full PBKDF2 run per guess — the same as attacking the

--- a/crates/thumos/src/keypad.rs
+++ b/crates/thumos/src/keypad.rs
@@ -54,7 +54,7 @@ pub(crate) const KEY_MAP: [[Key; COL_COUNT]; ROW_COUNT] = [
 /// Register address and bit mask for `pin` within the register bank at
 /// `bank_base` (an offset from `board::GPIO_BASE`).
 ///
-/// MT67xx layout: each bank controls 32 pins; the address stride within a
+/// `MT67xx` layout: each bank controls 32 pins; the address stride within a
 /// bank is 8 (value at +0x00, set/clear aliases at +0x04). Mirrors haphe's
 /// `gpio_reg`.
 #[inline]

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -9,7 +9,7 @@
 //! eMMC → display → GPIO keypad → secure boot → passphrase → encrypted fs →
 //! audit log → security mode → USB serial → CCCI modem → power → userspace.
 //!
-//! Pure planning logic (BootStep ordering, BootState, userspace spawn
+//! Pure planning logic (`BootStep` ordering, `BootState`, userspace spawn
 //! planning) lives in `kinit_plan` (#528) so the host test build compiles and
 //! runs its unit tests; this module keeps only the hardware-init-bearing
 //! boot sequence.
@@ -294,7 +294,7 @@ fn boot_verify_loop(
 /// First-boot setup (#446): enter, confirm, store the PBKDF2-strength
 /// verifier in the preamble, derive keys. Returns `true` once provisioning
 /// completes. There is deliberately no skip binding: dev-anchor builds
-/// never reach this loop (secure_boot_ok is false there), so every
+/// never reach this loop (`secure_boot_ok` is false there), so every
 /// production-signed boot of an unprovisioned device sets a passphrase.
 fn boot_setup_loop(
     serial: &mut Uart,

--- a/crates/thumos/src/kinit_plan.rs
+++ b/crates/thumos/src/kinit_plan.rs
@@ -65,7 +65,7 @@ pub(crate) enum BootStep {
     Passphrase = 11,
     /// Filesystem mount — plain (unprovisioned) or wrapped in
     /// `EncryptedBlockDevice` (derived data key). Trust-gated on
-    /// SecureBoot (#217); a locked payload is never plain-mounted (#446).
+    /// `SecureBoot` (#217); a locked payload is never plain-mounted (#446).
     Filesystem = 12,
     /// Tamper-evident audit log initialization.
     AuditLog = 13,
@@ -316,7 +316,7 @@ impl BootState {
     /// and denominator (`total_subsystems`) update together automatically
     /// -- the boot summary's "N / total" denominator was previously a
     /// hand-maintained literal independent of this list, and had already
-    /// drifted once (17 -> 18 when csprng_ok was added). The array length
+    /// drifted once (17 -> 18 when `csprng_ok` was added). The array length
     /// in the return type is compiler-checked against this literal, so the
     /// two can no longer silently diverge.
     const fn subsystem_flags(&self) -> [bool; 18] {

--- a/crates/thumos/src/lfs.rs
+++ b/crates/thumos/src/lfs.rs
@@ -319,7 +319,7 @@ pub(crate) const DIR_ENTRY_HEADER_SIZE: usize = 8; // 4 + 2 + 2
 /// Contains a magic number and metadata about the segment's contents.
 #[derive(Debug, Clone, Copy)]
 pub struct SegmentHeader {
-    /// Magic number: 0x5345_4721 ("SEG!").
+    /// Magic number: `0x5345_4721` ("SEG!").
     pub magic: u32,
     /// Monotonically increasing sequence number.
     pub sequence: u64,
@@ -1963,7 +1963,7 @@ mod tests {
         );
     }
 
-    /// (#627): validate_block_num previously excluded only block 0 (the
+    /// (#627): `validate_block_num` previously excluded only block 0 (the
     /// superblock), not the rest of reserved segment 0 -- blocks
     /// `[1, segment_size)` hold the checkpoint slots, imap, and segment
     /// bitmap. Block 1 (checkpoint slot A) is nonzero and well within
@@ -2154,7 +2154,7 @@ mod tests {
         );
     }
 
-    /// (#627): the check above catches block 0, but unlink()'s inline
+    /// (#627): the check above catches block 0, but `unlink()`'s inline
     /// bound previously stopped there too -- blocks `[1, segment_size)`
     /// (checkpoint slots, imap, segment bitmap) were left addressable.
     /// Block 1 (checkpoint slot A) is nonzero and well within the raw
@@ -2814,15 +2814,15 @@ mod tests {
         );
     }
 
-    /// unlink() on the LAST entry in a directory skips write_dir_block()
+    /// `unlink()` on the LAST entry in a directory skips `write_dir_block()`
     /// entirely (the empty-directory branch just zeroes parent.direct[0]),
-    /// so writer.write_inode(dir_inode, &parent) is the ONLY log write
-    /// attempted -- isolating it from write_dir_block's write_data_block
-    /// call, which already routed through map_write_data_block_err. A
-    /// disk-full LfsError::NoFreeSegments here must map to
-    /// VfsError::NoSpace, not IoError -- before #627's fix this call site
+    /// so `writer.write_inode(dir_inode`, &parent) is the ONLY log write
+    /// attempted -- isolating it from `write_dir_block`'s `write_data_block`
+    /// call, which already routed through `map_write_data_block_err`. A
+    /// disk-full `LfsError::NoFreeSegments` here must map to
+    /// `VfsError::NoSpace`, not `IoError` -- before #627's fix this call site
     /// hardcoded `.map_err(|_| VfsError::IoError)` regardless of the
-    /// underlying LfsError.
+    /// underlying `LfsError`.
     #[test]
     fn unlink_last_entry_out_of_space_reports_no_space_not_io_error() {
         // WHY the setup provisions room and exhausts it AFTERWARDS rather than
@@ -3097,10 +3097,10 @@ mod tests {
         );
     }
 
-    /// (SECURITY, #627): the on-disk superblock's block_count is passed
+    /// (SECURITY, #627): the on-disk superblock's `block_count` is passed
     /// unvalidated as the extent bound every imap/direct-block pointer is
-    /// checked against after mount (validate_block_num,
-    /// LfsImap::load_from_disk) -- a crafted value exceeding the device's
+    /// checked against after mount (`validate_block_num`,
+    /// `LfsImap::load_from_disk`) -- a crafted value exceeding the device's
     /// real capacity must be rejected at mount instead of silently
     /// trusted as that bound.
     #[test]
@@ -3125,10 +3125,10 @@ mod tests {
         );
     }
 
-    /// (#627): checkpoint.sequence == u64::MAX must not silently wrap to
-    /// 0 through mount()'s `+ 1`. A checkpoint written next with
+    /// (#627): checkpoint.sequence == `u64::MAX` must not silently wrap to
+    /// 0 through `mount()`'s `+ 1`. A checkpoint written next with
     /// sequence 0 compares as older than every prior nonzero sequence,
-    /// so pick_latest() would never select it again -- freezing the
+    /// so `pick_latest()` would never select it again -- freezing the
     /// filesystem's recoverable state at whatever checkpoint predated
     /// the wrap.
     #[test]

--- a/crates/thumos/src/lfs_compact.rs
+++ b/crates/thumos/src/lfs_compact.rs
@@ -310,7 +310,7 @@ fn pick_candidate(
     best.ok_or(LfsError::NoCompactionCandidate)
 }
 
-/// Collect all (inode_id, block_number) pairs from the imap.
+/// Collect all (`inode_id`, `block_number`) pairs from the imap.
 fn collect_imap_entries(imap: &LfsImap) -> Vec<(u32, u64)> {
     imap.iter().collect()
 }

--- a/crates/thumos/src/lfs_imap.rs
+++ b/crates/thumos/src/lfs_imap.rs
@@ -69,7 +69,7 @@ impl From<BlockError> for LfsError {
 // LfsImap
 // ---------------------------------------------------------------------------
 
-/// Entry size in the serialized imap: 4 bytes inode_id + 8 bytes block_number.
+/// Entry size in the serialized imap: 4 bytes `inode_id` + 8 bytes `block_number`.
 const IMAP_ENTRY_SIZE: usize = 12;
 
 /// Size of the count prefix in the serialized imap (u32).

--- a/crates/thumos/src/lock_screen.rs
+++ b/crates/thumos/src/lock_screen.rs
@@ -1087,7 +1087,7 @@ mod tests {
         );
     }
 
-    /// Map a decimal digit byte to its keypad key (inverse of key_to_digit).
+    /// Map a decimal digit byte to its keypad key (inverse of `key_to_digit`).
     fn digit_key(byte: u8) -> Key {
         match byte {
             b'0' => Key::Num0,

--- a/crates/thumos/src/main.rs
+++ b/crates/thumos/src/main.rs
@@ -2,7 +2,7 @@
 //!
 //! Bare-metal Rust kernel for the MT6739. ARM boot stub is inline
 //! assembly that sets up the stack and zeros BSS before jumping to
-//! kernel_main.
+//! `kernel_main`.
 
 #![no_std]
 #![cfg_attr(not(test), no_main)]
@@ -15,6 +15,13 @@
 // unfulfilled and prompts its own removal. All OTHER warning classes stay live
 // under the -D warnings gate.
 #![expect(dead_code, reason = "compiled-but-unwired surface, tracked #145/#420")]
+// WHY: unwrap_used/expect_used are denied crate-wide (Cargo.toml) to keep
+// panics out of shipping kernel paths, where a panic is a crash. In a test,
+// an unwrap()/expect() panic IS the assertion -- the failure signal the test
+// exists to produce -- so the rule is scoped to where it means something.
+// Production code is unaffected: this cfg_attr only takes effect when
+// compiling under `#[cfg(test)]`, and no other lint is added to this list.
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 extern crate alloc;
 
 #[cfg(not(test))]

--- a/crates/thumos/src/matrix_crypto.rs
+++ b/crates/thumos/src/matrix_crypto.rs
@@ -2,7 +2,7 @@
 //!
 //! Implements Matrix end-to-end encryption on top of the kernel's existing
 //! cryptographic primitives (`security.rs` SHA-256/HMAC/HKDF, `csprng.rs`
-//! ChaCha20 CSPRNG, `aes` crate for AES-256).
+//! `ChaCha20` CSPRNG, `aes` crate for AES-256).
 //!
 //! This is a **simplified** implementation suitable for the Thumos kernel's
 //! bare-metal environment. It implements the core cryptographic operations
@@ -155,7 +155,7 @@ pub enum CryptoError {
     /// The room id supplied for session creation is not a well-formed Matrix
     /// room identifier (#373).
     InvalidRoomId(crate::matrix_ids::MatrixIdError),
-    /// The Megolm session's message_index has reached u32::MAX; encrypting
+    /// The Megolm session's `message_index` has reached `u32::MAX`; encrypting
     /// further would reuse a (key, IV) pair (issue #282 finding 9). The
     /// session must be rotated.
     MegolmIndexExhausted,
@@ -672,7 +672,7 @@ impl MatrixCrypto {
     /// A session with a `session_id` already present is REPLACED in place
     /// (matching [`create_outbound_megolm`]'s replace-on-match semantics)
     /// instead of pushed as a duplicate -- without this, an adversary
-    /// resending the same session_id repeatedly fills all
+    /// resending the same `session_id` repeatedly fills all
     /// [`MAX_MEGOLM_INBOUND`] slots with copies of one session, permanently
     /// exhausting inbound capacity for every other room/device (issue #282
     /// finding 16).
@@ -758,7 +758,7 @@ fn generate_device_keys() -> Result<DeviceKeys, CryptoError> {
 
 /// AES-256-CBC encrypt with an explicit IV and PKCS#7 padding.
 ///
-/// Uses the audited RustCrypto `cbc` mode over the `aes` block cipher — no
+/// Uses the audited `RustCrypto` `cbc` mode over the `aes` block cipher — no
 /// hand-rolled chaining (audit #231). Returns the ciphertext blocks only; the
 /// IV is a caller responsibility (derived, for Megolm; prepended, for the
 /// standalone helper below).

--- a/crates/thumos/src/mmu.rs
+++ b/crates/thumos/src/mmu.rs
@@ -1,4 +1,4 @@
-//! ARMv7 MMU (Memory Management Unit) setup.
+//! `ARMv7` MMU (Memory Management Unit) setup.
 //!
 //! Configures the ARM two-level page table for the MT6739:
 //! - Level 1 (L1): 4096 entries, each covers 1 MB (section mapping)
@@ -33,7 +33,7 @@ mod flags {
     /// Access permission: PL1 (kernel) read/write, PL0 (user) NO access
     /// (AP[2:0] = 0b001: APX = 0 at bit 15 (unset), AP[1:0] = 0b01 at bits
     /// [11:10]). WHY (#323): kernel RAM and device MMIO sections must never
-    /// grant PL0 access -- the prior AP_FULL (AP[2:0] = 0b011) let any user
+    /// grant PL0 access -- the prior `AP_FULL` (AP[2:0] = 0b011) let any user
     /// process read and write kernel memory and MMIO directly.
     pub(crate) const AP_PL1_ONLY: u32 = 0b01 << 10;
     /// Shareable (bit 16).
@@ -51,7 +51,7 @@ mod flags {
 /// L2 (small page) descriptor flags (4 KB mapping).
 ///
 /// WHY: L1 section mapping (1 MB) is too coarse for userspace memory management.
-/// mmap/brk need page-level (4 KB) granularity. ARMv7 short-descriptor format
+/// mmap/brk need page-level (4 KB) granularity. `ARMv7` short-descriptor format
 /// uses L2 page tables (256 entries x 4 bytes = 1 KB) pointed to by L1 "page
 /// table" descriptors.
 pub(crate) mod page_flags {
@@ -74,10 +74,10 @@ pub(crate) mod page_flags {
     pub(crate) const SHAREABLE: u32 = 1 << 10;
     /// Normal memory for small pages: TEX[2:0]=0b001 (bits [8:6]), C=1 (bit 3), B=1 (bit 2).
     pub(crate) const NORMAL_WB_WA: u32 = (0b001 << 6) | (1 << 3) | (1 << 2);
-    /// Not-global (nG, bit 11), repurposed as a software USER_OWNED tag (#496).
+    /// Not-global (nG, bit 11), repurposed as a software `USER_OWNED` tag (#496).
     /// Every user page (minted through `prot_to_l2_flags`) carries it; the kernel
     /// fills (`KERNEL_DEFAULT_PAGE`, `wx_page_attrs`) never do. This lets
-    /// `l2_entry_is_user` recognise a PROT_NONE user page -- whose AP (0b01) is
+    /// `l2_entry_is_user` recognise a `PROT_NONE` user page -- whose AP (0b01) is
     /// byte-identical to a kernel fill -- so fork/exit/exec enumeration copies +
     /// frees it. HW effect: nG makes the TLB entry ASID-tagged; harmless here
     /// because CONTEXTIDR is pinned 0 (see `program_translation`) and every
@@ -92,7 +92,7 @@ pub(crate) struct L2Table {
     pub entries: [u32; 256],
 }
 
-/// Dedicated L2 table for the kernel's 1 MB region at 0x4000_0000, mapped with
+/// Dedicated L2 table for the kernel's 1 MB region at `0x4000_0000`, mapped with
 /// W^X page permissions (#417). Permanent (not drawn from the userspace pool).
 static mut KERNEL_L2: L2Table = L2Table { entries: [0; 256] };
 
@@ -105,11 +105,11 @@ static mut L2_TABLES: [L2Table; L2_POOL_SIZE] = {
     [EMPTY; L2_POOL_SIZE]
 };
 
-/// Allocation bitmask for L2_TABLES. Bit N = 1 means slot N is in use.
+/// Allocation bitmask for `L2_TABLES`. Bit N = 1 means slot N is in use.
 static mut L2_ALLOC: u64 = 0;
 
 /// WHY (#416): guards every `L2_ALLOC` accessor (`alloc_l2_table`,
-/// `free_l2_table`) -- same defect class as #331/PAGE_LOCK.
+/// `free_l2_table`) -- same defect class as #`331/PAGE_LOCK`.
 static L2_POOL_LOCK: irq::IrqSpinlock = irq::IrqSpinlock::new();
 
 /// Allocate an L2 page table from the pool. Returns its physical address.
@@ -170,9 +170,9 @@ pub(crate) mod prot {
     pub(crate) const PROT_EXEC: u32 = 0x4;
 }
 
-/// Translate POSIX prot flags to ARMv7 L2 small page descriptor attributes.
+/// Translate POSIX prot flags to `ARMv7` L2 small page descriptor attributes.
 ///
-/// WHY: userspace passes POSIX prot flags (PROT_READ|PROT_WRITE|PROT_EXEC),
+/// WHY: userspace passes POSIX prot flags (`PROT_READ|PROT_WRITE|PROT_EXEC`),
 /// but the ARM MMU uses AP bits and XN to control access and execution.
 pub(crate) fn prot_to_l2_flags(prot_flags: u32) -> u32 {
     // #496: this function is the SOLE funnel for user L2 descriptors (image,
@@ -245,7 +245,7 @@ pub unsafe fn map_page(l1_phys: usize, virt_addr: usize, phys_addr: usize, l2_at
 
         // Write the L2 entry
         let l2_entry_ptr = (l2_phys as *mut u32).add(l2_index);
-        let l2_desc = (phys_addr as u32 & 0xFFFFF000) | l2_attrs;
+        let l2_desc = (phys_addr as u32 & 0xFFFF_F000) | l2_attrs;
         l2_entry_ptr.write_volatile(l2_desc);
 
         true
@@ -380,14 +380,14 @@ pub(crate) unsafe fn read_l2_entry(l1_phys: usize, virt_addr: usize) -> Option<u
 /// A small-page descriptor is bits[1:0] = 0b1X (bit 1 marks the small page, bit
 /// 0 is XN), so `bit 1 set` catches an executable (0b10) or execute-never (0b11)
 /// page and rejects a large-page (0b01) or fault (0b00) entry. Ownership is then
-/// decided by the software `NG` (USER_OWNED) tag, NOT by AP: `prot_to_l2_flags`
+/// decided by the software `NG` (`USER_OWNED`) tag, NOT by AP: `prot_to_l2_flags`
 /// sets NG on every user page (image, stack, heap/mmap), while the kernel fills
 /// (`KERNEL_DEFAULT_PAGE`, `wx_page_attrs`, the shared `KERNEL_L2`) never do.
 ///
-/// WHY NG and not AP (#496): a PROT_NONE user page maps to AP=0b01
+/// WHY NG and not AP (#496): a `PROT_NONE` user page maps to AP=0b01
 /// (`AP_KERNEL_ONLY`) -- byte-identical to a kernel fill -- so the old AP >= 0b10
 /// test dropped it from fork's deep-copy and from exit/exec teardown. Keying on
-/// the ownership tag enumerates PROT_NONE user pages while still rejecting every
+/// the ownership tag enumerates `PROT_NONE` user pages while still rejecting every
 /// kernel entry.
 pub(crate) fn l2_entry_is_user(entry: u32) -> bool {
     entry & page_flags::SMALL_PAGE != 0 && entry & page_flags::NG != 0
@@ -516,7 +516,7 @@ pub unsafe fn read_l2_phys(l1_phys: usize, virt_addr: usize) -> Option<usize> {
             return None;
         }
 
-        Some((l2_val & 0xFFFFF000) as usize)
+        Some((l2_val & 0xFFFF_F000) as usize)
     }
 }
 
@@ -549,7 +549,7 @@ pub unsafe fn update_page_prot(l1_phys: usize, virt_addr: usize, l2_attrs: u32) 
         }
 
         // Preserve the physical address, replace the attribute bits
-        let new_desc = (old & 0xFFFFF000) | l2_attrs;
+        let new_desc = (old & 0xFFFF_F000) | l2_attrs;
         l2_entry_ptr.write_volatile(new_desc);
 
         true
@@ -609,7 +609,7 @@ pub unsafe fn flush_tlb_all() {
 #[cfg(not(target_arch = "arm"))]
 pub unsafe fn flush_tlb_all() {}
 
-/// D-cache line size in bytes, decoded from CTR (CP15 c0, c0, 1) DminLine
+/// D-cache line size in bytes, decoded from CTR (CP15 c0, c0, 1) `DminLine`
 /// (bits [19:16], ARM ARM B4.1.61): the smallest data/unified cache line is
 /// `2^DminLine` words, so its byte size is `4 << DminLine`. Pure so the
 /// encoding is host-testable without CP15 access.
@@ -796,10 +796,10 @@ fn map_section(virt_mb: usize, phys_mb: usize, mem_type: MemoryType) {
 /// Set up the initial page table and enable the MMU.
 ///
 /// Identity maps:
-/// - 0x0000_0000 - 0x0FFF_FFFF: boot ROM / SRAM (device)
-/// - 0x1000_0000 - 0x1FFF_FFFF: peripheral MMIO (device)
-/// - 0x2000_0000 - 0x2FFF_FFFF: modem / CCCI (device)
-/// - 0x4000_0000 - 0x7FFF_FFFF: DRAM 1 GB (normal RAM)
+/// - `0x0000_0000` - `0x0FFF_FFFF`: boot ROM / SRAM (device)
+/// - `0x1000_0000` - `0x1FFF_FFFF`: peripheral MMIO (device)
+/// - `0x2000_0000` - `0x2FFF_FFFF`: modem / CCCI (device)
+/// - `0x4000_0000` - `0x7FFF_FFFF`: DRAM 1 GB (normal RAM)
 ///
 /// # Safety
 ///
@@ -1012,7 +1012,7 @@ static mut USER_TABLES: [UserL1Table; 16] = {
     [EMPTY; 16]
 };
 
-/// Allocation bitmask for USER_TABLES. Bit N = 1 means slot N is in use.
+/// Allocation bitmask for `USER_TABLES`. Bit N = 1 means slot N is in use.
 // NOTE: cfg(test) makes it pub(crate) so process.rs tests can call reset helpers.
 #[cfg(test)]
 pub(crate) static mut ADDR_SPACE_ALLOC: u16 = 0;
@@ -1020,7 +1020,7 @@ pub(crate) static mut ADDR_SPACE_ALLOC: u16 = 0;
 static mut ADDR_SPACE_ALLOC: u16 = 0;
 
 /// WHY (#416): guards every `ADDR_SPACE_ALLOC` accessor (`alloc_addr_space`,
-/// `free_addr_space`) -- same defect class as #331/PAGE_LOCK.
+/// `free_addr_space`) -- same defect class as #`331/PAGE_LOCK`.
 static ADDR_SPACE_LOCK: irq::IrqSpinlock = irq::IrqSpinlock::new();
 
 /// Allocate a free user L1 page table FROM the pool.
@@ -1099,12 +1099,12 @@ pub unsafe fn free_addr_space(phys_addr: usize) -> bool {
 }
 
 /// Copy all 4096 L1 entries FROM the source address space INTO the destination.
-/// Used by fork() to clone the kernel's mappings INTO a new process table.
+/// Used by `fork()` to clone the kernel's mappings INTO a new process table.
 ///
 /// # Safety
 ///
 /// Both `src_phys` and `dst_phys` must be valid physical addresses of
-/// 16 KB-aligned L1 tables (either the kernel L1 or a USER_TABLES slot).
+/// 16 KB-aligned L1 tables (either the kernel L1 or a `USER_TABLES` slot).
 pub unsafe fn clone_addr_space(src_phys: usize, dst_phys: usize) {
     // SAFETY: caller guarantees both pointers are valid 16 KB-aligned L1 tables.
     unsafe {
@@ -1292,8 +1292,8 @@ mod tests {
         }
     }
 
-    /// #225/#226: read_l2_phys must return the mapped frame while the page is
-    /// mapped, and None once unmap_page has cleared the entry.
+    /// #225/#226: `read_l2_phys` must return the mapped frame while the page is
+    /// mapped, and None once `unmap_page` has cleared the entry.
     #[test]
     fn read_l2_phys_returns_mapped_frame_and_none_after_unmap() {
         reset();

--- a/crates/thumos/src/net.rs
+++ b/crates/thumos/src/net.rs
@@ -1,12 +1,12 @@
 //! Network subsystem foundation.
 //!
 //! Wraps smoltcp to provide the kernel's TCP/IP stack. This module is the
-//! layer that WiFi, DHCP, DNS, and socket syscalls all build on.
+//! layer that `WiFi`, DHCP, DNS, and socket syscalls all build on.
 //!
 //! # Architecture
 //!
 //! [`NetworkStack`] owns a smoltcp [`Interface`] and [`SocketSet`], wired
-//! together with a [`phy::Device`] implementor (loopback for testing, WiFi
+//! together with a [`phy::Device`] implementor (loopback for testing, `WiFi`
 //! hardware for production). The stack is polled periodically — each call
 //! to [`NetworkStack::poll`] drives packet ingress/egress and socket state
 //! machines forward.
@@ -66,7 +66,7 @@ const DEFAULT_MTU: usize = 1514;
 /// Ethernet header length before the layer-3 payload.
 const ETHERNET_HEADER_LEN: usize = 14;
 
-/// EtherType for IPv4 frames.
+/// `EtherType` for IPv4 frames.
 const ETHERTYPE_IPV4: u16 = 0x0800;
 
 /// Generate a locally administered unicast Ethernet address for kernel stacks.
@@ -86,7 +86,7 @@ pub(crate) fn randomized_local_ethernet_address() -> EthernetAddress {
 pub(crate) enum NetworkDeviceKind {
     /// Host-only loopback smoke path. Useful for stack tests, not connectivity.
     LoopbackSmoke,
-    /// Real WiFi hardware data path.
+    /// Real `WiFi` hardware data path.
     Wifi,
 }
 
@@ -267,7 +267,7 @@ impl Device for LoopbackDevice {
 // WiFi device adapter
 // ---------------------------------------------------------------------------
 
-/// smoltcp device adapter for the kernel WiFi hardware boundary.
+/// smoltcp device adapter for the kernel `WiFi` hardware boundary.
 ///
 /// This adapter only exposes TX/RX tokens after the hardware backend reports
 /// its Ethernet data path ready. The current MT6739 backend returns false, so
@@ -279,7 +279,7 @@ pub(crate) struct WifiDevice<H: WifiHwOps> {
 }
 
 impl<H: WifiHwOps> WifiDevice<H> {
-    /// Create a WiFi smoltcp adapter around hardware operations.
+    /// Create a `WiFi` smoltcp adapter around hardware operations.
     pub(crate) const fn new(hw: H) -> Self {
         Self {
             hw,
@@ -398,7 +398,7 @@ impl<H: WifiHwOps> Device for WifiDevice<H> {
 /// leaves non-IPv4 traffic untouched, and preserves the existing `Device`
 /// contract for boot smoke tests and future WiFi-backed devices.
 /// Boot network device behind the firewall wrapper (#403). `LoopbackDevice`
-/// until the WiFi data path lands (#129) -- the same build-time alias pattern as
+/// until the `WiFi` data path lands (#129) -- the same build-time alias pattern as
 /// `telephony::BootModemTransport`, so swapping in a real NIC is a one-line
 /// change. INVARIANT (kardia `KernelState`): this device must stay
 /// synchronous/polled; if a future NIC becomes IRQ-fed, its ISR must hand frames
@@ -545,7 +545,7 @@ fn frame_allowed_tx(firewall: &mut Firewall, frame: &[u8]) -> bool {
 ///
 /// Wraps a smoltcp [`Interface`] and [`SocketSet`] with convenience methods
 /// for socket creation, removal, and polling. The stack is generic over the
-/// underlying device — use [`LoopbackDevice`] for tests and the WiFi driver
+/// underlying device — use [`LoopbackDevice`] for tests and the `WiFi` driver
 /// for production.
 pub(crate) struct NetworkStack<D: Device> {
     /// The smoltcp network interface (handles ARP, IP routing, etc.).

--- a/crates/thumos/src/nous.rs
+++ b/crates/thumos/src/nous.rs
@@ -209,7 +209,7 @@ impl CapabilitySet {
 
     /// Whether any autonomous-class grant exists -- the new-model meaning
     /// of "can auto-execute" (#552). Auto-execution is per-capability
-    /// (SendMessagesAutonomous, ModifyContactsAutonomous), never a rank.
+    /// (`SendMessagesAutonomous`, `ModifyContactsAutonomous`), never a rank.
     #[must_use]
     pub(crate) const fn can_auto_execute(&self) -> bool {
         const AUTO_BITS: u32 = (1 << NousCapability::SendMessagesAutonomous as u32)
@@ -244,15 +244,15 @@ pub enum CapabilityPreset {
     /// + read contacts metadata, draft messages.
     Assistant = 2,
     /// + read messages (metadata and content), read calendar, draft
-    /// calendar events. Design-reading note (#552): the design table's
-    /// "Read messages" spans both message rows -- granting content without
-    /// metadata would be incoherent for an advisor.
+    ///   calendar events. Design-reading note (#552): the design table's
+    ///   "Read messages" spans both message rows -- granting content without
+    ///   metadata would be incoherent for an advisor.
     Advisor = 3,
     /// + send messages with confirmation, modify contacts with confirmation.
     Agent = 4,
     /// + send messages autonomously per rules, modify contacts
-    /// autonomously. Reachable ONLY via an explicit opt-in confirmation --
-    /// never by cycling (#552).
+    ///   autonomously. Reachable ONLY via an explicit opt-in confirmation --
+    ///   never by cycling (#552).
     Autonomous = 5,
     /// A custom set matching no preset exactly.
     Custom = 6,
@@ -415,7 +415,7 @@ pub(crate) struct ActionRequirement {
 /// Mapping notes (the design has no rows for these; flagged for operator
 /// review): `open_dialer`, `start_timer`, `set_alarm`, `open_feature` are
 /// low-risk device/UI actions bound to the draft class with Always-confirm;
-/// `scan_start` is an observation action bound to ReadState;
+/// `scan_start` is an observation action bound to `ReadState`;
 /// `add_safe_network` modifies a security-adjacent allowlist and binds to
 /// the mode-confirmation class (Always-confirm, every time).
 #[must_use]
@@ -485,7 +485,7 @@ pub(crate) struct AuditReceipt {
     pub(crate) action: String,
     /// The capability the action required (when known).
     pub(crate) required: Option<NousCapability>,
-    /// The decision, rendered ("granted", "requires_confirmation",
+    /// The decision, rendered ("granted", "`requires_confirmation`",
     /// "denied:<reason>").
     pub(crate) decision: String,
 }
@@ -515,8 +515,8 @@ pub(crate) const MAX_RECEIPTS: usize = 64;
 /// regardless of grants -- the adversarial proof that no preset, custom
 /// map, or runtime path reaches panic/wipe/security-disable/keys/SIGINT
 /// (#552). Matching is defense-in-depth: these strings are not in the
-/// binding table, so they would already deny as UnknownAction; the
-/// KernelNever reason makes the boundary explicit in the receipt.
+/// binding table, so they would already deny as `UnknownAction`; the
+/// `KernelNever` reason makes the boundary explicit in the receipt.
 const NEVER_ACTIONS: &[&str] = &[
     "wipe",
     "wipe_device",

--- a/crates/thumos/src/panic_wipe.rs
+++ b/crates/thumos/src/panic_wipe.rs
@@ -19,7 +19,7 @@
 //! range is zeroed in place — free and in-use alike — via
 //! [`page::zero_usable_range`], which walks physical addresses directly
 //! and performs no heap allocation (#321: the previous alloc_page-then-
-//! free_page loop only reached free frames and could abort via
+//! `free_page` loop only reached free frames and could abort via
 //! `handle_alloc_error` under memory pressure). This is destructive to any
 //! live kernel/user state backed by that range and must be the LAST
 //! action taken before an immediate halt/reboot.
@@ -209,7 +209,7 @@ pub struct WipeResult {
     /// `failed_targets`'s entry for `WipeTarget::Keys`, which reflects
     /// ONLY the on-disk key-file overwrite (defense-in-depth, currently
     /// always fails per #324/#129) -- conflating the two under one bit
-    /// would let a reader mistake "Keys in failed_targets" for "the
+    /// would let a reader mistake "Keys in `failed_targets`" for "the
     /// encryption keys are still recoverable" when the in-memory keys
     /// (the actual protection) are already destroyed. Set inside the
     /// IRQ-masked critical section in Step 1 (finding 15).
@@ -220,7 +220,7 @@ pub struct WipeResult {
     /// slots; unused slots are `None`). WHY (SECURITY, finding 9): the
     /// caller needs to know WHICH category of sensitive data survived an
     /// incomplete wipe, not just how many -- a bare count cannot
-    /// distinguish "WiFi credentials intact" from "message store intact".
+    /// distinguish "`WiFi` credentials intact" from "message store intact".
     pub failed_targets: [Option<WipeTarget>; PANIC_WIPE_TARGET_COUNT],
     /// Whether memory scrub was performed.
     pub memory_scrubbed: bool,

--- a/crates/thumos/src/pipe.rs
+++ b/crates/thumos/src/pipe.rs
@@ -13,7 +13,7 @@
 //!
 //! WHY static array of 8 pipes: avoids heap allocation, consistent with the
 //! rest of the kernel's fixed-size-table pattern. 8 concurrent pipes is
-//! sufficient for an early BusyBox shell (pipelines have at most 2-3 stages).
+//! sufficient for an early `BusyBox` shell (pipelines have at most 2-3 stages).
 
 use crate::fd::EMFILE;
 // Signal is only used in the #[cfg(not(test))] SIGPIPE delivery block.
@@ -118,7 +118,7 @@ static mut PIPE_POOL: [Option<PipeBuffer>; MAX_PIPES] = {
 };
 
 /// Maximum pipes a single process may have open at once, so one process
-/// cannot exhaust the entire MAX_PIPES pool and starve every other
+/// cannot exhaust the entire `MAX_PIPES` pool and starve every other
 /// process of pipe fds.
 const MAX_PIPES_PER_PROCESS: usize = 4;
 
@@ -204,10 +204,10 @@ pub(crate) fn pipe_flags(pipe_idx: usize, end: u32) -> u32 {
 /// Extract the pipe index from an fd flags word.
 ///
 /// WHY 0x07 not 0x7F: the previous 7-bit mask (max 127) did not match
-/// MAX_PIPES (8 slots) -- a flags word with any of bits 12-15 set would
+/// `MAX_PIPES` (8 slots) -- a flags word with any of bits 12-15 set would
 /// decode to an out-of-range pipe index and panic on the array index in
-/// get_pipe_mut/on_pipe_fd_closed/maybe_free_pipe. This mask covers
-/// exactly the valid 0..MAX_PIPES range.
+/// `get_pipe_mut/on_pipe_fd_closed/maybe_free_pipe`. This mask covers
+/// exactly the valid `0..MAX_PIPES` range.
 pub(crate) fn pipe_idx_from_flags(flags: u32) -> usize {
     ((flags >> FD_PIPE_IDX_SHIFT) & 0x07) as usize
 }
@@ -226,7 +226,7 @@ pub(crate) fn is_write_end(flags: u32) -> bool {
 // Syscall implementation
 // ---------------------------------------------------------------------------
 
-/// SYS_pipe: create a pipe and write two fd numbers to userspace.
+/// `SYS_pipe`: create a pipe and write two fd numbers to userspace.
 ///
 /// # Arguments
 /// - `fds_ptr`: pointer to a `[u32; 2]` in userspace.
@@ -313,9 +313,9 @@ pub(crate) fn sys_pipe(fds_ptr: u32) -> u32 {
     0
 }
 
-/// SYS_read on a pipe fd.
+/// `SYS_read` on a pipe fd.
 ///
-/// Called from the generic sys_read path when the fd is detected as a pipe.
+/// Called from the generic `sys_read` path when the fd is detected as a pipe.
 ///
 /// # Returns
 /// Bytes read on success, 0 on EOF, negative error code on failure.
@@ -354,9 +354,9 @@ pub(crate) fn sys_pipe_read(pipe_idx: usize, buf_ptr: u32, count: u32) -> u32 {
     buf.read(dst) as u32
 }
 
-/// SYS_write on a pipe fd.
+/// `SYS_write` on a pipe fd.
 ///
-/// Called from the generic sys_write path when the fd is detected as a pipe.
+/// Called from the generic `sys_write` path when the fd is detected as a pipe.
 /// `writer_pid` is the PID of the calling process (for SIGPIPE delivery).
 ///
 /// # Returns
@@ -405,7 +405,7 @@ pub(crate) fn sys_pipe_write(pipe_idx: usize, buf_ptr: u32, count: u32, writer_p
     buf.write(src) as u32
 }
 
-/// Called from sys_close when a pipe fd is closed.
+/// Called from `sys_close` when a pipe fd is closed.
 /// Marks the appropriate end closed and frees the slot if both ends are gone.
 pub fn on_pipe_fd_closed(pipe_idx: usize, end_is_write: bool) {
     // SAFETY: single-core cooperative kernel; no concurrent mutation.

--- a/crates/thumos/src/power.rs
+++ b/crates/thumos/src/power.rs
@@ -3,7 +3,7 @@
 //! Two concerns live here:
 //!
 //! 1. **Radio kill switches** — GPIO-controlled power gates for cellular,
-//!    WiFi, BT, GPS, FM.  When off the hardware is physically disconnected
+//!    `WiFi`, BT, GPS, FM.  When off the hardware is physically disconnected
 //!    from power; software cannot override a hardware kill.
 //!
 //! 2. **CPU power governor** (REQ-19) — DVFS, core parking, and display
@@ -13,11 +13,11 @@
 //!
 //! | Register      | Address       | Purpose                              |
 //! |---------------|---------------|--------------------------------------|
-//! | ARMPLL_CON1   | 0x1000_C104   | CPU PLL divider → frequency          |
-//! | MCDI_BASE     | 0x1000_DC00   | Multi-Core Deep Idle control block   |
-//! | MCDI_CORE_EN  | 0x1000_DC04   | Per-core power-down enable bitmask   |
+//! | `ARMPLL_CON1`   | `0x1000_C104`   | CPU PLL divider → frequency          |
+//! | `MCDI_BASE`     | `0x1000_DC00`   | Multi-Core Deep Idle control block   |
+//! | `MCDI_CORE_EN`  | `0x1000_DC04`   | Per-core power-down enable bitmask   |
 //!
-//! ARMPLL_CON1 encoding used here matches the four frequency steps
+//! `ARMPLL_CON1` encoding used here matches the four frequency steps
 //! supported by the MT6739 stock DVFS table (1500 / 1200 / 900 / 600 MHz).
 //! The exact PCW (post-divider control word) values are documented in the
 //! MT6739 Clock Management Unit (CMU) specification rev 1.3 §4.2.
@@ -32,19 +32,19 @@
 
 /// CPU frequency operating points.
 ///
-/// `repr(u32)` values are written directly to ARMPLL_CON1.  The PCW
+/// `repr(u32)` values are written directly to `ARMPLL_CON1`.  The PCW
 /// values are truncated approximations; a production kernel reads the
 /// exact values from the efuse OPP table during boot.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum CpuFreq {
-    /// 1 500 MHz — full performance (PCW 0x009_6000 ≈ 0x0096_0000).
+    /// 1 500 MHz — full performance (PCW `0x009_6000` ≈ `0x0096_0000`).
     Mhz1500 = 0x0096_0000,
-    /// 1 200 MHz — mid-high (PCW ≈ 0x0078_0000).
+    /// 1 200 MHz — mid-high (PCW ≈ `0x0078_0000`).
     Mhz1200 = 0x0078_0000,
-    /// 900 MHz — mid-low (PCW ≈ 0x005A_0000).
+    /// 900 MHz — mid-low (PCW ≈ `0x005A_0000`).
     Mhz900 = 0x005A_0000,
-    /// 600 MHz — low power (PCW ≈ 0x003C_0000).
+    /// 600 MHz — low power (PCW ≈ `0x003C_0000`).
     Mhz600 = 0x003C_0000,
 }
 
@@ -87,7 +87,7 @@ const LOAD_HISTORY_LEN: usize = 4;
 /// CPU governor and display timeout state.
 ///
 /// One global instance is accessed from the timer IRQ handler only
-/// (single-core ARMv7, IRQs disabled during the handler).  No lock needed.
+/// (single-core `ARMv7`, IRQs disabled during the handler).  No lock needed.
 pub(crate) struct CpuGovernor {
     /// Current CPU frequency operating point.
     current_freq: CpuFreq,
@@ -101,10 +101,10 @@ pub(crate) struct CpuGovernor {
     backlight_timeout_ticks: u64,
     /// Rolling CPU load history (load % per tick, most-recent last).
     load_history: [u8; LOAD_HISTORY_LEN],
-    /// Write pointer into load_history (circular).
+    /// Write pointer into `load_history` (circular).
     load_idx: usize,
     /// Number of valid samples in `load_history` (saturates at
-    /// LOAD_HISTORY_LEN once the ring buffer has filled once after boot).
+    /// `LOAD_HISTORY_LEN` once the ring buffer has filled once after boot).
     load_samples: usize,
 }
 
@@ -145,7 +145,7 @@ impl CpuGovernor {
 // ---------------------------------------------------------------------------
 
 /// Global CPU governor.  Written only from the timer IRQ handler on a
-/// single-core ARMv7 with interrupts disabled — no lock needed.
+/// single-core `ARMv7` with interrupts disabled — no lock needed.
 static mut GOVERNOR: CpuGovernor = CpuGovernor::new();
 
 // ---------------------------------------------------------------------------
@@ -211,8 +211,8 @@ pub(crate) fn evaluate_dvfs(load_percent: u8) {
 /// stays on.
 ///
 /// MT6739 MCDI register addresses:
-/// * `0x1000_DC00` — MCDI_BASE
-/// * `0x1000_DC04` — MCDI_CORE_EN: bit N=1 powers down core N
+/// * `0x1000_DC00` — `MCDI_BASE`
+/// * `0x1000_DC04` — `MCDI_CORE_EN`: bit N=1 powers down core N
 ///
 /// # Safety
 ///
@@ -334,7 +334,7 @@ unsafe fn display_wake() {
 
 /// Write a zero-parameter DCS command to DSI0.
 ///
-/// DSI0 CMD_FIFO register: 0x1400_D000 + offset 0x200.
+/// DSI0 `CMD_FIFO` register: `0x1400_D000` + offset 0x200.
 /// Format: bits [7:0] = DCS opcode, bit 8 = last-byte flag.
 unsafe fn dcs_cmd0(cmd: u8) {
     // WHY(qemu): virt models no DSI0 block; the FIFO write would data-abort
@@ -590,8 +590,8 @@ impl Default for PowerManager {
 /// security-relevant radio).
 ///
 /// Used by the boot sequence (Wave 8) and by [`ModeManager`] on mode
-/// transitions to enforce radio policy without coupling security_mode
-/// directly to PowerManager internals.
+/// transitions to enforce radio policy without coupling `security_mode`
+/// directly to `PowerManager` internals.
 pub(crate) fn apply_mode_policy(policy: &crate::security_mode::ModePolicy, pm: &mut PowerManager) {
     let to_state = |enabled: bool| -> PowerState {
         if enabled {

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -5,7 +5,7 @@
 //! ready process and context-switches to it on each timer tick, swapping
 //! TTBR0 so each process has an independent virtual address space.
 //!
-//! On ARMv7 (#465), a context switch is a FULL trap-frame swap: the exception
+//! On `ARMv7` (#465), a context switch is a FULL trap-frame swap: the exception
 //! stub (exceptions.rs) captures the interrupted register file (r0-r12, banked
 //! sp/lr, resume pc, cpsr) into a `Context` on the handler stack, `switch_to`
 //! copies that into the current PCB and loads the next process's `Context`
@@ -37,7 +37,7 @@ pub enum State {
     Running,
     /// Blocked waiting for an event.
     Blocked,
-    /// Sleeping until wake_tick (set by nanosleep).
+    /// Sleeping until `wake_tick` (set by nanosleep).
     Sleeping,
     /// Terminated, awaiting cleanup.
     Dead,
@@ -72,7 +72,7 @@ const CPSR_MODE_USER: u32 = 0x10;
 /// Kill-vs-halt decision for a fault, from the SAVED CPSR in the trap frame.
 ///
 /// ONLY User mode (0x10) is killable: scheduled processes run at User
-/// (spawn_user/exec) or System (PID 0 + spawn kernel threads), and System-mode
+/// (`spawn_user/exec`) or System (PID 0 + spawn kernel threads), and System-mode
 /// code is kernel code in the kernel address space, so its faults are kernel
 /// bugs. A saved exception mode (SVC/IRQ/ABT/UND/FIQ) means a HANDLER faulted
 /// -- also a kernel bug; ABT/UND halting here is what bounds recursion if the
@@ -96,14 +96,14 @@ pub(crate) fn fault_exit_status(kind: FaultKind) -> i32 {
 }
 
 /// Kill the CURRENT process for `kind`, from abort/undef trap context: notify
-/// PID 0 (Dead + fd drain + IPC, via notify_fault), then run the exit path
-/// (exit_current: resource teardown + trap-frame swap to the successor). On
+/// PID 0 (Dead + fd drain + IPC, via `notify_fault`), then run the exit path
+/// (`exit_current`: resource teardown + trap-frame swap to the successor). On
 /// return the trap frame holds the successor's context and the stub epilogue
 /// exception-returns into it -- the same unwind contract as the Exit syscall.
 ///
-/// INVARIANT: exit_current frees the victim's L1 while TTBR0 still points at
-/// it; safe because free_addr_space only clears a pool bit (tables are zeroed
-/// at ALLOC, not free) and nothing allocates before switch_to's TTBR0 +
+/// INVARIANT: `exit_current` frees the victim's L1 while TTBR0 still points at
+/// it; safe because `free_addr_space` only clears a pool bit (tables are zeroed
+/// at ALLOC, not free) and nothing allocates before `switch_to`'s TTBR0 +
 /// TLBIALL -- the exact pattern the Exit-syscall path already relies on.
 pub(crate) fn fault_exit_current(kind: FaultKind) {
     notify_fault(current_pid(), kind);
@@ -179,18 +179,18 @@ pub struct VmMapping {
     pub start: usize,
     /// Number of 4 KB pages in this mapping.
     pub pages: usize,
-    /// POSIX protection flags (PROT_READ | PROT_WRITE | PROT_EXEC).
+    /// POSIX protection flags (`PROT_READ` | `PROT_WRITE` | `PROT_EXEC`).
     pub prot: u32,
 }
 
 /// Default initial program break for new processes.
-/// WHY: 0x1000_0000 is above device MMIO (0x0-0x2FFF_FFFF) but below DRAM
-/// (0x4000_0000), providing a clean region for the user heap that won't
+/// WHY: `0x1000_0000` is above device MMIO (0x0-0x2FFF_FFFF) but below DRAM
+/// (`0x4000_0000`), providing a clean region for the user heap that won't
 /// conflict with kernel data structures or device mappings.
 pub(crate) const DEFAULT_HEAP_BREAK: usize = 0x1000_0000;
 
 /// Base address for mmap allocations, above the heap region.
-/// WHY: 0x2000_0000 provides 256 MB of VA space for mmap before hitting
+/// WHY: `0x2000_0000` provides 256 MB of VA space for mmap before hitting
 /// the modem region, keeping mmap and brk regions non-overlapping.
 pub(crate) const MMAP_BASE: usize = 0x2000_0000;
 
@@ -200,9 +200,9 @@ pub(crate) struct Process {
     pub pid: Pid,
     pub state: State,
     pub ctx: Context,
-    /// Parent PID, if this process was created via fork().
+    /// Parent PID, if this process was created via `fork()`.
     pub parent: Option<Pid>,
-    /// Exit status SET by exit_with_status() / exit_cleanup().
+    /// Exit status SET by `exit_with_status()` / `exit_cleanup()`.
     pub exit_status: i32,
     /// Physical address of this process's L1 page table.
     /// 0 means "use kernel global L1" (process 0 / kinit).
@@ -223,8 +223,8 @@ pub(crate) struct Process {
     /// UID. A future setuid syscall can lower (but not raise) this value.
     pub uid: u32,
     /// Tick count at which this process should wake from Sleeping state.
-    /// Only meaningful when state == Sleeping. Set by sys_nanosleep;
-    /// the scheduler transitions the process to Ready when ticks() >= wake_tick.
+    /// Only meaningful when state == Sleeping. Set by `sys_nanosleep`;
+    /// the scheduler transitions the process to Ready when `ticks()` >= `wake_tick`.
     pub wake_tick: u64,
     /// Capability bitfield: which sensitive kernel operations this process may
     /// invoke. kinit (PID 0) holds ALL capabilities. Forked children inherit a
@@ -382,7 +382,7 @@ pub(crate) fn spawn(entry_point: fn() -> !) -> Option<Pid> {
     }
 }
 
-/// Map a loaded ELF's PT_LOAD segments PL0-accessible at their identity VAs in
+/// Map a loaded ELF's `PT_LOAD` segments PL0-accessible at their identity VAs in
 /// process page table `pt`, with W^X page permissions from each segment's ELF
 /// flags (#482): text RX, rodata RO+XN, data/bss RW+XN. Fails closed on an
 /// unaligned segment vaddr (a page would carry two permission classes) or
@@ -476,24 +476,24 @@ unsafe fn map_signal_trampoline(pt: usize) -> Option<usize> {
 /// No-op trampoline mapping for non-ARM (host test) builds: host page frames
 /// are simulated addresses — never dereference-able — and fork's deep-copy
 /// walk WOULD deref every user page's phys, so mapping a simulated frame
-/// here segfaults the host fork tests. The map_page/shatter composition is
+/// here segfaults the host fork tests. The `map_page/shatter` composition is
 /// host-covered in mmu.rs's own tests; the real grant is covered end-to-end
-/// by the QEMU signal witness. `Some(0)` keeps spawn_user's rollback shape
-/// (free_page validates allocator range, so 0 is a safe no-op there).
+/// by the QEMU signal witness. `Some(0)` keeps `spawn_user`'s rollback shape
+/// (`free_page` validates allocator range, so 0 is a safe no-op there).
 #[cfg(not(target_arch = "arm"))]
 unsafe fn map_signal_trampoline(_pt: usize) -> Option<usize> {
     Some(0)
 }
 
 /// Drop the PL0 grant on `pages` frames from `base` in `pt`: rewrite each L2
-/// entry back to the identity KERNEL_DEFAULT_PAGE (PL1-only, #489). NOT
-/// unmap_page (zeroing an entry inside a shattered identity MB would fault the
-/// kernel on its next access there), and NOT reset_shattered_section for a
+/// entry back to the identity `KERNEL_DEFAULT_PAGE` (PL1-only, #489). NOT
+/// `unmap_page` (zeroing an entry inside a shattered identity MB would fault the
+/// kernel on its next access there), and NOT `reset_shattered_section` for a
 /// stack (old and new exec stacks can share an allocator MB, so a whole-MB
 /// reset would revoke the new stack's grants). The caller flushes the TLB.
 ///
 /// # Safety
-/// `pt` is a caller-owned L1; each VA was granted via map_user_stack/image.
+/// `pt` is a caller-owned L1; each VA was granted via `map_user_stack/image`.
 unsafe fn revoke_user_pages(pt: usize, base: usize, pages: usize) {
     for i in 0..pages {
         let va = base + i * page::PAGE_SIZE;
@@ -523,7 +523,7 @@ unsafe fn revoke_user_pages(pt: usize, base: usize, pages: usize) {
 /// run is orphaned for the rest of the boot: there is no PCB and no page table
 /// left that could ever reclaim it.
 ///
-/// WHY this matters now (#492): spawn_user used to be called only by kinit's
+/// WHY this matters now (#492): `spawn_user` used to be called only by kinit's
 /// one-shot boot spawns, where a full process table / exhausted address-space
 /// pool is not a realistic condition. The fault supervisor relaunches a
 /// crash-looping service through the same path repeatedly, so a leak per
@@ -618,14 +618,14 @@ pub(crate) fn spawn_user(loaded: &crate::elf::LoadedElf) -> Option<Pid> {
 
 /// Free every PL0-mapped frame of `pt` back to the allocator (#478).
 ///
-/// `try_free_page`'s own validation makes this exact: a spawn_user image at
-/// USER_TEXT_BASE lies OUTSIDE the allocator range (kinit passes USER_TEXT_BASE
+/// `try_free_page`'s own validation makes this exact: a `spawn_user` image at
+/// `USER_TEXT_BASE` lies OUTSIDE the allocator range (kinit passes `USER_TEXT_BASE`
 /// as the upper bound) and is rejected as a no-op, while fork-copied image
 /// pages, stack backing, and heap/mmap frames are allocator pages freed exactly
 /// once. Ownership derives from the page table, not a separate record.
 ///
 /// # Safety
-/// `pt` is a valid L1; the current TTBR0 must be the KERNEL table (try_free_page
+/// `pt` is a valid L1; the current TTBR0 must be the KERNEL table (`try_free_page`
 /// zeroes the frame through the live TTBR0, so a user-remapped VA would alias).
 unsafe fn free_user_pages(pt: usize) {
     // SAFETY: caller guarantees pt valid + kernel TTBR0; try_free_page validates
@@ -775,14 +775,14 @@ unsafe fn fork_pl0(
 /// Create a child process (POSIX fork).
 ///
 /// A PL0 (userspace) parent gets a fresh ISOLATED address space with its user
-/// pages deep-copied (#478, fork_pl0). A PL1 parent (PID 0 / spawn kernel
+/// pages deep-copied (#478, `fork_pl0`). A PL1 parent (PID 0 / spawn kernel
 /// threads / host tests) takes the legacy path: shallow L1 clone + fresh
 /// translated stack (correct because kernel threads share the kernel identity
 /// map and their stacks are sections, not L2 mappings).
 ///
-/// NOTE: unlike POSIX fork(), both parent and child continue FROM the next
+/// NOTE: unlike POSIX `fork()`, both parent and child continue FROM the next
 /// scheduler tick; the child resumes at the fork return (its ctx is seeded from
-/// the live trap frame) with r0 = 0, the parent with r0 = child_pid.
+/// the live trap frame) with r0 = 0, the parent with r0 = `child_pid`.
 pub(crate) fn fork() -> Option<Pid> {
     // SAFETY: current process PCB pointer is valid; set by the scheduler on
     // context switch. addr_of_mut! avoids intermediate references to static mut.
@@ -1031,11 +1031,11 @@ pub(crate) fn waitpid(child_pid: Pid) -> Option<i32> {
 /// free pool; returns the count reaped.
 ///
 /// WHY (#491 review): a fault-killed process is marked Dead by the abort
-/// handler (fault_exit_current), but its PCB slot is only reclaimed by waitpid,
+/// handler (`fault_exit_current`), but its PCB slot is only reclaimed by waitpid,
 /// which is otherwise reachable only via the SVC Waitpid syscall. The kardia
 /// service loop (PID 0, the parent of every spawned process) calls this each
 /// tick so a fault-killed slot does not leak -- without it the process table
-/// monotonically exhausts at MAX_PROCS after repeated user faults, and every
+/// monotonically exhausts at `MAX_PROCS` after repeated user faults, and every
 /// subsequent spawn/fork silently fails while the kernel still appears alive.
 /// Scan-based (not fault-inbox-driven) so it reaps every Dead child even if the
 /// fault notification was dropped on a full inbox, and without consuming any
@@ -1218,7 +1218,7 @@ pub(crate) fn current_pid() -> Pid {
 ///
 /// Used by the power governor to decide how many cores to keep active.
 /// Called from the timer IRQ handler with interrupts disabled — safe to
-/// read PROCS without a lock on single-core ARMv7.
+/// read PROCS without a lock on single-core `ARMv7`.
 pub(crate) fn runnable_count() -> usize {
     // SAFETY: called from timer IRQ handler (single-core, IRQs disabled).
     // addr_of! avoids an intermediate reference to the static mut.
@@ -1235,7 +1235,7 @@ pub(crate) fn runnable_count() -> usize {
 /// Simple round-robin scheduler. Called FROM the timer tick handler.
 /// Returns the PID to switch to (may be the same as current).
 ///
-/// Also wakes any Sleeping processes whose wake_tick has been reached,
+/// Also wakes any Sleeping processes whose `wake_tick` has been reached,
 /// transitioning them to Ready so they can be scheduled next tick.
 pub(crate) fn schedule() -> Pid {
     // SAFETY: called from the timer IRQ handler with interrupts disabled on
@@ -1343,10 +1343,10 @@ pub(crate) fn set_trap_return(val: u32) {
 ///
 /// Serves BOTH the preemptive (timer IRQ) and cooperative (Yield/Exit/futex,
 /// from SVC) paths -- both enter through an exception stub that established
-/// ACTIVE_FRAME.
+/// `ACTIVE_FRAME`.
 ///
 /// # Safety
-/// Must be called from trap context (ACTIVE_FRAME live) with interrupts masked.
+/// Must be called from trap context (`ACTIVE_FRAME` live) with interrupts masked.
 pub unsafe fn switch_to(next_pid: Pid) {
     // SAFETY: trap context; PROCS/CURRENT are accessed with interrupts masked
     // and no concurrent access on this single core.
@@ -1395,9 +1395,9 @@ pub unsafe fn switch_to(next_pid: Pid) {
 
 /// Run `f` on the CURRENT process's fd table (#267). Returns None (fail
 /// closed) when the current PCB slot is absent -- fd syscalls map that to
-/// EBADF, matching the current_uid() posture (#282).
+/// EBADF, matching the `current_uid()` posture (#282).
 ///
-/// INVARIANT: `f` must not re-enter process:: accessors -- PROCS is
+/// INVARIANT: `f` must not re-enter `process::` accessors -- PROCS is
 /// mutably borrowed for the duration of the closure.
 pub(crate) fn with_current_fds<R>(f: impl FnOnce(&mut crate::fd::FdTable) -> R) -> Option<R> {
     // SAFETY: current process PCB pointer is valid; set by the scheduler on
@@ -1413,7 +1413,7 @@ pub(crate) fn with_current_fds<R>(f: impl FnOnce(&mut crate::fd::FdTable) -> R) 
 /// Read the current process's working directory (#437). `f` receives the path
 /// bytes (length `cwd_len`). Returns None when there is no current process.
 ///
-/// INVARIANT: as with_current_fds — `f` must not re-enter process:: accessors.
+/// INVARIANT: as `with_current_fds` — `f` must not re-enter `process::` accessors.
 pub(crate) fn with_current_cwd<R>(f: impl FnOnce(&[u8]) -> R) -> Option<R> {
     // SAFETY: current process PCB pointer is valid; read-only access to the
     // current PCB's cwd via addr_of_mut! (no mutation of PROCS itself).
@@ -1424,7 +1424,7 @@ pub(crate) fn with_current_cwd<R>(f: impl FnOnce(&[u8]) -> R) -> Option<R> {
     }
 }
 
-/// Set the current process's working directory (#437), truncating to CWD_MAX.
+/// Set the current process's working directory (#437), truncating to `CWD_MAX`.
 /// Returns None when there is no current process.
 pub(crate) fn set_current_cwd(path: &str) -> Option<()> {
     // SAFETY: current process PCB pointer is valid; mutation via addr_of_mut!,
@@ -1607,9 +1607,9 @@ pub(crate) fn current_capabilities() -> u32 {
     }
 }
 
-/// Set the current process's wake_tick and transition it to Sleeping.
+/// Set the current process's `wake_tick` and transition it to Sleeping.
 ///
-/// Called by sys_nanosleep after computing the target tick count.
+/// Called by `sys_nanosleep` after computing the target tick count.
 /// The scheduler will transition this process back to Ready when
 /// `exceptions::ticks() >= wake_tick`.
 pub(crate) fn set_wake_tick(wake_tick: u64) {
@@ -1628,8 +1628,8 @@ pub(crate) fn set_wake_tick(wake_tick: u64) {
 
 /// Clear the Sleeping state after the process wakes, transitioning to Running.
 ///
-/// Called by sys_nanosleep after the busy-wait loop confirms the wake tick
-/// has elapsed. Resets wake_tick to 0 and marks the process Running again.
+/// Called by `sys_nanosleep` after the busy-wait loop confirms the wake tick
+/// has elapsed. Resets `wake_tick` to 0 and marks the process Running again.
 pub(crate) fn clear_wake_tick() {
     // SAFETY: same as set_wake_tick — called from syscall context only.
     unsafe {
@@ -1754,7 +1754,7 @@ pub unsafe fn deliver_signal_to(pid: Pid, sig: Signal) -> u32 {
 
 /// Reset all signal handlers and the pending mask for the current process.
 ///
-/// Called by sys_execve (POSIX: exec resets all signal dispositions to SIG_DFL
+/// Called by `sys_execve` (POSIX: exec resets all signal dispositions to `SIG_DFL`
 /// and clears any pending signals that were set by a handler).
 ///
 /// # Safety
@@ -1789,7 +1789,7 @@ pub unsafe fn reset_signal_state() {
 /// Returns `false` if the new image/stack could not be mapped (L2-pool
 /// exhaustion). The old image is already gone by then, so the caller MUST kill
 /// the process (it is unrecoverable); the PCB is left consistent for
-/// exit_cleanup's page-table walk.
+/// `exit_cleanup`'s page-table walk.
 #[must_use]
 pub unsafe fn exec_replace_context(
     loaded: &crate::elf::LoadedElf,
@@ -1972,7 +1972,7 @@ pub unsafe fn exec_replace_context(
 }
 
 /// Clear the lowest-numbered pending signal for the current process.
-/// Called by sys_sigreturn after the handler returns.
+/// Called by `sys_sigreturn` after the handler returns.
 ///
 /// # Safety
 ///
@@ -1990,8 +1990,8 @@ pub unsafe fn clear_any_pending() {
 }
 
 /// Clear the pending bit for EXACTLY `sig` on the current process (#446).
-/// Called at dispatch time by signal::deliver, so the handler runs once per
-/// raise; distinct from clear_any_pending (next-pending semantics), which
+/// Called at dispatch time by `signal::deliver`, so the handler runs once per
+/// raise; distinct from `clear_any_pending` (next-pending semantics), which
 /// can clear the wrong signal when several are pending at once.
 pub(crate) fn clear_pending_for_current(sig: crate::signal::Signal) {
     // SAFETY: current process PCB pointer is valid; mutation via addr_of_mut!,
@@ -2806,10 +2806,10 @@ mod tests {
         }
     }
 
-    /// fork() must NOT let the child inherit a signal that was pending in the
+    /// `fork()` must NOT let the child inherit a signal that was pending in the
     /// parent at fork time: signal HANDLERS are inherited but the pending mask
-    /// is cleared (process.rs fork(), `s.pending = 0`), matching POSIX
-    /// fork() semantics.
+    /// is cleared (process.rs `fork()`, `s.pending = 0`), matching POSIX
+    /// `fork()` semantics.
     #[test]
     fn fork_clears_child_pending_signal_mask() {
         // SAFETY: test-only; reset_all reinitialises global state. Single-threaded
@@ -2910,7 +2910,7 @@ mod tests {
         }
     }
 
-    /// #251: an OOM partway through spawn()'s stack allocation must roll
+    /// #251: an OOM partway through `spawn()`'s stack allocation must roll
     /// back exactly the pages allocated so far, verified against the bitmap
     /// free-count (not assumed physically contiguous).
     #[test]
@@ -2949,8 +2949,8 @@ mod tests {
         }
     }
 
-    /// #251: an OOM partway through fork()'s child-stack allocation must roll
-    /// back exactly the pages allocated so far. #208 rewrote fork()'s SUCCESS
+    /// #251: an OOM partway through `fork()`'s child-stack allocation must roll
+    /// back exactly the pages allocated so far. #208 rewrote `fork()`'s SUCCESS
     /// path (translated sp + stack copy) but left the rollback assuming
     /// physical contiguity; this guards the re-derived array-tracked rollback.
     #[test]
@@ -3007,7 +3007,7 @@ mod tests {
         }
     }
 
-    /// #232: waitpid must reject any PID >= MAX_PROCS instead of indexing
+    /// #232: waitpid must reject any PID >= `MAX_PROCS` instead of indexing
     /// the fixed-size table out of bounds.
     #[test]
     fn waitpid_rejects_out_of_bounds_pid() {
@@ -3031,7 +3031,7 @@ mod tests {
         }
     }
 
-    /// #218/#224: fork/exit/waitpid MAX_PROCS times must leave every
+    /// #218/#224: fork/exit/waitpid `MAX_PROCS` times must leave every
     /// non-init slot reaped (None), and a further fork must then succeed —
     /// not permanently exhaust the table with Dead-but-unreaped PCBs.
     #[test]
@@ -3283,7 +3283,7 @@ mod tests {
         }
     }
 
-    /// #225: exec_replace_context must unmap and free every previously
+    /// #225: `exec_replace_context` must unmap and free every previously
     /// tracked mmap page and every grown heap page, not just reset the
     /// tracking state and leak the physical frames.
     #[test]
@@ -3399,7 +3399,7 @@ mod tests {
         }
     }
 
-    /// set_wake_tick transitions the process to Sleeping with the correct tick.
+    /// `set_wake_tick` transitions the process to Sleeping with the correct tick.
     #[test]
     fn nanosleep_sets_wake_time() {
         // SAFETY: test-only; reset_all reinitialises global state.
@@ -3427,7 +3427,7 @@ mod tests {
         }
     }
 
-    /// clear_wake_tick returns the process to Running state.
+    /// `clear_wake_tick` returns the process to Running state.
     #[test]
     fn clear_wake_tick_restores_running() {
         // SAFETY: test-only; reset_all reinitialises global state.
@@ -3452,11 +3452,11 @@ mod tests {
         }
     }
 
-    /// schedule()'s first pass wakes a Sleeping process once its wake_tick has
+    /// `schedule()`'s first pass wakes a Sleeping process once its `wake_tick` has
     /// elapsed (`now >= wake_tick`), transitioning it to Ready; a process whose
-    /// wake_tick has NOT yet elapsed must stay Sleeping. exceptions::ticks()
+    /// `wake_tick` has NOT yet elapsed must stay Sleeping. `exceptions::ticks()`
     /// is only ever written FROM the real timer IRQ handler, so it reads 0 for
-    /// the life of the host test binary -- wake_tick 0 is therefore already due.
+    /// the life of the host test binary -- `wake_tick` 0 is therefore already due.
     #[test]
     fn schedule_wakes_sleeping_process_past_wake_tick() {
         // SAFETY: test-only; reset_all reinitialises global state. Single-threaded
@@ -3843,7 +3843,7 @@ mod tests {
         }
     }
 
-    /// #269: kinit (PID 0) must never be a valid deliver_signal_to target,
+    /// #269: kinit (PID 0) must never be a valid `deliver_signal_to` target,
     /// even for SIGKILL.
     #[test]
     fn deliver_signal_to_rejects_pid_zero() {
@@ -3932,7 +3932,7 @@ mod tests {
         }
     }
 
-    /// #269: sys_kill must reject PID 0 outright, even for a self-signal
+    /// #269: `sys_kill` must reject PID 0 outright, even for a self-signal
     /// from kinit, before any capability check.
     #[test]
     fn sys_kill_rejects_pid_zero_even_for_self() {
@@ -3952,8 +3952,8 @@ mod tests {
         }
     }
 
-    /// #379 (REQ-09): a process without CAP_KILL may not signal a
-    /// different, non-zero process -- sys_kill must return EPERM and the
+    /// #379 (REQ-09): a process without `CAP_KILL` may not signal a
+    /// different, non-zero process -- `sys_kill` must return EPERM and the
     /// target must be left untouched.
     #[test]
     fn sys_kill_cross_process_denied_without_cap_kill() {
@@ -3999,8 +3999,8 @@ mod tests {
         }
     }
 
-    /// #379 (REQ-09): a process holding CAP_KILL may signal a different,
-    /// non-zero process -- sys_kill succeeds and the default action
+    /// #379 (REQ-09): a process holding `CAP_KILL` may signal a different,
+    /// non-zero process -- `sys_kill` succeeds and the default action
     /// (SIGTERM -> terminate) is applied to the target.
     #[test]
     fn sys_kill_cross_process_allowed_with_cap_kill() {
@@ -4042,8 +4042,8 @@ mod tests {
         }
     }
 
-    /// #371: sys_send (Syscall::Send) targeting PID 0 must be denied when
-    /// the sender lacks CAP_IPC_INIT, and the message must not be
+    /// #371: `sys_send` (`Syscall::Send`) targeting PID 0 must be denied when
+    /// the sender lacks `CAP_IPC_INIT`, and the message must not be
     /// delivered into kinit's inbox.
     #[test]
     fn sys_send_to_pid_zero_denied_without_ipc_init_cap() {
@@ -4080,7 +4080,7 @@ mod tests {
         }
     }
 
-    /// #371: a process explicitly granted CAP_IPC_INIT may message PID 0,
+    /// #371: a process explicitly granted `CAP_IPC_INIT` may message PID 0,
     /// and the delivered message carries the sender's PID and tag.
     #[test]
     fn sys_send_to_pid_zero_allowed_with_ipc_init_cap() {

--- a/crates/thumos/src/provision.rs
+++ b/crates/thumos/src/provision.rs
@@ -17,9 +17,9 @@
 //! the same untrusted bundle it protects, so it catches corruption but proves
 //! nothing about origin. The Ed25519 signature covers the same magic + length
 //! + payload region and is the sole authenticity guarantee — verified against
-//! [`PROVISION_PUBLIC_KEY`], a compile-time-embedded public key whose
-//! corresponding private key is held offline by the operator, mirroring the
-//! secure-boot Ed25519 key custody model (see [`secure_boot`]).
+//!   [`PROVISION_PUBLIC_KEY`], a compile-time-embedded public key whose
+//!   corresponding private key is held offline by the operator, mirroring the
+//!   secure-boot Ed25519 key custody model (see [`secure_boot`]).
 //!
 //! ## Provisioning flow
 //!
@@ -246,7 +246,7 @@ pub(crate) struct Provisioner {
     /// Successfully deserialized bundle (set after finalize).
     bundle: Option<ProvisionBundle>,
     /// Ed25519 public key used to verify bundle signatures. Always
-    /// PROVISION_PUBLIC_KEY outside tests; test-injectable via
+    /// `PROVISION_PUBLIC_KEY` outside tests; test-injectable via
     /// [`Provisioner::new_with_key`] to exercise verification against a
     /// locally generated keypair.
     provision_public_key: [u8; secure_boot::PUBLIC_KEY_LEN],

--- a/crates/thumos/src/ramfs.rs
+++ b/crates/thumos/src/ramfs.rs
@@ -35,7 +35,7 @@ struct RamInode {
     inode_type: InodeType,
     /// File contents (empty for directories).
     data: Vec<u8>,
-    /// Child entries for directories: (name, inode_id) pairs.
+    /// Child entries for directories: (name, `inode_id`) pairs.
     children: Vec<(String, u32)>,
     /// Parent directory inode id (root's parent is itself).
     parent: u32,
@@ -52,7 +52,7 @@ struct RamInode {
 pub(crate) struct RamFs {
     /// All inodes in the filesystem. Index == inode id.
     inodes: Vec<RamInode>,
-    /// Next inode id to allocate (always == inodes.len()).
+    /// Next inode id to allocate (always == `inodes.len()`).
     next_inode: u32,
 }
 
@@ -242,8 +242,8 @@ impl RamFs {
 
             // Determine entry type from mode field
             // S_IFMT mask = 0o170000, S_IFDIR = 0o040000, S_IFREG = 0o100000
-            let file_type = mode & 0o170000;
-            let is_dir = file_type == 0o040000;
+            let file_type = mode & 0o170_000;
+            let is_dir = file_type == 0o040_000;
 
             if !name.is_empty() && name != "." {
                 // Strip leading "./" if present (common in CPIO archives)
@@ -254,7 +254,7 @@ impl RamFs {
                     if is_dir {
                         // Ensure the directory exists in the tree
                         fs.ensure_directory_path(clean_name);
-                    } else if filesize > 0 || file_type == 0o100000 {
+                    } else if filesize > 0 || file_type == 0o100_000 {
                         // Regular file: ensure parent directories exist, then add file
                         fs.insert_file_at_path(clean_name, &data[data_start..data_end]);
                     }

--- a/crates/thumos/src/screen_contacts.rs
+++ b/crates/thumos/src/screen_contacts.rs
@@ -139,9 +139,9 @@ enum AddField {
 pub(crate) struct ContactsScreen {
     /// Sorted indices into the contact manager.
     sorted_indices: Vec<usize>,
-    /// Contact names for display (parallel to sorted_indices).
+    /// Contact names for display (parallel to `sorted_indices`).
     display_names: Vec<String>,
-    /// Contact numbers for display (parallel to sorted_indices).
+    /// Contact numbers for display (parallel to `sorted_indices`).
     display_numbers: Vec<String>,
     /// Currently selected index in the sorted list.
     selected: usize,

--- a/crates/thumos/src/screen_home.rs
+++ b/crates/thumos/src/screen_home.rs
@@ -60,7 +60,7 @@ pub enum OperatingMode {
 
 impl From<crate::security_mode::SecurityMode> for OperatingMode {
     /// Bridge the runtime security-mode manager into the home-screen display
-    /// mode (#404): the badge/color follow the live ModeManager, not a hardcode.
+    /// mode (#404): the badge/color follow the live `ModeManager`, not a hardcode.
     fn from(m: crate::security_mode::SecurityMode) -> Self {
         match m {
             crate::security_mode::SecurityMode::Daily => Self::Daily,

--- a/crates/thumos/src/screen_messages.rs
+++ b/crates/thumos/src/screen_messages.rs
@@ -24,8 +24,8 @@
 //! ## Transport badges
 //!
 //! Each inbox entry is prefixed with a short badge identifying the
-//! transport: `S` (SMS), `M` (Matrix), `B` (Briar), `L` (LoRa/
-//! Meshtastic), `W` (bridged WhatsApp), `Sl` (bridged Slack),
+//! transport: `S` (SMS), `M` (Matrix), `B` (Briar), `L` (`LoRa`/
+//! Meshtastic), `W` (bridged `WhatsApp`), `Sl` (bridged Slack),
 //! `T` (bridged Telegram).
 //!
 //! ## Data source
@@ -62,9 +62,9 @@ pub enum MessageTransport {
     Matrix,
     /// Briar peer-to-peer messaging.
     Briar,
-    /// Meshtastic LoRa mesh.
+    /// Meshtastic `LoRa` mesh.
     Meshtastic,
-    /// WhatsApp bridged through Matrix.
+    /// `WhatsApp` bridged through Matrix.
     BridgedWhatsApp,
     /// Slack bridged through Matrix.
     BridgedSlack,
@@ -92,7 +92,7 @@ impl MessageTransport {
     /// Cycle to the next transport in compose mode.
     ///
     /// Cycles through: Sms -> Matrix -> Briar -> Meshtastic ->
-    /// BridgedWhatsApp -> BridgedSlack -> BridgedTelegram -> Sms.
+    /// `BridgedWhatsApp` -> `BridgedSlack` -> `BridgedTelegram` -> Sms.
     #[must_use]
     pub(crate) const fn next(self) -> Self {
         match self {

--- a/crates/thumos/src/screen_privacy.rs
+++ b/crates/thumos/src/screen_privacy.rs
@@ -135,7 +135,7 @@ const fn default_categories() -> [DataCategory; CATEGORY_COUNT] {
         },
         DataCategory {
             name: "Messages",
-            size_bytes: 524288,
+            size_bytes: 524_288,
             retention_days: 90,
             purgeable: true,
         },
@@ -159,13 +159,13 @@ const fn default_categories() -> [DataCategory; CATEGORY_COUNT] {
         },
         DataCategory {
             name: "SIGINT",
-            size_bytes: 262144,
+            size_bytes: 262_144,
             retention_days: 7,
             purgeable: true,
         },
         DataCategory {
             name: "Location",
-            size_bytes: 131072,
+            size_bytes: 131_072,
             retention_days: 14,
             purgeable: true,
         },
@@ -223,7 +223,7 @@ impl SizeBuf {
 
 /// Format a byte count as a human-readable string (B, KB, MB, GB).
 ///
-/// Uses integer division for no_std compatibility. Rounds down.
+/// Uses integer division for `no_std` compatibility. Rounds down.
 fn format_size(bytes: u64) -> SizeBuf {
     let mut buf = SizeBuf::new();
 
@@ -265,7 +265,7 @@ fn format_size_display(bytes: u64) -> SizeBufDisplay {
     SizeBufDisplay(format_size(bytes))
 }
 
-/// Wrapper to implement Display for SizeBuf without heap allocation.
+/// Wrapper to implement Display for `SizeBuf` without heap allocation.
 struct SizeBufDisplay(SizeBuf);
 
 impl core::fmt::Display for SizeBufDisplay {
@@ -274,7 +274,7 @@ impl core::fmt::Display for SizeBufDisplay {
     }
 }
 
-/// Write a u64 value as decimal digits into a SizeBuf.
+/// Write a u64 value as decimal digits into a `SizeBuf`.
 fn write_u64(buf: &mut SizeBuf, mut val: u64) {
     if val == 0 {
         buf.push(b'0');
@@ -344,7 +344,7 @@ impl RetentionBuf {
     }
 }
 
-/// Write a u16 value as decimal digits into a RetentionBuf.
+/// Write a u16 value as decimal digits into a `RetentionBuf`.
 fn write_u16_ret(buf: &mut RetentionBuf, mut val: u16) {
     if val == 0 {
         buf.push(b'0');
@@ -443,7 +443,7 @@ pub(crate) struct PrivacyScreen {
     scroll_offset: usize,
     /// Current sub-view.
     view: PrivacyView,
-    /// Purge confirmation state (valid when view == PurgeConfirm).
+    /// Purge confirmation state (valid when view == `PurgeConfirm`).
     purge_state: Option<PurgeConfirmState>,
     /// Total storage usage across all categories (cached).
     total_bytes: u64,

--- a/crates/thumos/src/screen_radio.rs
+++ b/crates/thumos/src/screen_radio.rs
@@ -1,11 +1,11 @@
 //! Radio control panel for the thumos kernel UI.
 //!
 //! Displays per-radio ON/OFF status for all wireless subsystems
-//! (cellular, WiFi, Bluetooth, GPS) and provides quick-action
+//! (cellular, `WiFi`, Bluetooth, GPS) and provides quick-action
 //! presets for privacy-oriented operation:
 //!
 //! - **COVERT LOCK**: all radios off (full RF silence)
-//! - **STEALTH**: cellular off, WiFi + BT on (local-only connectivity)
+//! - **STEALTH**: cellular off, `WiFi` + BT on (local-only connectivity)
 //! - **RESTORE**: all radios on (normal operation)
 //!
 //! The screen does not directly control hardware; it sets a desired
@@ -57,7 +57,7 @@ const PRESET_COUNT: usize = 3;
 pub struct RadioState {
     /// Cellular modem (voice + data).
     pub cellular: bool,
-    /// WiFi radio.
+    /// `WiFi` radio.
     pub wifi: bool,
     /// Bluetooth radio.
     pub bluetooth: bool,
@@ -82,7 +82,7 @@ impl RadioState {
         gps: false,
     };
 
-    /// Stealth mode: cellular + GPS off, WiFi + BT on.
+    /// Stealth mode: cellular + GPS off, `WiFi` + BT on.
     pub(crate) const STEALTH: Self = Self {
         cellular: false,
         wifi: true,

--- a/crates/thumos/src/screen_settings.rs
+++ b/crates/thumos/src/screen_settings.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides a menu-style settings hub with subpages:
 //! - Main settings menu (scrollable list of categories)
-//! - WiFi settings (current connection state, SSID, signal, IP)
+//! - `WiFi` settings (current connection state, SSID, signal, IP)
 //! - Bluetooth settings (paired count, scanning status)
 //! - About screen (device info, OS version, build date)
 //!
@@ -324,13 +324,13 @@ impl Screen for AboutScreen {
 // WiFi settings screen
 // ---------------------------------------------------------------------------
 
-/// Snapshot of WiFi state for display on the settings screen.
+/// Snapshot of `WiFi` state for display on the settings screen.
 ///
 /// Decoupled from `wifi::WifiState` to avoid coupling screen rendering
 /// to the driver state machine. Updated each render cycle.
 #[derive(Debug, Clone)]
 pub struct WifiSettingsState {
-    /// Whether WiFi is connected.
+    /// Whether `WiFi` is connected.
     pub connected: bool,
     /// Current SSID (empty if not connected).
     pub ssid: [u8; 32],
@@ -357,14 +357,14 @@ impl Default for WifiSettingsState {
     }
 }
 
-/// WiFi settings screen (read-only display of WiFi state).
+/// `WiFi` settings screen (read-only display of `WiFi` state).
 pub(crate) struct WifiSettingsScreen {
-    /// Current WiFi state snapshot.
+    /// Current `WiFi` state snapshot.
     pub state: WifiSettingsState,
 }
 
 impl WifiSettingsScreen {
-    /// Create a new WiFi settings screen with default (disconnected) state.
+    /// Create a new `WiFi` settings screen with default (disconnected) state.
     pub(crate) fn new() -> Self {
         Self {
             state: WifiSettingsState::default(),
@@ -687,7 +687,7 @@ impl Screen for BtSettingsScreen {
 // Formatting helpers (no_std, no alloc for small values)
 // ---------------------------------------------------------------------------
 
-/// Small fixed-capacity buffer for no_std number formatting.
+/// Small fixed-capacity buffer for `no_std` number formatting.
 struct SmallBuf {
     data: [u8; 16],
     len: usize,

--- a/crates/thumos/src/screen_threat.rs
+++ b/crates/thumos/src/screen_threat.rs
@@ -83,7 +83,7 @@ const COLOR_ORANGE: u16 = color::from_rgb(255, 165, 0);
 // ---------------------------------------------------------------------------
 
 /// The canonical threat severity level: defined ONCE in `sema_core` (the
-/// no_std+alloc core shared with the `sema` workspace crate) and re-exported
+/// `no_std+alloc` core shared with the `sema` workspace crate) and re-exported
 /// here. The pre-#545 kernel copy drifted (bands 25/50/75 vs the canonical
 /// 30/60/80 protocol invariants) — the exact divergence class #545 exists
 /// to kill. Screen-specific presentation rides in the extension trait
@@ -137,7 +137,7 @@ pub enum ThreatAlertType {
     ImsiCatcher,
     /// BLE tracker device following the user.
     BleTracker,
-    /// WiFi deauthentication attack in progress.
+    /// `WiFi` deauthentication attack in progress.
     DeauthAttack,
     /// CCCI modem traffic anomaly detected.
     CcciAnomaly,

--- a/crates/thumos/src/secrets.rs
+++ b/crates/thumos/src/secrets.rs
@@ -29,7 +29,7 @@
 //! The boot verifier is PLAINTEXT by construction, like the salt: it must
 //! be readable before any passphrase-derived key exists, and it is not a
 //! fast oracle — it is `HKDF(primary, "thumos-verify-v1")` where the
-//! primary is PBKDF2-HMAC-SHA256(passphrase, salt, 100_000), so a disk
+//! primary is PBKDF2-HMAC-SHA256(passphrase, salt, `100_000`), so a disk
 //! image buys an attacker exactly the same per-guess cost as attacking
 //! the encrypted payload itself (and NEVER a raw SHA-256(passphrase)
 //! fast-path). It carries no entropy of its own beyond the passphrase.

--- a/crates/thumos/src/secure_boot.rs
+++ b/crates/thumos/src/secure_boot.rs
@@ -422,7 +422,7 @@ pub(crate) enum SecureBootDecision {
 ///
 /// - `Present` + valid signature: proceed, trusted.
 /// - `Present` + anything else: halt (fail closed).
-/// - `Absent` (no boot medium): proceed UNTRUSTED — secure_boot_ok stays
+/// - `Absent` (no boot medium): proceed UNTRUSTED — `secure_boot_ok` stays
 ///   false and every downstream trust gate (LFS mount, passphrase,
 ///   encrypted mount, audit key, persistent userspace) stays locked.
 pub(crate) fn evaluate_boot_image(source: &BootImageSource<'_>) -> SecureBootDecision {
@@ -862,7 +862,7 @@ mod tests {
         );
     }
 
-    /// Test split_image correctly separates payload and signature.
+    /// Test `split_image` correctly separates payload and signature.
     #[test]
     fn split_image_correct() {
         let mut image = [0u8; 128];
@@ -962,7 +962,7 @@ mod tests {
         );
     }
 
-    /// Test that an image shorter than MIN_IMAGE_SIZE is rejected by
+    /// Test that an image shorter than `MIN_IMAGE_SIZE` is rejected by
     /// [`verify_combined_image`] before any signature verification.
     #[test]
     fn combined_image_too_short_fails() {
@@ -974,7 +974,7 @@ mod tests {
         );
     }
 
-    /// Test Display impl for SecureBootError.
+    /// Test Display impl for `SecureBootError`.
     #[test]
     fn error_display() {
         let msg = SecureBootError::ImageTooShort.to_string();

--- a/crates/thumos/src/security_mode.rs
+++ b/crates/thumos/src/security_mode.rs
@@ -234,7 +234,7 @@ pub enum ModeTransitionError {
     /// (`pin_hash` is `None`) -- distinct from `PinMismatch` so an
     /// unprovisioned manager fails closed instead of silently accepting or
     /// permanently masquerading as a wrong-PIN lockout (issue #282,
-    /// security_mode.rs).
+    /// `security_mode.rs`).
     NotProvisioned,
 }
 
@@ -309,7 +309,7 @@ pub(crate) struct ModeManager {
     /// cryptographically negligible, so an all-zero `pin_hash` would be
     /// indistinguishable from "unprovisioned" yet would silently behave as
     /// if provisioned -- permanently failing every future PIN check
-    /// (issue #282, security_mode.rs).
+    /// (issue #282, `security_mode.rs`).
     pin_hash: Option<[u8; 32]>,
 }
 
@@ -884,12 +884,12 @@ mod tests {
         derived
     }
 
-    /// Helper: create a ModeManager with a known test PIN.
+    /// Helper: create a `ModeManager` with a known test PIN.
     fn mode_manager_with_test_pin() -> ModeManager {
         ModeManager::new(derive_test_pin_hash(b"123456"))
     }
 
-    /// Helper: create a KeyManager with loaded keys for testing.
+    /// Helper: create a `KeyManager` with loaded keys for testing.
     fn key_manager_with_derived_keys() -> KeyManager {
         let mut km = KeyManager::new();
         let primary = {
@@ -918,7 +918,7 @@ mod tests {
     /// A `Default`-constructed manager has never been provisioned with a
     /// real PIN; Sentinel exit must fail closed (`NotProvisioned`), not
     /// silently accept any input and not masquerade as an ordinary
-    /// wrong-PIN `PinMismatch` (issue #282, security_mode.rs).
+    /// wrong-PIN `PinMismatch` (issue #282, `security_mode.rs`).
     #[test]
     fn default_mode_manager_is_unprovisioned_and_cannot_exit_sentinel() {
         let mut mm = ModeManager::default();

--- a/crates/thumos/src/signal.rs
+++ b/crates/thumos/src/signal.rs
@@ -38,7 +38,7 @@
 //! vDSO-shaped answer: PL0 can execute but never write it, the kernel wrote
 //! it once through the PL1 mapping, the address is known without per-frame
 //! code, and fork copies it / exec inherits it (it sits outside the
-//! USER_TEXT section exec rebuilds) / exit's page walk reclaims it.
+//! `USER_TEXT` section exec rebuilds) / exit's page walk reclaims it.
 
 /// Number of u32 registers saved in the signal frame (r0-r12, sp, lr, pc, cpsr).
 pub(crate) const SIGNAL_FRAME_REGS: usize = 17;
@@ -49,10 +49,10 @@ pub(crate) const SIGNAL_FRAME_SIZE: usize = SIGNAL_FRAME_REGS * 4;
 
 /// Virtual address of the per-process sigreturn trampoline page: the page
 /// directly below `USER_TEXT_BASE`. WHY here: heap grows up from
-/// `DEFAULT_HEAP_BREAK` (0x1000_0000) and mmap from `MMAP_BASE`
-/// (0x2000_0000), so this page is unreachable by legitimate user mappings;
-/// it sits OUTSIDE the USER_TEXT 1 MB section that exec revokes and rebuilds
-/// (exec_replace_context resets only USER_TEXT_BASE's section), so the
+/// `DEFAULT_HEAP_BREAK` (`0x1000_0000`) and mmap from `MMAP_BASE`
+/// (`0x2000_0000`), so this page is unreachable by legitimate user mappings;
+/// it sits OUTSIDE the `USER_TEXT` 1 MB section that exec revokes and rebuilds
+/// (`exec_replace_context` resets only `USER_TEXT_BASE`'s section), so the
 /// trampoline survives exec; and fork's copy-all-user-pages replicates it
 /// for the child automatically.
 pub(crate) const SIGNAL_TRAMPOLINE_VA: usize =
@@ -150,7 +150,7 @@ pub(crate) unsafe fn write_trampoline_page(_phys: usize) {}
 
 /// Sigreturn (#446): restore the interrupted context the signal frame saved,
 /// resuming user mode exactly where the signal interrupted it. Called from
-/// svc_handler_rust's special case for syscall 81 with the SVC trap frame:
+/// `svc_handler_rust`'s special case for syscall 81 with the SVC trap frame:
 /// the trampoline page's `svc` entered with user sp = the signal frame's
 /// base, and the pending bit was already cleared at dispatch, so this
 /// function only restores — it never touches pending state (the old
@@ -175,7 +175,7 @@ pub(crate) unsafe fn sigreturn_frame(frame: &mut crate::process::Context) {
     }
 }
 
-/// Unreachable by design: svc_handler_rust special-cases syscall 81 before
+/// Unreachable by design: `svc_handler_rust` special-cases syscall 81 before
 /// the generic dispatch, because the frame restore needs the SVC trap frame
 /// (which `dispatch` does not receive). This shim exists only so the
 /// dispatcher's match stays exhaustive (#446).
@@ -183,7 +183,7 @@ pub(crate) fn sigreturn_unreachable() -> u32 {
     crate::syscall::ENOSYS
 }
 
-/// The sigreturn syscall number (81), for svc_handler_rust's special case.
+/// The sigreturn syscall number (81), for `svc_handler_rust`'s special case.
 pub(crate) const SIGRETURN_NUM: u32 = 81;
 
 /// Recognized signal numbers.
@@ -232,7 +232,7 @@ impl Signal {
 
     /// Whether this signal can be caught or ignored.
     ///
-    /// WHY: POSIX requires SIGKILL to always terminate; no handler or SIG_IGN
+    /// WHY: POSIX requires SIGKILL to always terminate; no handler or `SIG_IGN`
     /// can override it. Rejecting sigaction for SIGKILL here enforces that rule.
     pub(crate) const fn can_catch(self) -> bool {
         !matches!(self, Self::Sigkill)
@@ -250,14 +250,14 @@ pub enum DefaultAction {
 
 /// Per-signal action: what to do when the signal is delivered.
 ///
-/// WHY: `#[derive(Clone, Copy)]` — SignalAction is stored inline in the
+/// WHY: `#[derive(Clone, Copy)]` — `SignalAction` is stored inline in the
 /// fixed-size `SignalState::handlers` array, which must be `Copy` so the
 /// whole `Process` struct can be cloned in `fork()` without a heap allocation.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum SignalAction {
     /// Apply the kernel default action (terminate or ignore).
     Default,
-    /// Explicitly ignore this signal (SIG_IGN, handler_ptr == 1).
+    /// Explicitly ignore this signal (`SIG_IGN`, `handler_ptr` == 1).
     Ignore,
     /// Call this user-space function pointer when the signal is delivered.
     /// The value is a virtual address in the process's address space.
@@ -265,10 +265,10 @@ pub enum SignalAction {
 }
 
 impl SignalAction {
-    /// Sentinel value userspace passes in handler_ptr to mean SIG_IGN.
+    /// Sentinel value userspace passes in `handler_ptr` to mean `SIG_IGN`.
     pub(crate) const SIG_IGN: u32 = 1;
 
-    /// Sentinel value userspace passes in handler_ptr to mean SIG_DFL.
+    /// Sentinel value userspace passes in `handler_ptr` to mean `SIG_DFL`.
     pub(crate) const SIG_DFL: u32 = 0;
 }
 
@@ -609,8 +609,8 @@ mod tests {
     }
 
     /// The trampoline page's VA is the reserved slot one page below
-    /// USER_TEXT_BASE — outside the section exec rebuilds, above every
-    /// growing user region (heap at 0x1000_0000, mmap at 0x2000_0000).
+    /// `USER_TEXT_BASE` — outside the section exec rebuilds, above every
+    /// growing user region (heap at `0x1000_0000`, mmap at `0x2000_0000`).
     #[test]
     fn signal_trampoline_va_is_the_reserved_slot() {
         assert_eq!(
@@ -630,7 +630,7 @@ mod tests {
         );
     }
 
-    /// trampoline_words() must emit [mov r7, #81; svc #0] — the whole
+    /// `trampoline_words()` must emit [mov r7, #81; svc #0] — the whole
     /// trampoline, exactly what the ARM writer emits into the page.
     #[test]
     fn trampoline_words_are_mov_then_svc() {
@@ -641,7 +641,7 @@ mod tests {
 
     // --- #446 frame build + restore ---
 
-    /// deliver() must lay out the 17 saved Context words on the user stack
+    /// `deliver()` must lay out the 17 saved Context words on the user stack
     /// and rewrite the trap frame to enter the handler with the frame as its
     /// stack, r0 = the signum, and lr = the RX trampoline page.
     #[test]
@@ -687,7 +687,7 @@ mod tests {
         }
     }
 
-    /// sigreturn_frame() must restore all 17 saved registers into the SVC
+    /// `sigreturn_frame()` must restore all 17 saved registers into the SVC
     /// trap frame, resuming the interrupted context exactly.
     #[test]
     fn sigreturn_frame_restores_interrupted_context() {

--- a/crates/thumos/src/slab.rs
+++ b/crates/thumos/src/slab.rs
@@ -455,7 +455,7 @@ mod tests {
     static mut TEST_FREED_PAGES: [usize; TEST_PAGES] = [0; TEST_PAGES];
     static mut TEST_FREED_COUNT: usize = 0;
 
-    /// Fake alloc_page: returns the next page from TEST_POOL.
+    /// Fake `alloc_page`: returns the next page from `TEST_POOL`.
     unsafe fn fake_alloc_page() -> Option<usize> {
         // SAFETY: single-threaded test execution; TEST_NEXT_PAGE is private.
         unsafe {
@@ -469,7 +469,7 @@ mod tests {
         }
     }
 
-    /// Fake free_page: records the freed address.
+    /// Fake `free_page`: records the freed address.
     unsafe fn fake_free_page(addr: usize) {
         // SAFETY: single-threaded test execution.
         unsafe {
@@ -480,7 +480,7 @@ mod tests {
         }
     }
 
-    /// Create a fresh, initialized SlabAllocator for each test.
+    /// Create a fresh, initialized `SlabAllocator` for each test.
     fn make_allocator() -> SlabAllocator {
         let mut sa = SlabAllocator::new();
         sa.init();

--- a/crates/thumos/src/socket.rs
+++ b/crates/thumos/src/socket.rs
@@ -9,14 +9,14 @@
 //! # Architecture
 //!
 //! - `SOCKET_TABLE`: fixed-size array of `Option<SocketInfo>`, indexed by fd
-//!   number (0..MAX_FDS). Populated on `sys_socket`, cleared on close.
+//!   number (`0..MAX_FDS`). Populated on `sys_socket`, cleared on close.
 //! - `NETWORK_STACK`: global firewall-backed loopback stack. Socket creation
-//!   and I/O go through this host-only smoke path until WiFi hardware frame
+//!   and I/O go through this host-only smoke path until `WiFi` hardware frame
 //!   TX/RX is available; it must not be reported as production connectivity.
 //! - fd flags encode `FD_KIND_SOCKET` in the kind field so that close, read,
 //!   and write dispatch can identify socket fds without consulting the table.
 //!
-//! WHY separate table instead of extending FileDescriptor: FileDescriptor
+//! WHY separate table instead of extending `FileDescriptor`: `FileDescriptor`
 //! is `Copy` and fixed-layout. Adding an `Option<SocketInfo>` would break
 //! that and balloon the fd table. A parallel table is the same pattern
 //! pipes use (pipe index encoded in flags, buffer pool separate).
@@ -63,7 +63,7 @@ pub(crate) const EOPNOTSUPP: u32 = 0u32.wrapping_sub(95);
 pub(crate) const EADDRINUSE: u32 = 0u32.wrapping_sub(98);
 
 /// Address not available (an unaddressable remote/local endpoint, e.g. a
-/// zero port or unspecified address smoltcp's connect()/send() refused).
+/// zero port or unspecified address smoltcp's `connect()/send()` refused).
 pub(crate) const EADDRNOTAVAIL: u32 = 0u32.wrapping_sub(99);
 
 /// Resource temporarily unavailable (no datagram currently queued).
@@ -85,7 +85,7 @@ pub(crate) const EISCONN: u32 = 0u32.wrapping_sub(106);
 // -- fd kind encoding (same bit-field scheme as pipe.rs) --
 
 /// FD kind mask: low 8 bits of flags identify the fd type.
-/// WHY: matches pipe.rs FD_KIND_MASK (0x00FF). A plain VFS fd has
+/// WHY: matches pipe.rs `FD_KIND_MASK` (0x00FF). A plain VFS fd has
 /// kind 0; pipe is 1; socket is 2.
 pub(crate) const FD_KIND_MASK: u32 = 0x00FF;
 
@@ -105,16 +105,16 @@ pub enum SocketType {
     Udp,
 }
 
-/// Metadata for an open socket, stored in SOCKET_TABLE.
+/// Metadata for an open socket, stored in `SOCKET_TABLE`.
 #[derive(Debug, Clone, Copy)]
 pub struct SocketInfo {
-    /// Handle into the smoltcp SocketSet.
+    /// Handle into the smoltcp `SocketSet`.
     pub socket_handle: SocketHandle,
     /// TCP or UDP.
     pub socket_type: SocketType,
-    /// Local port bound via bind() (0 = unbound).
+    /// Local port bound via `bind()` (0 = unbound).
     pub bound_port: u16,
-    /// Whether a connect() has been performed.
+    /// Whether a `connect()` has been performed.
     pub connected: bool,
     /// Peer address and port (set by connect, or per-datagram for UDP).
     pub peer_addr: Option<(Ipv4Address, u16)>,
@@ -131,7 +131,7 @@ pub struct SocketInfo {
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub struct SockaddrIn {
-    /// Address family (AF_INET = 2).
+    /// Address family (`AF_INET` = 2).
     pub sin_family: u16,
     /// Port number in network byte order (big-endian).
     pub sin_port: u16,
@@ -153,7 +153,7 @@ impl SockaddrIn {
         Ipv4Address::new(octets[0], octets[1], octets[2], octets[3])
     }
 
-    /// Create a SockaddrIn from host-order values.
+    /// Create a `SockaddrIn` from host-order values.
     pub(crate) fn new(port: u16, addr: Ipv4Address) -> Self {
         let o = addr.octets();
         let sin_addr = u32::from_be_bytes([o[0], o[1], o[2], o[3]]);
@@ -172,11 +172,11 @@ impl SockaddrIn {
 
 /// Socket metadata table, indexed by fd number.
 ///
-/// WHY parallel table: SocketInfo is not Copy-friendly with SocketHandle
-/// (opaque smoltcp type) and would bloat FileDescriptor. A separate table
+/// WHY parallel table: `SocketInfo` is not Copy-friendly with `SocketHandle`
+/// (opaque smoltcp type) and would bloat `FileDescriptor`. A separate table
 /// indexed by the same fd number keeps the two in sync with minimal coupling.
 ///
-/// Entries are set on sys_socket, cleared on socket close.
+/// Entries are set on `sys_socket`, cleared on socket close.
 static mut SOCKET_TABLE: [Option<SocketInfo>; MAX_FDS] = {
     const NONE: Option<SocketInfo> = None;
     [NONE; MAX_FDS]
@@ -184,11 +184,11 @@ static mut SOCKET_TABLE: [Option<SocketInfo>; MAX_FDS] = {
 
 /// Global network stack for socket I/O.
 ///
-/// Uses a firewall-backed LoopbackDevice for now. Production WiFi readiness is
+/// Uses a firewall-backed `LoopbackDevice` for now. Production `WiFi` readiness is
 /// tracked separately during boot and remains false until hardware frame I/O is
 /// available.
 ///
-/// WHY Option: NetworkStack::new() is not const. Initialized by
+/// WHY Option: `NetworkStack::new()` is not const. Initialized by
 /// `init_network_stack()` during kernel boot or test setup.
 type SocketNetworkStack = NetworkStack<FirewallDevice<LoopbackDevice>>;
 
@@ -265,7 +265,7 @@ fn socket_flags() -> u32 {
 /// WHY static counter: fallback sequential allocation from the IANA
 /// ephemeral range (49152-65535), used only while the CSPRNG is not yet
 /// seeded (see `alloc_ephemeral_port`). Good enough for a kernel with
-/// MAX_SOCKETS=32.
+/// `MAX_SOCKETS=32`.
 static mut NEXT_EPHEMERAL_PORT: u16 = 49152;
 
 /// Allocate an ephemeral port that is not currently in use.
@@ -284,8 +284,8 @@ static mut NEXT_EPHEMERAL_PORT: u16 = 49152;
 ///
 /// # Safety
 ///
-/// Single-core cooperative kernel ensures exclusive access to NEXT_EPHEMERAL_PORT
-/// and SOCKET_TABLE.
+/// Single-core cooperative kernel ensures exclusive access to `NEXT_EPHEMERAL_PORT`
+/// and `SOCKET_TABLE`.
 unsafe fn alloc_ephemeral_port() -> Option<u16> {
     unsafe {
         let table = get_socket_table();
@@ -326,11 +326,11 @@ unsafe fn alloc_ephemeral_port() -> Option<u16> {
 // Syscall implementations
 // ---------------------------------------------------------------------------
 
-/// SYS_socket: create a network socket.
+/// `SYS_socket`: create a network socket.
 ///
 /// # Arguments
-/// - `domain`: address family (AF_INET = 2)
-/// - `sock_type`: socket type (SOCK_STREAM = 1, SOCK_DGRAM = 2)
+/// - `domain`: address family (`AF_INET` = 2)
+/// - `sock_type`: socket type (`SOCK_STREAM` = 1, `SOCK_DGRAM` = 2)
 /// - `_protocol`: protocol (ignored, auto-selected from type)
 ///
 /// # Returns
@@ -398,7 +398,7 @@ pub(crate) fn sys_socket(domain: u32, sock_type: u32, _protocol: u32) -> u32 {
     fd_num as u32
 }
 
-/// SYS_bind: bind a socket to a local address and port.
+/// `SYS_bind`: bind a socket to a local address and port.
 ///
 /// # Arguments
 /// - `fd`: socket file descriptor
@@ -516,7 +516,7 @@ pub(crate) fn sys_bind(fd: u32, addr_ptr: u32, addr_len: u32) -> u32 {
     0
 }
 
-/// SYS_listen: mark a TCP socket as listening.
+/// `SYS_listen`: mark a TCP socket as listening.
 ///
 /// # Returns
 /// EOPNOTSUPP — full listen/accept is deferred to a future phase.
@@ -526,7 +526,7 @@ pub(crate) fn sys_listen(_fd: u32, _backlog: u32) -> u32 {
     EOPNOTSUPP
 }
 
-/// SYS_accept: accept a connection on a listening socket.
+/// `SYS_accept`: accept a connection on a listening socket.
 ///
 /// # Returns
 /// EOPNOTSUPP — full listen/accept is deferred to a future phase.
@@ -536,7 +536,7 @@ pub(crate) fn sys_accept(_fd: u32, _addr_ptr: u32, _addr_len_ptr: u32) -> u32 {
     EOPNOTSUPP
 }
 
-/// SYS_connect: initiate a connection on a socket.
+/// `SYS_connect`: initiate a connection on a socket.
 ///
 /// For TCP: initiates a three-way handshake to the peer.
 /// For UDP: sets the default peer address for subsequent send/recv.
@@ -696,7 +696,7 @@ pub(crate) fn sys_connect(fd: u32, addr_ptr: u32, addr_len: u32) -> u32 {
     0
 }
 
-/// SYS_sendto: send data on a socket.
+/// `SYS_sendto`: send data on a socket.
 ///
 /// For TCP: sends data on a connected stream. `dest_addr_ptr` is ignored.
 /// For UDP: sends a datagram. If `dest_addr_ptr` is non-null, sends to that
@@ -832,7 +832,7 @@ pub(crate) fn sys_sendto(
     }
 }
 
-/// SYS_recvfrom: receive data from a socket.
+/// `SYS_recvfrom`: receive data from a socket.
 ///
 /// For TCP: receives data from a connected stream. `src_addr_ptr` is ignored.
 /// For UDP: receives a datagram. If `src_addr_ptr` is non-null, writes the
@@ -970,7 +970,7 @@ pub(crate) fn sys_recvfrom(
 /// Release a socket's network resources at OFD refcount zero (#267).
 ///
 /// Called from `fd::ofd_unref` when the LAST fd referencing this open-file
-/// description is closed; `ofd_idx` is the OFD index that keys SOCKET_TABLE.
+/// description is closed; `ofd_idx` is the OFD index that keys `SOCKET_TABLE`.
 /// WHY at refcount zero, not per close: with dup/fork several fds may share
 /// one socket OFD, so the smoltcp socket must be released only when the last
 /// of them closes.
@@ -1002,7 +1002,7 @@ mod tests {
     /// # Safety
     ///
     /// Test-only. Resets the process fd table + shared OFD table (#267),
-    /// SOCKET_TABLE, and NETWORK_STACK.
+    /// `SOCKET_TABLE`, and `NETWORK_STACK`.
     unsafe fn setup_test_network() {
         unsafe {
             // Reset the process fd table and the shared OFD table (#267).
@@ -1263,9 +1263,9 @@ mod tests {
 
     /// Pointer-dependent test: only runs on 32-bit targets.
     ///
-    /// WHY function-local `static mut`: sys_bind now validates addr_ptr via
-    /// validate_user_buffer before dereferencing it. A stack address (e.g.
-    /// `&addr`) falls outside [board::KERNEL_END, board::RAM_END) on
+    /// WHY function-local `static mut`: `sys_bind` now validates `addr_ptr` via
+    /// `validate_user_buffer` before dereferencing it. A stack address (e.g.
+    /// `&addr`) falls outside [`board::KERNEL_END`, `board::RAM_END`) on
     /// this host binary and would be rejected before bind logic runs; a
     /// function-local static lands inside that window (see fd.rs tests for
     /// the same pattern).
@@ -1399,8 +1399,8 @@ mod tests {
         );
     }
 
-    /// Regression test for issue #307: bind() must leave a TCP socket in
-    /// CLOSED state (not LISTEN), so a subsequent connect() is not
+    /// Regression test for issue #307: `bind()` must leave a TCP socket in
+    /// CLOSED state (not LISTEN), so a subsequent `connect()` is not
     /// refused.
     ///
     /// Pointer-dependent test: only runs on 32-bit targets.
@@ -1816,10 +1816,10 @@ mod tests {
     }
 
     /// ISOLATION (CRITICAL): a different process must not be able to name
-    /// proc0's socket by fd number. SOCKET_TABLE is keyed by OFD index, not
+    /// proc0's socket by fd number. `SOCKET_TABLE` is keyed by OFD index, not
     /// raw fd number, and every socket syscall resolves the fd through the
     /// CURRENT process's own table first -- a process whose table lacks
-    /// this fd slot fails closed with EBADF before SOCKET_TABLE is ever
+    /// this fd slot fails closed with EBADF before `SOCKET_TABLE` is ever
     /// consulted (#267 -- this is the security core the two-level fd model
     /// exists to close for sockets).
     #[cfg(target_pointer_width = "32")]

--- a/crates/thumos/src/supervisor.rs
+++ b/crates/thumos/src/supervisor.rs
@@ -8,7 +8,7 @@
 //! WHY a dedicated ring, not PID 0's IPC inbox: `notify_fault` used to
 //! `ipc::send(0, ..)` the report, but nothing ever drained it, so reports piled
 //! up and (at `INBOX_SIZE`) were dropped, while any legitimate userspace
-//! `send(0, ..)` then failed with InboxFull. A naive drain is not the answer
+//! `send(0, ..)` then failed with `InboxFull`. A naive drain is not the answer
 //! either -- `ipc::recv` pops the FRONT regardless of tag, so it would discard
 //! real user->PID0 IPC. Separating the channels is what makes the drain safe,
 //! and it also drops the `CURRENT`-swap hack `notify_fault` needed only so
@@ -32,7 +32,7 @@
 //!   masked for exactly as long as the loop holds this lock, so no user process
 //!   can run -- and therefore no PL0 fault can be raised -- inside that window.
 //! - A PL1 (kernel) fault taken under the lock never reaches here at all:
-//!   `process::fault_disposition` routes a non-User-mode fault to KernelHalt
+//!   `process::fault_disposition` routes a non-User-mode fault to `KernelHalt`
 //!   (fail-closed), not to `notify_fault`.
 //!
 //! So `report_fault` only ever runs when the loop is NOT in its critical section.

--- a/crates/thumos/src/syscall.rs
+++ b/crates/thumos/src/syscall.rs
@@ -292,7 +292,7 @@ impl Syscall {
 
     /// All defined syscall variants in declaration ORDER.
     /// WHY: enables exhaustive iteration for tests and introspection
-    /// without relying on external derive macros in no_std.
+    /// without relying on external derive macros in `no_std`.
     pub(crate) const ALL: [Self; SYSCALL_COUNT] = [
         // Legacy
         Self::Exit,
@@ -366,12 +366,12 @@ impl Syscall {
 ///
 /// # Syscall implementation status
 ///
-/// Implemented: exit, write, yield, getpid, alloc_page, free_page, uptime,
+/// Implemented: exit, write, yield, getpid, `alloc_page`, `free_page`, uptime,
 ///   sleep, send, recv, fork, waitpid, execve, kill, getuid, brk, mmap,
 ///   munmap, mprotect, open, close, read, stat, fstat, lseek, ioctl, fcntl,
-///   dup, dup2, mkdir, unlink, getcwd, chdir, pipe, futex, metaxu_submit,
-///   metaxu_poll (both ENOSYS off the `metaxu-probe` feature), socket, bind,
-///   connect, sendto, recvfrom, clock_gettime, nanosleep, sigaction, sigreturn
+///   dup, dup2, mkdir, unlink, getcwd, chdir, pipe, futex, `metaxu_submit`,
+///   `metaxu_poll` (both ENOSYS off the `metaxu-probe` feature), socket, bind,
+///   connect, sendto, recvfrom, `clock_gettime`, nanosleep, sigaction, sigreturn
 /// Stub (returns EOPNOTSUPP): listen, accept
 pub(crate) fn dispatch(num: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> u32 {
     let Some(call) = Syscall::from_u32(num) else {
@@ -639,7 +639,7 @@ fn sys_metaxu_poll_dispatch() -> u32 {
 // the flags before delegating to the appropriate handler, keeping all pipe
 // logic in pipe.rs and the dispatch minimal.
 
-/// SYS_read: dispatch to pipe or ramfs based on fd kind.
+/// `SYS_read`: dispatch to pipe or ramfs based on fd kind.
 fn sys_read_with_pipe(fd: u32, buf_ptr: u32, count: u32) -> u32 {
     let fd_idx = fd as usize;
     let flags = match fd::current_fd_flags(fd_idx) {
@@ -655,11 +655,11 @@ fn sys_read_with_pipe(fd: u32, buf_ptr: u32, count: u32) -> u32 {
     }
 }
 
-/// SYS_write: dispatch to pipe, UART (stdout), or VFS file based on fd kind.
+/// `SYS_write`: dispatch to pipe, UART (stdout), or VFS file based on fd kind.
 ///
-/// - Pipe fd: dispatch to pipe::sys_pipe_write.
-/// - VFS fd (including a `dup2`-redirected fd 1): dispatch to fd::sys_write.
-/// - fd 1 with no FD_TABLE entry: the default, un-redirected case — write to
+/// - Pipe fd: dispatch to `pipe::sys_pipe_write`.
+/// - VFS fd (including a `dup2`-redirected fd 1): dispatch to `fd::sys_write`.
+/// - fd 1 with no `FD_TABLE` entry: the default, un-redirected case — write to
 ///   UART serial (legacy behavior).
 fn sys_write_dispatch(fd: u32, buf_ptr: u32, count: u32) -> u32 {
     let fd_idx = fd as usize;
@@ -707,16 +707,16 @@ const ENOENT: u32 = 0u32.wrapping_sub(2);
 /// Exec format error (two's complement -8, matches Linux ENOEXEC).
 const ENOEXEC: u32 = 0u32.wrapping_sub(8);
 
-/// execve(path_ptr, argv_ptr, _envp_ptr): replace the current process image.
+/// `execve(path_ptr`, `argv_ptr`, _`envp_ptr)`: replace the current process image.
 ///
 /// # Steps
 ///
 /// 1. Validate and read the path string from user space.
 /// 2. Find the file in the global ramfs.
 /// 3. Parse and validate the ELF header (must be ARM32 LE).
-/// 4. Load ELF PT_LOAD segments (identity-mapped; elf::load writes to vaddr).
+/// 4. Load ELF `PT_LOAD` segments (identity-mapped; `elf::load` writes to vaddr).
 /// 5. Allocate a new stack; push argc and argv onto it.
-/// 6. Reset all signal handlers to SIG_DFL (POSIX exec semantics).
+/// 6. Reset all signal handlers to `SIG_DFL` (POSIX exec semantics).
 /// 7. Update the PCB: entry → lr, stack top → sp, reset heap break + mappings.
 ///
 /// # On success
@@ -727,7 +727,7 @@ const ENOEXEC: u32 = 0u32.wrapping_sub(8);
 /// # Preserved across exec
 ///
 /// - PID (same process, new image)
-/// - File descriptors without FD_CLOEXEC (close-on-exec fds are closed, #267)
+/// - File descriptors without `FD_CLOEXEC` (close-on-exec fds are closed, #267)
 ///
 /// # envp
 ///
@@ -1003,14 +1003,14 @@ fn sys_execve(path_ptr: u32, argv_ptr: u32, _envp_ptr: u32) -> u32 {
 const EINVAL: u32 = 0u32.wrapping_sub(22);
 /// Out of memory (two's complement -12, matches Linux ENOMEM).
 const ENOMEM: u32 = 0u32.wrapping_sub(12);
-/// mmap failure sentinel (MAP_FAILED = (void *)-1).
+/// mmap failure sentinel (`MAP_FAILED` = (void *)-1).
 const MAP_FAILED: u32 = u32::MAX;
-/// MAP_ANONYMOUS flag (Linux mman.h).
+/// `MAP_ANONYMOUS` flag (Linux mman.h).
 const MAP_ANONYMOUS: u32 = 0x20;
 
 // --- Memory management syscall implementations ---
 
-/// brk(new_break): adjust the program break.
+/// `brk(new_break)`: adjust the program break.
 ///
 /// If `new_break_raw` is 0, returns the current break without modifying it.
 /// If `new_break_raw` > current break: allocates pages and maps them.
@@ -1172,15 +1172,15 @@ fn sys_brk(new_break_raw: u32) -> u32 {
     break_u32
 }
 
-/// mmap(addr_hint, length, prot, flags_and_fd):
+/// `mmap(addr_hint`, length, prot, `flags_and_fd)`:
 ///
 /// WHY: ARM syscall convention passes only 4 registers (r0-r3). POSIX mmap
 /// takes 6 arguments. We pack flags in the low 16 bits of arg3 and fd in
 /// the high 16 bits. Offset is not supported (anonymous only).
 ///
-/// - arg0: addr hint (ignored for MAP_ANONYMOUS, we pick the address)
+/// - arg0: addr hint (ignored for `MAP_ANONYMOUS`, we pick the address)
 /// - arg1: length in bytes
-/// - arg2: prot flags (PROT_READ | PROT_WRITE | PROT_EXEC)
+/// - arg2: prot flags (`PROT_READ` | `PROT_WRITE` | `PROT_EXEC`)
 /// - arg3: low 16 bits = flags, high 16 bits = fd (as i16, -1 = 0xFFFF)
 fn sys_mmap(arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> u32 {
     let _addr_hint = arg0 as usize;
@@ -1522,7 +1522,7 @@ fn sys_mprotect(arg0: u32, arg1: u32, arg2: u32) -> u32 {
 #[cfg(test)]
 mod tests {
 
-    /// #282 finding 13: an OOM partway through sys_mmap's page allocation must
+    /// #282 finding 13: an OOM partway through `sys_mmap`'s page allocation must
     /// roll back exactly the pages it mapped before failing, freeing their
     /// physical frames -- not just unmapping them (same class as #226).
     #[test]
@@ -1995,8 +1995,8 @@ mod tests {
     /// stopped at `reset_for_test`'s absent-entry table, so `map_page` only
     /// ever took its "no mapping -> allocate an L2" branch: every
     /// mmap/brk/mprotect test passed against an L1 shape no real process has,
-    /// while sys_mmap returned MAP_FAILED on every real boot (#496) and
-    /// sys_brk growth never worked at all. mmu.rs's own tests build the
+    /// while `sys_mmap` returned `MAP_FAILED` on every real boot (#496) and
+    /// `sys_brk` growth never worked at all. mmu.rs's own tests build the
     /// faithful shape exactly this way.
     unsafe fn setup_mm() {
         unsafe {
@@ -2010,7 +2010,7 @@ mod tests {
         }
     }
 
-    /// #533 fixture-faithfulness guard: setup_mm() must produce a CLONED
+    /// #533 fixture-faithfulness guard: `setup_mm()` must produce a CLONED
     /// IDENTITY table -- the heap and mmap windows covered by 1 MB SECTION
     /// descriptors (bits[1:0]=0b10), not the absent entries the old synthetic
     /// fixture had. A fixture regression fails THIS test with a clear message
@@ -2331,7 +2331,7 @@ mod tests {
     /// REQ-07: execve must return EFAULT for an invalid (null or kernel-space)
     /// path pointer before attempting any filesystem lookup.
     ///
-    /// WHY: validate_user_buffer is the first gate in sys_execve. Verifying it
+    /// WHY: `validate_user_buffer` is the first gate in `sys_execve`. Verifying it
     /// returns EFAULT for out-of-range pointers confirms that the implementation
     /// rejects bad pointers before touching any kernel data structures.
     #[test]
@@ -2367,9 +2367,9 @@ mod tests {
         );
     }
 
-    /// #220: a path_ptr within MAX_PATH (256) bytes of RAM_END must be
+    /// #220: a `path_ptr` within `MAX_PATH` (256) bytes of `RAM_END` must be
     /// rejected with EFAULT before any read, instead of scanning past
-    /// RAM_END into unmapped/device memory.
+    /// `RAM_END` into unmapped/device memory.
     #[test]
     fn execve_rejects_path_pointer_near_ram_end() {
         let result = sys_execve((board::RAM_END - 1) as u32, 0, 0);
@@ -2381,7 +2381,7 @@ mod tests {
 
     /// REQ-07: execve must return ENOENT when the path is not found in ramfs.
     ///
-    /// WHY: after path validation, sys_execve calls fd::ramfs_find. This test
+    /// WHY: after path validation, `sys_execve` calls `fd::ramfs_find`. This test
     /// confirms that the lookup correctly returns None (→ ENOENT) for a path
     /// that was never added to the filesystem.
     // NOTE(un-gate): surfaced when syscall was un-gated for host testing. The
@@ -2423,7 +2423,7 @@ mod tests {
         assert_eq!(ENOENT, 0xFFFF_FFFEu32, "ENOENT must be two's complement -2");
     }
 
-    /// #255: write(1, ...) after dup2(pipe_write_end, 1) must deliver data to
+    /// #255: write(1, ...) after `dup2(pipe_write_end`, 1) must deliver data to
     /// the pipe, not silently continue to UART.
     #[cfg(target_pointer_width = "32")]
     #[test]
@@ -2467,7 +2467,7 @@ mod tests {
 
     // ---- Syscall table completeness tests ----
 
-    /// Verify every variant in Syscall::ALL is either implemented (does not
+    /// Verify every variant in `Syscall::ALL` is either implemented (does not
     /// return ENOSYS in the dispatch handler) or has a documented deferral to
     /// a named future phase.
     ///
@@ -2650,7 +2650,7 @@ mod tests {
     /// Null pointer must be rejected for any length, including zero.
     ///
     /// WHY: null dereference is always invalid. The null check in
-    /// validate_user_buffer is an unconditional first gate.
+    /// `validate_user_buffer` is an unconditional first gate.
     #[test]
     fn null_pointer_rejected() {
         // Non-zero lengths.
@@ -2670,7 +2670,7 @@ mod tests {
     /// A buffer starting near the top of the address space that would wrap
     /// around must be rejected.
     ///
-    /// WHY: without the checked_add overflow guard, ptr + len wraps to a low
+    /// WHY: without the `checked_add` overflow guard, ptr + len wraps to a low
     /// address that passes the range check, allowing kernel memory access
     /// through an apparently "valid" user pointer.
     #[test]
@@ -2742,7 +2742,7 @@ mod tests {
     /// back to the requested value AND return the underlying physical pages
     /// to the allocator (#226) — not just unmap the page-table entries.
     ///
-    /// WHY: brk shrink is how musl's free() returns memory. An incorrect
+    /// WHY: brk shrink is how musl's `free()` returns memory. An incorrect
     /// shrink leaves the break misreported, breaking subsequent brk queries;
     /// unmapping without freeing leaks the physical frame permanently.
     #[test]
@@ -2814,9 +2814,9 @@ mod tests {
     /// mmap N pages then munmap them — subsequent mmap in the same range must
     /// succeed (mapping table is consistent after munmap).
     ///
-    /// WHY: munmap must remove the VmMapping record so the first-fit allocator
+    /// WHY: munmap must remove the `VmMapping` record so the first-fit allocator
     /// can reuse that virtual address range. A stale entry would cause
-    /// mmap_munmap cycles to exhaust the mapping table (MAX_MAPPINGS = 32).
+    /// `mmap_munmap` cycles to exhaust the mapping table (`MAX_MAPPINGS` = 32).
     #[test]
     fn mmap_munmap_balance() {
         unsafe {
@@ -2851,14 +2851,14 @@ mod tests {
         );
     }
 
-    /// #251: an OOM partway through sys_execve's stack allocation must roll
+    /// #251: an OOM partway through `sys_execve`'s stack allocation must roll
     /// back exactly the pages allocated so far. Uses a minimal ELF32 LE ARM
-    /// header with e_phnum = 0 (mirrors elf.rs's make_valid_ehdr test
-    /// helper) so elf::load consumes zero pages and only the execve stack
+    /// header with `e_phnum` = 0 (mirrors elf.rs's `make_valid_ehdr` test
+    /// helper) so `elf::load` consumes zero pages and only the execve stack
     /// allocation exercises the page allocator; the ramfs Vec allocation in
-    /// fd::ramfs_find is unaffected because #[global_allocator] is
+    /// `fd::ramfs_find` is unaffected because #[`global_allocator`] is
     /// #[cfg(not(test))]-only (heap allocations under test use the host's
-    /// default allocator, decoupled from page::alloc_page()).
+    /// default allocator, decoupled from `page::alloc_page()`).
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn execve_oom_rollback_frees_exact_stack_pages() {
@@ -2929,8 +2929,8 @@ mod tests {
 
     // ---- Slab allocator integration test ----
 
-    /// Perform many alloc/dealloc cycles on a local SlabAllocator and verify
-    /// that alloc_count equals free_count (no leaks).
+    /// Perform many alloc/dealloc cycles on a local `SlabAllocator` and verify
+    /// that `alloc_count` equals `free_count` (no leaks).
     ///
     /// WHY: the same slab logic backs the global heap used by all kernel paths
     /// including syscall handlers. Equal alloc/free counts confirm that the
@@ -3007,9 +3007,9 @@ mod tests {
 
     // ---- Sleep syscall (#264) ----
 
-    /// #264: SYS_Sleep's tick-conversion must round up like sys_nanosleep's
-    /// (ceil(ms / TICK_MS)), now that Sleep uses the same set_wake_tick +
-    /// busy-wait + clear_wake_tick pattern instead of a bare uptime_ms()
+    /// #264: `SYS_Sleep`'s tick-conversion must round up like `sys_nanosleep`'s
+    /// (ceil(ms / `TICK_MS`)), now that Sleep uses the same `set_wake_tick` +
+    /// busy-wait + `clear_wake_tick` pattern instead of a bare `uptime_ms()`
     /// busy-wait that never touched process state at all.
     #[test]
     fn sleep_tick_conversion_matches_nanosleep_rounding() {
@@ -3029,11 +3029,11 @@ mod tests {
         );
     }
 
-    /// #264: Sleep(0) must exercise the full set_wake_tick -> wait ->
-    /// clear_wake_tick sequence and leave the process Running, not stuck
-    /// Sleeping. arg0 = 0 makes wake_tick == now_ticks so the wait loop
+    /// #264: Sleep(0) must exercise the full `set_wake_tick` -> wait ->
+    /// `clear_wake_tick` sequence and leave the process Running, not stuck
+    /// Sleeping. arg0 = 0 makes `wake_tick` == `now_ticks` so the wait loop
     /// resolves immediately without hanging the single-threaded host test
-    /// (nothing else advances the settable exceptions_stub tick source).
+    /// (nothing else advances the settable `exceptions_stub` tick source).
     #[test]
     fn sleep_zero_round_trips_process_state() {
         unsafe {

--- a/crates/thumos/src/t9.rs
+++ b/crates/thumos/src/t9.rs
@@ -430,7 +430,7 @@ impl T9Input {
 
     /// Convert the key sequence to letters (multi-tap committed bytes).
     ///
-    /// In multi-tap mode, the key_sequence stores raw letter bytes
+    /// In multi-tap mode, the `key_sequence` stores raw letter bytes
     /// after they are committed.
     fn key_sequence_as_letters(&self) -> String {
         let mut s = String::with_capacity(self.key_sequence.len());

--- a/crates/thumos/src/telephony.rs
+++ b/crates/thumos/src/telephony.rs
@@ -144,7 +144,7 @@ pub enum Urc {
     Busy,
     /// Signal quality report (+CSQ: rssi,ber).
     Csq { rssi: u8, ber: u8 },
-    /// Network registration status changed (+CREG: stat[,...,AcT]).
+    /// Network registration status changed (+CREG: stat[,...,`AcT`]).
     Creg {
         stat: RegStatus,
         act: Option<RadioAccessTech>,
@@ -566,7 +566,7 @@ pub struct Telephony<T: ModemTransport> {
     signal_ber: u8,
     /// Operator name.
     operator_name: [u8; MAX_OPERATOR_LEN],
-    /// Length of valid bytes in operator_name.
+    /// Length of valid bytes in `operator_name`.
     operator_len: u8,
     /// Registration status detail. [`Telephony::is_registered`] derives
     /// directly from this -- no separate `registered` bool is kept, so
@@ -1188,7 +1188,7 @@ impl<T: ModemTransport> Telephony<T> {
 pub struct CcciModemTransport {
     /// Receive line buffer for accumulating bytes.
     rx_buf: [u8; MAX_LINE_LEN],
-    /// Number of valid bytes in rx_buf.
+    /// Number of valid bytes in `rx_buf`.
     rx_len: usize,
 }
 

--- a/crates/thumos/src/telephony_mock.rs
+++ b/crates/thumos/src/telephony_mock.rs
@@ -18,7 +18,7 @@ pub(crate) struct MockModemTransport {
     pub response_lines: Vec<Vec<u8>>,
     /// URC lines to return from `poll_urc_line`, in FIFO order.
     pub urc_lines: Vec<Vec<u8>>,
-    /// Whether send_at should succeed.
+    /// Whether `send_at` should succeed.
     pub send_ok: bool,
     /// Number of upcoming `recv_line` calls that must fail with
     /// `TransportError` regardless of queued lines, decrementing on each

--- a/crates/thumos/src/telephony_parser.rs
+++ b/crates/thumos/src/telephony_parser.rs
@@ -48,7 +48,7 @@ pub(crate) fn parse_final_result(line: &[u8]) -> Option<AtResponse> {
 
 /// Parse a +CSQ response line: "+CSQ: <rssi>,<ber>"
 ///
-/// Returns (rssi_raw, ber) where rssi_raw is 0-31 or 99 (unknown).
+/// Returns (`rssi_raw`, ber) where `rssi_raw` is 0-31 or 99 (unknown).
 pub(crate) fn parse_csq_response(line: &[u8]) -> Option<(u8, u8)> {
     let rest = strip_prefix(line, b"+CSQ: ")?;
     let comma = memchr(b',', rest)?;

--- a/crates/thumos/src/time.rs
+++ b/crates/thumos/src/time.rs
@@ -1,12 +1,12 @@
-//! Kernel time services: clock_gettime and nanosleep.
+//! Kernel time services: `clock_gettime` and nanosleep.
 //!
 //! # Clock sources
 //!
-//! CLOCK_MONOTONIC reads the ARM generic timer (CNTPCT) which counts at
+//! `CLOCK_MONOTONIC` reads the ARM generic timer (CNTPCT) which counts at
 //! a fixed frequency (CNTFRQ, typically 13 MHz on MT6739). It measures
 //! time elapsed since the timer was enabled at boot and never goes backward.
 //!
-//! CLOCK_REALTIME adds a boot-epoch offset to the monotonic counter. The
+//! `CLOCK_REALTIME` adds a boot-epoch offset to the monotonic counter. The
 //! offset is hardcoded to 2025-01-01 00:00:00 UTC at boot and may be
 //! updated later when the modem RTC becomes available. Accuracy before
 //! RTC sync is ±1 minute (based on OEM firmware boot time estimates).
@@ -25,7 +25,7 @@
 //! offset 0: tv_sec  (u32, seconds)
 //! offset 4: tv_nsec (u32, nanoseconds, 0..999_999_999)
 //! ```
-//! This matches the 32-bit ABI layout used by musl on ARMv7.
+//! This matches the 32-bit ABI layout used by musl on `ARMv7`.
 
 use crate::exceptions;
 use crate::memguard::validate_user_buffer;
@@ -49,7 +49,7 @@ const EINVAL: u32 = 0u32.wrapping_sub(22);
 /// Nanoseconds per second.
 const NANOS_PER_SEC: u64 = 1_000_000_000;
 
-/// Boot epoch offset for CLOCK_REALTIME: 2025-01-01 00:00:00 UTC in seconds
+/// Boot epoch offset for `CLOCK_REALTIME`: 2025-01-01 00:00:00 UTC in seconds
 /// since the Unix epoch (1970-01-01).
 ///
 /// WHY: the kernel has no RTC access at boot. We use a hardcoded recent date
@@ -57,7 +57,7 @@ const NANOS_PER_SEC: u64 = 1_000_000_000;
 /// RTC driver (ccci) may update this later via `set_realtime_offset()`.
 ///
 /// Calculation: days from 1970-01-01 to 2025-01-01:
-///   55 years × 365.25 days ≈ 20088 days → 20088 × 86400 = 1_735_603_200 s
+///   55 years × 365.25 days ≈ 20088 days → 20088 × 86400 = `1_735_603_200` s
 pub(crate) static mut REALTIME_OFFSET_SECS: u64 = 1_735_603_200;
 
 // ---------------------------------------------------------------------------
@@ -120,7 +120,7 @@ fn compute_realtime_offset(unix_now_secs: u64, elapsed_secs: u64) -> Option<u64>
 ///
 /// Writes to a static mut. Must be called from a single-threaded context
 /// (e.g., kinit before spawning userspace, or from an IPC handler with
-/// interrupts disabled). On ARMv7 a 64-bit store is not atomic; callers
+/// interrupts disabled). On `ARMv7` a 64-bit store is not atomic; callers
 /// are responsible for ensuring no concurrent read occurs.
 #[cfg(not(test))]
 pub unsafe fn set_realtime_offset(unix_now_secs: u64) -> Result<(), ImplausibleEpoch> {
@@ -169,11 +169,11 @@ fn counter_to_timespec(count: u64, freq: u64) -> (u32, u32) {
 // tick-wait is target_arch-split (real hint on ARM, no-op on the host).
 // ---------------------------------------------------------------------------
 
-/// sys_clock_gettime — fill a user-space timespec with the requested clock.
+/// `sys_clock_gettime` — fill a user-space timespec with the requested clock.
 ///
 /// # Arguments
 ///
-/// * `clock_id` — 0 (CLOCK_REALTIME) or 1 (CLOCK_MONOTONIC)
+/// * `clock_id` — 0 (`CLOCK_REALTIME`) or 1 (`CLOCK_MONOTONIC`)
 /// * `ts_ptr`   — user-space pointer to `{ tv_sec: u32, tv_nsec: u32 }`
 ///
 /// # Returns
@@ -219,7 +219,7 @@ pub(crate) fn sys_clock_gettime(clock_id: u32, ts_ptr: u32) -> u32 {
     0
 }
 
-/// sys_nanosleep — suspend the calling process for (at least) the specified duration.
+/// `sys_nanosleep` — suspend the calling process for (at least) the specified duration.
 ///
 /// Reads the duration from a user-space timespec, converts it to a future
 /// tick count, records it in the PCB, and marks the process as Sleeping.
@@ -342,9 +342,9 @@ mod tests {
 
     /// EINVAL constant matches Linux ARM EINVAL (-22).
     ///
-    /// NOTE: sys_clock_gettime itself is not callable from host tests (it depends
+    /// NOTE: `sys_clock_gettime` itself is not callable from host tests (it depends
     /// on #[cfg(not(test))] modules). This test verifies the error constant value
-    /// that sys_clock_gettime returns for unknown clock IDs, which is the
+    /// that `sys_clock_gettime` returns for unknown clock IDs, which is the
     /// observable ABI contract.
     #[test]
     fn clock_gettime_invalid_clock_returns_error() {
@@ -352,7 +352,7 @@ mod tests {
         assert_eq!(EINVAL, 0u32.wrapping_sub(22), "EINVAL must be -22 as u32");
     }
 
-    /// CLOCK_REALTIME and CLOCK_MONOTONIC IDs have the correct POSIX values.
+    /// `CLOCK_REALTIME` and `CLOCK_MONOTONIC` IDs have the correct POSIX values.
     #[test]
     fn clock_gettime_null_ptr_returns_efault() {
         // We verify the clock ID constants; the actual EFAULT path requires
@@ -362,8 +362,8 @@ mod tests {
         assert_eq!(CLOCK_MONOTONIC, 1, "CLOCK_MONOTONIC must be 1");
     }
 
-    /// CLOCK_MONOTONIC increases between two consecutive reads.
-    /// Uses the counter_to_timespec helper directly since we can't drive
+    /// `CLOCK_MONOTONIC` increases between two consecutive reads.
+    /// Uses the `counter_to_timespec` helper directly since we can't drive
     /// the hardware timer from a host test.
     #[test]
     fn clock_gettime_monotonic_increases() {
@@ -396,7 +396,7 @@ mod tests {
     }
 
     /// #374: a plausible epoch within the accepted window computes the
-    /// expected offset (unix_now_secs - elapsed_secs).
+    /// expected offset (`unix_now_secs` - `elapsed_secs`).
     #[test]
     fn compute_realtime_offset_accepts_plausible_window() {
         assert_eq!(
@@ -472,10 +472,10 @@ mod tests {
         assert_eq!(ticks_needed, 1, "5 ms sleep must round up to 1 tick");
     }
 
-    /// POSIX requires EINVAL when tv_nsec is out of [0, 999_999_999]; the
+    /// POSIX requires EINVAL when `tv_nsec` is out of [0, `999_999_999`]; the
     /// kernel must not silently fold an out-of-range value into extra
     /// whole seconds of sleep. A `static mut` buffer is used (not a stack
-    /// array) so its address lands inside validate_user_buffer's accepted
+    /// array) so its address lands inside `validate_user_buffer`'s accepted
     /// user-DRAM range on the 32-bit test target.
     #[cfg(target_pointer_width = "32")]
     #[test]

--- a/crates/thumos/src/timer.rs
+++ b/crates/thumos/src/timer.rs
@@ -1,9 +1,9 @@
 //! ARM Generic Timer driver.
 //!
-//! The Cortex-A53 has an integrated generic timer (CNTPCT, CNTP_TVAL, CNTP_CTL).
+//! The Cortex-A53 has an integrated generic timer (CNTPCT, `CNTP_TVAL`, `CNTP_CTL`).
 //! We use the physical timer (not virtual) since we're the kernel.
 //!
-//! The timer fires an IRQ (typically IRQ 30 on GICv2 for the physical timer PPI)
+//! The timer fires an IRQ (typically IRQ 30 on `GICv2` for the physical timer PPI)
 //! which we use as the scheduler tick.
 //!
 //! WHY `TIMER_IRQ` is feature-conditional (#544): the `CNTP_*` registers

--- a/crates/thumos/src/timer_stub.rs
+++ b/crates/thumos/src/timer_stub.rs
@@ -35,7 +35,7 @@ pub(crate) fn elapsed_ms() -> u64 {
 }
 
 /// Host-test mirror of the production `set_ms` tick-conversion arithmetic.
-/// `timer::set_ms` itself is ARM-only (it also programs CNTP_TVAL/CNTP_CTL
+/// `timer::set_ms` itself is ARM-only (it also programs `CNTP_TVAL/CNTP_CTL`
 /// via CP15, which does not exist on the host target); this mirrors just
 /// the overflow-safety fix so it has host-test coverage. Kept in lockstep
 /// with the arithmetic in `timer::set_ms`.

--- a/crates/thumos/src/ui.rs
+++ b/crates/thumos/src/ui.rs
@@ -403,7 +403,7 @@ pub(crate) fn draw_str_centered(
 /// (`s.chars().enumerate()`), so the width budget must be a character
 /// count -- using the UTF-8 byte length overestimates the rendered width
 /// for multi-byte content (e.g., an accented contact name), mis-centering
-/// or mis-aligning text that draw_str_centered/status_bar/softkey
+/// or mis-aligning text that `draw_str_centered/status_bar/softkey`
 /// right-alignment all depend on (#397).
 pub(crate) fn str_pixel_width(s: &str) -> u16 {
     let char_count = u16::try_from(s.chars().count()).unwrap_or(u16::MAX);
@@ -588,7 +588,7 @@ pub enum ScreenId {
     Alarms,
     /// FM Radio.
     FmRadio,
-    /// WiFi settings (read-only display of wifi state).
+    /// `WiFi` settings (read-only display of wifi state).
     WifiSettings,
     /// Bluetooth settings (read-only display of BT state).
     BtSettings,

--- a/crates/thumos/src/usb.rs
+++ b/crates/thumos/src/usb.rs
@@ -14,7 +14,7 @@
 //! ## Register reference
 //!
 //! Offsets FROM the MUSB Programmer's Guide, verified against MT6739 BSP
-//! `drivers/usb/musb/musb_core.h` and the hardware_info provided in the
+//! `drivers/usb/musb/musb_core.h` and the `hardware_info` provided in the
 //! dispatch prompt.
 
 // ---------------------------------------------------------------------------
@@ -32,13 +32,13 @@ use crate::irq;
 // Common register offsets (relative to MUSB_BASE)
 // ---------------------------------------------------------------------------
 
-/// Function address  -  device address after SET_ADDRESS (8-bit).
+/// Function address  -  device address after `SET_ADDRESS` (8-bit).
 const REG_FADDR: usize = 0x00;
 /// Power management  -  SOFTCONN, HSENAB, suspend, resume, reset (8-bit).
 const REG_POWER: usize = 0x01;
-/// TX endpoint interrupt status  -  bit N = EPn (16-bit, reading clears).
+/// TX endpoint interrupt status  -  bit N = `EPn` (16-bit, reading clears).
 const REG_INTRTX: usize = 0x02;
-/// RX endpoint interrupt status  -  bit N = EPn (16-bit, reading clears).
+/// RX endpoint interrupt status  -  bit N = `EPn` (16-bit, reading clears).
 const REG_INTRRX: usize = 0x04;
 /// TX endpoint interrupt enable mask (16-bit).
 const REG_INTRTXE: usize = 0x06;
@@ -62,28 +62,28 @@ const REG_TESTMODE: usize = 0x10;
 // EP0 uses REG_EP0_CSR; EP1+ use REG_TXCSR / REG_RXCSR.
 // ---------------------------------------------------------------------------
 
-/// EP0 control/status register (16-bit); valid when REG_INDEX == 0.
+/// EP0 control/status register (16-bit); valid when `REG_INDEX` == 0.
 const REG_EP0_CSR: usize = 0x110;
-/// EPx TX control/status register (16-bit); valid when REG_INDEX >= 1.
+/// `EPx` TX control/status register (16-bit); valid when `REG_INDEX` >= 1.
 const REG_TXCSR: usize = 0x112;
-/// EPx RX control/status register (16-bit); valid when REG_INDEX >= 1.
+/// `EPx` RX control/status register (16-bit); valid when `REG_INDEX` >= 1.
 const REG_RXCSR: usize = 0x116;
-/// EPx TX max packet size (16-bit).
+/// `EPx` TX max packet size (16-bit).
 const REG_TXMAXP: usize = 0x118;
-/// EPx RX max packet size (16-bit).
+/// `EPx` RX max packet size (16-bit).
 const REG_RXMAXP: usize = 0x11A;
-/// EPx RX byte count for the last received OUT packet (16-bit); valid
-/// when REG_INDEX >= 1. Source: MUSB Programmer's Guide `RxCount`/`COUNT0`
-/// -- may be less than REG_RXMAXP for a short packet (issue #221). Placed
-/// immediately after REG_RXMAXP to follow this driver's banked-register
+/// `EPx` RX byte count for the last received OUT packet (16-bit); valid
+/// when `REG_INDEX` >= 1. Source: MUSB Programmer's Guide `RxCount`/`COUNT0`
+/// -- may be less than `REG_RXMAXP` for a short packet (issue #221). Placed
+/// immediately after `REG_RXMAXP` to follow this driver's banked-register
 /// layout (which already reorders from the raw Mentor Graphics offsets).
 ///
 /// WARNING: this offset is inferred from the driver's banked layout, NOT
 /// confirmed against the MT6739 BSP header — the drain is clamped to
-/// EP1_MAX_PKT so a wrong value cannot overrun the ring buffer, but the
+/// `EP1_MAX_PKT` so a wrong value cannot overrun the ring buffer, but the
 /// exact offset must be verified before trusting short-packet lengths on
 /// real silicon.
-/// TODO(#221)[deliberate-prudent]: confirm REG_RXCOUNT against the MT6739 MUSB BSP header.
+/// TODO(#221)[deliberate-prudent]: confirm `REG_RXCOUNT` against the MT6739 MUSB BSP header.
 const REG_RXCOUNT: usize = 0x11C;
 
 // ---------------------------------------------------------------------------
@@ -93,7 +93,7 @@ const REG_RXCOUNT: usize = 0x11C;
 // queue data INTO the FIFO; reads dequeue. MUSB auto-advances on each write.
 // ---------------------------------------------------------------------------
 
-/// EP FIFO base. FIFO for EPn is at MUSB_BASE + REG_FIFO_BASE + n * 4.
+/// EP FIFO base. FIFO for `EPn` is at `MUSB_BASE` + `REG_FIFO_BASE` + n * 4.
 const REG_FIFO_BASE: usize = 0x120;
 
 // ---------------------------------------------------------------------------
@@ -142,48 +142,48 @@ const INTRRX_EP1: u16 = 1 << 1;
 // REG_EP0_CSR bit fields (when REG_INDEX == 0)
 // ---------------------------------------------------------------------------
 
-/// RxPktRdy: a SETUP or OUT data packet is in the FIFO.
+/// `RxPktRdy`: a SETUP or OUT data packet is in the FIFO.
 const EP0_RXPKTRDY: u16 = 1 << 0;
-/// TxPktRdy: arm the FIFO for transmission (SET to send IN data).
+/// `TxPktRdy`: arm the FIFO for transmission (SET to send IN data).
 const EP0_TXPKTRDY: u16 = 1 << 1;
-/// SentStall: a STALL handshake was sent; clear after handling.
+/// `SentStall`: a STALL handshake was sent; clear after handling.
 const EP0_SENTSTALL: u16 = 1 << 2;
-/// DataEnd: SET alongside TxPktRdy (or alone for no-data status) to end the
+/// `DataEnd`: SET alongside `TxPktRdy` (or alone for no-data status) to end the
 /// control transfer. MUSB clears it automatically after the status stage.
 const EP0_DATAEND: u16 = 1 << 3;
-/// SetupEnd: an IN control transfer was aborted by the host; must be cleared.
+/// `SetupEnd`: an IN control transfer was aborted by the host; must be cleared.
 const EP0_SETUPEND: u16 = 1 << 4;
-/// SendStall: issue a STALL handshake for unrecognised requests.
+/// `SendStall`: issue a STALL handshake for unrecognised requests.
 const EP0_SENDSTALL: u16 = 1 << 5;
-/// ServicedRxPktRdy: clear RxPktRdy after reading the SETUP/OUT packet.
+/// `ServicedRxPktRdy`: clear `RxPktRdy` after reading the SETUP/OUT packet.
 const EP0_SVDRXPKTRDY: u16 = 1 << 6;
-/// ServicedSetupEnd: acknowledge the SetupEnd condition.
+/// `ServicedSetupEnd`: acknowledge the `SetupEnd` condition.
 const EP0_SVDSETUPEND: u16 = 1 << 7;
 
 // ---------------------------------------------------------------------------
 // REG_TXCSR bit fields (when REG_INDEX >= 1)
 // ---------------------------------------------------------------------------
 
-/// TxPktRdy: arm TX FIFO for transmission.
+/// `TxPktRdy`: arm TX FIFO for transmission.
 const TXCSR_TXPKTRDY: u16 = 1 << 0;
-/// FIFONotEmpty: TX FIFO still contains data.
+/// `FIFONotEmpty`: TX FIFO still contains data.
 const TXCSR_FIFONOTEMPTY: u16 = 1 << 1;
 /// Underrun: host issued an IN token when FIFO was empty.
 const TXCSR_UNDERRUN: u16 = 1 << 2;
-/// FlushFIFO: discard the current TX FIFO contents.
+/// `FlushFIFO`: discard the current TX FIFO contents.
 const TXCSR_FLUSHFIFO: u16 = 1 << 3;
-/// ClrDataTog: reset data toggle to DATA0 (call after configuration).
+/// `ClrDataTog`: reset data toggle to DATA0 (call after configuration).
 const TXCSR_CLRDATATOG: u16 = 1 << 6;
 
 // ---------------------------------------------------------------------------
 // REG_RXCSR bit fields (when REG_INDEX >= 1)
 // ---------------------------------------------------------------------------
 
-/// RxPktRdy: a packet has arrived in the RX FIFO.
+/// `RxPktRdy`: a packet has arrived in the RX FIFO.
 const RXCSR_RXPKTRDY: u16 = 1 << 0;
-/// FlushFIFO: discard the current RX FIFO contents.
+/// `FlushFIFO`: discard the current RX FIFO contents.
 const RXCSR_FLUSHFIFO: u16 = 1 << 4;
-/// ClrDataTog: reset data toggle to DATA0 (call after configuration).
+/// `ClrDataTog`: reset data toggle to DATA0 (call after configuration).
 const RXCSR_CLRDATATOG: u16 = 1 << 7;
 
 // ---------------------------------------------------------------------------
@@ -207,26 +207,26 @@ const USB_DT_CS_INTERFACE: u8 = 0x24;
 // USB standard request codes (bRequest)
 // ---------------------------------------------------------------------------
 
-/// GET_STATUS: return 2-byte status word.
+/// `GET_STATUS`: return 2-byte status word.
 const USB_REQ_GET_STATUS: u8 = 0x00;
-/// SET_ADDRESS: assign the device address after enumeration.
+/// `SET_ADDRESS`: assign the device address after enumeration.
 const USB_REQ_SET_ADDRESS: u8 = 0x05;
-/// GET_DESCRIPTOR: return a descriptor by type and index.
+/// `GET_DESCRIPTOR`: return a descriptor by type and index.
 const USB_REQ_GET_DESCRIPTOR: u8 = 0x06;
-/// SET_CONFIGURATION: activate a configuration.
+/// `SET_CONFIGURATION`: activate a configuration.
 const USB_REQ_SET_CONFIGURATION: u8 = 0x09;
 
 // ---------------------------------------------------------------------------
 // CDC ACM class request codes (bRequest)
 // ---------------------------------------------------------------------------
 
-/// SET_LINE_CODING: configure serial port parameters (baud, stop bits, parity).
+/// `SET_LINE_CODING`: configure serial port parameters (baud, stop bits, parity).
 const CDC_REQ_SET_LINE_CODING: u8 = 0x20;
-/// GET_LINE_CODING: return current serial port parameters.
+/// `GET_LINE_CODING`: return current serial port parameters.
 const CDC_REQ_GET_LINE_CODING: u8 = 0x21;
-/// SET_CONTROL_LINE_STATE: SET DTR/RTS control lines.
+/// `SET_CONTROL_LINE_STATE`: SET DTR/RTS control lines.
 const CDC_REQ_SET_CONTROL_LINE_STATE: u8 = 0x22;
-/// SET_LINE_CODING's fixed payload length (baud[4] + stop[1] + parity[1] +
+/// `SET_LINE_CODING`'s fixed payload length (baud[4] + stop[1] + parity[1] +
 /// data bits[1] = 7 bytes) per the CDC ACM spec.
 const LINE_CODING_LEN: u16 = 7;
 
@@ -271,7 +271,7 @@ const EP2_MAX_PKT: u16 = 16;
 // USB device identity constants
 // ---------------------------------------------------------------------------
 
-/// USB VID  -  NetChip Technology (used for CDC ACM examples; suitable for debug).
+/// USB VID  -  `NetChip` Technology (used for CDC ACM examples; suitable for debug).
 const USB_VID: u16 = 0x0525;
 /// USB PID  -  Linux-USB CDC ACM gadget.
 const USB_PID: u16 = 0xA4A7;
@@ -510,9 +510,9 @@ enum Ep0State {
     Setup,
     /// Sending descriptor/data to host (IN direction).
     DataIn,
-    /// Receiving data FROM host (OUT direction, e.g., SET_LINE_CODING).
+    /// Receiving data FROM host (OUT direction, e.g., `SET_LINE_CODING`).
     DataOut,
-    /// SET_ADDRESS pending  -  address written to FAddr after status stage.
+    /// `SET_ADDRESS` pending  -  address written to `FAddr` after status stage.
     AddressPending,
 }
 
@@ -580,7 +580,7 @@ impl SetupPacket {
 // ACM line coding
 // ---------------------------------------------------------------------------
 
-/// CDC ACM line coding (7 bytes, as returned by GET_LINE_CODING).
+/// CDC ACM line coding (7 bytes, as returned by `GET_LINE_CODING`).
 #[derive(Debug, Clone, Copy)]
 pub struct LineCoding {
     /// Baud rate (bits per second).
@@ -605,7 +605,7 @@ impl LineCoding {
         }
     }
 
-    /// Serialize to 7 bytes for GET_LINE_CODING response.
+    /// Serialize to 7 bytes for `GET_LINE_CODING` response.
     #[must_use]
     pub(crate) fn to_bytes(self) -> [u8; 7] {
         let r = self.dw_dte_rate.to_le_bytes();
@@ -620,7 +620,7 @@ impl LineCoding {
         ]
     }
 
-    /// Parse FROM 7 bytes received in SET_LINE_CODING.
+    /// Parse FROM 7 bytes received in `SET_LINE_CODING`.
     #[must_use]
     pub(crate) fn from_bytes(b: &[u8; 7]) -> Self {
         Self {
@@ -643,15 +643,15 @@ impl LineCoding {
 
 /// Interrupt register snapshot captured on USB IRQ entry.
 ///
-/// Reading IntrUSB, IntrTx, and IntrRx FROM MUSB clears those bits
+/// Reading `IntrUSB`, `IntrTx`, and `IntrRx` FROM MUSB clears those bits
 /// atomically. The ISR must save them here before dispatching.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct UsbIrqStatus {
-    /// IntrUSB snapshot (reset/suspend/resume/SOF).
+    /// `IntrUSB` snapshot (reset/suspend/resume/SOF).
     pub intrusb: u8,
-    /// IntrTx snapshot (EP0 + TX EPs).
+    /// `IntrTx` snapshot (EP0 + TX EPs).
     pub intrtx: u16,
-    /// IntrRx snapshot (RX EPs).
+    /// `IntrRx` snapshot (RX EPs).
     pub intrrx: u16,
 }
 
@@ -710,9 +710,9 @@ fn clamp_rx_count(raw_count: u16, max_pkt: u16) -> usize {
     usize::from(raw_count).min(usize::from(max_pkt))
 }
 
-/// True if `w_length` matches SET_LINE_CODING's fixed [`LINE_CODING_LEN`].
+/// True if `w_length` matches `SET_LINE_CODING`'s fixed [`LINE_CODING_LEN`].
 ///
-/// SET_LINE_CODING declares a fixed-size (7-byte) payload per the CDC ACM
+/// `SET_LINE_CODING` declares a fixed-size (7-byte) payload per the CDC ACM
 /// spec. A request with any other `wLength` did not actually send the
 /// number of bytes `handle_ep0_data_out` unconditionally reads FROM the
 /// FIFO (issue #282 finding 20).
@@ -742,7 +742,7 @@ pub(crate) struct UsbController {
     base: usize,
     /// EP0 state machine.
     ep0_state: Ep0State,
-    /// Device address to apply after SET_ADDRESS status stage.
+    /// Device address to apply after `SET_ADDRESS` status stage.
     pending_address: u8,
     /// EP0 transmit buffer for descriptor/data responses.
     ep0_buf: [u8; EP0_BUF_LEN],
@@ -750,9 +750,9 @@ pub(crate) struct UsbController {
     ep0_buf_len: usize,
     /// Next byte index to send FROM `ep0_buf`.
     ep0_buf_pos: usize,
-    /// Current ACM line coding (updated by SET_LINE_CODING).
+    /// Current ACM line coding (updated by `SET_LINE_CODING`).
     line_coding: LineCoding,
-    /// True after SET_CONFIGURATION activates the gadget.
+    /// True after `SET_CONFIGURATION` activates the gadget.
     configured: bool,
 }
 
@@ -915,8 +915,8 @@ impl UsbController {
     /// Read and dispatch a USB interrupt.
     ///
     /// Called FROM the GIC interrupt handler for the MUSB IRQ line. Reads
-    /// IntrUSB, IntrTx, and IntrRx (which auto-clear on read), then dispatches
-    /// to reset, EP0, or EPx handlers.
+    /// `IntrUSB`, `IntrTx`, and `IntrRx` (which auto-clear on read), then dispatches
+    /// to reset, EP0, or `EPx` handlers.
     ///
     /// Returns the captured interrupt status for the caller to inspect.
     ///
@@ -1287,7 +1287,7 @@ impl UsbController {
         }
     }
 
-    /// Build and begin sending a GET_DESCRIPTOR response.
+    /// Build and begin sending a `GET_DESCRIPTOR` response.
     ///
     /// Loads the requested descriptor INTO `ep0_buf` and begins the IN data stage.
     ///
@@ -1326,7 +1326,7 @@ impl UsbController {
         unsafe { self.ep0_send_next_chunk() };
     }
 
-    /// Send up to one EP0_MAX_PKT chunk FROM ep0_buf to the host.
+    /// Send up to one `EP0_MAX_PKT` chunk FROM `ep0_buf` to the host.
     ///
     /// # Safety
     ///
@@ -1356,11 +1356,11 @@ impl UsbController {
         }
     }
 
-    /// Receive SET_LINE_CODING data (7 bytes) FROM EP0 OUT FIFO.
+    /// Receive `SET_LINE_CODING` data (7 bytes) FROM EP0 OUT FIFO.
     ///
     /// # Safety
     ///
-    /// Called FROM EP0 handler when DataOut is in progress.
+    /// Called FROM EP0 handler when `DataOut` is in progress.
     unsafe fn handle_ep0_data_out(&mut self) {
         // SAFETY: FIFO reads and register writes.
         unsafe {
@@ -1433,7 +1433,7 @@ impl UsbController {
     ///
     /// # Safety
     ///
-    /// EP0 FIFO must contain a valid SETUP packet (RxPktRdy SET).
+    /// EP0 FIFO must contain a valid SETUP packet (`RxPktRdy` SET).
     unsafe fn read_ep0_fifo_setup(&self) -> SetupPacket {
         // SAFETY: FIFO read; caller ensures SETUP packet is ready.
         let fifo = self.base + REG_FIFO_BASE;
@@ -1498,7 +1498,7 @@ impl UsbController {
     /// correctly-sized 16-bit access -- unlike `mmio::wait_bits_clear`,
     /// which performs an unconditional 32-bit load and would straddle
     /// adjacent register bytes when polling a 16-bit-only MUSB register
-    /// such as REG_TXCSR at an odd half-word offset (issue #227).
+    /// such as `REG_TXCSR` at an odd half-word offset (issue #227).
     ///
     /// # Safety
     ///
@@ -1519,7 +1519,7 @@ impl UsbController {
 // Shared controller instance (#666)
 // ---------------------------------------------------------------------------
 
-/// WHY (#322/#331 class, same reasoning as SERIAL_RX_RING_LOCK above): an
+/// WHY (#322/#331 class, same reasoning as `SERIAL_RX_RING_LOCK` above): an
 /// `irq::IrqSpinlock`, not bare single-core-cooperative reasoning -- once
 /// the MUSB IRQ is registered with the GIC (`board::m7::MUSB_IRQ`, `None`
 /// until hardware-confirmed), `handle_musb_interrupt` runs in interrupt
@@ -2171,8 +2171,8 @@ mod tests {
     /// ordering to manifest, which is what makes it a reliable witness
     /// even on x86 CI hardware.
     ///
-    /// Each producer pushes a disjoint value lane (0..PUSH_PER_LANE and
-    /// PUSH_PER_LANE..2*PUSH_PER_LANE) so the drained stream can still be
+    /// Each producer pushes a disjoint value lane (`0..PUSH_PER_LANE` and
+    /// `PUSH_PER_LANE..2`*`PUSH_PER_LANE`) so the drained stream can still be
     /// checked per-lane after interleaving. Two properties a
     /// torn/lost/duplicated/reordered ring slot would break: exact count
     /// conservation (every `push()` that reported `accepted` is either

--- a/crates/thumos/src/vfs.rs
+++ b/crates/thumos/src/vfs.rs
@@ -487,7 +487,7 @@ impl Default for MountTable {
 // Path resolution
 // ---------------------------------------------------------------------------
 
-/// Resolve an absolute path to a (mount_index, inode_id) pair.
+/// Resolve an absolute path to a (`mount_index`, `inode_id`) pair.
 ///
 /// Walks each component of `path` via `Filesystem::lookup()`, starting from
 /// the filesystem root inode. Handles `.` (current directory, skip) and `..`
@@ -855,10 +855,10 @@ mod tests {
         assert_eq!(result, Err(VfsError::AlreadyExists));
     }
 
-    /// A non-root trailing-slash mount path can never win lookup()'s
+    /// A non-root trailing-slash mount path can never win `lookup()`'s
     /// longest-prefix match against an ordinary child path -- it would
     /// sit in the table as a dead entry that matches nothing (#627).
-    /// Reject it at mount() instead of installing it.
+    /// Reject it at `mount()` instead of installing it.
     #[test]
     fn mount_rejects_trailing_slash() {
         let mut mt = MountTable::new();

--- a/crates/thumos/src/watchdog.rs
+++ b/crates/thumos/src/watchdog.rs
@@ -1,28 +1,28 @@
 //! MT6739 Watchdog Timer (WDT) driver.
 //!
-//! The MT6739 WDT is a hardware timer that resets the SoC if the kernel
+//! The MT6739 WDT is a hardware timer that resets the `SoC` if the kernel
 //! stops petting it within the configured timeout. This provides a safety
 //! net against kernel hangs (infinite loops, deadlocks, interrupt starvation).
 //!
-//! Register map (base 0x1000_7000, per MTK BSP reference):
+//! Register map (base `0x1000_7000`, per MTK BSP reference):
 //!
 //! | Offset | Register    | Description                              |
 //! |--------|-------------|------------------------------------------|
-//! | 0x00   | WDT_MODE    | Enable/disable, auto-restart mode        |
-//! | 0x04   | WDT_LENGTH  | Timeout value (encoded, see below)       |
-//! | 0x08   | WDT_RESTART | Write 0x1971 to reset the countdown      |
-//! | 0x0C   | WDT_STA     | Status register (bit 0 = WDT reset flag) |
+//! | 0x00   | `WDT_MODE`    | Enable/disable, auto-restart mode        |
+//! | 0x04   | `WDT_LENGTH`  | Timeout value (encoded, see below)       |
+//! | 0x08   | `WDT_RESTART` | Write 0x1971 to reset the countdown      |
+//! | 0x0C   | `WDT_STA`     | Status register (bit 0 = WDT reset flag) |
 //!
-//! Timeout encoding (WDT_LENGTH):
+//! Timeout encoding (`WDT_LENGTH)`:
 //!   bits [15:5] = timeout in units of 512/32768 s ≈ 15.6 ms per unit
 //!   bits [4:0]  = key (must be 0x08 to commit the write)
 //!
 //! For a 5-second timeout: 5 / (512/32768) ≈ 320 units → 320 << 5 | 0x08.
 //!
-//! WDT_MODE bit fields:
-//!   bit 0  = WDT_EN   (1 = enabled)
-//!   bit 1  = WDT_AUTO (1 = auto-restart on IRQ ACK; we leave this 0)
-//!   bit 6  = WDT_KEY  (always write 1 to commit mode changes)
+//! `WDT_MODE` bit fields:
+//!   bit 0  = `WDT_EN`   (1 = enabled)
+//!   bit 1  = `WDT_AUTO` (1 = auto-restart on IRQ ACK; we leave this 0)
+//!   bit 6  = `WDT_KEY`  (always write 1 to commit mode changes)
 //!
 //! WHY 5-second timeout: long enough for the scheduler to complete a full
 //! tick cycle even under heavy load, short enough to recover from a hang
@@ -31,35 +31,35 @@
 use crate::mmio;
 
 /// WDT register base address for MT6739.
-/// WHY: 0x1000_7000 is the documented WDT base in the MT6739 BSP and matches
-/// the typical MTK layout for this SoC family. Verify against your specific
-/// BSP header (wdt.h or mach/mt_wdt.h) if porting to a different MT variant.
-/// WDT_MODE: enable/disable and mode control.
+/// WHY: `0x1000_7000` is the documented WDT base in the MT6739 BSP and matches
+/// the typical MTK layout for this `SoC` family. Verify against your specific
+/// BSP header (wdt.h or `mach/mt_wdt.h`) if porting to a different MT variant.
+/// `WDT_MODE`: enable/disable and mode control.
 const WDT_MODE: usize = crate::board::WDT_BASE + 0x00;
 
-/// WDT_LENGTH: timeout value register.
+/// `WDT_LENGTH`: timeout value register.
 const WDT_LENGTH: usize = crate::board::WDT_BASE + 0x04;
 
-/// WDT_RESTART: write 0x1971 here to pet the watchdog.
+/// `WDT_RESTART`: write 0x1971 here to pet the watchdog.
 const WDT_RESTART: usize = crate::board::WDT_BASE + 0x08;
 
 /// Magic value required to pet (restart) the watchdog countdown.
 const WDT_RESTART_KEY: u32 = 0x1971;
 
-/// WDT_MODE enable bit (bit 0).
+/// `WDT_MODE` enable bit (bit 0).
 const WDT_MODE_EN: u32 = 1 << 0;
 
-/// WDT_MODE key bit (bit 6): must be set to commit any mode write.
+/// `WDT_MODE` key bit (bit 6): must be set to commit any mode write.
 const WDT_MODE_KEY: u32 = 1 << 6;
 
-/// WDT_LENGTH key bits [4:0]: must be 0x08 to commit a length write.
+/// `WDT_LENGTH` key bits [4:0]: must be 0x08 to commit a length write.
 const WDT_LENGTH_KEY: u32 = 0x08;
 
-/// Timeout in WDT_LENGTH units (each unit ≈ 15.6 ms; 320 ≈ 5 seconds).
-/// Calculation: 5_000 ms / 15.625 ms = 320.
+/// Timeout in `WDT_LENGTH` units (each unit ≈ 15.6 ms; 320 ≈ 5 seconds).
+/// Calculation: `5_000` ms / 15.625 ms = 320.
 const WDT_TIMEOUT_UNITS: u32 = 320;
 
-/// Encoded WDT_LENGTH register value: timeout units in [15:5] | key in [4:0].
+/// Encoded `WDT_LENGTH` register value: timeout units in [15:5] | key in [4:0].
 const WDT_LENGTH_VAL: u32 = (WDT_TIMEOUT_UNITS << 5) | WDT_LENGTH_KEY;
 
 /// Initialize the hardware watchdog with a 5-second timeout and start it.
@@ -70,7 +70,7 @@ const WDT_LENGTH_VAL: u32 = (WDT_TIMEOUT_UNITS << 5) | WDT_LENGTH_KEY;
 /// # Safety
 ///
 /// Writes to MMIO registers at the MT6739 WDT base address. Safe only
-/// after the MMU has identity-mapped device MMIO (which includes 0x1000_7000).
+/// after the MMU has identity-mapped device MMIO (which includes `0x1000_7000`).
 pub unsafe fn init() {
     // SAFETY: WDT_LENGTH and WDT_MODE are MMIO registers at the MT6739 WDT base,
     // identity-mapped as device memory by mmu::init_and_enable(). Write ordering
@@ -97,7 +97,7 @@ pub unsafe fn init() {
 ///
 /// # Safety
 ///
-/// Writes to the WDT_RESTART MMIO register. Safe after `init()` has
+/// Writes to the `WDT_RESTART` MMIO register. Safe after `init()` has
 /// been called and the MMU has identity-mapped device MMIO.
 pub unsafe fn pet() {
     // SAFETY: WDT_RESTART is a write-only MMIO register; writing 0x1971 resets
@@ -114,7 +114,7 @@ pub unsafe fn pet() {
 ///
 /// # Safety
 ///
-/// Writes to WDT_MODE. Safe after `init()` has been called.
+/// Writes to `WDT_MODE`. Safe after `init()` has been called.
 pub unsafe fn disable() {
     // SAFETY: WDT_MODE is an MMIO register at the MT6739 WDT base. Writing
     // only the key bit (WDT_MODE_KEY) with WDT_MODE_EN clear disables the WDT.

--- a/crates/thumos/src/wifi.rs
+++ b/crates/thumos/src/wifi.rs
@@ -1,16 +1,16 @@
-//! WiFi network interface and WPA supplicant for the MT6739 combo chip.
+//! `WiFi` network interface and WPA supplicant for the MT6739 combo chip.
 //!
 //! Ports essential logic from the `aither` userspace crate into the kernel:
 //! - MAC randomization via the kernel CSPRNG (`csprng.rs`)
 //! - WPA2-Personal 4-way handshake state machine
 //! - EAPOL frame parsing and construction (IEEE 802.1X-2020)
-//! - WiFi hardware abstraction via `WifiHwOps` trait
+//! - `WiFi` hardware abstraction via `WifiHwOps` trait
 //!
 //! ## Hardware path
 //!
-//! The MT6739 WiFi hardware is accessed through the WMT combo chip:
-//! - `board::CONSYS_BASE = 0x1800_0000` (combo-chip base, board::m7 #534)
-//! - `board::WLAN_BASE  = 0x180F_0000` (WiFi MMIO region, board::m7 #534)
+//! The MT6739 `WiFi` hardware is accessed through the WMT combo chip:
+//! - `board::CONSYS_BASE = 0x1800_0000` (combo-chip base, `board::m7` #534)
+//! - `board::WLAN_BASE  = 0x180F_0000` (`WiFi` MMIO region, `board::m7` #534)
 //!
 //! Data path goes through WMT STP framing (kelyphos handles the transport).
 //! The `WifiHw` struct provides `#[cfg(not(test))]` MMIO access with a
@@ -43,7 +43,7 @@ use crate::security::{hmac_sha1, pbkdf2_hmac_sha1, prf_384};
 // Error types
 // ---------------------------------------------------------------------------
 
-/// WiFi subsystem errors.
+/// `WiFi` subsystem errors.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum WifiError {
@@ -74,7 +74,7 @@ pub enum WifiError {
     },
     /// No scan results matched the configured network.
     NetworkNotFound,
-    /// The WiFi hardware is not initialized.
+    /// The `WiFi` hardware is not initialized.
     NotInitialized,
 }
 
@@ -103,7 +103,7 @@ impl core::fmt::Display for WifiError {
 // WiFi state machine
 // ---------------------------------------------------------------------------
 
-/// WiFi connection lifecycle state machine.
+/// `WiFi` connection lifecycle state machine.
 ///
 /// Transitions are driven by external events: scan results, association
 /// responses, EAPOL frames, and timeouts.
@@ -129,7 +129,7 @@ pub enum WifiState {
 // Security types
 // ---------------------------------------------------------------------------
 
-/// WiFi security protocol.
+/// `WiFi` security protocol.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub enum WifiSecurity {
@@ -153,7 +153,7 @@ pub(crate) const MAX_SSID_LEN: usize = 32;
 /// Maximum passphrase length in bytes (WPA2-Personal: 8-63 ASCII).
 pub(crate) const MAX_PASSPHRASE_LEN: usize = 64;
 
-/// WiFi network configuration.
+/// `WiFi` network configuration.
 ///
 /// Stores SSID and passphrase in fixed-size arrays to avoid heap allocation
 /// in the connection hot path.
@@ -172,7 +172,7 @@ pub struct WifiConfig {
 }
 
 impl WifiConfig {
-    /// Create a new WiFi configuration.
+    /// Create a new `WiFi` configuration.
     ///
     /// Truncates SSID and passphrase to their respective maximum lengths
     /// rather than returning an error.
@@ -219,7 +219,7 @@ impl Drop for WifiConfig {
     }
 }
 
-/// A single scan result from the WiFi firmware.
+/// A single scan result from the `WiFi` firmware.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScanResult {
     /// Advertised SSID (raw bytes from beacon/probe response).
@@ -436,8 +436,8 @@ const EAPOL_HEADER_LEN: usize = 4;
 
 /// Size of the fixed portion of an EAPOL-Key body (before variable key data).
 ///
-/// Fields: descriptor_type(1) + key_info(2) + key_length(2) + replay_counter(8)
-/// + nonce(32) + iv(16) + rsc(8) + reserved(8) + mic(16) + key_data_length(2) = 95
+/// Fields: `descriptor_type(1)` + `key_info(2)` + `key_length(2)` + `replay_counter(8)`
+/// + nonce(32) + iv(16) + rsc(8) + reserved(8) + mic(16) + `key_data_length(2)` = 95
 const EAPOL_KEY_FIXED_LEN: usize = 95;
 
 /// Nonce field length in bytes.
@@ -546,7 +546,7 @@ pub struct EapolKeyFrame {
     pub key_length: u16,
     /// Strictly monotonic replay counter.
     pub replay_counter: u64,
-    /// Authenticator or supplicant nonce (ANonce / SNonce).
+    /// Authenticator or supplicant nonce (`ANonce` / `SNonce`).
     pub nonce: [u8; NONCE_LEN],
     /// Key IV (all-zero for CCMP; used by TKIP).
     pub iv: [u8; IV_LEN],
@@ -743,10 +743,10 @@ fn eapol_encode_key_frame(kf: &EapolKeyFrame) -> Vec<u8> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub enum HandshakeState {
-    /// Waiting for Message 1 (ANonce from authenticator).
+    /// Waiting for Message 1 (`ANonce` from authenticator).
     #[default]
     AwaitMsg1,
-    /// Message 1 received; supplicant generated SNonce and derived PTK.
+    /// Message 1 received; supplicant generated `SNonce` and derived PTK.
     /// Waiting to send Message 2.
     SendMsg2,
     /// Message 2 sent; waiting for Message 3 (GTK + Install).
@@ -1035,12 +1035,12 @@ impl Default for WpaHandshake {
 // WiFi hardware abstraction
 // ---------------------------------------------------------------------------
 
-/// Hardware operations trait for WiFi driver abstraction.
+/// Hardware operations trait for `WiFi` driver abstraction.
 ///
 /// Allows test-friendly mocking of MMIO access. The real implementation
 /// (`WifiHw`) uses `#[cfg(not(test))]` MMIO; tests provide a mock.
 pub(crate) trait WifiHwOps {
-    /// Return true once the WiFi data path can exchange Ethernet frames.
+    /// Return true once the `WiFi` data path can exchange Ethernet frames.
     ///
     /// The default is closed so partially wired hardware operations cannot be
     /// mistaken for production connectivity.
@@ -1048,10 +1048,10 @@ pub(crate) trait WifiHwOps {
         false
     }
 
-    /// Transmit a frame to the WiFi hardware.
+    /// Transmit a frame to the `WiFi` hardware.
     fn send_frame(&mut self, data: &[u8]) -> Result<(), WifiError>;
 
-    /// Receive a frame from the WiFi hardware, if one is available.
+    /// Receive a frame from the `WiFi` hardware, if one is available.
     fn recv_frame(&mut self) -> Option<Vec<u8>>;
 
     /// Initiate a passive scan.
@@ -1064,9 +1064,9 @@ pub(crate) trait WifiHwOps {
     fn associate(&mut self, ssid: &[u8], bssid: &[u8; 6]) -> Result<(), WifiError>;
 }
 
-/// WiFi hardware driver for the MT6739 WMT combo chip.
+/// `WiFi` hardware driver for the MT6739 WMT combo chip.
 ///
-/// Provides MMIO-based access to the WiFi hardware on the real target,
+/// Provides MMIO-based access to the `WiFi` hardware on the real target,
 /// and a mock-friendly scan result buffer for testing.
 #[cfg(not(any(test, feature = "qemu")))]
 pub(crate) struct WifiHw {
@@ -1080,7 +1080,7 @@ pub(crate) struct WifiHw {
 
 #[cfg(not(any(test, feature = "qemu")))]
 impl WifiHw {
-    /// Construct a new WiFi hardware driver.
+    /// Construct a new `WiFi` hardware driver.
     #[must_use]
     pub(crate) const fn new() -> Self {
         Self {
@@ -1129,7 +1129,7 @@ impl WifiHwOps for WifiHw {
 // WiFi driver (combines state machine + hardware + WPA)
 // ---------------------------------------------------------------------------
 
-/// WiFi network driver combining state machine, hardware ops, and WPA handshake.
+/// `WiFi` network driver combining state machine, hardware ops, and WPA handshake.
 ///
 /// Orchestrates the full connection lifecycle: scan, associate, handshake,
 /// connected. Uses MAC randomization for each new connection attempt.
@@ -1147,7 +1147,7 @@ pub(crate) struct WifiDriver<H: WifiHwOps> {
 }
 
 impl<H: WifiHwOps> WifiDriver<H> {
-    /// Create a new WiFi driver with the given hardware backend.
+    /// Create a new `WiFi` driver with the given hardware backend.
     ///
     /// Generates an initial random MAC address.
     #[must_use]
@@ -1210,7 +1210,7 @@ impl<H: WifiHwOps> WifiDriver<H> {
 // Test mock
 // ---------------------------------------------------------------------------
 
-/// Mock WiFi hardware for testing.
+/// Mock `WiFi` hardware for testing.
 ///
 /// Records calls and returns pre-configured results without MMIO access.
 #[cfg(test)]
@@ -1219,7 +1219,7 @@ pub struct MockWifiHw {
     pub scan_results: Vec<ScanResult>,
     /// Frames sent via `send_frame`.
     pub sent_frames: Vec<Vec<u8>>,
-    /// Whether scan_start should succeed.
+    /// Whether `scan_start` should succeed.
     pub scan_ok: bool,
     /// Whether associate should succeed.
     pub associate_ok: bool,


### PR DESCRIPTION
## Status: partial burn-down, paused for a usage reset

This is the mechanical share of #672. Three classes are finished and pushed; one class and one verification step are not — both called out explicitly below rather than claimed.

## Prerequisite this branch depends on

`origin/main`'s `crates/thumos/build.rs` currently has its own 18 `-D warnings` errors (issue #663, fix in open PR #668 on `fix/663-kernel-clippy-stage`, held pending this issue). A build script that fails to compile aborts `cargo clippy` before it ever reaches `src/`, so none of the counts below were reachable against plain `origin/main`. This branch is based on `origin/main` and does **not** touch `build.rs` — all discovery/verification runs used a scratch copy with #668's `build.rs` patched in locally, never committed. Once #668 merges, re-gating this branch should show the same `src/` counts.

## The rule-scoping correction (operator decision)

`crates/thumos/src/main.rs`:

```rust
#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
```

This is a scoping correction, not a suppression: `unwrap_used`/`expect_used` are denied crate-wide to keep panics out of shipping kernel paths, where a panic is a crash. In a test, an `unwrap()`/`expect()` panic **is** the assertion — the intended failure signal. The `cfg_attr` only takes effect when compiling under `#[cfg(test)]`; production code keeps the deny unchanged, and no other lint was added to the allow list.

**Unverified**: I did not get to the falsification check (introduce one `unwrap()` in a non-test fn, confirm clippy still errors, remove it) before pausing. This needs to run before merge — do not treat production denial as confirmed from this PR alone.

## Mechanical classes fixed

All three applied by parsing clippy's own JSON diagnostics (`--message-format=json`) and patching each finding's exact byte span with its own suggested replacement — no hand-editing, no lint-level overrides, no `cargo clippy --fix` blanket pass (which would have also rewritten out-of-scope lints).

| class | production | test | how |
|---|---:|---:|---|
| `clippy::doc_markdown` (doc backticks) | 724 | 189 | clippy's `MachineApplicable` suggestion, applied verbatim |
| `clippy::unreadable_literal` (long literal separators) | 15 | — (left alone, test-side out of scope) | clippy's suggested replacement (hex/octal/decimal) |
| `clippy::doc_lazy_continuation` (doc list indentation) | 8 | — (test-side had 0) | clippy's suggested indentation, hand-verified against each site's prose before applying (see below) |

**Counts vs. the issue's census**: the issue's numbers (636/60/15/8 production, 269 test) were measured against `fix/663-kernel-clippy-stage` before three large feature PRs landed on `main` since (#669 pteron, #670 gps, #675 usb). Re-measured live against current `main` + #668's `build.rs` patched in locally: `doc_markdown` is 724 production / 189 test (not 636 / 269), `unreadable_literal` and `doc_lazy_continuation` match exactly (15 and 8). I fixed the live counts, not the stale census, per the task's own framing ("same mechanical class, same invariant").

**Classification methodology note**: separating production from test findings required diffing two clippy runs (`--bin thumos` alone vs. `--bin thumos --tests`) rather than parsing `#[cfg(test)]` blocks by hand. `--bin thumos --tests` compiles the crate as two separate units and double-reports every finding in non-gated shared code, so a naive multiset diff overcounts test-only findings substantially (e.g. it made `clippy::double_must_use` look like it had 73 test-side sites — it has zero; those were duplicate reports of the same 73 production sites). Fixed with a set-based (not multiset) diff. Flagging this because anyone re-deriving these counts by hand will hit the same trap.

**`doc_lazy_continuation` sites were read individually, not blindly auto-applied**: clippy offers two possible fixes (indent, or insert a blank line to start a new paragraph) and picking wrong changes meaning. All 8 production sites (`nous.rs` x5, `provision.rs` x3) are continuations of one flowing sentence, not a real new paragraph, so clippy's own "indent" suggestion was correct at every site — confirmed by reading each one, not assumed.

## Diff-invariant check (run exactly as specified)

```
git diff -U0 | grep -E '^\+' | grep -vE '^\+\+\+' | grep -vE '^\+\s*(///|//!|//|#\[)' | grep -vE '0x[0-9A-Fa-f_]+'
```

```
+pub(crate) const O_CLOEXEC: u32 = 0o2_000_000;
+pub(crate) const S_IFREG: u32 = 0o100_000;
+pub(crate) const S_IFDIR: u32 = 0o040_000;
+pub(crate) const S_IFCHR: u32 = 0o020_000;
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+            let file_type = mode & 0o170_000;
+            let is_dir = file_type == 0o040_000;
+                    } else if filesize > 0 || file_type == 0o100_000 {
+            size_bytes: 524_288,
+            size_bytes: 262_144,
+            size_bytes: 131_072,
```

11 survivors, all justified:
- 1 is the operator-approved `cfg_attr` line (the one explicit exception).
- 10 are `clippy::unreadable_literal` fixes in octal/decimal form. The given regex only excludes hex (`0x...`); it has a blind spot for `0o...` and bare decimal literals. Each pair was checked against `git diff` with full context to confirm the numeric *value* is unchanged and only `_` separators were inserted (e.g. `0o040000` → `0o040_000`, `524288` → `524_288`) — no other characters differ on any of these lines.

`cargo fmt --all --check` and `cargo fmt --manifest-path crates/thumos/Cargo.toml --check` both pass (exit 0) on the patched tree — no formatting corruption from the byte-offset patching.

## What remains (not in this PR)

- **`clippy::double_must_use` (73 production sites, ~60 in the original stale census)**: each needs an authored message describing what the caller must do with the value, not a mechanical replacement (clippy offers no suggested text for this lint). All 73 sites were located and their function signatures extracted; none have been patched yet. Left for the next pass rather than rushed.
- **Test-side doc backticks were completed** (189, included above) — this was in scope and is done.
- **Everything else** stays exactly as scoped in the issue: the ~14 correctness-adjacent findings (cast wrap/alignment/fallible-conversion — owned by the sibling `672-casts` task), the production structural findings (`let...else`, collapsible `if`, identical match arms, unused `self`, `is_multiple_of`, `div_ceil` — separate PR), the remaining test-side structural findings (items-after-statements, large stack arrays, redundant closures, `ref_as_ptr`, `map_or`, etc. — separate PR), and the 21 unfulfilled lint expectations (need per-site thought, not mechanical).
- 3 `error[E0133]` (`unsafe_op_in_unsafe_fn`) sites turned out to be in test code, not production as the issue's original comment implied — noted for whoever picks up the correctness-adjacent bucket.

## Verification run

- `cargo fmt --all --check` → exit 0
- `cargo fmt --manifest-path crates/thumos/Cargo.toml --check` → exit 0
- Full `cargo clippy --bin thumos --tests --target i686-unknown-linux-gnu` re-run to confirm the finding-count drop, and `scripts/kernel-host-tests.sh` to confirm the test count is unchanged, were **not** run before pausing — flagging as the next step, not claiming them.

Refs #672
