### PR TITLE
fix(kernel): give must-use attributes real messages or drop them

### DIFF
--- a/crates/thumos/src/audit.rs
+++ b/crates/thumos/src/audit.rs
@@ -332,7 +332,6 @@ impl AuditLog {
     /// `entries` is built element-by-element into a heap-allocated `Vec`
     /// and converted to a boxed slice, so the ~64 KiB backing storage is
     /// never materialized as a single stack frame (#297).
-    #[must_use]
     pub(crate) fn new() -> Self {
         let mut entries = Vec::with_capacity(MAX_ENTRIES);
         for _ in 0..MAX_ENTRIES {
@@ -495,7 +494,6 @@ impl AuditLog {
     /// array.
     ///
     /// To iterate in order: process `older` first, then `newer`.
-    #[must_use]
     pub(crate) fn recent(&self, n: usize) -> (&[AuditEntry], &[AuditEntry]) {
         if self.count == 0 || n == 0 {
             return (&[], &[]);

--- a/crates/thumos/src/block.rs
+++ b/crates/thumos/src/block.rs
@@ -215,7 +215,6 @@ impl MemBlockDevice {
     /// # Errors
     ///
     /// Returns [`BlockError::InvalidArgument`] if `sector_count` is zero.
-    #[must_use]
     pub(crate) fn new(sector_count: u64) -> Result<Self, BlockError> {
         if sector_count == 0 {
             return Err(BlockError::InvalidArgument);
@@ -498,7 +497,6 @@ pub(crate) use msdc_wrapper::{MsdcBlockDevice, MsdcBlockDeviceUninit};
 ///
 /// Returns [`BlockError`] if the underlying sector read fails or the
 /// block address is out of bounds.
-#[must_use]
 pub(crate) fn read_block(
     dev: &dyn BlockDevice,
     block_num: u64,
@@ -517,7 +515,6 @@ pub(crate) fn read_block(
 ///
 /// Returns [`BlockError`] if the underlying sector write fails or the
 /// block address is out of bounds.
-#[must_use]
 pub(crate) fn write_block(
     dev: &mut dyn BlockDevice,
     block_num: u64,

--- a/crates/thumos/src/bluetooth.rs
+++ b/crates/thumos/src/bluetooth.rs
@@ -535,7 +535,6 @@ impl<H: BtHwOps> BtAdapter<H> {
     /// Initialize the BT adapter: power on, HCI reset, set random address.
     ///
     /// Transitions from `Off` to `Ready` on success, or to `Error` on failure.
-    #[must_use]
     pub(crate) fn init(&mut self, current_tick_ms: u64) -> Result<(), BtError> {
         if self.state != BtState::Off {
             return Err(BtError::InvalidState);
@@ -583,7 +582,6 @@ impl<H: BtHwOps> BtAdapter<H> {
     /// address and rotation timestamp are committed only after the hardware
     /// write succeeds, so a rejected/failed write leaves state unchanged and
     /// eligible for retry on the next call.
-    #[must_use]
     pub(crate) fn maybe_rotate_address(&mut self, current_tick_ms: u64) -> Result<bool, BtError> {
         if !matches!(self.state, BtState::Ready | BtState::Scanning) {
             return Ok(false);
@@ -620,7 +618,6 @@ impl<H: BtHwOps> BtAdapter<H> {
     /// Start a BLE passive scan.
     ///
     /// Sets scan parameters (passive, random address, accept all) then enables scanning.
-    #[must_use]
     pub(crate) fn start_scan(&mut self) -> Result<(), BtError> {
         match self.state {
             BtState::Ready => {}
@@ -644,7 +641,6 @@ impl<H: BtHwOps> BtAdapter<H> {
     }
 
     /// Stop the BLE passive scan.
-    #[must_use]
     pub(crate) fn stop_scan(&mut self) -> Result<(), BtError> {
         if self.state != BtState::Scanning {
             return Err(BtError::InvalidState);

--- a/crates/thumos/src/bt_audio.rs
+++ b/crates/thumos/src/bt_audio.rs
@@ -241,7 +241,6 @@ impl<H: BtHwOps> A2dpProfile<H> {
     ///   SBC parameters once signaling has started would silently diverge the
     ///   local encoder from the format already negotiated with the peer via
     ///   `SetConfiguration`.
-    #[must_use]
     pub(crate) fn configure(&mut self, sample_rate: u32, channels: u8) -> Result<(), BtAudioError> {
         if self.state != A2dpState::Disconnected {
             return Err(BtAudioError::InvalidState);
@@ -279,7 +278,6 @@ impl<H: BtHwOps> A2dpProfile<H> {
     /// - [`BtAudioError::InvalidState`] -- not in Disconnected state.
     /// - [`BtAudioError::NoPeer`] -- no peer address configured.
     /// - [`BtAudioError::HciError`] -- HCI send failed.
-    #[must_use]
     pub(crate) fn connect(&mut self, now_ms: u64) -> Result<(), BtAudioError> {
         if self.state != A2dpState::Disconnected {
             return Err(BtAudioError::InvalidState);
@@ -335,7 +333,6 @@ impl<H: BtHwOps> A2dpProfile<H> {
     /// - [`BtAudioError::InvalidState`] -- not in Connecting state.
     /// - [`BtAudioError::AvdtpError`] -- unknown or unexpected signal ID.
     /// - [`BtAudioError::HciError`] -- HCI send failed.
-    #[must_use]
     pub(crate) fn advance_signaling(&mut self, signal: u8) -> Result<(), BtAudioError> {
         if !matches!(self.state, A2dpState::Connecting | A2dpState::Connected) {
             return Err(BtAudioError::InvalidState);
@@ -420,7 +417,6 @@ impl<H: BtHwOps> A2dpProfile<H> {
     /// - [`BtAudioError::SbcError`] -- SBC encoding failed.
     /// - [`BtAudioError::BufferTooSmall`] -- internal frame buffer too small.
     /// - [`BtAudioError::HciError`] -- HCI send failed.
-    #[must_use]
     pub(crate) fn send_audio(&mut self, pcm: &[i16]) -> Result<usize, BtAudioError> {
         if self.state != A2dpState::Streaming {
             return Err(BtAudioError::InvalidState);
@@ -450,7 +446,6 @@ impl<H: BtHwOps> A2dpProfile<H> {
     ///
     /// - [`BtAudioError::InvalidState`] -- not in Streaming state.
     /// - [`BtAudioError::HciError`] -- HCI send failed.
-    #[must_use]
     pub(crate) fn suspend(&mut self) -> Result<(), BtAudioError> {
         if self.state != A2dpState::Streaming {
             return Err(BtAudioError::InvalidState);
@@ -480,7 +475,6 @@ impl<H: BtHwOps> A2dpProfile<H> {
     ///
     /// - [`BtAudioError::InvalidState`] -- not in Connected state.
     /// - [`BtAudioError::HciError`] -- HCI send failed.
-    #[must_use]
     pub(crate) fn resume(&mut self) -> Result<(), BtAudioError> {
         if self.state != A2dpState::Connected {
             return Err(BtAudioError::InvalidState);

--- a/crates/thumos/src/ccci_logger.rs
+++ b/crates/thumos/src/ccci_logger.rs
@@ -174,7 +174,6 @@ impl CcciLogger {
     ///
     /// Returns a pair of slices `(older, newer)` due to the ring buffer
     /// potentially wrapping.
-    #[must_use]
     pub(crate) fn entries(&self) -> (&[CcciLogEntry], &[CcciLogEntry]) {
         if self.count == 0 {
             return (&[], &[]);
@@ -358,7 +357,6 @@ impl fmt::Display for ModemBaseline {
 ///
 /// * `log` -- the CCCI traffic logger with recorded entries
 /// * `window_end_ms` -- the end timestamp of the 60s baseline window
-#[must_use]
 pub(crate) fn build_baseline(log: &CcciLogger, window_end_ms: u64) -> ModemBaseline {
     let window_start = window_end_ms.saturating_sub(BASELINE_WINDOW_MS);
 
@@ -789,7 +787,6 @@ impl CcciFirewall {
     }
 
     /// Current firewall mode.
-    #[must_use]
     pub(crate) fn mode(&self) -> FirewallMode {
         self.mode
     }

--- a/crates/thumos/src/contacts.rs
+++ b/crates/thumos/src/contacts.rs
@@ -99,7 +99,6 @@ impl Contact {
     /// byte outside the GSM dial-string charset (an empty `number` is
     /// valid -- Matrix-only contacts have no phone number). A rejected
     /// number is never truncated-and-stored: reject, don't sanitize.
-    #[must_use]
     pub(crate) fn new(name: &str, number: &str) -> Result<Self, ContactError> {
         if !number
             .bytes()
@@ -142,7 +141,6 @@ impl Contact {
     ///
     /// Returns [`ContactError::InvalidNumber`] under the same condition as
     /// [`Contact::new`].
-    #[must_use]
     pub(crate) fn with_matrix_id(
         name: &str,
         number: &str,

--- a/crates/thumos/src/dhcp.rs
+++ b/crates/thumos/src/dhcp.rs
@@ -131,7 +131,7 @@ impl DhcpClient {
     ///
     /// Returns `Err(DhcpError::SocketSetFull)` if the socket set has
     /// reached [`MAX_SOCKETS`].
-    #[must_use]
+    #[must_use = "store the returned client; dropping it orphans its socket in `stack` with no handle left to reclaim the slot"]
     pub(crate) fn new<D: Device>(stack: &mut NetworkStack<D>) -> Result<Self, DhcpError> {
         if stack.socket_count() >= MAX_SOCKETS {
             return Err(DhcpError::SocketSetFull);

--- a/crates/thumos/src/dns.rs
+++ b/crates/thumos/src/dns.rs
@@ -518,7 +518,6 @@ impl DnsResolver {
     /// This is a non-blocking "start resolve" — the caller must poll the
     /// network stack and call [`poll_resolve`](Self::poll_resolve) to
     /// check for results, since bare-metal kernels cannot block on I/O.
-    #[must_use]
     pub(crate) fn resolve<D: Device>(
         &mut self,
         _stack: &mut NetworkStack<D>,
@@ -551,7 +550,6 @@ impl DnsResolver {
     /// Returns the wire-format bytes and the transaction ID. The caller
     /// is responsible for sending this via a UDP socket to the
     /// appropriate DNS server on port 53.
-    #[must_use]
     pub(crate) fn build_query(&mut self, hostname: &str) -> Result<(Vec<u8>, u16), DnsError> {
         let txid = random_txid();
         let packet = build_dns_query(hostname, txid)?;
@@ -561,7 +559,6 @@ impl DnsResolver {
     /// Process a DNS response and cache the result.
     ///
     /// Returns the resolved address on success.
-    #[must_use]
     pub(crate) fn process_response(
         &mut self,
         hostname: &str,

--- a/crates/thumos/src/dns_tls.rs
+++ b/crates/thumos/src/dns_tls.rs
@@ -169,7 +169,6 @@ pub(crate) trait TlsTransport {
 ///
 /// Returns the framed message or `DotError::MessageTooLarge` if the
 /// DNS message exceeds `MAX_DNS_MESSAGE_SIZE`.
-#[must_use]
 pub(crate) fn frame_dns_message(dns_message: &[u8]) -> Result<Vec<u8>, DotError> {
     if dns_message.len() > MAX_DNS_MESSAGE_SIZE {
         return Err(DotError::MessageTooLarge);
@@ -194,7 +193,6 @@ pub(crate) fn parse_frame_length(header: &[u8; 2]) -> u16 {
 ///
 /// Reads the 2-byte length prefix, then reads the DNS message body.
 /// Returns the DNS message payload (without the length prefix).
-#[must_use]
 pub(crate) fn read_dot_frame<T: TlsTransport>(
     transport: &mut T,
     deadline_ms: u64,
@@ -246,7 +244,6 @@ pub(crate) fn read_dot_frame<T: TlsTransport>(
 ///
 /// Returns the wire-format query bytes and the transaction ID.
 /// The query has flags RD=1 (recursion desired), QDCOUNT=1.
-#[must_use]
 pub(crate) fn build_dns_query(hostname: &str, txid: u16) -> Result<Vec<u8>, DotError> {
     if hostname.is_empty() {
         return Err(DotError::InvalidName);
@@ -295,7 +292,6 @@ pub(crate) fn build_dns_query(hostname: &str, txid: u16) -> Result<Vec<u8>, DotE
 /// Build a DNS query for an arbitrary record type.
 ///
 /// Like `build_dns_query` but accepts a custom record type value.
-#[must_use]
 pub(crate) fn build_dns_query_typed(
     hostname: &str,
     txid: u16,
@@ -435,7 +431,6 @@ impl<T: TlsTransport> DotClient<T> {
     ///
     /// Returns `Ok(())` if the hashes match, or
     /// `Err(DotError::PinMismatch)` if they differ.
-    #[must_use]
     pub(crate) fn verify_server_pin(
         &self,
         received_spki: &[u8; SPKI_HASH_LEN],
@@ -452,7 +447,6 @@ impl<T: TlsTransport> DotClient<T> {
     /// Builds a DNS A query, wraps it in a `DoT` frame, sends it over
     /// the TLS transport, reads the response frame, and returns the
     /// raw DNS response message.
-    #[must_use]
     pub(crate) fn query(
         &mut self,
         name: &str,
@@ -497,7 +491,6 @@ impl<T: TlsTransport> DotClient<T> {
     /// Send a raw DNS message over `DoT` and return the raw response.
     ///
     /// The caller is responsible for building and parsing the DNS message.
-    #[must_use]
     pub(crate) fn send_raw(
         &mut self,
         dns_message: &[u8],

--- a/crates/thumos/src/ekphrasis.rs
+++ b/crates/thumos/src/ekphrasis.rs
@@ -258,7 +258,6 @@ pub struct WsFrame {
 
 impl WsFrame {
     /// Create a new frame with the given opcode and payload.
-    #[must_use]
     pub(crate) fn new(opcode: WsOpcode, payload: Vec<u8>) -> Self {
         Self { opcode, payload }
     }
@@ -284,7 +283,6 @@ impl fmt::Display for WsFrame {
 /// - [`EkphrasisError::Incomplete`] if the buffer doesn't contain a full frame.
 /// - [`EkphrasisError::InvalidFrame`] if the opcode is unknown.
 /// - [`EkphrasisError::PayloadTooLarge`] if the payload exceeds the limit.
-#[must_use]
 pub(crate) fn parse_ws_frame(data: &[u8]) -> Result<(WsFrame, usize), EkphrasisError> {
     // Minimum frame size: 2 bytes (FIN+opcode, MASK+payload-len).
     if data.len() < 2 {
@@ -437,7 +435,6 @@ fn contains_control_byte(s: &str) -> bool {
 /// Returns [`EkphrasisError::InvalidUpgradeParam`] if `host` or `ws_key`
 /// contains a control character (CR, LF, NUL, etc.) that could corrupt
 /// the HTTP request line or inject additional headers.
-#[must_use]
 pub(crate) fn build_ws_upgrade(
     host: &str,
     path: &str,
@@ -586,7 +583,6 @@ pub struct AudioCaptureConfig {
 
 impl AudioCaptureConfig {
     /// Configuration for STT audio capture (16 kHz, mono, 16-bit PCM).
-    #[must_use]
     pub(crate) const fn stt_default() -> Self {
         Self {
             sample_rate_hz: AUDIO_SAMPLE_RATE_HZ,
@@ -1012,7 +1008,6 @@ impl Ekphrasis {
     }
 
     /// Return a reference to the current state.
-    #[must_use]
     pub(crate) fn state(&self) -> &EkphrasisState {
         &self.state
     }
@@ -1030,7 +1025,6 @@ impl Ekphrasis {
     }
 
     /// Return the audio capture configuration.
-    #[must_use]
     pub(crate) fn capture_config(&self) -> AudioCaptureConfig {
         self.capture_config
     }
@@ -1116,7 +1110,6 @@ pub struct ActionProposal {
 
 impl ActionProposal {
     /// Create a new action proposal.
-    #[must_use]
     pub(crate) fn new(action: String, params: Vec<(String, String)>, description: String) -> Self {
         Self {
             action,

--- a/crates/thumos/src/gps.rs
+++ b/crates/thumos/src/gps.rs
@@ -258,7 +258,6 @@ impl GpsTime {
 /// Returns `GpsError::ChecksumMismatch` if the checksum is invalid.
 /// Returns `GpsError::NoFix` if fix quality is 0 or an undefined code.
 /// Returns `GpsError::ParseError` if the sentence cannot be parsed.
-#[must_use]
 pub(crate) fn parse_gga(sentence: &[u8]) -> Result<GpsPosition, GpsError> {
     Ok(topos_core::parse_gga(sentence)?.into())
 }
@@ -270,7 +269,6 @@ pub(crate) fn parse_gga(sentence: &[u8]) -> Result<GpsPosition, GpsError> {
 /// Returns `GpsError::ChecksumMismatch` if the checksum is invalid.
 /// Returns `GpsError::NoFix` if status is 'V' (void).
 /// Returns `GpsError::ParseError` if the sentence cannot be parsed.
-#[must_use]
 pub(crate) fn parse_rmc(sentence: &[u8]) -> Result<(GpsPosition, GpsTime), GpsError> {
     let (fix, time) = topos_core::parse_rmc(sentence)?;
     Ok((fix.into(), time.into()))
@@ -453,7 +451,6 @@ impl<H: GpsHwOps> GpsReceiver<H> {
     }
 
     /// Initialize the GPS receiver: power on and begin searching.
-    #[must_use]
     pub(crate) fn init(&mut self) -> Result<(), GpsError> {
         if self.state != GpsState::Off {
             return Err(GpsError::InvalidState);
@@ -515,7 +512,6 @@ impl<H: GpsHwOps> GpsReceiver<H> {
     /// Clears the last known position/time fix and any partially
     /// accumulated NMEA bytes so a subsequent `init()` does not resume
     /// with stale data left over from before shutdown.
-    #[must_use]
     pub(crate) fn shutdown(&mut self) -> Result<(), GpsError> {
         self.hw.power_off()?;
         self.state = GpsState::Off;

--- a/crates/thumos/src/harmostes.rs
+++ b/crates/thumos/src/harmostes.rs
@@ -437,7 +437,6 @@ impl MatrixClient {
     // -----------------------------------------------------------------------
 
     /// Return the list of tracked rooms.
-    #[must_use]
     pub(crate) fn rooms(&self) -> &[Room] {
         &self.rooms
     }
@@ -497,7 +496,6 @@ impl MatrixClient {
     }
 
     /// Return the current outbox contents.
-    #[must_use]
     pub(crate) fn outbox(&self) -> &[PendingMessage] {
         &self.outbox
     }

--- a/crates/thumos/src/http_client.rs
+++ b/crates/thumos/src/http_client.rs
@@ -231,7 +231,6 @@ impl HttpRequest {
     ///
     /// Returns [`HttpError::EmptyHost`] if `self.host` is empty, or
     /// [`HttpError::EmptyPath`] if `self.path` is empty.
-    #[must_use]
     pub(crate) fn build_raw(&self) -> Result<Vec<u8>, HttpError> {
         if self.host.is_empty() {
             return Err(HttpError::EmptyHost);
@@ -359,7 +358,6 @@ impl HttpResponse {
     /// - [`HttpError::InvalidContentLength`] — Content-Length is not a
     ///   valid number.
     /// - [`HttpError::BodyTooLarge`] — body exceeds [`MAX_BODY_SIZE`].
-    #[must_use]
     pub(crate) fn parse(data: &[u8]) -> Result<Self, HttpError> {
         // Find the end of the header block: \r\n\r\n.
         let header_end = find_header_end(data).ok_or(HttpError::Incomplete)?;

--- a/crates/thumos/src/json_mini.rs
+++ b/crates/thumos/src/json_mini.rs
@@ -456,7 +456,6 @@ impl<'a> JsonParser<'a> {
     ///
     /// Returns [`JsonError`] if the input is not valid JSON (within
     /// the subset we support).
-    #[must_use]
     pub(crate) fn parse(data: &'a [u8]) -> Result<JsonValue, JsonError> {
         let mut parser = Self {
             data,

--- a/crates/thumos/src/lfs.rs
+++ b/crates/thumos/src/lfs.rs
@@ -401,7 +401,6 @@ pub(crate) struct Lfs {
 ///
 /// - [`LfsError::BlockIo`] if any block write fails.
 /// - [`LfsError::InvalidSuperblock`] if the device is too small.
-#[must_use]
 pub(crate) fn format(dev: &mut dyn BlockDevice) -> Result<(), LfsError> {
     let total_sectors = dev.sector_count();
     let total_blocks = total_sectors / SECTORS_PER_BLOCK as u64;
@@ -512,7 +511,6 @@ pub(crate) fn format(dev: &mut dyn BlockDevice) -> Result<(), LfsError> {
 /// - [`LfsError::InvalidSuperblock`] if the superblock magic/version is wrong.
 /// - [`LfsError::Corrupt`] if neither checkpoint is valid.
 /// - [`LfsError::BlockIo`] if any block read fails.
-#[must_use]
 pub(crate) fn mount(mut dev: Box<dyn BlockDevice>) -> Result<Lfs, LfsError> {
     let mut cache = BlockCache::new();
 

--- a/crates/thumos/src/lfs_checkpoint.rs
+++ b/crates/thumos/src/lfs_checkpoint.rs
@@ -98,7 +98,6 @@ impl CheckpointHeader {
     /// # Errors
     ///
     /// Returns [`LfsError::Corrupt`] if the magic number does not match.
-    #[must_use]
     pub(crate) fn from_block(buf: &[u8; BLOCK_SIZE]) -> Result<Self, LfsError> {
         if buf.len() < HEADER_SERIALIZED_SIZE {
             return Err(LfsError::Corrupt);

--- a/crates/thumos/src/lfs_imap.rs
+++ b/crates/thumos/src/lfs_imap.rs
@@ -180,7 +180,6 @@ impl LfsImap {
     /// Returns [`LfsError::Corrupt`] if the buffer is too short, contains
     /// invalid data, or any entry's block number is inside the reserved
     /// segment 0 or `>= device_blocks`.
-    #[must_use]
     pub(crate) fn deserialize(
         buf: &[u8],
         segment_size: u32,

--- a/crates/thumos/src/lfs_writer.rs
+++ b/crates/thumos/src/lfs_writer.rs
@@ -60,7 +60,7 @@ impl LfsWriter {
     /// # Errors
     ///
     /// Returns [`LfsError::NoFreeSegments`] if no segments are available.
-    #[must_use]
+    #[must_use = "store the returned writer; dropping it leaks the allocated segment in `seg_mgr`, which only this writer can `free`"]
     pub(crate) fn new(seg_mgr: &mut LfsSegmentManager) -> Result<Self, LfsError> {
         let seg = seg_mgr.allocate().ok_or(LfsError::NoFreeSegments)?;
         Ok(Self {

--- a/crates/thumos/src/matrix_crypto.rs
+++ b/crates/thumos/src/matrix_crypto.rs
@@ -406,7 +406,6 @@ impl MatrixCrypto {
     }
 
     /// Return a reference to this device's identity keys.
-    #[must_use]
     pub(crate) fn device_keys(&self) -> &DeviceKeys {
         &self.device_keys
     }
@@ -418,19 +417,16 @@ impl MatrixCrypto {
     }
 
     /// Return the outbound Megolm sessions.
-    #[must_use]
     pub(crate) fn megolm_outbound(&self) -> &[MegolmSession] {
         &self.megolm_outbound
     }
 
     /// Return the inbound Megolm sessions.
-    #[must_use]
     pub(crate) fn megolm_inbound(&self) -> &[MegolmSession] {
         &self.megolm_inbound
     }
 
     /// Return the active Olm sessions.
-    #[must_use]
     pub(crate) fn olm_sessions(&self) -> &[OlmSession] {
         &self.olm_sessions
     }

--- a/crates/thumos/src/net.rs
+++ b/crates/thumos/src/net.rs
@@ -601,7 +601,6 @@ impl<D: Device> NetworkStack<D> {
     /// Set the default IPv4 gateway for the interface.
     ///
     /// Returns `Err(NetError::RouteTableFull)` if the route table is full.
-    #[must_use]
     pub(crate) fn set_default_gateway(&mut self, gateway: Ipv4Address) -> Result<(), NetError> {
         self.iface
             .routes_mut()
@@ -614,7 +613,7 @@ impl<D: Device> NetworkStack<D> {
     ///
     /// Returns `Err(NetError::SocketSetFull)` if [`MAX_SOCKETS`] has been
     /// reached.
-    #[must_use]
+    #[must_use = "pass the handle to `remove_socket` when done, or the slot leaks until reboot"]
     pub(crate) fn add_tcp_socket(&mut self) -> Result<SocketHandle, NetError> {
         if self.socket_count >= MAX_SOCKETS {
             return Err(NetError::SocketSetFull);
@@ -631,7 +630,7 @@ impl<D: Device> NetworkStack<D> {
     ///
     /// Returns `Err(NetError::SocketSetFull)` if [`MAX_SOCKETS`] has been
     /// reached.
-    #[must_use]
+    #[must_use = "pass the handle to `remove_socket` when done, or the slot leaks until reboot"]
     pub(crate) fn add_udp_socket(&mut self) -> Result<SocketHandle, NetError> {
         if self.socket_count >= MAX_SOCKETS {
             return Err(NetError::SocketSetFull);

--- a/crates/thumos/src/nous.rs
+++ b/crates/thumos/src/nous.rs
@@ -260,7 +260,6 @@ pub enum CapabilityPreset {
 
 impl CapabilityPreset {
     /// The capability set this preset constructs (design table, verbatim).
-    #[must_use]
     pub(crate) const fn grants(self) -> CapabilitySet {
         const RS: u32 = 1 << NousCapability::ReadState as u32;
         const RCM: u32 = 1 << NousCapability::ReadContactsMetadata as u32;
@@ -291,7 +290,6 @@ impl CapabilityPreset {
     }
 
     /// The preset whose constructor produces `set`, or `Custom`.
-    #[must_use]
     pub(crate) fn of(set: &CapabilitySet) -> Self {
         for preset in [
             Self::Off,
@@ -314,7 +312,6 @@ impl CapabilityPreset {
     /// explicit opt-in confirmation, not a dial step. `Custom` and
     /// `Autonomous` cycle back to `Off` (re-entering the ladder re-selects
     /// a preset constructor).
-    #[must_use]
     pub(crate) const fn next_grantable(self) -> Self {
         match self {
             Self::Off => Self::Observer,
@@ -666,13 +663,11 @@ impl NousEntity {
     }
 
     /// The entity's capability set (read-only view).
-    #[must_use]
     pub(crate) const fn grants(&self) -> &CapabilitySet {
         &self.grants
     }
 
     /// The preset matching this entity's current set, or `Custom` (#552).
-    #[must_use]
     pub(crate) fn preset(&self) -> CapabilityPreset {
         CapabilityPreset::of(&self.grants)
     }

--- a/crates/thumos/src/provision.rs
+++ b/crates/thumos/src/provision.rs
@@ -286,7 +286,6 @@ impl Provisioner {
     }
 
     /// Current provisioning state.
-    #[must_use]
     pub(crate) fn state(&self) -> &ProvisionState {
         &self.state
     }
@@ -308,7 +307,6 @@ impl Provisioner {
     /// Returns the new state after processing. The caller should keep
     /// feeding data until the state is [`ProvisionState::Complete`] or
     /// [`ProvisionState::Error`].
-    #[must_use]
     pub(crate) fn receive_chunk(&mut self, data: &[u8]) -> &ProvisionState {
         // Don't accept data in terminal states.
         match &self.state {

--- a/crates/thumos/src/screen_messages.rs
+++ b/crates/thumos/src/screen_messages.rs
@@ -93,7 +93,6 @@ impl MessageTransport {
     ///
     /// Cycles through: Sms -> Matrix -> Briar -> Meshtastic ->
     /// `BridgedWhatsApp` -> `BridgedSlack` -> `BridgedTelegram` -> Sms.
-    #[must_use]
     pub(crate) const fn next(self) -> Self {
         match self {
             Self::Sms => Self::Matrix,

--- a/crates/thumos/src/sms.rs
+++ b/crates/thumos/src/sms.rs
@@ -369,7 +369,6 @@ impl SmsManager {
     /// - [`SmsError::PduDecode`] -- PDU is truncated or malformed.
     /// - [`SmsError::UnsupportedDcs`] -- PDU is well-formed but uses a data
     ///   coding scheme other than GSM-7 (0x00).
-    #[must_use]
     pub(crate) fn handle_incoming(pdu_data: &[u8]) -> Result<SmsMessage, SmsError> {
         let mut cur = Cursor::new(pdu_data);
 

--- a/crates/thumos/src/vfs.rs
+++ b/crates/thumos/src/vfs.rs
@@ -352,7 +352,6 @@ impl MountTable {
     ///   a non-root path with a trailing `/`.
     /// - `VfsError::AlreadyExists` if the path is already mounted.
     /// - `VfsError::NoSpace` if all mount slots are occupied.
-    #[must_use]
     pub(crate) fn mount(&mut self, path: &str, fs: Box<dyn Filesystem>) -> Result<(), VfsError> {
         if !path.starts_with('/') {
             return Err(VfsError::InvalidPath);
@@ -499,7 +498,6 @@ impl Default for MountTable {
 /// - `VfsError::InvalidPath` if the path is empty or does not start with `/`.
 /// - `VfsError::NotFound` if any path component cannot be found.
 /// - `VfsError::NotADirectory` if a non-terminal component is not a directory.
-#[must_use]
 pub(crate) fn resolve_path(mounts: &MountTable, path: &str) -> Result<(usize, u32), VfsError> {
     if path.is_empty() || !path.starts_with('/') {
         return Err(VfsError::InvalidPath);

--- a/crates/thumos/src/wifi.rs
+++ b/crates/thumos/src/wifi.rs
@@ -580,7 +580,6 @@ pub struct EapolFrame {
 /// declared packet length, [`WifiError::UnknownEapolType`] for
 /// unrecognised packet type bytes, and [`WifiError::UnknownKeyDescriptorType`]
 /// when an EAPOL-Key frame's descriptor type is not RSN (0x02).
-#[must_use]
 pub(crate) fn eapol_parse(data: &[u8]) -> Result<EapolFrame, WifiError> {
     if data.len() < EAPOL_HEADER_LEN {
         return Err(WifiError::FrameTooShort {
@@ -1185,7 +1184,6 @@ impl<H: WifiHwOps> WifiDriver<H> {
     /// # Errors
     ///
     /// Returns `WifiError` if the hardware scan cannot be started.
-    #[must_use]
     pub(crate) fn start_scan(&mut self) -> Result<(), WifiError> {
         // Fresh MAC for each scan (privacy)
         self.mac = generate_random_mac();


### PR DESCRIPTION
## Finding fixed

`clippy::double_must_use` across `crates/thumos/src/`: a function marked `#[must_use]` whose return type is already must-use on its own (`Result<_, E>`, or a locally-defined `#[must_use]` struct/enum reached through `&`, `&mut`, `*const`/`*mut`, `[T]`/`[T; N]`, a tuple field, or `Self`). The bare attribute adds nothing in that case — clippy is right that it's dead weight, and it either needs to say something the type doesn't, or go away.

**72 sites fixed, split 68 / 4.**

Each site was read individually — the return type, the containing `impl`, and (for anything touching a shared structure) whether dropping the return value leaves something registered with no way back to it. No blanket sweep in either direction.

### 68 sites: removed the redundant attribute

The return type's own must-use — `Result<_, E>`, or a `#[must_use]` struct/enum reached through a reference, slice, or tuple — already forces the caller to handle it. A message here would only restate the type, which the task brief calls out as worse than no message.

Covers:
- Plain fallible parsers/builders with no side effects beyond their own return value: DNS/DoT frame and query (de)serialization, EAPOL, minimal-JSON, HTTP request/response, WebSocket frames, NMEA GGA/RMC.
- Accessors returning slices or references into a struct's own state (`&[Room]`, `&[MegolmSession]`, `&EkphrasisState`, `entries()`, `recent()`, ...).
- State-machine transitions (`Result<(), E>` / `Result<bool, E>`) in the BT/A2DP, GPS, and WiFi drivers — discarding the result loses error visibility, which `Result`'s own must-use already covers; nothing else is owed.
- Self-contained constructors (`Result<Self, E>` / `Self`) where every field the constructor allocates is owned by the returned value, so dropping it cleanly frees everything — `Contact::new`, `MemBlockDevice::new`, `HttpResponse::parse`, `JsonParser::parse`, `AuditLog::new`, `LfsCheckpointHeader::from_block`, `LfsImap::deserialize`, etc.

### 4 sites: added a real `#[must_use = "..."]` message

Each is a constructor that registers a handle in a **shared, capacity-bounded structure the caller keeps** (not the returned value) — the structure has no `Drop` impl or automatic cleanup path, and the *only* handle able to release the slot is the value clippy was flagging as pointless to mark. Silently discarding `Ok(_)` here doesn't just lose an error — it permanently leaks a slot out of a finite pool:

- `NetworkStack::add_tcp_socket` / `add_udp_socket` (`src/net.rs`) — registers a socket in `self.sockets` and returns only the `SocketHandle`; `remove_socket(handle)` is the sole release path.
  `#[must_use = "pass the handle to \`remove_socket\` when done, or the slot leaks until reboot"]`
- `DhcpClient::new` (`src/dhcp.rs`) — adds a socket to the caller's `NetworkStack` before returning `Self`; `DhcpClient` has no `Drop` impl and no `close()`.
  `#[must_use = "store the returned client; dropping it orphans its socket in \`stack\` with no handle left to reclaim the slot"]`
- `LfsWriter::new` (`src/lfs_writer.rs`) — allocates a segment from `LfsSegmentManager` before returning `Self`; `LfsSegmentManager::free(idx)` is the sole release path and only the writer knows the index.
  `#[must_use = "store the returned writer; dropping it leaks the allocated segment in \`seg_mgr\`, which only this writer can \`free\`"]`

## Scope

Only `#[must_use]` attributes were touched — no doc backticks, `let...else`, collapsible-`if`, or cast-related findings from #672 were fixed here; those are separate lanes. `git diff --stat` is exactly 26 files, every changed line is either a `#[must_use]` deletion or a `#[must_use]` → `#[must_use = "..."]` replacement.

## Verification

- `cargo fmt --all --check` — clean
- `cargo fmt --manifest-path crates/thumos/Cargo.toml --check` — clean
- `scripts/check-witness-extraction.sh` — no drift
- `scripts/check-pr-title.sh` — title validates against the conventional-commit grammar
- `scripts/check-target-test-ledger.sh` requires a full i686 `cargo nextest list` build; skipped locally per the "no heavy local builds" instruction — this box was under vgate core-budget contention from concurrent dispatch work (confirmed via `vgate --status`: this job sat `WAITING`, ticket-queued behind other admitted jobs consuming the full 6-core budget, for several minutes with zero CPU time). CI-exact gate on the build box is the authority for this check and for the full clippy re-run.
- Site discovery: the prescribed `cargo clippy --bin thumos --tests --target i686-unknown-linux-gnu` command never got real CPU time locally (confirmed both via OS-level 0% CPU sampling and via `vgate --status` showing the job WAITING, not ADMITTED). Sites were instead found and verified through static analysis of every bare `#[must_use]` attribute (463 in `src/`, 337 attached to functions) cross-checked against clippy's actual `is_must_use_ty` recursion, which was independently confirmed against this exact toolchain using small `VGATE_ALLOW_TMPFS=1` probe crates (real `cargo clippy -D clippy::double_must_use` runs) rather than assumed from memory — notably, this caught that `Option<T>` is *not* must-use at the type level in std (only `Result` is), which an initial pass had wrongly assumed. Every one of the 72 flagged sites was read in full before deciding remove-vs-message.

Refs #672
