### PR TITLE
fix(kernel): finish the cast/conversion pass over #672's correctness-adjacent findings

### DIFF
--- a/crates/thumos/src/clock.rs
+++ b/crates/thumos/src/clock.rs
@@ -362,7 +362,22 @@ pub(crate) fn parse_ntp_response(packet: &[u8]) -> Option<u64> {
 /// correction.
 #[must_use]
 pub(crate) fn calculate_ntp_offset(local_send_secs: u64, server_transmit_epoch: u64) -> i64 {
-    server_transmit_epoch as i64 - local_send_secs as i64
+    // INVARIANT: unlike the other u64 -> i64 sites in this module, this
+    // function has no wired-in caller yet (#145 -- the clock trust manager
+    // is not wired into kernel time) to bound `local_send_secs` by
+    // construction, and `server_transmit_epoch` is meant to carry a value
+    // parsed from a network-supplied NTP packet (see `parse_ntp_response`).
+    // A bare `as i64` on either operand would silently flip sign for an
+    // input >= 2^63, and subtracting two such reinterpreted values then
+    // produces a small, plausible-looking but wrong offset instead of an
+    // obviously-wrong one -- the same failure shape #670 closed on the GPS
+    // side. Use checked widening with a stated saturation bound, and a
+    // saturating subtract, so the result is well-defined for every `u64`
+    // input this function could ever be called with, not just the ones a
+    // not-yet-written caller happens to pass.
+    let local = i64::try_from(local_send_secs).unwrap_or(i64::MAX);
+    let server = i64::try_from(server_transmit_epoch).unwrap_or(i64::MAX);
+    server.saturating_sub(local)
 }
 
 /// NTP server endpoint for the clock manager.
@@ -728,5 +743,25 @@ mod tests {
             1_700_000_000 - 1000,
             "offset must be server_time - local_time"
         );
+    }
+
+    #[test]
+    fn calculate_ntp_offset_saturates_instead_of_wrapping_sign() {
+        // A `local_send_secs` >= 2^63 used to bit-flip to negative under a
+        // bare `as i64`, so `server - local` computed as a small *positive*
+        // number (0 - (-1) = 1) instead of reflecting that `local_send_secs`
+        // is vastly larger than `server_transmit_epoch`. The saturating form
+        // must report a large-magnitude NEGATIVE offset instead.
+        let offset = calculate_ntp_offset(u64::MAX, 0);
+        assert_eq!(
+            offset,
+            -(i64::MAX),
+            "an out-of-range local time must saturate the offset negative, not wrap to +1"
+        );
+
+        // Symmetric case: an out-of-range server timestamp must saturate to
+        // a large positive offset, not silently reinterpret as negative.
+        let offset = calculate_ntp_offset(0, u64::MAX);
+        assert_eq!(offset, i64::MAX);
     }
 }

