### PR TITLE
ci(kernel): lint the qemu-gated configuration too

### DIFF
--- a/scripts/kernel-clippy.sh
+++ b/scripts/kernel-clippy.sh
@@ -24,4 +24,26 @@ rustup target list --installed 2>/dev/null | grep -q '^i686-unknown-linux-gnu$' 
 # --tests covers the #[cfg(test)] unit tests kernel-host-tests.sh exercises
 # on this exact target; build.rs stays in scope regardless of target
 # selection, since a build script is always a prerequisite of the bin.
-(cd "$KERNEL_DIR" && cargo clippy --bin thumos --tests --target i686-unknown-linux-gnu -- -D warnings)
+#
+# WHY a second, --features qemu pass (#672): the pass above never sets that
+# feature, so every #[cfg(feature = "qemu")] item is stripped before clippy
+# ever sees it -- a lint cannot report on code the compiler never compiled.
+# kardia.rs::firewall_boot_smoke carried the identical `uptime_ms() as i64`
+# pattern as three already-fixed siblings and never appeared on any #672
+# site list, purely because of this gap. The second pass reuses the i686
+# target already built above (incremental, not a fresh cross-compile), so
+# it is comparatively cheap. Each pass's output is tagged with its own
+# configuration below so a merged list does not reintroduce, one level
+# down, the same ambiguity #672 exists to close.
+(cd "$KERNEL_DIR" && cargo clippy --bin thumos --tests --target i686-unknown-linux-gnu -- -D warnings) 2>&1 \
+    | sed 's/^/[default] /'
+pass1=${PIPESTATUS[0]}
+
+(cd "$KERNEL_DIR" && cargo clippy --bin thumos --tests --features qemu --target i686-unknown-linux-gnu -- -D warnings) 2>&1 \
+    | sed 's/^/[qemu]    /'
+pass2=${PIPESTATUS[0]}
+
+if [ "$pass1" -ne 0 ] || [ "$pass2" -ne 0 ]; then
+    echo "FAIL: kernel clippy failed (default config rc=$pass1, --features qemu config rc=$pass2)" >&2
+    exit 1
+fi


### PR DESCRIPTION
## The blind spot

`scripts/kernel-clippy.sh` ran `cargo clippy --bin thumos --tests --target i686-unknown-linux-gnu -- -D warnings` with no `--features qemu`. Every `#[cfg(feature = "qemu")]` item is stripped by the compiler before clippy ever sees it — a lint cannot report on code the compiler never compiled. Every finding count filed against #672 was therefore a floor, not a total.

Concrete evidence (from the issue thread): `kardia.rs::firewall_boot_smoke` carries the identical `uptime_ms() as i64` pattern as three already-fixed siblings and never appeared on any #672 site list, purely because of this gate. `fm_radio.rs::seek_step` was cited as a second instance.

## What the script now runs

Two mandatory passes over the same already-built i686 target, each tagged so a merged log does not reintroduce the same ambiguity one level down:

```
[default] cargo clippy --bin thumos --tests --target i686-unknown-linux-gnu -- -D warnings
[qemu]    cargo clippy --bin thumos --tests --features qemu --target i686-unknown-linux-gnu -- -D warnings
```

