### PR TITLE
docs(convergence): derive the port-marker count instead of restating it

### DIFF
--- a/docs/convergence.toml
+++ b/docs/convergence.toml
@@ -13,9 +13,13 @@
 #   workspace-owned  — the workspace crate is canonical; the kernel copy is a
 #                      transport/board adapter only
 #
-# The ratchet: current "ported from" comments = 6 (firewall×2, gsm7, sms,
-# screen_dialer, plus gps/wifi/bluetooth/telephony doc headers count as
-# provenance notes, not live duplication markers — see notes per pair).
+# The ratchet: [ratchet].ported_from_comments below is the count, and
+# scripts/check-convergence.sh derives the live figure from the tree and fails
+# if it ever rises. WHY this header names no number: a count restated here is a
+# second copy that drifts the moment a pair converges — this one said 6 while
+# the ratchet said 3 and one of the files it named had already been deleted.
+# A doc-header inventory of a thing a script already measures is drift waiting
+# to happen; read the ratchet and the per-pair notes instead.
 
 [[pair]]
 name = "threat-semantics"


### PR DESCRIPTION
## Finding

`docs/convergence.toml`'s file header carried its own inventory of live `ported from` markers:

```
# The ratchet: current "ported from" comments = 6 (firewall×2, gsm7, sms,
# screen_dialer, ...)
```

`[ratchet].ported_from_comments` in the same file says **3**, and `scripts/check-convergence.sh` derives the live figure from the tree on every run. The header also named `gsm7` — a file the klesis convergence (#664) deleted.

Found by the agent settling the keypad row, which flagged it rather than silently working around it.

## Why this matters

The header restated a number that a script already measures. That is a second copy of a fact, and it drifted the moment a pair converged — which is the whole failure mode this ledger exists to catch one level down, in the code.

It also mattered practically: a reader trusting the header would believe four duplications are live that are not, and would look for `gsm7` in a tree where it no longer exists.

## Correction

The header now names the mechanism — the `[ratchet]` block and the checker that enforces it — and states why it deliberately carries no number. Nothing else changed.

## Verification

```
./scripts/check-convergence.sh
convergence ledger: 9 pairs classified, 3 port markers, 0 stale #126 pointers, ratchet holding
CONV_EXIT=0
```

Refs #545