### PR TITLE
docs(convergence): settle the keypad-matrix-scan disposition

### DIFF
--- a/docs/convergence.toml
+++ b/docs/convergence.toml
@@ -30,10 +30,10 @@ notes = "The live divergence that proved the class: screen bands and the detecto
 name = "keypad-matrix-scan"
 kernel = "keypad.rs (mirrors haphe's scan/debounce algorithm, #446)"
 workspace = "haphe (gpio.rs)"
-disposition = "extract-core"
-canonical = "pending: matrix geometry + debounce state machine could lift into a no_std core crate when a second consumer justifies it; the event models genuinely differ today (boot taps vs queued press/release/held)"
-owner = "#446"
-notes = "The kernel boot reader reports confirmed presses only (no queue, no release/held events) and cannot link the std workspace crate; pin assignments are shared placeholders pending AGM M7 schematic verification."
+disposition = "kernel-owned"
+canonical = "keypad.rs's BootKeypad is the only consumed matrix-scan/debounce implementation; haphe::gpio's GpioKeypad/Debounce/KeyMatrix are pub(crate) and reached only by their own test module, so the duplicate has no consumer to converge with"
+owner = "#545 (this PR)"
+notes = "The event models genuinely differ: BootKeypad::poll_with_matrix (keypad.rs) returns Option<Key>, the first confirmed press only, no queue, no release/held -- it runs before interrupts, the heap, or the real KPD hardware block exist. GpioKeypad::process_matrix (haphe/gpio.rs) pushes InputEvent::Key { key, state: Pressed | Released } into a 64-slot InputQueue for a running input loop. But no second consumer exists to justify lifting a shared core: GpioKeypad/Debounce/KeyMatrix/gpio_reg/read_matrix are pub(crate), unreachable outside haphe, and called only from gpio.rs's own tests -- eidolon, haphe's one real external consumer, imports haphe::input::{Key, TouchPoint} and never touches haphe::gpio. Pin assignments are shared placeholders pending AGM M7 schematic verification either way. haphe has been #![no_std] with zero dependencies since its first commit and crates/thumos/Cargo.toml already path-links it as a dev-dependency for host tests (#615) -- \"cannot link a std crate\" is not the real reason keypad.rs stays independent; visibility and the differing event shape are. The workspace matrix-scan code is a deletion candidate under this disposition's own rule (the duplicate deletes when its consumers are gone) whenever a real second consumer is decided against; it is kept here only because deleting it is outside this ledger decision's scope."
 
 [[pair]]
 name = "gps"


### PR DESCRIPTION
Settles the `keypad-matrix-scan` pair in the #545 convergence ledger. This is a ledger-decision change only — no `src/*.rs` files touched.

## The two implementations

**Kernel** — `crates/thumos/src/keypad.rs` (`BootKeypad`):

```rust
pub(crate) fn poll_with_matrix(&mut self, matrix: KeyMatrix) -> Option<Key> {
    for (row, row_keys) in KEY_MAP.iter().enumerate() {
        for (col, &key) in row_keys.iter().enumerate() {
            let pressed = matrix.is_pressed(row, col);
            if let Some(slot) = self.debounce.get_mut(row * COL_COUNT + col)
                && let Some(true) = slot.update(pressed)
            {
                return Some(key);
            }
        }
    }
    None
}
```

Returns `Option<Key>` — the first newly-confirmed *press* of the scan cycle, no queue, no release/held events. It exists to gate the boot passphrase prompt (`kinit.rs` Step 8a/8c), which runs before the real MT6739 KPD hardware block is enabled and verified, and before interrupts or the heap are up.

**Workspace** — `crates/haphe/src/gpio.rs` (`GpioKeypad`):

```rust
pub(crate) struct GpioKeypad { debounce: [Debounce; KEY_COUNT] }

fn process_matrix(&mut self, matrix: KeyMatrix, queue: &mut InputQueue) {
    for (row, row_keys) in KEY_MAP.iter().enumerate() {
        for (col, &key) in row_keys.iter().enumerate() {
            let idx = row * COL_COUNT + col;
            let pressed = matrix.is_pressed(row, col);
            if let Some(debounce) = self.debounce.get_mut(idx)
                && let Some(state) = debounce.update(pressed)
            {
                queue.push(InputEvent::Key { key, state });
            }
        }
    }
}
```

Pushes `InputEvent::Key { key, state: Pressed | Released }` into a 64-slot `InputQueue` (`crates/haphe/src/input.rs`) — a running-loop input model, not a one-shot poll.