Both are required; the script fails if either does (`PIPESTATUS` captured independently per pass, so the `sed` tagging in between can't swallow a real failure).

## Falsification

Injected a deliberate `clippy::unreadable_literal` violation (`let _falsify_672_marker: u32 = 0x12345678;`) as the first line of `kardia.rs::firewall_boot_smoke` — the exact function named in the issue, `#[cfg(feature = "qemu")]`-only.

- **`[default]` pass: did not report it.** Grepped the full default-pass output for `falsify_672_marker` — zero matches. The function is invisible to this configuration by construction.
- **`[qemu]` pass: reported it.**
  ```
  error: long literal lacking separators
     --> src/kardia.rs:613:40
      |
  613 |         let _falsify_672_marker: u32 = 0x12345678;
      |                                        ^^^^^^^^^^ help: consider: `0x1234_5678`
  ```

That asymmetry — same source tree, same target, one line added inside a `qemu`-gated function, caught by one pass and structurally invisible to the other — is the coverage gap #672 named, closed. The marker was reverted immediately after (`git diff` against `origin/main` on `kardia.rs` is empty).

## Newly-visible findings: 20 distinct sites

Measured on `main` at the branch point (`7489dad`, v0.2.2): the default pass reports 720 findings (matches the issue's last count exactly); the `--features qemu` pass reports 57 distinct `error`/`error[Exxxx]` diagnostics at 55 distinct locations, of which 35 duplicate a default-pass site (same code compiles under both configurations, e.g. `process.rs`'s `unsafe_op_in_unsafe_fn` sites) and **20 are exclusively visible under `--features qemu`**:

| file:line | class | root cause |
|---|---|---|
| `block.rs:547,568,579,594` (4) | `E0433` undeclared `PartitionBlockDevice` | `block.rs`'s own `#[cfg(test)] mod tests` calls `PartitionBlockDevice::new(...)` unconditionally; the type itself is `#[cfg(not(feature = "qemu"))]` (deliberately — "the only production consumer today is the eMMC/LFS mount path, M7-only"). The test isn't gated to match. |
| `block.rs:823,824,908` (3) | `E0425`/`E0433` undeclared `MsdcBlockDevice`/`MsdcBlockDeviceUninit` | Same shape: these types live in `msdc_wrapper`, `#[cfg(not(feature = "qemu"))]`; `block.rs`'s test helpers reference them unconditionally. |
| `gps.rs:850` | `E0433` undeclared `GpsHw` | Same shape again: `GpsHw` (real WMT hardware access) is `#[cfg(not(feature = "qemu"))]`; the test `production_gps_hw_fails_closed_without_wmt_transport` isn't. |
| `secure_boot.rs:662,712,714,754,770,786,796` (7) | `E0425`/`E0599` undeclared `boot_image_source`/`verify_image_streamed`/`BootImageSource::PresentStreamed` | Same shape a fourth time: all three are `#[cfg(not(feature = "qemu"))]`; the test module's calls into them are not. |
| `qemu.rs:33,34,62,63` (4) | `invalid register r0/r1: unknown register` | `qemu.rs` contains AArch32 semihosting inline asm (`svc #0x123456`, `r0`/`r1`), gated only on `feature = "qemu"`, with no `target_arch` guard. It compiles for the armv7a target `--features qemu` is meant for; on i686 the registers don't exist. Same root shape as #673 (`examples/qemu_smoke.rs`), one file over — not a style lint, an architecture mismatch this invocation surfaces. |
| `board/mod.rs:32` | `unused import: virt::*` | Possibly a genuine finding, possibly a cascade of the errors above (once the `qemu`-only consumers of `board::*` fail to compile, nothing left in the crate reaches this re-export). Worth re-checking once the block.rs/gps.rs/secure_boot.rs sites above are fixed, since that may make it disappear on its own. |

Four repeating root causes, one repeating shape: a type or function is deliberately `#[cfg(not(feature = "qemu"))]`-gated (the M7-only real-hardware path), and the test exercising it isn't gated to match — the exact same class of bug the `--features qemu` pass exists to surface. `qemu.rs` is a fifth, different shape: genuine ARM/i686 architecture incompatibility, not a missing cfg.

## Fixed vs. deferred

**Fixed: 0.**

**Deferred: all 20**, listed above with `file:line` + class. Three siblings are concurrently editing this crate right now (`fix/672-core`, `fix/672-drivers`, `fix/672-tail` — the third owns everything else under `src/` not in the other two's file lists). Every one of the 20 sites lands in `block.rs`, `gps.rs`, `secure_boot.rs`, `qemu.rs`, or `board/mod.rs` — none in the two named lists, all therefore owned by the "everything else" sibling. Per the task's file-conflict-avoidance directive, none are touched here. This PR's deliverable is the coverage, not the cleanup.

## armv7a coverage: NOT COVERED, not attempted

The kernel builds three configurations: default i686 (host tests), `--features qemu` i686 (this PR), and `armv7a-none-eabi` (the real hardware/QEMU-boot target). This PR does not add a third invocation and does not measure it, for a stated reason rather than an assumption:

- No cached `target/armv7a-none-eabi/` exists in this worktree — a first clippy pass would cross-compile every `no_std` dependency (`smoltcp`, `ed25519-dalek`, `aes`, the workspace `-core` crates, …) from scratch. That is not a cheap incremental reuse like the qemu pass above; it is a genuinely large build cost.
- The box was under sustained 1-minute load of 12–26 (8 cores) for the duration of this work — three sibling `#672` lanes plus other concurrent dispatch work, gated by `vgate`'s admission control (`VGATE_LOAD_LIMIT=12`). Adding a cold cross-target build on top would compete with that work for no strong reason, given the operator's own CI-exact gate run is the next step regardless.

Left explicitly uncovered rather than assumed clean. A fast-follow should measure this on an idle box or the dedicated build box, the same way the qemu pass was validated here.

## Verification

Ran the full updated script end-to-end (not just the two invocations independently): both passes execute, output is correctly tagged, and the script exits non-zero because both passes still fail (`FAIL: kernel clippy failed (default config rc=101, --features qemu config rc=101)`) — expected, since #672's backlog (720 default + the 20 qemu-only sites above) is still open and being worked by the sibling lanes in parallel. The `KCLIPPY` stage stays red on this PR by design; judge it on the coverage being real (falsification above) and the other gate stages being green.

Refs #672
