### PR TITLE
fix(release): derive the kernel lockfile's first-party versions instead of naming one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,13 @@ jobs:
         # reds on an unclassified pair, a rising port-marker count, or a
         # stale #126 pointer. Cheap, source-level.
         run: scripts/check-convergence.sh
+      - name: Kernel lockfile version drift (#688)
+        # WHY (#688): crates/thumos is excluded from the workspace and keeps its
+        # own lockfile. release-please updates it via an explicit selector that
+        # once named a single crate by hand, so six first-party versions sat
+        # three releases behind while cargo rewrote the file underfoot on every
+        # build. An enumeration of things that grow goes stale quietly.
+        run: scripts/check-kernel-lockfile-versions.sh
       - name: Kernel cross-compile (armv7a) + zero-warning gate (#431)
         # WHY (#431): the zero-warning gate lives in crates/thumos/.cargo/
         # config.toml's rustflags; scripts/kernel-build.sh builds through it

--- a/.kanon-ci.toml
+++ b/.kanon-ci.toml
@@ -33,6 +33,7 @@ stages = [
     "kernel qemu witnesses",
     "wiring inventory",
     "doc inventory",
+    "kernel lockfile versions",
     "target test ledger",
     "cargo clippy",
     "cargo nextest",
@@ -129,6 +130,15 @@ timeout_secs = 300
 [stages."doc inventory"]
 cmd = "scripts/check-doc-inventory.sh"
 timeout_secs = 300
+
+# WHY (#688): crates/thumos is excluded from the workspace and carries its own
+# lockfile. release-please updates it through an explicit selector that once
+# named a single crate, so six first-party versions sat three releases behind
+# while cargo silently rewrote the file on every build. An enumeration of
+# things that grow goes stale quietly; this makes it loud.
+[stages."kernel lockfile versions"]
+cmd = "scripts/check-kernel-lockfile-versions.sh"
+timeout_secs = 60
 
 [stages."cargo clippy"]
 cmd = "cargo clippy --workspace --all-targets --jobs 8 -- -D warnings"

--- a/crates/thumos/Cargo.lock
+++ b/crates/thumos/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "asphaleia-core"
-version = "0.1.18"
+version = "0.2.2"
 
 [[package]]
 name = "bitflags"
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "haphe"
-version = "0.1.18"
+version = "0.2.2"
 
 [[package]]
 name = "hash32"
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "klesis-core"
-version = "0.1.18"
+version = "0.2.2"
 
 [[package]]
 name = "libc"
@@ -369,7 +369,7 @@ checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "metaxu-core"
-version = "0.1.18"
+version = "0.2.2"
 dependencies = [
  "compact_str",
  "ed25519-dalek",
@@ -479,7 +479,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sema-core"
-version = "0.1.18"
+version = "0.2.2"
 dependencies = [
  "serde",
 ]
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "topos-core"
-version = "0.1.18"
+version = "0.2.2"
 
 [[package]]
 name = "typenum"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -80,7 +80,7 @@
         {
           "type": "toml",
           "path": "crates/thumos/Cargo.lock",
-          "jsonpath": "$.package[?(@.name == 'sema-core')].version"
+          "jsonpath": "$.package[?(!@.source && @.name != 'thumos')].version"
         }
       ]
     }

--- a/scripts/check-kernel-lockfile-versions.sh
+++ b/scripts/check-kernel-lockfile-versions.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# check-kernel-lockfile-versions.sh — the kernel lockfile's first-party crates
+# must carry the workspace version.
+#
+# WHY this exists rather than trusting the release config: crates/thumos is
+# excluded from the workspace and keeps its own lockfile so the bare-metal
+# dependency graph is reproducible on its own. release-please updates that file
+# through an explicit selector, and the selector previously named ONE crate
+# literally while the root lockfile used a predicate. Four core crates were
+# added without anyone extending the list, so six versions sat three releases
+# behind and cargo silently rewrote the file on every build — a lockfile the
+# build edits underfoot pins nothing. #650 and #629 each fixed an instance of
+# this; the enumeration is what let it return.
+#
+# An enumeration of things that grow goes stale silently. This check is what
+# makes the staleness loud.
+#
+# WHY `thumos` is exempt: its 0.1.0 in crates/thumos/Cargo.toml is its own
+# version, deliberately not workspace-inherited, so it must NOT track releases.
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+python3 - "$REPO_ROOT" <<'PYEOF'
+import re
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+
+ws = re.search(
+    r'^\[workspace\.package\][^\[]*?^version\s*=\s*"([^"]+)"',
+    (root / "Cargo.toml").read_text(),
+    re.M | re.S,
+)
+if not ws:
+    print("LOCKFILE DRIFT: cannot read workspace.package.version", file=sys.stderr)
+    sys.exit(1)
+want = ws.group(1)
+
+lock = (root / "crates" / "thumos" / "Cargo.lock").read_text()
+
+# A first-party crate is one with no `source` line in its [[package]] block.
+rc = 0
+checked = 0
+for block in lock.split("[[package]]")[1:]:
+    name = re.search(r'^name\s*=\s*"([^"]+)"', block, re.M)
+    ver = re.search(r'^version\s*=\s*"([^"]+)"', block, re.M)
+    if not name or not ver:
+        continue
+    if re.search(r"^source\s*=", block, re.M):
+        continue
+    if name.group(1) == "thumos":
+        continue
+    checked += 1
+    if ver.group(1) != want:
+        print(
+            f"LOCKFILE DRIFT: crates/thumos/Cargo.lock pins {name.group(1)} at "
+            f"{ver.group(1)}, workspace is {want} — release-please's selector for "
+            f"this file is not covering it (see #688)",
+            file=sys.stderr,
+        )
+        rc = 1
+
+if checked == 0:
+    print(
+        "LOCKFILE DRIFT: no first-party crates found in crates/thumos/Cargo.lock — "
+        "the check matched nothing, which is not the same as passing",
+        file=sys.stderr,
+    )
+    rc = 1
+
+if rc == 0:
+    print(f"kernel lockfile: {checked} first-party crates all at {want}")
+sys.exit(rc)
+PYEOF


### PR DESCRIPTION
## Finding

`crates/thumos/Cargo.lock` pinned six first-party path dependencies at **0.1.18** against a **0.2.2** workspace — three releases behind.

`release-please-config.json` updated that file through a selector naming one crate literally, while the root lockfile used a predicate:

```json
{"path": "Cargo.lock",               "jsonpath": "$.package[?(!@.source)].version"}
{"path": "crates/thumos/Cargo.lock", "jsonpath": "$.package[?(@.name == 'sema-core')].version"}
```

The root entry self-maintains. The kernel entry needed a manual addition per crate, and four `*-core` crates landed (#661, #664, #670, #677) without one. `haphe` was never listed at all.

Observed independently while running kernel tooling: `cargo` rewrote `crates/thumos/Cargo.lock` on its own, twice, to sync those strings. **A lockfile the build edits underfoot is not pinning anything.**

## Why it matters

The kernel is excluded from the workspace and keeps a separate lockfile precisely so its bare-metal dependency graph is reproducible independently. A file that drifts from what is actually built does not deliver that.

#629 and #650 each fixed an instance of this class. The enumeration is what let it come back.

## Correction

**The selector now derives.** It matches every first-party crate except `thumos` itself, whose `0.1.0` in `crates/thumos/Cargo.toml` is deliberately its own version rather than workspace-inherited — a bare `!@.source` predicate would have wrongly bumped it, which is the trap in the obvious fix.

**The drift is now checked**, because the selector fix alone only resets the clock. `scripts/check-kernel-lockfile-versions.sh` asserts every first-party entry carries the workspace version, and **fails when it matches zero packages** rather than reporting a vacuous pass — a check that cannot detect its own scope being wrong is the failure mode this repo has hit repeatedly today. Wired into `.kanon-ci.toml` and `.github/workflows/ci.yml`.

## Verification

Run against the **drifted** tree before fixing anything — it named all six:

```
LOCKFILE DRIFT: crates/thumos/Cargo.lock pins asphaleia-core at 0.1.18, workspace is 0.2.2 ...
LOCKFILE DRIFT: ... haphe ... klesis-core ... metaxu-core ... sema-core ... topos-core ...
EXIT=1
```

After correcting the six pins:

```
kernel lockfile: 6 first-party crates all at 0.2.2
EXIT=0
```

`.kanon-ci.toml` and `ci.yml` both parse; `check-convergence.sh`, `check-doc-inventory.sh`, and both `cargo fmt` invocations pass.

Expect the `kernel clippy` stage to remain red — that is #672's backlog, unrelated.

Closes #688