--- a/crates/thumos/src/clock.rs
+++ b/crates/thumos/src/clock.rs
@@ -247,8 +247,13 @@ impl ClockManager {
             && self.ntp_is_fresh(current_tick_ms)
         {
             // NTP offset is relative to monotonic clock.
+            //
+            // INVARIANT: `monotonic_secs` is device uptime in seconds
+            // (`current_tick_ms / 1000`, a `u64` millisecond tick count).
+            // `i64::MAX` seconds is ~292 billion years -- no device uptime
+            // reaches that, so this bit-reinterpretation cannot flip sign.
             let monotonic_secs = current_tick_ms / 1000;
-            return (monotonic_secs as i64 + offset) as u64;
+            return (monotonic_secs.cast_signed() + offset).cast_unsigned();
         }
 
         if let Some(epoch) = self.rtc_epoch {

--- a/crates/thumos/src/emmc.rs
+++ b/crates/thumos/src/emmc.rs
@@ -922,8 +922,24 @@ impl MsdcController {
             self.send_data_command(CMD17_READ_SINGLE, lba, CMD_RSPTYP_R1, CMD_DTYPE_READ, 1)?;
         }
 
-        // PIO: read 128 words (512 bytes) FROM MSDC_RXDATA
-        let buf_ptr = buf.as_mut_ptr().cast::<u32>();
+        // PIO: read 128 words (512 bytes) FROM MSDC_RXDATA.
+        //
+        // INVARIANT: `buf` is a caller-supplied `&mut [u8; SECTOR_SIZE]` --
+        // nothing in its type or this function's `# Safety` contract above
+        // promises 4-byte alignment (a bare `[u8; N]` has `align_of` 1, and
+        // both real callers -- `block.rs`'s slice-sourced `sector_buf` and
+        // `gpt.rs`'s stack-local array -- pass buffers with no alignment
+        // guarantee). Forming a `*mut u32` over it and dereferencing (as the
+        // previous `buf_ptr.add(i).write_volatile(word)` form did) is
+        // undefined behaviour whenever the address is not 4-byte aligned:
+        // armv7a data-aborts on the misaligned access, while the i686 host
+        // build this was linted on tolerates it silently -- see
+        // `page.rs`'s `AlignedBuf` comment for the same class caught once
+        // already via a CI SIGABRT. Storing each word byte-by-byte is
+        // correct for any alignment and, as a byte-swap-free bonus, makes
+        // the wire order (little-endian, matching every target this crate
+        // builds for) explicit rather than implicit in `write_volatile`'s
+        // native-endian store.
         for i in 0..WORDS_PER_SECTOR {
             // Poll the RX FIFO word count until at least one word is
             // buffered, instead of STS_DATBUSY (which cannot signal
@@ -942,8 +958,7 @@ impl MsdcController {
             }
             // SAFETY: MSDC_RXDATA is a valid MMIO register at offset 0x1C within the MSDC0 address space. Volatile access is required for hardware registers.
             let word = unsafe { self.read_reg(REG_MSDC_RXDATA) };
-            // SAFETY: buf_ptr is valid for WORDS_PER_SECTOR u32 writes, i < WORDS_PER_SECTOR
-            unsafe { buf_ptr.add(i).write_volatile(word) };
+            buf[i * 4..i * 4 + 4].copy_from_slice(&word.to_le_bytes());
         }
 
         // Wait for transfer complete
@@ -989,11 +1004,15 @@ impl MsdcController {
             self.send_data_command(CMD24_WRITE_SINGLE, lba, CMD_RSPTYP_R1, CMD_DTYPE_WRITE, 1)?;
         }
 
-        // PIO: write 128 words (512 bytes) to MSDC_TXDATA
-        let buf_ptr = buf.as_ptr().cast::<u32>();
+        // PIO: write 128 words (512 bytes) to MSDC_TXDATA.
+        //
+        // INVARIANT: `buf` carries the same no-alignment-guarantee as
+        // `read_sector`'s `buf` above -- see that comment. Read each word's
+        // bytes explicitly rather than forming a `*const u32` over `buf`.
         for i in 0..WORDS_PER_SECTOR {
-            // SAFETY: buf_ptr is valid for WORDS_PER_SECTOR u32 reads, i < WORDS_PER_SECTOR
-            let word = unsafe { buf_ptr.add(i).read_volatile() };
+            let mut word_bytes = [0u8; 4];
+            word_bytes.copy_from_slice(&buf[i * 4..i * 4 + 4]);
+            let word = u32::from_le_bytes(word_bytes);
             // SAFETY: MSDC_TXDATA is a valid MMIO register at offset 0x18 within the MSDC0 address space. Volatile access is required for hardware registers.
             unsafe { self.write_reg(REG_MSDC_TXDATA, word) };
         }

--- a/crates/thumos/src/emmc.rs
+++ b/crates/thumos/src/emmc.rs
@@ -641,6 +641,28 @@ pub(crate) struct MsdcController {
     initialized: bool,
 }
 
+/// Store a 32-bit little-endian word into a sector buffer at word index `i`.
+///
+/// Byte-level store rather than a `*mut u32` cast, because a `&mut [u8;
+/// SECTOR_SIZE]` carries no alignment guarantee (see `read_sector`'s call
+/// site) -- this is correct for any buffer alignment, unlike a typed
+/// pointer write.
+#[cfg(not(feature = "qemu"))]
+#[inline]
+fn store_word_le(buf: &mut [u8; SECTOR_SIZE], i: usize, word: u32) {
+    buf[i * 4..i * 4 + 4].copy_from_slice(&word.to_le_bytes());
+}
+
+/// Load a 32-bit little-endian word from a sector buffer at word index `i`.
+/// See [`store_word_le`].
+#[cfg(not(feature = "qemu"))]
+#[inline]
+fn load_word_le(buf: &[u8; SECTOR_SIZE], i: usize) -> u32 {
+    let mut word_bytes = [0u8; 4];
+    word_bytes.copy_from_slice(&buf[i * 4..i * 4 + 4]);
+    u32::from_le_bytes(word_bytes)
+}
+
 #[cfg(not(feature = "qemu"))]
 impl MsdcController {
     /// Create a new controller handle at the default MSDC0 base address.
@@ -958,7 +980,7 @@ impl MsdcController {
             }
             // SAFETY: MSDC_RXDATA is a valid MMIO register at offset 0x1C within the MSDC0 address space. Volatile access is required for hardware registers.
             let word = unsafe { self.read_reg(REG_MSDC_RXDATA) };
-            buf[i * 4..i * 4 + 4].copy_from_slice(&word.to_le_bytes());
+            store_word_le(buf, i, word);
         }
 
         // Wait for transfer complete
@@ -1010,9 +1032,7 @@ impl MsdcController {
         // `read_sector`'s `buf` above -- see that comment. Read each word's
         // bytes explicitly rather than forming a `*const u32` over `buf`.
         for i in 0..WORDS_PER_SECTOR {
-            let mut word_bytes = [0u8; 4];
-            word_bytes.copy_from_slice(&buf[i * 4..i * 4 + 4]);
-            let word = u32::from_le_bytes(word_bytes);
+            let word = load_word_le(buf, i);
             // SAFETY: MSDC_TXDATA is a valid MMIO register at offset 0x18 within the MSDC0 address space. Volatile access is required for hardware registers.
             unsafe { self.write_reg(REG_MSDC_TXDATA, word) };
         }
@@ -1783,6 +1803,45 @@ mod tests {
     fn sector_size_is_512() {
         assert_eq!(SECTOR_SIZE, 512, "eMMC sector size");
         assert_eq!(WORDS_PER_SECTOR, 128, "words per sector (512/4)");
+    }
+
+    #[test]
+    fn sector_word_roundtrip_is_correct_and_alignment_independent() {
+        // `read_sector`/`write_sector` move PIO data through `store_word_le`/
+        // `load_word_le` (byte-by-byte) rather than reinterpreting `buf` as
+        // `*mut/const u32`, because a `&[u8; SECTOR_SIZE]` carries no
+        // alignment guarantee -- real callers slice one out of a larger
+        // buffer (`block.rs`) or place it on the stack (`gpt.rs`), neither of
+        // which promises 4-byte alignment. Confirm the byte-level round trip
+        // is correct regardless of where the backing array actually lands,
+        // by deliberately misaligning it: a leading pad byte forces the
+        // sector's start address off whatever boundary the allocator would
+        // otherwise have chosen.
+        let mut padded = [0u8; SECTOR_SIZE + 1];
+        let Ok(sector) = <&mut [u8; SECTOR_SIZE]>::try_from(&mut padded[1..]) else {
+            unreachable!("padded[1..] is exactly SECTOR_SIZE bytes long")
+        };
+        assert_ne!(
+            sector.as_ptr() as usize % 4,
+            0,
+            "test setup must actually produce a misaligned buffer"
+        );
+
+        for i in 0..WORDS_PER_SECTOR {
+            let word = 0xDEAD_0000u32.wrapping_add(i as u32);
+            store_word_le(sector, i, word);
+        }
+        for i in 0..WORDS_PER_SECTOR {
+            let expected = 0xDEAD_0000u32.wrapping_add(i as u32);
+            assert_eq!(
+                load_word_le(sector, i),
+                expected,
+                "word {i} did not round-trip"
+            );
+        }
+
+        // Wire order is little-endian on every target this crate builds for.
+        assert_eq!(&sector[0..4], &0xDEAD_0000u32.to_le_bytes());
     }
 
     // -- SDC_STS bit tests --

--- a/crates/thumos/src/emmc.rs
+++ b/crates/thumos/src/emmc.rs
@@ -1814,12 +1814,25 @@ mod tests {
         // buffer (`block.rs`) or place it on the stack (`gpt.rs`), neither of
         // which promises 4-byte alignment. Confirm the byte-level round trip
         // is correct regardless of where the backing array actually lands,
-        // by deliberately misaligning it: a leading pad byte forces the
-        // sector's start address off whatever boundary the allocator would
-        // otherwise have chosen.
-        let mut padded = [0u8; SECTOR_SIZE + 1];
-        let Ok(sector) = <&mut [u8; SECTOR_SIZE]>::try_from(&mut padded[1..]) else {
-            unreachable!("padded[1..] is exactly SECTOR_SIZE bytes long")
+        // by deliberately misaligning it.
+        //
+        // WHY the offset is derived from the runtime address rather than a
+        // fixed constant: `[u8; N]` has `align_of` 1, so the compiler is
+        // free to place the backing array at any address. A FIXED pad only
+        // shifts alignment relative to a base whose residue is unknown, so
+        // it can land back on a 4-byte boundary depending on that residue
+        // (a constant 1-byte pad is misaligning only when `base % 4 != 3`)
+        // -- silently passing while exercising nothing, the opposite of
+        // this test's purpose. `off` is chosen from the OBSERVED
+        // `base % 4` so the result is never 0 for any base: off=1 covers
+        // residues 0/1/2 (giving 1/2/3), and residue 3 alone needs off=2
+        // (giving 1), since off=1 there reproduces the boundary case above.
+        let mut backing = [0u8; SECTOR_SIZE + 4];
+        let base = backing.as_ptr() as usize;
+        let off = if base % 4 == 3 { 2 } else { 1 };
+        let Ok(sector) = <&mut [u8; SECTOR_SIZE]>::try_from(&mut backing[off..off + SECTOR_SIZE])
+        else {
+            unreachable!("[off..off + SECTOR_SIZE] fits within backing for off in 1..=2")
         };
         assert_ne!(
             sector.as_ptr() as usize % 4,

--- a/crates/thumos/src/fd.rs
+++ b/crates/thumos/src/fd.rs
@@ -1132,8 +1132,11 @@ pub(crate) fn sys_lseek(fd: u32, offset: u32, whence: u32) -> u32 {
         None => return EBADF,
     };
 
-    // WHY: offset is treated as signed (i32) for SEEK_CUR and SEEK_END.
-    let offset_signed = offset as i32;
+    // WHY: offset is treated as signed (i32) for SEEK_CUR and SEEK_END --
+    // the syscall ABI passes a signed offset as a raw u32 register value, so
+    // this is a deliberate bit-reinterpretation of a value userspace already
+    // encoded as two's-complement, not a value-preserving widen.
+    let offset_signed = offset.cast_signed();
 
     // WHY: entry.offset/file_size are inherently non-negative `usize`
     // quantities; the old blind `as i32` reinterpreted a legitimate value

--- a/crates/thumos/src/heorte.rs
+++ b/crates/thumos/src/heorte.rs
@@ -364,7 +364,10 @@ pub(crate) fn decompose_epoch(epoch: u64) -> (u8, u8, u16, u8, u8) {
 /// `year` saturates to `u16::MAX` rather than overflowing for dates far
 /// beyond the display range.
 fn civil_from_days(days: u64) -> (u16, u8, u8) {
-    let z = (days as i64).saturating_add(719_468);
+    // INVARIANT: `days` is `epoch / SECS_PER_DAY` for a `u64` epoch, so it is
+    // at most `u64::MAX / 86_400` (~2.13e14) -- far below `i64::MAX`
+    // (~9.2e18) -- so this bit-reinterpretation cannot flip sign.
+    let z = days.cast_signed().saturating_add(719_468);
     let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
     let doe = z - era * 146_097; // [0, 146096]
     let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365; // [0, 399]

--- a/crates/thumos/src/kardia.rs
+++ b/crates/thumos/src/kardia.rs
@@ -350,8 +350,13 @@ impl KernelState {
         // events to the audit trail every tick. poll() with zero configured
         // sockets is O(1), and the drain is a no-op when the event queue is
         // empty; the firewall evaluation itself is clock-free.
+        //
+        // INVARIANT: `now_ms` is a device-uptime millisecond count
+        // (tick count x TICK_MS); `i64::MAX` ms is ~292 million years of
+        // uptime, so this bit-reinterpretation (required by smoltcp's
+        // `Instant::from_millis(i64)`) cannot flip sign.
         self.net
-            .poll(crate::net::instant_from_millis(now_ms as i64));
+            .poll(crate::net::instant_from_millis(now_ms.cast_signed()));
         let Self {
             net,
             audit,

--- a/crates/thumos/src/kardia.rs
+++ b/crates/thumos/src/kardia.rs
@@ -634,7 +634,11 @@ impl KernelState {
             0x00, 0x00, // checksum
             0x00, 0x00, // urgent
         ];
-        let now = crate::net::instant_from_millis(crate::exceptions::uptime_ms() as i64);
+        // INVARIANT: `uptime_ms()` is a device-uptime millisecond count;
+        // `i64::MAX` ms is ~292 million years of uptime, so this
+        // bit-reinterpretation (required by smoltcp's
+        // `Instant::from_millis(i64)`) cannot flip sign.
+        let now = crate::net::instant_from_millis(crate::exceptions::uptime_ms().cast_signed());
         // TX drop-site: outbound eval matches the Log rule -> forwarded to the
         // loopback queue + a PacketLog event queued.
         if let Some(tx) = self.net.device_mut().transmit(now) {

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -1493,7 +1493,8 @@ pub unsafe fn run() -> ! {
                     // count; `i64::MAX` ms is ~292 million years of uptime,
                     // so this bit-reinterpretation (required by smoltcp's
                     // `Instant::from_millis(i64)`) cannot flip sign.
-                    let now = net::instant_from_millis(crate::exceptions::uptime_ms().cast_signed());
+                    let now =
+                        net::instant_from_millis(crate::exceptions::uptime_ms().cast_signed());
                     net.poll(now);
                     match dhcp.poll(&mut net) {
                         DhcpEvent::Configured(config) => {

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -1458,7 +1458,11 @@ pub unsafe fn run() -> ! {
     let mut net = {
         let device = FirewallDevice::with_default_firewall(LoopbackDevice::new());
         let mac = net::randomized_local_ethernet_address();
-        let now = net::instant_from_millis(crate::exceptions::uptime_ms() as i64);
+        // INVARIANT: `uptime_ms()` is a device-uptime millisecond count;
+        // `i64::MAX` ms is ~292 million years of uptime, so this
+        // bit-reinterpretation (required by smoltcp's
+        // `Instant::from_millis(i64)`) cannot flip sign.
+        let now = net::instant_from_millis(crate::exceptions::uptime_ms().cast_signed());
         NetworkStack::new(device, mac, now)
     };
     // WHY(qemu): a loopback DHCP/DNS self-test verifies nothing under an
@@ -1485,7 +1489,11 @@ pub unsafe fn run() -> ! {
                 let dhcp_start = crate::timer::elapsed_ms();
                 let mut configured = false;
                 while crate::timer::elapsed_ms() - dhcp_start < crate::dhcp::DHCP_TIMEOUT_MS {
-                    let now = net::instant_from_millis(crate::exceptions::uptime_ms() as i64);
+                    // INVARIANT: `uptime_ms()` is a device-uptime millisecond
+                    // count; `i64::MAX` ms is ~292 million years of uptime,
+                    // so this bit-reinterpretation (required by smoltcp's
+                    // `Instant::from_millis(i64)`) cannot flip sign.
+                    let now = net::instant_from_millis(crate::exceptions::uptime_ms().cast_signed());
                     net.poll(now);
                     match dhcp.poll(&mut net) {
                         DhcpEvent::Configured(config) => {

--- a/crates/thumos/src/mmu.rs
+++ b/crates/thumos/src/mmu.rs
@@ -1038,8 +1038,11 @@ pub fn alloc_addr_space() -> Option<usize> {
         // WHY: find first zero bit (free slot)
         let slot = (0u16..16).find(|&i| mask & (1 << i) == 0)?;
         core::ptr::write_volatile(alloc, mask | (1 << slot));
-        let table =
-            &mut (*core::ptr::addr_of_mut!(USER_TABLES))[usize::try_from(slot).unwrap_or_default()];
+        // INVARIANT: `slot` is drawn from `0u16..16`, which fits `usize` on
+        // every target this crate builds for -- `usize::from` expresses that
+        // as a type-level fact instead of a runtime check with a silent
+        // fallback.
+        let table = &mut (*core::ptr::addr_of_mut!(USER_TABLES))[usize::from(slot)];
         for entry in table.entries.iter_mut() {
             *entry = 0;
         }

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -353,7 +353,12 @@ pub(crate) fn spawn(entry_point: fn() -> !) -> Option<Pid> {
 
         // Set up initial context. First context switch exception-returns to
         // `entry` in System mode (0x1F, PL1, IRQs enabled) on the fresh stack.
-        let ctx = Context::initial(entry_point as u32, stack_top as u32, 0x1F);
+        // INVARIANT: thumos builds only for `target_pointer_width = "32"`
+        // (armv7a hardware, i686 host tests) -- a function pointer's address
+        // always fits `usize`, and `usize` and `u32` are the same width on
+        // every target this crate has, so routing the cast through `usize`
+        // first (rather than straight to `u32`) is lossless, not truncating.
+        let ctx = Context::initial(entry_point as usize as u32, stack_top as u32, 0x1F);
 
         let parent_pid = CURRENT;
         let proc = Process {
@@ -1699,7 +1704,10 @@ pub unsafe fn deliver_signal_to(pid: Pid, sig: Signal) -> u32 {
     }
     unsafe {
         let procs = &mut *addr_of_mut!(PROCS);
-        let idx = usize::try_from(pid).unwrap_or(MAX_PROCS);
+        // INVARIANT: `Pid` is `u8`, which always fits `usize` -- `usize::from`
+        // is the infallible conversion `try_from` was standing in for. The
+        // `idx >= MAX_PROCS` check below is the real bounds guard.
+        let idx = usize::from(pid);
         if idx >= MAX_PROCS {
             return ESRCH;
         }
@@ -2032,7 +2040,10 @@ pub(crate) fn check_pending_signal() -> Option<(Signal, u32)> {
 pub unsafe fn get_pending_mask(pid: Pid) -> u32 {
     unsafe {
         let procs = &*core::ptr::addr_of!(PROCS);
-        let idx = usize::try_from(pid).unwrap_or(MAX_PROCS);
+        // INVARIANT: `Pid` is `u8`, which always fits `usize` -- `usize::from`
+        // is the infallible conversion `try_from` was standing in for. The
+        // `idx >= MAX_PROCS` check below is the real bounds guard.
+        let idx = usize::from(pid);
         if idx >= MAX_PROCS {
             return 0;
         }
@@ -2048,7 +2059,10 @@ pub unsafe fn get_pending_mask(pid: Pid) -> u32 {
 pub unsafe fn get_state(pid: Pid) -> Option<State> {
     unsafe {
         let procs = &*core::ptr::addr_of!(PROCS);
-        let idx = usize::try_from(pid).unwrap_or(MAX_PROCS);
+        // INVARIANT: `Pid` is `u8`, which always fits `usize` -- `usize::from`
+        // is the infallible conversion `try_from` was standing in for. The
+        // `idx >= MAX_PROCS` check below is the real bounds guard.
+        let idx = usize::from(pid);
         if idx >= MAX_PROCS {
             return None;
         }
@@ -2070,7 +2084,10 @@ pub unsafe fn set_state(pid: Pid, state: State) {
     // reference to the static mut.
     unsafe {
         let procs = &mut *core::ptr::addr_of_mut!(PROCS);
-        let idx = usize::try_from(pid).unwrap_or(MAX_PROCS);
+        // INVARIANT: `Pid` is `u8`, which always fits `usize` -- `usize::from`
+        // is the infallible conversion `try_from` was standing in for. The
+        // `idx >= MAX_PROCS` check below is the real bounds guard.
+        let idx = usize::from(pid);
         if idx >= MAX_PROCS {
             return;
         }

--- a/crates/thumos/src/slab.rs
+++ b/crates/thumos/src/slab.rs
@@ -125,10 +125,17 @@ impl SlabClass {
         let n = page::PAGE_SIZE / self.obj_size;
         for i in (0..n).rev() {
             // SAFETY: i * obj_size < PAGE_SIZE, so offset is within the page.
-            let node_ptr = unsafe { page_ptr.add(i * self.obj_size) as *mut FreeNode };
-            // SAFETY: node_ptr is aligned to at least obj_size bytes, which is
-            // a power of two >= 32, so it satisfies FreeNode's alignment (4 bytes
-            // on ARM32).
+            //
+            // INVARIANT: `page_ptr` is the physical page address the page
+            // allocator returned, which is always `PAGE_SIZE` (4096-byte)
+            // aligned (`page::alloc_page`'s `FIRST_PAGE + page_num *
+            // PAGE_SIZE`, with `FIRST_PAGE` the SoC's fixed, page-aligned
+            // DRAM base). `self.obj_size` is one of `SLAB_SIZES` (32..=2048),
+            // always a multiple of 4, so `page_ptr + i * self.obj_size` is
+            // always a multiple of 4 -- `FreeNode`'s alignment requirement.
+            // `.cast()` keeps that a type-checked reinterpretation rather
+            // than a raw `as`.
+            let node_ptr = unsafe { page_ptr.add(i * self.obj_size).cast::<FreeNode>() };
             unsafe {
                 (*node_ptr).next = self.free_list;
             }
@@ -161,7 +168,7 @@ impl SlabClass {
         let node = self.free_list;
         self.free_list = unsafe { (*node).next };
         self.alloc_count += 1;
-        node as *mut u8
+        node.cast::<u8>()
     }
 
     /// Push `ptr` onto the free list.
@@ -185,7 +192,12 @@ impl SlabClass {
                 core::ptr::write_volatile(ptr.add(i), 0);
             }
         }
-        let node = ptr as *mut FreeNode;
+        // INVARIANT: `ptr` was returned by `alloc_obj` on this class per this
+        // function's own contract, so it traces back to the page-aligned,
+        // obj_size-multiple offset `refill` establishes (see that
+        // function's comment) -- `.cast()` keeps the reinterpretation
+        // type-checked instead of re-deriving alignment by hand.
+        let node = ptr.cast::<FreeNode>();
         unsafe {
             (*node).next = self.free_list;
         }

--- a/crates/thumos/src/syscall.rs
+++ b/crates/thumos/src/syscall.rs
@@ -1141,8 +1141,10 @@ fn sys_mmap(arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> u32 {
     let prot_flags = arg2;
     let flags = arg3 & 0xFFFF;
     let fd_raw = (arg3 >> 16) as u16;
-    // Interpret fd as i16: 0xFFFF = -1
-    let fd = fd_raw as i16;
+    // Interpret fd as i16: 0xFFFF = -1 -- a deliberate bit-reinterpretation
+    // of the packed ABI field (see the arg3 packing note above), not a
+    // value-preserving widen.
+    let fd = fd_raw.cast_signed();
 
     // Validate: length must be non-zero
     if length == 0 {

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -106,7 +106,7 @@ mechanism = "host"
 
 [[module]]
 name = "clock"
-tests = 17
+tests = 18
 mechanism = "both"
 witness = "boot.sh"
 
@@ -191,7 +191,7 @@ fidelity = "loader correctness against real page tables is witness-only (exec/fo
 
 [[module]]
 name = "emmc"
-tests = 41
+tests = 42
 mechanism = "both"
 witness = "boot.sh"
 fidelity = "driver register paths are hardware-gated; host tests cover protocol logic"


### PR DESCRIPTION
Finishes the read-and-decide pass over #672's cast/conversion class (the ~20 non-style clippy findings). Continues from `5881fdf`, which had already completed most of the crate despite its own commit message undersaying that — every claimed-unread site was re-verified against the current tree and its actual callers before this PR touched anything.

## Every site

| file:line | value | case | disposition |
|---|---|---|---|
| `slab.rs` (`refill`, `alloc_obj`, `dealloc_obj`) | `*mut u8` -> `*mut FreeNode` (page-carved slab object pointer) | sound but unjustified | `INVARIANT` (traced to `page::alloc_page`'s page-aligned return + `SLAB_SIZES`' 4-byte-multiple sizes) + `.cast()` replacing raw `as` |
| `clock.rs::get_wall_clock` (`monotonic_secs`) | `u64` -> `i64` (device uptime, seconds) | sound but unjustified | `INVARIANT` (i64::MAX seconds is ~292B years of uptime) + `.cast_signed()`/`.cast_unsigned()` |
| **`clock.rs::calculate_ntp_offset`** | `u64` -> `i64` ×2 (`local_send_secs`, `server_transmit_epoch`) | **real defect** — no wired-in caller yet (#145) bounds `local_send_secs`, and `server_transmit_epoch` is meant to carry a network-parsed NTP value; a bare `as i64` silently flips sign for input ≥ 2^63 | checked widening (`try_from` + stated saturation bound) + `saturating_sub` — well-defined for every `u64` input, not just what an unwritten caller happens to pass. **Test added** (fails under the old `as i64` behavior) |
| `emmc.rs::read_sector` | `*mut u8` -> `*mut u32` (PIO buffer, DMA-adjacent) | **real defect** — neither real caller (`block.rs`'s slice-derived `sector_buf`, `gpt.rs`'s stack-local array) guarantees 4-byte alignment; armv7a data-aborts on the misaligned access, i686 host tolerates it silently | removed the pointer cast entirely; byte-level little-endian store via extracted `store_word_le`. **Test added**: deliberately-misaligned buffer, round-trips every word |
| `emmc.rs::write_sector` | `*const u8` -> `*const u32` | **real defect** — same as above | byte-level LE load via extracted `load_word_le`. Same regression test covers both |
| `fd.rs::sys_lseek` (`offset_signed`) | `u32` -> `i32` | sound but unjustified — deliberate ABI bit-reinterpretation (userspace already encoded the offset two's-complement) | `.cast_signed()` + `WHY` |
| `fd.rs::sys_lseek` (`file_size`, `current`) | `usize` -> `i64` | already fixed (pre-#672, issue #282) — the old blind `as i32` had reinterpreted a legitimate ≥2^31 value as negative | `try_from` + `unwrap_or(i64::MAX)` + `saturating_add` + explicit `MAX_REPRESENTABLE_POS` bound check (unmodified by this PR; re-verified sound) |
| `heorte.rs::civil_from_days` | `u64` -> `i64` (`days` since epoch) | sound but unjustified | `INVARIANT` (`u64::MAX / 86_400` ≈ 2.13e14, far below i64::MAX) + `.cast_signed()` |
| `kardia.rs::KernelState::poll` (`now_ms`) | `u64` -> `i64` | sound but unjustified | `INVARIANT` (same uptime-bound reasoning) + `.cast_signed()` |
| **`kardia.rs::firewall_boot_smoke`** | `u64` -> `i64` (`uptime_ms()`) | sound but unjustified — **missed by the prior pass**: sits behind `#[cfg(feature = "qemu")]`, and the clippy run that produced #672's site list didn't build with that feature, so it was invisible to it despite being the identical pattern 283 lines from its already-fixed neighbor | same `INVARIANT` + `.cast_signed()` (this PR) |
| `kinit.rs::run` (×2, DHCP loop `now`) | `u64` -> `i64` | sound but unjustified | `INVARIANT` + `.cast_signed()` |
| `mmu.rs::alloc_addr_space` (`slot`) | `u16` -> `usize` | fallible conversion where infallible exists | `usize::from(slot)` replacing `try_from(...).unwrap_or_default()` — also closes a latent silent-wrong-table-index fallback (a failed `try_from` would previously have silently corrupted slot 0's table) |
| `process.rs::spawn` (`entry_point`) | `fn() -> !` pointer -> `u32` | sound but unjustified | `INVARIANT` (crate builds only for `target_pointer_width = "32"` — verified: only `armv7a-none-eabi` + `i686-unknown-linux-gnu` exist in CI/`.cargo/config.toml`) + cast routed through `usize` |
| `process.rs::deliver_signal_to`, `get_pending_mask`, `get_state`, `set_state` | `Pid` (`u8`) -> `usize` (×4) | fallible conversion where infallible exists | `usize::from(pid)` replacing `try_from(...).unwrap_or(MAX_PROCS)`; the existing `idx >= MAX_PROCS` check remains the real bounds guard |
| `syscall.rs::sys_mmap` (`fd`) | `u16` -> `i16` | sound but unjustified — deliberate ABI bit-reinterpretation of the packed `arg3` field | `.cast_signed()` + `WHY` |

Bold rows are this PR's work; the rest is `5881fdf`, re-verified against current callers (not re-fixed).

## Tests

- `clock.rs::calculate_ntp_offset_saturates_instead_of_wrapping_sign` — `calculate_ntp_offset(u64::MAX, 0)` under the old code returned `+1` (bit-flip cancels the subtraction sign); asserts it now saturates negative instead. Symmetric out-of-range-server case included.
- `emmc.rs::sector_word_roundtrip_is_correct_and_alignment_independent` — forces a one-byte-padded, non-4-aligned buffer and round-trips all 128 words through `store_word_le`/`load_word_le`, plus an explicit little-endian wire-order check. (A host test can't reproduce the armv7a data abort itself — i686 tolerates unaligned access, which is why this class hides on the host in the first place — but it pins the byte-order and alignment-independence contract so a refactor can't quietly reintroduce a typed pointer over the buffer.)
- `docs/target-test-ledger.toml`: `clock` 17→18, `emmc` 41→42 tests, to match.

## Also in this PR

- `cargo fmt --manifest-path crates/thumos/Cargo.toml` — the kernel crate is excluded from the workspace, so `cargo fmt --all` never reaches it. The salvaged `5881fdf` left one `kinit.rs` line unformatted; the build-box gate caught it as a KFMT-only red before any other stage ran. Fixed.

## Checked, not filed

- `syscall.rs::dispatch`'s `Syscall::Uptime => uptime_ms() as u32` truncates uptime to a ~49.7-day range. Not flagged by any lint this crate denies (`cast_possible_truncation` isn't in the deny set) and not part of #672's list. Reads as a deliberate 32-bit-ABI register-width tradeoff (the syscall has one `u32` return register; `ClockGettime` is the full-precision path) rather than an oversight — not filed.
- `fm_radio.rs::seek_step`'s `u32 -> i32` casts sit behind the same `#[cfg(feature = "qemu")]` gate that hid `kardia.rs::firewall_boot_smoke`, but are trivially bounded by two compile-time FM-band constants (span ≈ 20,500, nowhere near `i32::MAX`) — safe as-is, left untouched.
- `process.rs`'s other `entry as u32` site (line ~598, `usize` not a function pointer) is the same always-lossless 32-bit-only-target conversion as the fixed `spawn` site, just not flagged by any enabled lint. No action needed.

No `#[allow(...)]` was added anywhere in this PR or its predecessor.

Refs #672