## Is the event-model divergence real, or just described that way?

Real. `Debounce::update` in each file returns a different shape by design: the kernel's (`keypad.rs:124`) returns `Option<bool>` and only ever fires on the confirmed release→press transition; haphe's (`gpio.rs:239`) returns `Option<KeyState>` and fires on both press and release. The boot gate genuinely cannot use haphe's model as-is — it has no queue to drain and nothing (yet) capable of consuming `KeyState::Held`/repeat semantics at that point in boot.

## Is there a real second consumer?

No — and this is the finding that changes the disposition. `GpioKeypad`, `Debounce`, `KeyMatrix`, `gpio_reg`, and `read_matrix` in `gpio.rs` are all `pub(crate)` (`crates/haphe/src/gpio.rs:264`):

```
$ grep -rn "GpioKeypad" --include='*.rs' .
crates/haphe/src/gpio.rs   # only file — impl + its own #[cfg(test)] module
```

`eidolon` is haphe's one real external consumer (`crates/eidolon/src/widget.rs:6`, `widgets/{dialer,dialog,menu,list}.rs`), and every one of those imports `haphe::input::{Key, TouchPoint}` — never `haphe::gpio`. There is no `main`/`bin`/`example` anywhere in the workspace that instantiates `GpioKeypad` or calls `.scan()`. The matrix-scan/debounce logic in `haphe` has zero consumers, inside or outside its own crate, beyond its own test module.

The ledger's pending note asked whether a core crate is worth extracting "when a second consumer justifies it." That consumer — live or hypothetical-but-planned — doesn't exist today. `haphe::gpio`'s own `[dependencies]` list is empty and nothing calls in.

## The "cannot link" premise doesn't hold

`keypad.rs`'s header and the prior ledger note both frame the split as forced by haphe being "a std workspace crate" the kernel can't link. That's factually wrong:

- `crates/haphe/src/lib.rs:1` — `#![no_std]`, and has been since haphe's first commit (`c22e6cf`, workspace scaffold).
- `crates/haphe/Cargo.toml` — `[dependencies]` is empty.
- `crates/thumos/Cargo.toml:141-147` already path-links haphe today, as a `[dev-dependencies]` entry used by `ui.rs`'s `shared_prefix_discriminants_match_haphe` test (#615) on the `i686-unknown-linux-gnu` host target.

The actual reason `keypad.rs` can't call into `haphe::gpio` is `GpioKeypad`'s `pub(crate)` visibility plus the genuinely different event shape — not a std/no_std boundary.

## Disposition: `kernel-owned`

`keypad.rs`'s `BootKeypad` is canonical for the boot-time matrix scan; it is the only implementation of this logic that anything actually consumes. Per this disposition's own definition in the ledger header ("the workspace duplicate deletes when its consumers are gone"), `haphe::gpio`'s matrix-scan code already meets that bar — it has no consumers to lose. I did not delete it here (out of scope for a ledger-only decision, and `crates/haphe/src/*.rs` is a `src/*.rs` file this task was scoped to leave alone), but the ledger now records it plainly as a deletion candidate rather than a pending extraction, so a future pass can act on it without re-deriving the analysis.

No `src/*.rs` file was edited to reach this conclusion.

## Ratchet

`keypad.rs` never carried a `"ported from"` comment (it says "mirrors haphe's..."), so this pair contributed nothing to `ratchet.ported_from_comments`. That count stays at 3 (firewall, sms, screen_dialer) — unchanged.

## Verification

```
./scripts/check-convergence.sh    # convergence ledger: 9 pairs classified, 3 port markers, 0 stale #126 pointers, ratchet holding
./scripts/check-doc-inventory.sh  # doc inventory: 20 crates verified, 17 docs/ files verified
cargo fmt --all --check           # clean
```

Heavy builds/gate were intentionally not run here per task scope; the operator will run the CI-exact gate on the build box. `KCLIPPY` is expected red — unrelated #672 backlog being burned down in parallel.

## Aside (not addressed in this PR, flagged for the orchestrator)

`docs/convergence.toml`'s top-of-file header comment (`current "ported from" comments = 6 (firewall×2, gsm7, sms, screen_dialer, ...)`) is stale against the actual `ratchet.ported_from_comments = 3` and against the `telephony-sms` row's own note that the kernel's duplicate `gsm7.rs` is deleted. Out of scope for this row-scoped decision; worth a follow-up pass.

Refs #545
