### PR TITLE
refactor(kernel): resolve structural lints across the device drivers

### DIFF
--- a/crates/thumos/Cargo.lock
+++ b/crates/thumos/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "asphaleia-core"
-version = "0.1.18"
+version = "0.2.2"
 
 [[package]]
 name = "bitflags"
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "haphe"
-version = "0.1.18"
+version = "0.2.2"
 
 [[package]]
 name = "hash32"
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "klesis-core"
-version = "0.1.18"
+version = "0.2.2"
 
 [[package]]
 name = "libc"
@@ -369,7 +369,7 @@ checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "metaxu-core"
-version = "0.1.18"
+version = "0.2.2"
 dependencies = [
  "compact_str",
  "ed25519-dalek",
@@ -479,7 +479,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sema-core"
-version = "0.1.18"
+version = "0.2.2"
 dependencies = [
  "serde",
 ]
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "topos-core"
-version = "0.1.18"
+version = "0.2.2"
 
 [[package]]
 name = "typenum"

--- a/crates/thumos/src/ccci.rs
+++ b/crates/thumos/src/ccci.rs
@@ -515,30 +515,7 @@ impl CcciChannel {
     /// SECURITY: Used at the modem boundary to reject unknown channel IDs.
     /// Only channels defined in the protocol are accepted.
     pub(crate) fn is_valid(ch: u32) -> bool {
-        matches!(
-            ch,
-            0 | 1
-                | 2
-                | 3
-                | 4
-                | 5
-                | 6
-                | 7
-                | 8
-                | 9
-                | 10
-                | 11
-                | 12
-                | 13
-                | 14
-                | 15
-                | 16
-                | 17
-                | 18
-                | 19
-                | 20
-                | 21
-        )
+        matches!(ch, 0..=21)
     }
 }
 
@@ -648,8 +625,9 @@ impl BootStep {
             Self::MapHardware => Self::ReleaseMd,
             Self::ReleaseMd => Self::SendRuntime,
             Self::SendRuntime => Self::WaitAck,
-            Self::WaitAck => Self::Complete,
-            Self::Complete => Self::Complete,
+            // WHY: Complete is terminal -- once boot finishes, next() stays
+            // at Complete rather than cycling back to EnableClocks.
+            Self::WaitAck | Self::Complete => Self::Complete,
         }
     }
 }
@@ -797,6 +775,7 @@ impl fmt::Debug for CldmaGpd {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CldmaGpd")
             .field("flags", &format_args!("{:#010x}", self.flags))
+            .field("checksum", &self.checksum)
             .field("data_ptr", &format_args!("{:#010x}", self.data_ptr))
             .field("next", &format_args!("{:#010x}", self.next))
             .field("data_len", &self.data_len)
@@ -891,7 +870,12 @@ impl TxRing {
     }
 
     /// Physical address of the first descriptor (for CLDMA start register).
-    pub(crate) fn start_addr(&self, base_addr: u32) -> u32 {
+    ///
+    /// WHY: no `self` -- the descriptor chain always starts at
+    /// `self.descriptors[0]`, so the caller-supplied physical `base_addr`
+    /// of that first descriptor already IS the answer; nothing about the
+    /// ring's own state changes it.
+    pub(crate) fn start_addr(base_addr: u32) -> u32 {
         base_addr
     }
 }
@@ -1533,7 +1517,7 @@ impl WdtStatus {
     }
 
     /// Whether the modem has crashed (WDT triggered).
-    pub(crate) fn is_triggered(&self) -> bool {
+    pub(crate) fn is_triggered(self) -> bool {
         self.raw != 0
     }
 }
@@ -1670,7 +1654,7 @@ pub(crate) unsafe fn ccif_recv(buf: &mut [u8]) -> usize {
         // Access is synchronized via CCIF doorbell.
         let word = unsafe { mmio::read32(sram_base + offset) };
         let bytes = word.to_le_bytes();
-        buf[offset] = bytes.get(0).copied().unwrap_or_default();
+        buf[offset] = bytes.first().copied().unwrap_or_default();
         buf[offset + 1] = bytes.get(1).copied().unwrap_or_default();
         buf[offset + 2] = bytes.get(2).copied().unwrap_or_default();
         buf[offset + 3] = bytes.get(3).copied().unwrap_or_default();
@@ -2104,8 +2088,11 @@ impl CcciDriver {
     /// shared memory region into `dest`. The copy uses volatile reads to
     /// prevent the modem from modifying data between validation and use
     /// (TOCTOU defense).
+    ///
+    /// WHY: no `self` -- every byte this reads comes from `region` (bounds,
+    /// physical address) and `dest`; nothing about the `CcciDriver`
+    /// instance participates in the copy.
     pub(crate) fn copy_from_shared(
-        &self,
         region: &SharedMemRegion,
         offset: u32,
         dest: &mut [u8],
@@ -2123,7 +2110,7 @@ impl CcciDriver {
             // Access is synchronized via CCIF doorbell.
             let word = unsafe { mmio::read32(base + i) };
             let bytes = word.to_le_bytes();
-            dest[i] = bytes.get(0).copied().unwrap_or_default();
+            dest[i] = bytes.first().copied().unwrap_or_default();
             dest[i + 1] = bytes.get(1).copied().unwrap_or_default();
             dest[i + 2] = bytes.get(2).copied().unwrap_or_default();
             dest[i + 3] = bytes.get(3).copied().unwrap_or_default();
@@ -2481,7 +2468,7 @@ mod tests {
         assert_eq!(len, 256, "received length must match");
 
         // Rearm the descriptor
-        ring.rearm(idx, buf_addrs.get(0).copied().unwrap_or_default(), 2048);
+        ring.rearm(idx, buf_addrs.first().copied().unwrap_or_default(), 2048);
         assert!(
             ring.descriptors[idx].is_hw_owned(),
             "descriptor must be HW-owned after rearm"
@@ -2956,7 +2943,7 @@ mod tests {
     fn cldma_tx_interrupt_done() {
         let events = parse_cldma_tx_status(CLDMA_TX_INT_DONE);
         assert_eq!(
-            events.get(0).copied().unwrap_or_default(),
+            events.first().copied().unwrap_or_default(),
             Some(CldmaIrqEvent::TxDone(0x0F)),
             "all 4 queues done"
         );
@@ -2967,7 +2954,7 @@ mod tests {
         let status = CLDMA_TX_INT_DONE | CLDMA_TX_INT_ERROR;
         let events = parse_cldma_tx_status(status);
         assert_eq!(
-            events.get(0).copied().unwrap_or_default(),
+            events.first().copied().unwrap_or_default(),
             Some(CldmaIrqEvent::TxDone(0x0F)),
             "done bits"
         );
@@ -2982,7 +2969,7 @@ mod tests {
     fn cldma_rx_interrupt_done() {
         let events = parse_cldma_rx_status(CLDMA_RX_INT_DONE);
         assert_eq!(
-            events.get(0).copied().unwrap_or_default(),
+            events.first().copied().unwrap_or_default(),
             Some(CldmaIrqEvent::RxDone),
             "RX done"
         );
@@ -2993,7 +2980,7 @@ mod tests {
         let status = CLDMA_RX_INT_DONE | CLDMA_RX_INT_QUEUE_EMPTY | CLDMA_RX_INT_ERROR;
         let events = parse_cldma_rx_status(status);
         assert_eq!(
-            events.get(0).copied().unwrap_or_default(),
+            events.first().copied().unwrap_or_default(),
             Some(CldmaIrqEvent::RxDone),
             "RX done"
         );
@@ -3013,7 +3000,7 @@ mod tests {
     fn cldma_tx_no_interrupts() {
         let events = parse_cldma_tx_status(0);
         assert!(
-            events.iter().all(|e| e.is_none()),
+            events.iter().all(Option::is_none),
             "zero status = no events"
         );
     }

--- a/crates/thumos/src/ccci_logger.rs
+++ b/crates/thumos/src/ccci_logger.rs
@@ -390,18 +390,18 @@ pub(crate) fn build_baseline(log: &CcciLogger, window_end_ms: u64) -> ModemBasel
         // Data0OutOfRange anomaly detection.
         let clamped_data0 = entry.data0.min(CCCI_MTU as u32);
 
-        if !stats.active {
-            // First packet on this channel: initialize min/max.
-            stats.active = true;
-            stats.min_size = entry.packet_len;
-            stats.max_size = entry.packet_len;
-        } else {
+        if stats.active {
             if entry.packet_len < stats.min_size {
                 stats.min_size = entry.packet_len;
             }
             if entry.packet_len > stats.max_size {
                 stats.max_size = entry.packet_len;
             }
+        } else {
+            // First packet on this channel: initialize min/max.
+            stats.active = true;
+            stats.min_size = entry.packet_len;
+            stats.max_size = entry.packet_len;
         }
 
         // SECURITY: control-plane sentinel packets (data0 == CCCI_MAGIC) are
@@ -413,17 +413,17 @@ pub(crate) fn build_baseline(log: &CcciLogger, window_end_ms: u64) -> ModemBasel
         // baseline max to u32::MAX, permanently defeating the upper-bound
         // Data0OutOfRange check (issue #282 finding 1).
         if entry.data0 != CCCI_MAGIC {
-            if !*d0_seen {
-                *d0_seen = true;
-                stats.min_data0 = clamped_data0;
-                stats.max_data0 = clamped_data0;
-            } else {
+            if *d0_seen {
                 if clamped_data0 < stats.min_data0 {
                     stats.min_data0 = clamped_data0;
                 }
                 if clamped_data0 > stats.max_data0 {
                     stats.max_data0 = clamped_data0;
                 }
+            } else {
+                *d0_seen = true;
+                stats.min_data0 = clamped_data0;
+                stats.max_data0 = clamped_data0;
             }
         }
 
@@ -562,7 +562,7 @@ pub(crate) fn detect_anomalies(
     }
 
     // Per-channel: check for active channels, rate, and data0.
-    for ch in 0..CHANNEL_COUNT {
+    for (ch, out_of_range) in out_of_range_data0.iter().enumerate() {
         let ch_u32 = ch as u32;
         let live_count = log.channel_count_since(ch_u32, since);
         let baseline_stats = &baseline.channels[ch];
@@ -609,7 +609,7 @@ pub(crate) fn detect_anomalies(
         // SECURITY: checking only the most recent packet let an
         // adversarial modem smuggle an out-of-range data0 in any packet
         // except the last and evade detection entirely (issue #248).
-        if let Some(d0) = out_of_range_data0[ch] {
+        if let Some(d0) = *out_of_range {
             if count < MAX_ANOMALIES {
                 anomalies[count] = Some(CcciAnomaly {
                     timestamp: now,
@@ -938,7 +938,7 @@ mod tests {
 
         let entry = log.get(0);
         assert!(entry.is_some());
-        let e = entry.unwrap_or_else(|| &CcciLogEntry {
+        let e = entry.unwrap_or(&CcciLogEntry {
             timestamp: 0,
             channel: 0,
             direction: PacketDirection::Rx,
@@ -969,7 +969,7 @@ mod tests {
         // Oldest live entry should be entry #10 (0-9 overwritten).
         let oldest = log.get(0);
         assert!(oldest.is_some());
-        let o = oldest.unwrap_or_else(|| &CcciLogEntry {
+        let o = oldest.unwrap_or(&CcciLogEntry {
             timestamp: 0,
             channel: 0,
             direction: PacketDirection::Rx,
@@ -1776,9 +1776,12 @@ mod tests {
 
         // Accumulate counters in Daily mode: ControlTx/SystemTx are
         // allowlisted (allow), MdLogRx is not (drop).
-        fw.evaluate(CcciChannel::ControlTx as u32);
-        fw.evaluate(CcciChannel::SystemTx as u32);
-        fw.evaluate(CcciChannel::MdLogRx as u32);
+        // WHY: the per-call FirewallVerdict is discarded -- this test
+        // asserts on the accumulated allow_count()/drop_count() below, not
+        // on any individual verdict.
+        let _ = fw.evaluate(CcciChannel::ControlTx as u32);
+        let _ = fw.evaluate(CcciChannel::SystemTx as u32);
+        let _ = fw.evaluate(CcciChannel::MdLogRx as u32);
         assert_eq!(fw.allow_count(), 2);
         assert_eq!(fw.drop_count(), 1);
 
@@ -1808,12 +1811,14 @@ mod tests {
     fn firewall_counters_accumulate() {
         let mut fw = CcciFirewall::new(FirewallMode::Sentinel);
 
-        // 3 allows, 2 drops.
-        fw.evaluate(CcciChannel::ControlTx as u32);
-        fw.evaluate(CcciChannel::ControlRx as u32);
-        fw.evaluate(CcciChannel::SystemTx as u32);
-        fw.evaluate(CcciChannel::Uart1Tx as u32);
-        fw.evaluate(CcciChannel::FsTx as u32);
+        // 3 allows, 2 drops. WHY: see firewall_apply_mode_preserves_counters
+        // above -- the per-call verdict is discarded; the counters below
+        // are what this test asserts on.
+        let _ = fw.evaluate(CcciChannel::ControlTx as u32);
+        let _ = fw.evaluate(CcciChannel::ControlRx as u32);
+        let _ = fw.evaluate(CcciChannel::SystemTx as u32);
+        let _ = fw.evaluate(CcciChannel::Uart1Tx as u32);
+        let _ = fw.evaluate(CcciChannel::FsTx as u32);
 
         assert_eq!(fw.allow_count(), 3);
         assert_eq!(fw.drop_count(), 2);

--- a/crates/thumos/src/emmc.rs
+++ b/crates/thumos/src/emmc.rs
@@ -106,30 +106,57 @@ const REG_SDC_DCRC_STS: usize = 0x60;
 const REG_SDC_ADV_CFG0: usize = 0x64;
 
 /// eMMC config 0: boot mode, part access.
-#[expect(dead_code, reason = "reserved for boot mode configuration (#145)")]
+// WHY cfg_attr(not(test)): a regression test asserts this offset/value
+// against the datasheet, so it is used under the host test build; on
+// armv7a nothing outside tests reads it, and the expectation lives
+// exactly there so it stays fulfilled in both configurations.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "reserved for boot mode configuration (#145)")
+)]
 const REG_EMMC_CFG0: usize = 0x70;
 
 /// eMMC config 1.
-#[expect(dead_code, reason = "reserved for boot mode configuration (#145)")]
+// WHY cfg_attr(not(test)): see REG_EMMC_CFG0 above -- same reasoning.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "reserved for boot mode configuration (#145)")
+)]
 const REG_EMMC_CFG1: usize = 0x74;
 
 /// eMMC status: boot ack.
-#[expect(dead_code, reason = "reserved for boot status readback (#145)")]
+// WHY cfg_attr(not(test)): see REG_EMMC_CFG0 above -- same reasoning.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "reserved for boot status readback (#145)")
+)]
 const REG_EMMC_STS: usize = 0x78;
 
 /// eMMC I/O control.
-#[expect(dead_code, reason = "reserved for eMMC I/O tuning (#145)")]
+// WHY cfg_attr(not(test)): see REG_EMMC_CFG0 above -- same reasoning.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "reserved for eMMC I/O tuning (#145)")
+)]
 const REG_EMMC_IOCON: usize = 0x7C;
 
 /// DMA start address [35:32] (4 MSB).
-#[expect(dead_code, reason = "MT6739 is 32-bit; high bits unused (#145)")]
+// WHY cfg_attr(not(test)): see REG_EMMC_CFG0 above -- same reasoning.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "MT6739 is 32-bit; high bits unused (#145)")
+)]
 const REG_MSDC_DMA_SA_HIGH: usize = 0x8C;
 
 /// DMA start address [31:0].
 const REG_MSDC_DMA_SA: usize = 0x90;
 
 /// DMA current address.
-#[expect(dead_code, reason = "reserved for DMA progress monitoring (#145)")]
+// WHY cfg_attr(not(test)): see REG_EMMC_CFG0 above -- same reasoning.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "reserved for DMA progress monitoring (#145)")
+)]
 const REG_MSDC_DMA_CA: usize = 0x94;
 
 /// DMA control: start, stop, mode.
@@ -139,7 +166,11 @@ const REG_MSDC_DMA_CTRL: usize = 0x98;
 const REG_MSDC_DMA_CFG: usize = 0x9C;
 
 /// DMA transfer length.
-#[expect(dead_code, reason = "length encoded in GPD/BD descriptors (#145)")]
+// WHY cfg_attr(not(test)): see REG_EMMC_CFG0 above -- same reasoning.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "length encoded in GPD/BD descriptors (#145)")
+)]
 const REG_MSDC_DMA_LEN: usize = 0xA8;
 
 /// Patch register 0 (tuning overrides).
@@ -147,13 +178,21 @@ const REG_MSDC_DMA_LEN: usize = 0xA8;
 const REG_MSDC_PATCH_BIT0: usize = 0xB0;
 
 /// Version register.
-#[expect(dead_code, reason = "reserved for version readback (#145)")]
+// WHY cfg_attr(not(test)): see REG_EMMC_CFG0 above -- same reasoning.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "reserved for version readback (#145)")
+)]
 const REG_MSDC_VERSION: usize = 0x114;
 
 // NOTE: source `drivers/mmc/host/mediatek/ComboA/msdc_reg.h:75–221`
 
 /// Inline AES encryption SELECT.
-#[expect(dead_code, reason = "reserved for encrypted storage layer (#145)")]
+// WHY cfg_attr(not(test)): see REG_EMMC_CFG0 above -- same reasoning.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "reserved for encrypted storage layer (#145)")
+)]
 const REG_MSDC_AES_SEL: usize = 0x280;
 
 // ---------------------------------------------------------------------------
@@ -170,7 +209,11 @@ const CFG_CKDIV_SHIFT: u32 = 8;
 const CFG_BUSWIDTH_1: u32 = 0b00 << 20;
 
 /// Bus width: 4-bit (bits [21:20] = 0b01).
-#[expect(dead_code, reason = "eMMC uses 8-bit; kept for SD card support (#145)")]
+// WHY cfg_attr(not(test)): see REG_EMMC_CFG0 above -- same reasoning.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "eMMC uses 8-bit; kept for SD card support (#145)")
+)]
 const CFG_BUSWIDTH_4: u32 = 0b01 << 20;
 
 /// Bus width: 8-bit (bits [21:20] = 0b10).
@@ -686,7 +729,7 @@ impl MsdcController {
     }
 
     /// Absolute register address from offset.
-    #[inline(always)]
+    #[inline]
     fn reg(&self, offset: usize) -> usize {
         self.base + offset
     }
@@ -1620,7 +1663,7 @@ mod tests {
         assert_eq!(gpd.data_len, 1536, "total length = 3 * 512");
 
         assert!(
-            !bds.get(0).copied().unwrap_or_default().is_eol(),
+            !bds.first().copied().unwrap_or_default().is_eol(),
             "first BD is not EOL"
         );
         assert!(
@@ -1633,7 +1676,7 @@ mod tests {
         );
 
         assert_eq!(
-            bds.get(0).copied().unwrap_or_default().ptr,
+            bds.first().copied().unwrap_or_default().ptr,
             0x4000_0000,
             "segment 0 address"
         );

--- a/crates/thumos/src/lfs.rs
+++ b/crates/thumos/src/lfs.rs
@@ -146,7 +146,7 @@ impl LfsSuperblock {
     /// # Errors
     ///
     /// This method is infallible.
-    fn to_block(&self) -> [u8; BLOCK_SIZE] {
+    fn to_block(self) -> [u8; BLOCK_SIZE] {
         let mut buf = [0u8; BLOCK_SIZE];
         let mut off = 0;
         write_u32_le(&mut buf, &mut off, self.magic);
@@ -338,7 +338,7 @@ impl SegmentHeader {
     /// # Errors
     ///
     /// This method is infallible.
-    pub(crate) fn to_block(&self) -> [u8; BLOCK_SIZE] {
+    pub(crate) fn to_block(self) -> [u8; BLOCK_SIZE] {
         let mut buf = [0u8; BLOCK_SIZE];
         let mut off = 0;
         write_u32_le(&mut buf, &mut off, self.magic);
@@ -849,9 +849,8 @@ impl Lfs {
             return Ok(());
         }
 
-        let writer = match self.writer.as_mut() {
-            Some(w) => w,
-            None => return Ok(()),
+        let Some(writer) = self.writer.as_mut() else {
+            return Ok(());
         };
 
         let mut dev = self.dev.borrow_mut();
@@ -2727,19 +2726,20 @@ mod tests {
             .expect("write keeper inode");
 
         // Write 4/5: initial directory block listing both entries.
-        let mut entries: Vec<DiskDirEntry> = Vec::new();
-        entries.push(DiskDirEntry {
-            inode_id: 1,
-            name_len: 6,
-            record_len: ((DIR_ENTRY_HEADER_SIZE + 6 + 3) & !3) as u16,
-            name: String::from("victim"),
-        });
-        entries.push(DiskDirEntry {
-            inode_id: 2,
-            name_len: 6,
-            record_len: ((DIR_ENTRY_HEADER_SIZE + 6 + 3) & !3) as u16,
-            name: String::from("keeper"),
-        });
+        let entries: Vec<DiskDirEntry> = alloc::vec![
+            DiskDirEntry {
+                inode_id: 1,
+                name_len: 6,
+                record_len: ((DIR_ENTRY_HEADER_SIZE + 6 + 3) & !3) as u16,
+                name: String::from("victim"),
+            },
+            DiskDirEntry {
+                inode_id: 2,
+                name_len: 6,
+                record_len: ((DIR_ENTRY_HEADER_SIZE + 6 + 3) & !3) as u16,
+                name: String::from("keeper"),
+            },
+        ];
         let dir_block =
             Lfs::write_dir_block(&mut dev, &mut cache, &mut writer, &mut seg_mgr, &entries)
                 .expect("write initial dir block");
@@ -2975,15 +2975,16 @@ mod tests {
         // entries; see create_past_one_block_capacity_fails_without_dropping_entries).
         let mut created = 0usize;
         loop {
-            let name = format!("file{:03}", created);
+            let name = format!("file{created:03}");
             match fs.create(root, &name, InodeType::RegularFile) {
                 Ok(_) => created += 1,
                 Err(VfsError::NoSpace) => break,
                 Err(e) => panic!("unexpected error at entry {created}: {e:?}"),
             }
-            if created > 300 {
-                panic!("directory did not report NoSpace within expected bounds");
-            }
+            assert!(
+                created <= 300,
+                "directory did not report NoSpace within expected bounds"
+            );
         }
 
         // The 257th create() allocated (and durably wrote) a new inode
@@ -3197,13 +3198,20 @@ mod tests {
         // absorb without reclaim (roughly 13 blocks of log traffic per
         // iteration) -- sustained success across all of them is only
         // possible if compaction is actually running.
-        let payload = [0xABu8; 12 * BLOCK_SIZE];
+        //
+        // WHY vec! not a boxed array: 12 * BLOCK_SIZE (48 KiB) on the stack
+        // trips clippy's large_stack_arrays -- and `Box::new([0xAB; N])`
+        // does NOT avoid that, since the array literal is still built as a
+        // stack temporary before the move into the box. `vec![elem; N]`
+        // allocates directly on the heap, never materializing the full
+        // buffer on the stack.
+        let payload = alloc::vec![0xABu8; 12 * BLOCK_SIZE];
         for i in 0..300 {
             let name = format!("f{i}");
             let file_id = fs
                 .create(root, &name, InodeType::RegularFile)
                 .unwrap_or_else(|e| panic!("create at iteration {i} failed: {e:?}"));
-            fs.write(file_id, 0, &payload)
+            fs.write(file_id, 0, &payload[..])
                 .unwrap_or_else(|e| panic!("write at iteration {i} failed: {e:?}"));
             fs.unlink(root, &name)
                 .unwrap_or_else(|e| panic!("unlink at iteration {i} failed: {e:?}"));
@@ -3226,15 +3234,16 @@ mod tests {
         // vanish (#287).
         let mut created = 0usize;
         loop {
-            let name = format!("file{:03}", created);
+            let name = format!("file{created:03}");
             match fs.create(root, &name, InodeType::RegularFile) {
                 Ok(_) => created += 1,
                 Err(VfsError::NoSpace) => break,
                 Err(e) => panic!("unexpected error at entry {created}: {e:?}"),
             }
-            if created > 300 {
-                panic!("directory did not report NoSpace within expected bounds");
-            }
+            assert!(
+                created <= 300,
+                "directory did not report NoSpace within expected bounds"
+            );
         }
 
         assert_eq!(
@@ -3245,7 +3254,7 @@ mod tests {
         // Every entry that WAS created must still be reachable -- none
         // were silently dropped while create() reported success.
         for i in 0..created {
-            let name = format!("file{:03}", i);
+            let name = format!("file{i:03}");
             assert!(
                 fs.lookup(root, &name).is_ok(),
                 "entry {name} must be reachable after fitting in the directory block"
@@ -3269,10 +3278,7 @@ mod tests {
         let mut fs = mount(Box::new(dev)).expect("mount");
         let root = fs.root_inode();
 
-        let mut name_bytes = Vec::new();
-        for _ in 0..256 {
-            name_bytes.push(b'a');
-        }
+        let name_bytes = alloc::vec![b'a'; 256];
         let long_name = String::from_utf8(name_bytes).expect("valid utf8");
 
         let result = fs.create(root, &long_name, InodeType::RegularFile);
@@ -3292,19 +3298,15 @@ mod tests {
         // wrapped this to a small value and bypassed the block-full
         // guard entirely (#290). Called directly to exercise the guard
         // independent of create()'s own 255-byte gate.
-        let mut name_bytes = Vec::new();
-        for _ in 0..65530 {
-            name_bytes.push(b'x');
-        }
+        let name_bytes = alloc::vec![b'x'; 65530];
         let huge_name = String::from_utf8(name_bytes).expect("valid utf8");
 
-        let mut entries: Vec<DiskDirEntry> = Vec::new();
-        entries.push(DiskDirEntry {
+        let entries: Vec<DiskDirEntry> = alloc::vec![DiskDirEntry {
             inode_id: 1,
             name_len: 0, // recomputed inside write_dir_block
             record_len: 0,
             name: huge_name,
-        });
+        }];
 
         let result =
             Lfs::write_dir_block(&mut dev, &mut cache, &mut writer, &mut seg_mgr, &entries);

--- a/crates/thumos/src/ramfs.rs
+++ b/crates/thumos/src/ramfs.rs
@@ -283,25 +283,22 @@ impl RamFs {
                 .find(|(n, _)| n == component)
                 .map(|(_, id)| *id);
 
-            match existing {
-                Some(child_id) => {
-                    current = child_id;
-                }
-                None => {
-                    // Create new directory inode
-                    let new_id = self.next_inode;
-                    self.next_inode += 1;
-                    self.inodes.push(RamInode {
-                        inode_type: InodeType::Directory,
-                        data: Vec::new(),
-                        children: Vec::new(),
-                        parent: current,
-                    });
-                    self.inodes[current as usize]
-                        .children
-                        .push((String::from(component), new_id));
-                    current = new_id;
-                }
+            if let Some(child_id) = existing {
+                current = child_id;
+            } else {
+                // Create new directory inode
+                let new_id = self.next_inode;
+                self.next_inode += 1;
+                self.inodes.push(RamInode {
+                    inode_type: InodeType::Directory,
+                    data: Vec::new(),
+                    children: Vec::new(),
+                    parent: current,
+                });
+                self.inodes[current as usize]
+                    .children
+                    .push((String::from(component), new_id));
+                current = new_id;
             }
         }
 
@@ -571,10 +568,11 @@ impl Filesystem for RamFs {
         let child_id = dir.children[child_pos].1;
 
         // If child is a directory, check it's empty
-        if let Some(child) = self.inodes.get(child_id as usize) {
-            if child.inode_type == InodeType::Directory && !child.children.is_empty() {
-                return Err(VfsError::NotEmpty);
-            }
+        if let Some(child) = self.inodes.get(child_id as usize)
+            && child.inode_type == InodeType::Directory
+            && !child.children.is_empty()
+        {
+            return Err(VfsError::NotEmpty);
         }
 
         // Remove from parent's children list
@@ -1052,8 +1050,8 @@ mod tests {
     #[test]
     fn parse_cpio_creates_files() {
         let mut archive = Vec::new();
-        archive.extend(build_cpio_entry("init", b"#!/bin/sh", 0o100755));
-        archive.extend(build_cpio_entry("config.toml", b"key=val", 0o100644));
+        archive.extend(build_cpio_entry("init", b"#!/bin/sh", 0o100_755));
+        archive.extend(build_cpio_entry("config.toml", b"key=val", 0o100_644));
         archive.extend(build_cpio_trailer());
 
         let fs = RamFs::from_cpio(&archive);
@@ -1072,8 +1070,8 @@ mod tests {
     #[test]
     fn parse_cpio_strips_dot_slash_prefixes() {
         let mut archive = Vec::new();
-        archive.extend(build_cpio_entry("./init", b"#!/bin/sh", 0o100755));
-        archive.extend(build_cpio_entry("./etc/hostname", b"thumos", 0o100644));
+        archive.extend(build_cpio_entry("./init", b"#!/bin/sh", 0o100_755));
+        archive.extend(build_cpio_entry("./etc/hostname", b"thumos", 0o100_644));
         archive.extend(build_cpio_trailer());
 
         let fs = RamFs::from_cpio(&archive);
@@ -1085,7 +1083,7 @@ mod tests {
 
     #[test]
     fn parse_cpio_rejects_zero_namesize() {
-        let mut archive = build_cpio_entry("init", b"#!/bin/sh", 0o100755);
+        let mut archive = build_cpio_entry("init", b"#!/bin/sh", 0o100_755);
         archive[94..102].copy_from_slice(b"00000000");
 
         let fs = RamFs::from_cpio(&archive);
@@ -1099,7 +1097,7 @@ mod tests {
 
     #[test]
     fn parse_cpio_rejects_invalid_utf8_name() {
-        let mut archive = build_cpio_entry("init", b"#!/bin/sh", 0o100755);
+        let mut archive = build_cpio_entry("init", b"#!/bin/sh", 0o100_755);
         // Corrupt the first name byte (header is exactly 110 bytes, so the
         // name field starts at offset 110). 0xFF can never start a valid
         // UTF-8 sequence.
@@ -1117,7 +1115,7 @@ mod tests {
 
     #[test]
     fn parse_cpio_rejects_filesize_exceeding_remaining_archive() {
-        let mut archive = build_cpio_entry("init", b"#!/bin/sh", 0o100755);
+        let mut archive = build_cpio_entry("init", b"#!/bin/sh", 0o100_755);
         // Claim a filesize far larger than any data actually present in
         // the archive -- data_end = data_start + filesize must be
         // rejected before the out-of-bounds slice &data[data_start..data_end]
@@ -1138,9 +1136,9 @@ mod tests {
     fn parse_cpio_creates_directories() {
         let mut archive = Vec::new();
         // Directory entry
-        archive.extend(build_cpio_entry("etc", &[], 0o040755));
+        archive.extend(build_cpio_entry("etc", &[], 0o040_755));
         // File inside directory
-        archive.extend(build_cpio_entry("etc/hostname", b"thumos", 0o100644));
+        archive.extend(build_cpio_entry("etc/hostname", b"thumos", 0o100_644));
         archive.extend(build_cpio_trailer());
 
         let fs = RamFs::from_cpio(&archive);
@@ -1184,7 +1182,7 @@ mod tests {
     fn parse_cpio_creates_implicit_parent_dirs() {
         let mut archive = Vec::new();
         // File in nested path without explicit directory entries
-        archive.extend(build_cpio_entry("usr/bin/hello", b"binary", 0o100755));
+        archive.extend(build_cpio_entry("usr/bin/hello", b"binary", 0o100_755));
         archive.extend(build_cpio_trailer());
 
         let fs = RamFs::from_cpio(&archive);

--- a/crates/thumos/src/sim.rs
+++ b/crates/thumos/src/sim.rs
@@ -206,8 +206,13 @@ impl SimManager {
                 self.sim_info.pin_required = true;
                 Ok(false)
             }
-            AtResponse::CmeError(code) => Err(TelephonyError::CmeError(code)),
-            AtResponse::CmsError(code) => Err(TelephonyError::CmeError(code)),
+            // WHY: CmsError deliberately collapses into the same
+            // TelephonyError::CmeError variant as CmeError -- there is no
+            // distinct CmsError case in TelephonyError, per
+            // query_operator_maps_at_error_branches below.
+            AtResponse::CmeError(code) | AtResponse::CmsError(code) => {
+                Err(TelephonyError::CmeError(code))
+            }
             AtResponse::Error => Err(TelephonyError::ModemError),
         }
     }
@@ -223,8 +228,9 @@ impl SimManager {
     /// "unknown" and must NOT assume attempts remain. NOTE: the exact
     /// MT6739 `+CPINR` report format is bench-verify before relying on the
     /// count for a last-attempt warning on hardware.
+    // WHY: no `self` -- the count comes straight back from the modem and is
+    // never cached on `SimManager` (same shape as `query_operator` below).
     pub(crate) fn pin_attempts_remaining<T: ModemTransport>(
-        &mut self,
         transport: &mut T,
     ) -> Result<Option<u8>, TelephonyError> {
         let (result, info_line, info_len) = send_with_info(transport, "AT+CPINR", 5000)?;
@@ -233,8 +239,10 @@ impl SimManager {
                 &info_line[..info_len],
             )),
             AtResponse::Ok => Ok(None),
-            AtResponse::CmeError(code) => Err(TelephonyError::CmeError(code)),
-            AtResponse::CmsError(code) => Err(TelephonyError::CmeError(code)),
+            // WHY: see check_pin above -- CmsError collapses into CmeError.
+            AtResponse::CmeError(code) | AtResponse::CmsError(code) => {
+                Err(TelephonyError::CmeError(code))
+            }
             AtResponse::Error => Err(TelephonyError::ModemError),
         }
     }
@@ -259,8 +267,10 @@ impl SimManager {
         let (result, _info, _len) = send_with_info(transport, &command, 8000)?;
         match result {
             AtResponse::Ok => self.check_pin(transport),
-            AtResponse::CmeError(code) => Err(TelephonyError::CmeError(code)),
-            AtResponse::CmsError(code) => Err(TelephonyError::CmeError(code)),
+            // WHY: see check_pin above -- CmsError collapses into CmeError.
+            AtResponse::CmeError(code) | AtResponse::CmsError(code) => {
+                Err(TelephonyError::CmeError(code))
+            }
             AtResponse::Error => Err(TelephonyError::ModemError),
         }
     }
@@ -284,7 +294,7 @@ impl SimManager {
         if !valid_puk_format(puk) || !valid_pin_format(new_pin) {
             return Err(TelephonyError::InvalidState);
         }
-        let attempts = self.pin_attempts_remaining(transport)?;
+        let attempts = Self::pin_attempts_remaining(transport)?;
         if attempts.unwrap_or(1) <= 1 && !confirm_last_attempt {
             return Err(TelephonyError::ConfirmationRequired);
         }
@@ -292,8 +302,10 @@ impl SimManager {
         let (result, _info, _len) = send_with_info(transport, &command, 8000)?;
         match result {
             AtResponse::Ok => self.check_pin(transport),
-            AtResponse::CmeError(code) => Err(TelephonyError::CmeError(code)),
-            AtResponse::CmsError(code) => Err(TelephonyError::CmeError(code)),
+            // WHY: see check_pin above -- CmsError collapses into CmeError.
+            AtResponse::CmeError(code) | AtResponse::CmsError(code) => {
+                Err(TelephonyError::CmeError(code))
+            }
             AtResponse::Error => Err(TelephonyError::ModemError),
         }
     }
@@ -326,8 +338,10 @@ impl SimManager {
                 Ok(())
             }
             AtResponse::Ok => Ok(()),
-            AtResponse::CmeError(code) => Err(TelephonyError::CmeError(code)),
-            AtResponse::CmsError(code) => Err(TelephonyError::CmeError(code)),
+            // WHY: see check_pin above -- CmsError collapses into CmeError.
+            AtResponse::CmeError(code) | AtResponse::CmsError(code) => {
+                Err(TelephonyError::CmeError(code))
+            }
             AtResponse::Error => Err(TelephonyError::ModemError),
         }
     }
@@ -366,8 +380,10 @@ impl SimManager {
                 }
             }
             AtResponse::Ok => Ok(&self.signal_info),
-            AtResponse::CmeError(code) => Err(TelephonyError::CmeError(code)),
-            AtResponse::CmsError(code) => Err(TelephonyError::CmeError(code)),
+            // WHY: see check_pin above -- CmsError collapses into CmeError.
+            AtResponse::CmeError(code) | AtResponse::CmsError(code) => {
+                Err(TelephonyError::CmeError(code))
+            }
             AtResponse::Error => Err(TelephonyError::ModemError),
         }
     }
@@ -387,10 +403,10 @@ impl SimManager {
         transport: &mut T,
         current_tick: u64,
     ) -> Option<Result<&SignalInfo, TelephonyError>> {
-        if let Some(last) = self.last_poll_tick {
-            if current_tick.saturating_sub(last) < SIGNAL_POLL_INTERVAL_MS {
-                return None;
-            }
+        if let Some(last) = self.last_poll_tick
+            && current_tick.saturating_sub(last) < SIGNAL_POLL_INTERVAL_MS
+        {
+            return None;
         }
 
         self.last_poll_tick = Some(current_tick);
@@ -416,8 +432,10 @@ impl SimManager {
                 telephony::parse_cops_response(line, name_buf).ok_or(TelephonyError::ParseError)
             }
             AtResponse::Ok => Ok(0),
-            AtResponse::CmeError(code) => Err(TelephonyError::CmeError(code)),
-            AtResponse::CmsError(code) => Err(TelephonyError::CmeError(code)),
+            // WHY: see check_pin above -- CmsError collapses into CmeError.
+            AtResponse::CmeError(code) | AtResponse::CmsError(code) => {
+                Err(TelephonyError::CmeError(code))
+            }
             AtResponse::Error => Err(TelephonyError::ModemError),
         }
     }
@@ -564,9 +582,8 @@ mod tests {
         let mut sim = SimManager::new();
         let result = sim.check_pin(&mut transport);
         assert!(result.is_ok(), "check_pin must succeed");
-        assert_eq!(
+        assert!(
             result.unwrap_or(false),
-            true,
             "READY response must indicate no PIN required"
         );
         assert!(
@@ -583,9 +600,8 @@ mod tests {
         let mut sim = SimManager::new();
         let result = sim.check_pin(&mut transport);
         assert!(result.is_ok(), "check_pin must succeed");
-        assert_eq!(
-            result.unwrap_or(true),
-            false,
+        assert!(
+            !result.unwrap_or(true),
             "SIM PIN response must indicate PIN required"
         );
         assert!(

--- a/crates/thumos/src/socket.rs
+++ b/crates/thumos/src/socket.rs
@@ -93,6 +93,20 @@ pub(crate) const FD_KIND_MASK: u32 = 0x00FF;
 pub(crate) const FD_KIND_SOCKET: u32 = 0x0002;
 
 // ---------------------------------------------------------------------------
+// Well-known addresses
+// ---------------------------------------------------------------------------
+
+/// The IPv4 loopback address (127.0.0.1).
+///
+/// WHY named constant + local allow: smoltcp's `Ipv4Address` carries
+/// `UNSPECIFIED`/`BROADCAST` but no `LOCALHOST` -- unlike
+/// `core::net::Ipv4Addr`, which clippy's `ip_constant` lint otherwise
+/// steers callers toward. This is the one place the raw octets are
+/// spelled out; every other use in this file names this constant instead.
+#[allow(clippy::ip_constant)]
+pub(crate) const LOOPBACK_ADDR: Ipv4Address = Ipv4Address::new(127, 0, 0, 1);
+
+// ---------------------------------------------------------------------------
 // Socket metadata
 // ---------------------------------------------------------------------------
 
@@ -128,6 +142,12 @@ pub struct SocketInfo {
 ///
 /// Layout matches the 32-bit ARM Linux `struct sockaddr_in`.
 /// Port and address are in network byte order (big-endian).
+// WHY: the `sin_*` prefix on every field is the actual POSIX `struct
+// sockaddr_in` field naming (`sin_family`, `sin_port`, `sin_addr`,
+// `sin_zero`) -- this struct exists to mirror that ABI layout field-for-
+// field; dropping the prefix would decouple the names from the spec they
+// document.
+#[allow(clippy::struct_field_names)]
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub struct SockaddrIn {
@@ -214,7 +234,7 @@ pub unsafe fn init_network_stack() {
         let device = FirewallDevice::with_default_firewall(LoopbackDevice::new());
         let mac = net::randomized_local_ethernet_address();
         let mut stack = NetworkStack::new(device, mac, Instant::from_millis(0));
-        stack.set_ipv4_addr(Ipv4Address::new(127, 0, 0, 1), 8);
+        stack.set_ipv4_addr(LOOPBACK_ADDR, 8);
         let ns = &mut *core::ptr::addr_of_mut!(NETWORK_STACK);
         *ns = Some(stack);
     }
@@ -288,9 +308,9 @@ static mut NEXT_EPHEMERAL_PORT: u16 = 49152;
 /// and `SOCKET_TABLE`.
 unsafe fn alloc_ephemeral_port() -> Option<u16> {
     unsafe {
+        const EPHEMERAL_RANGE: u16 = 65535 - 49152 + 1;
         let table = get_socket_table();
 
-        const EPHEMERAL_RANGE: u16 = 65535 - 49152 + 1;
         let start = {
             let mut rand_buf = [0u8; 2];
             match csprng::kernel_random_bytes(&mut rand_buf) {
@@ -348,9 +368,8 @@ pub(crate) fn sys_socket(domain: u32, sock_type: u32, _protocol: u32) -> u32 {
     };
 
     // SAFETY: single-core cooperative kernel; init_network_stack called.
-    let stack = match unsafe { get_network_stack() } {
-        Some(s) => s,
-        None => return fd::EBADF,
+    let Some(stack) = (unsafe { get_network_stack() }) else {
+        return fd::EBADF;
     };
 
     let handle = match socket_type {
@@ -440,9 +459,8 @@ pub(crate) fn sys_bind(fd: u32, addr_ptr: u32, addr_len: u32) -> u32 {
     // name a socket it owns, and the OFD index -- not the fd number -- keys
     // SOCKET_TABLE, so per-process fd numbers can never collide across
     // processes.
-    let flags = match fd::current_fd_flags(fd_idx) {
-        Some(f) => f,
-        None => return fd::EBADF,
+    let Some(flags) = fd::current_fd_flags(fd_idx) else {
+        return fd::EBADF;
     };
     if !is_socket_fd(flags) {
         return fd::EBADF;
@@ -470,18 +488,18 @@ pub(crate) fn sys_bind(fd: u32, addr_ptr: u32, addr_len: u32) -> u32 {
         if i == ofd_idx {
             continue;
         }
-        if let Some(other) = slot {
-            if other.bound_port == port && other.socket_type == socket_type {
-                return EADDRINUSE;
-            }
+        if let Some(other) = slot
+            && other.bound_port == port
+            && other.socket_type == socket_type
+        {
+            return EADDRINUSE;
         }
     }
 
     // Bind in smoltcp.
     // SAFETY: single-core cooperative kernel; init_network_stack called.
-    let stack = match unsafe { get_network_stack() } {
-        Some(s) => s,
-        None => return fd::EBADF,
+    let Some(stack) = (unsafe { get_network_stack() }) else {
+        return fd::EBADF;
     };
 
     let local_addr = sockaddr.ipv4_addr();
@@ -579,9 +597,8 @@ pub(crate) fn sys_connect(fd: u32, addr_ptr: u32, addr_len: u32) -> u32 {
     // name a socket it owns, and the OFD index -- not the fd number -- keys
     // SOCKET_TABLE, so per-process fd numbers can never collide across
     // processes.
-    let flags = match fd::current_fd_flags(fd_idx) {
-        Some(f) => f,
-        None => return fd::EBADF,
+    let Some(flags) = fd::current_fd_flags(fd_idx) else {
+        return fd::EBADF;
     };
     if !is_socket_fd(flags) {
         return fd::EBADF;
@@ -634,7 +651,7 @@ pub(crate) fn sys_connect(fd: u32, addr_ptr: u32, addr_len: u32) -> u32 {
             let connect_result = unsafe {
                 let stack_ptr = &mut *core::ptr::addr_of_mut!(NETWORK_STACK);
                 let stack_ref = match stack_ptr.as_mut() {
-                    Some(s) => s as *mut SocketNetworkStack,
+                    Some(s) => core::ptr::from_mut::<SocketNetworkStack>(s),
                     None => return fd::EBADF,
                 };
                 let cx = (*stack_ref).iface_mut().context();
@@ -736,9 +753,8 @@ pub(crate) fn sys_sendto(
     // name a socket it owns, and the OFD index -- not the fd number -- keys
     // SOCKET_TABLE, so per-process fd numbers can never collide across
     // processes.
-    let flags = match fd::current_fd_flags(fd_idx) {
-        Some(f) => f,
-        None => return fd::EBADF,
+    let Some(flags) = fd::current_fd_flags(fd_idx) else {
+        return fd::EBADF;
     };
     if !is_socket_fd(flags) {
         return fd::EBADF;
@@ -750,9 +766,8 @@ pub(crate) fn sys_sendto(
 
     // SAFETY: single-core cooperative kernel.
     let sock_table = unsafe { get_socket_table() };
-    let info = match &sock_table[ofd_idx] {
-        Some(i) => i,
-        None => return fd::EBADF,
+    let Some(info) = &sock_table[ofd_idx] else {
+        return fd::EBADF;
     };
 
     // SAFETY: validate_user_buffer confirmed [buf_ptr, buf_ptr+len) lies
@@ -760,9 +775,8 @@ pub(crate) fn sys_sendto(
     let data = unsafe { core::slice::from_raw_parts(buf_ptr as *const u8, len as usize) };
 
     // SAFETY: single-core cooperative kernel; init_network_stack called.
-    let stack = match unsafe { get_network_stack() } {
-        Some(s) => s,
-        None => return fd::EBADF,
+    let Some(stack) = (unsafe { get_network_stack() }) else {
+        return fd::EBADF;
     };
 
     match info.socket_type {
@@ -805,9 +819,8 @@ pub(crate) fn sys_sendto(
             // Auto-bind if not yet bound.
             if !udp_socket.is_open() {
                 // SAFETY: single-core cooperative kernel.
-                let local_port = match unsafe { alloc_ephemeral_port() } {
-                    Some(p) => p,
-                    None => return EADDRINUSE,
+                let Some(local_port) = (unsafe { alloc_ephemeral_port() }) else {
+                    return EADDRINUSE;
                 };
                 if udp_socket.bind(local_port).is_err() {
                     return fd::EINVAL;
@@ -873,9 +886,8 @@ pub(crate) fn sys_recvfrom(
     // name a socket it owns, and the OFD index -- not the fd number -- keys
     // SOCKET_TABLE, so per-process fd numbers can never collide across
     // processes.
-    let flags = match fd::current_fd_flags(fd_idx) {
-        Some(f) => f,
-        None => return fd::EBADF,
+    let Some(flags) = fd::current_fd_flags(fd_idx) else {
+        return fd::EBADF;
     };
     if !is_socket_fd(flags) {
         return fd::EBADF;
@@ -887,9 +899,8 @@ pub(crate) fn sys_recvfrom(
 
     // SAFETY: single-core cooperative kernel.
     let sock_table = unsafe { get_socket_table() };
-    let info = match &sock_table[ofd_idx] {
-        Some(i) => i,
-        None => return fd::EBADF,
+    let Some(info) = &sock_table[ofd_idx] else {
+        return fd::EBADF;
     };
 
     // SAFETY: validate_user_buffer confirmed [buf_ptr, buf_ptr+len) lies
@@ -897,9 +908,8 @@ pub(crate) fn sys_recvfrom(
     let buf = unsafe { core::slice::from_raw_parts_mut(buf_ptr as *mut u8, len as usize) };
 
     // SAFETY: single-core cooperative kernel; init_network_stack called.
-    let stack = match unsafe { get_network_stack() } {
-        Some(s) => s,
-        None => return fd::EBADF,
+    let Some(stack) = (unsafe { get_network_stack() }) else {
+        return fd::EBADF;
     };
 
     match info.socket_type {
@@ -977,9 +987,8 @@ pub(crate) fn sys_recvfrom(
 pub(crate) fn on_socket_fd_closed(ofd_idx: usize) {
     // SAFETY: single-core cooperative kernel.
     let sock_table = unsafe { get_socket_table() };
-    let info = match sock_table[ofd_idx].take() {
-        Some(i) => i,
-        None => return,
+    let Some(info) = sock_table[ofd_idx].take() else {
+        return;
     };
 
     // Remove the socket from the smoltcp stack.
@@ -1272,22 +1281,22 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "32")]
     fn bind_sets_local_port_syscall() {
-        unsafe {
-            setup_test_network();
-        }
-        let fd = sys_socket(AF_INET, SOCK_DGRAM, 0);
         static mut ADDR: SockaddrIn = SockaddrIn {
             sin_family: 0,
             sin_port: 0,
             sin_addr: 0,
             sin_zero: [0u8; 8],
         };
+        unsafe {
+            setup_test_network();
+        }
+        let fd = sys_socket(AF_INET, SOCK_DGRAM, 0);
         // SAFETY: test-only static; single-threaded per test.
         let addr = unsafe { &mut *core::ptr::addr_of_mut!(ADDR) };
-        *addr = SockaddrIn::new(8080, Ipv4Address::new(127, 0, 0, 1));
+        *addr = SockaddrIn::new(8080, LOOPBACK_ADDR);
         let result = sys_bind(
             fd,
-            addr as *const SockaddrIn as u32,
+            core::ptr::from_ref::<SockaddrIn>(addr) as u32,
             core::mem::size_of::<SockaddrIn>() as u32,
         );
         assert_eq!(result, 0, "bind should succeed");
@@ -1300,6 +1309,18 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "32")]
     fn udp_bind_does_not_conflict_with_tcp_bind_on_same_port() {
+        static mut TCP_ADDR: SockaddrIn = SockaddrIn {
+            sin_family: 0,
+            sin_port: 0,
+            sin_addr: 0,
+            sin_zero: [0u8; 8],
+        };
+        static mut UDP_ADDR: SockaddrIn = SockaddrIn {
+            sin_family: 0,
+            sin_port: 0,
+            sin_addr: 0,
+            sin_zero: [0u8; 8],
+        };
         unsafe {
             setup_test_network();
         }
@@ -1307,34 +1328,22 @@ mod tests {
         let udp_fd = sys_socket(AF_INET, SOCK_DGRAM, 0);
         assert!(tcp_fd < MAX_FDS as u32 && udp_fd < MAX_FDS as u32);
 
-        static mut TCP_ADDR: SockaddrIn = SockaddrIn {
-            sin_family: 0,
-            sin_port: 0,
-            sin_addr: 0,
-            sin_zero: [0u8; 8],
-        };
         // SAFETY: test-only static; single-threaded per test.
         let tcp_addr = unsafe { &mut *core::ptr::addr_of_mut!(TCP_ADDR) };
-        *tcp_addr = SockaddrIn::new(53, Ipv4Address::new(0, 0, 0, 0));
+        *tcp_addr = SockaddrIn::new(53, Ipv4Address::UNSPECIFIED);
         let tcp_bind = sys_bind(
             tcp_fd,
-            tcp_addr as *const SockaddrIn as u32,
+            core::ptr::from_ref::<SockaddrIn>(tcp_addr) as u32,
             core::mem::size_of::<SockaddrIn>() as u32,
         );
         assert_eq!(tcp_bind, 0, "TCP bind to port 53 must succeed");
 
-        static mut UDP_ADDR: SockaddrIn = SockaddrIn {
-            sin_family: 0,
-            sin_port: 0,
-            sin_addr: 0,
-            sin_zero: [0u8; 8],
-        };
         // SAFETY: test-only static; single-threaded per test.
         let udp_addr = unsafe { &mut *core::ptr::addr_of_mut!(UDP_ADDR) };
-        *udp_addr = SockaddrIn::new(53, Ipv4Address::new(0, 0, 0, 0));
+        *udp_addr = SockaddrIn::new(53, Ipv4Address::UNSPECIFIED);
         let udp_bind = sys_bind(
             udp_fd,
-            udp_addr as *const SockaddrIn as u32,
+            core::ptr::from_ref::<SockaddrIn>(udp_addr) as u32,
             core::mem::size_of::<SockaddrIn>() as u32,
         );
         assert_eq!(
@@ -1361,24 +1370,24 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "32")]
     fn udp_connect_rejects_peer_port_zero() {
-        unsafe {
-            setup_test_network();
-        }
-        let fd = sys_socket(AF_INET, SOCK_DGRAM, 0);
-        assert!(fd < MAX_FDS as u32);
-
         static mut ADDR: SockaddrIn = SockaddrIn {
             sin_family: 0,
             sin_port: 0,
             sin_addr: 0,
             sin_zero: [0u8; 8],
         };
+        unsafe {
+            setup_test_network();
+        }
+        let fd = sys_socket(AF_INET, SOCK_DGRAM, 0);
+        assert!(fd < MAX_FDS as u32);
+
         // SAFETY: test-only static; single-threaded per test.
         let addr = unsafe { &mut *core::ptr::addr_of_mut!(ADDR) };
         *addr = SockaddrIn::new(0, Ipv4Address::new(93, 184, 216, 34));
         let result = sys_connect(
             fd,
-            addr as *const SockaddrIn as u32,
+            core::ptr::from_ref::<SockaddrIn>(addr) as u32,
             core::mem::size_of::<SockaddrIn>() as u32,
         );
         assert_eq!(
@@ -1407,13 +1416,6 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "32")]
     fn tcp_bind_then_connect_succeeds() {
-        unsafe {
-            setup_test_network();
-        }
-
-        let fd = sys_socket(AF_INET, SOCK_STREAM, 0);
-        assert!(fd < MAX_FDS as u32);
-
         // WHY function-local `static mut`: sys_bind/sys_connect now validate
         // addr_ptr via validate_user_buffer (issue #291) before
         // dereferencing it. A stack address falls outside
@@ -1425,15 +1427,28 @@ mod tests {
             sin_addr: 0,
             sin_zero: [0u8; 8],
         };
+        static mut CONNECT_ADDR: SockaddrIn = SockaddrIn {
+            sin_family: 0,
+            sin_port: 0,
+            sin_addr: 0,
+            sin_zero: [0u8; 8],
+        };
+        unsafe {
+            setup_test_network();
+        }
+
+        let fd = sys_socket(AF_INET, SOCK_STREAM, 0);
+        assert!(fd < MAX_FDS as u32);
+
         // SAFETY: test-only static; single-threaded per test.
         let bind_addr = unsafe { &mut *core::ptr::addr_of_mut!(BIND_ADDR) };
-        *bind_addr = SockaddrIn::new(40000, Ipv4Address::new(0, 0, 0, 0));
+        *bind_addr = SockaddrIn::new(40000, Ipv4Address::UNSPECIFIED);
 
         // bind() to a specific source port first, per the standard POSIX
         // bind()-then-connect() client pattern.
         let bind_result = sys_bind(
             fd,
-            bind_addr as *const SockaddrIn as u32,
+            core::ptr::from_ref::<SockaddrIn>(bind_addr) as u32,
             core::mem::size_of::<SockaddrIn>() as u32,
         );
         assert_eq!(bind_result, 0, "bind must succeed");
@@ -1453,18 +1468,12 @@ mod tests {
             "bind() must leave the TCP socket in CLOSED state, not LISTEN"
         );
 
-        static mut CONNECT_ADDR: SockaddrIn = SockaddrIn {
-            sin_family: 0,
-            sin_port: 0,
-            sin_addr: 0,
-            sin_zero: [0u8; 8],
-        };
         // SAFETY: test-only static; single-threaded per test.
         let connect_addr = unsafe { &mut *core::ptr::addr_of_mut!(CONNECT_ADDR) };
         *connect_addr = SockaddrIn::new(80, Ipv4Address::new(93, 184, 216, 34));
         let connect_result = sys_connect(
             fd,
-            connect_addr as *const SockaddrIn as u32,
+            core::ptr::from_ref::<SockaddrIn>(connect_addr) as u32,
             core::mem::size_of::<SockaddrIn>() as u32,
         );
         assert_eq!(
@@ -1477,32 +1486,32 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "32")]
     fn tcp_connect_twice_returns_eisconn_not_econnrefused() {
-        unsafe {
-            setup_test_network();
-        }
-        let fd = sys_socket(AF_INET, SOCK_STREAM, 0);
-        assert!(fd < MAX_FDS as u32);
-
         static mut ADDR: SockaddrIn = SockaddrIn {
             sin_family: 0,
             sin_port: 0,
             sin_addr: 0,
             sin_zero: [0u8; 8],
         };
+        unsafe {
+            setup_test_network();
+        }
+        let fd = sys_socket(AF_INET, SOCK_STREAM, 0);
+        assert!(fd < MAX_FDS as u32);
+
         // SAFETY: test-only static; single-threaded per test.
         let addr = unsafe { &mut *core::ptr::addr_of_mut!(ADDR) };
         *addr = SockaddrIn::new(80, Ipv4Address::new(93, 184, 216, 34));
 
         let first = sys_connect(
             fd,
-            addr as *const SockaddrIn as u32,
+            core::ptr::from_ref::<SockaddrIn>(addr) as u32,
             core::mem::size_of::<SockaddrIn>() as u32,
         );
         assert_eq!(first, 0, "first connect() must succeed");
 
         let second = sys_connect(
             fd,
-            addr as *const SockaddrIn as u32,
+            core::ptr::from_ref::<SockaddrIn>(addr) as u32,
             core::mem::size_of::<SockaddrIn>() as u32,
         );
         assert_eq!(
@@ -1515,25 +1524,25 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "32")]
     fn tcp_connect_without_prior_bind_allocates_port_and_sets_connected_state() {
-        unsafe {
-            setup_test_network();
-        }
-        let fd = sys_socket(AF_INET, SOCK_STREAM, 0);
-        assert!(fd < MAX_FDS as u32);
-
         static mut ADDR: SockaddrIn = SockaddrIn {
             sin_family: 0,
             sin_port: 0,
             sin_addr: 0,
             sin_zero: [0u8; 8],
         };
+        unsafe {
+            setup_test_network();
+        }
+        let fd = sys_socket(AF_INET, SOCK_STREAM, 0);
+        assert!(fd < MAX_FDS as u32);
+
         // SAFETY: test-only static; single-threaded per test.
         let addr = unsafe { &mut *core::ptr::addr_of_mut!(ADDR) };
         *addr = SockaddrIn::new(80, Ipv4Address::new(93, 184, 216, 34));
 
         let result = sys_connect(
             fd,
-            addr as *const SockaddrIn as u32,
+            core::ptr::from_ref::<SockaddrIn>(addr) as u32,
             core::mem::size_of::<SockaddrIn>() as u32,
         );
         assert_eq!(
@@ -1589,18 +1598,18 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "32")]
     fn udp_sendto_unaddressable_dest_returns_edestaddrreq() {
-        unsafe {
-            setup_test_network();
-        }
-        let fd = sys_socket(AF_INET, SOCK_DGRAM, 0);
-        assert!(fd < MAX_FDS as u32);
-
         static mut DEST: SockaddrIn = SockaddrIn {
             sin_family: 0,
             sin_port: 0,
             sin_addr: 0,
             sin_zero: [0u8; 8],
         };
+        unsafe {
+            setup_test_network();
+        }
+        let fd = sys_socket(AF_INET, SOCK_DGRAM, 0);
+        assert!(fd < MAX_FDS as u32);
+
         // SAFETY: test-only static; single-threaded per test.
         let dest = unsafe { &mut *core::ptr::addr_of_mut!(DEST) };
         // Port 0 on an EXPLICIT sendto destination bypasses sys_connect()
@@ -1614,7 +1623,7 @@ mod tests {
             data.as_ptr() as u32,
             data.len() as u32,
             0,
-            dest as *const SockaddrIn as u32,
+            core::ptr::from_ref::<SockaddrIn>(dest) as u32,
             core::mem::size_of::<SockaddrIn>() as u32,
         );
         assert_eq!(
@@ -1627,13 +1636,13 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "32")]
     fn udp_recvfrom_with_no_data_returns_eagain_not_zero() {
+        static mut BUF: [u8; 16] = [0u8; 16];
         unsafe {
             setup_test_network();
         }
         let fd = sys_socket(AF_INET, SOCK_DGRAM, 0);
         assert!(fd < MAX_FDS as u32);
 
-        static mut BUF: [u8; 16] = [0u8; 16];
         // SAFETY: test-only static; single-threaded per test.
         let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUF) };
 
@@ -1649,6 +1658,25 @@ mod tests {
     #[test]
     #[cfg(target_pointer_width = "32")]
     fn udp_recvfrom_writes_back_the_real_datagram_source_address() {
+        static mut BIND_ADDR: SockaddrIn = SockaddrIn {
+            sin_family: 0,
+            sin_port: 0,
+            sin_addr: 0,
+            sin_zero: [0u8; 8],
+        };
+        static mut DEST_ADDR: SockaddrIn = SockaddrIn {
+            sin_family: 0,
+            sin_port: 0,
+            sin_addr: 0,
+            sin_zero: [0u8; 8],
+        };
+        static mut RECV_BUF: [u8; 32] = [0u8; 32];
+        static mut SRC_ADDR: SockaddrIn = SockaddrIn {
+            sin_family: 0,
+            sin_port: 0,
+            sin_addr: 0,
+            sin_zero: [0u8; 8],
+        };
         unsafe {
             setup_test_network();
         }
@@ -1676,18 +1704,12 @@ mod tests {
 
         // Receiver: bound to a fixed port, any local address.
         let receiver_fd = sys_socket(AF_INET, SOCK_DGRAM, 0);
-        static mut BIND_ADDR: SockaddrIn = SockaddrIn {
-            sin_family: 0,
-            sin_port: 0,
-            sin_addr: 0,
-            sin_zero: [0u8; 8],
-        };
         // SAFETY: test-only static; single-threaded per test.
         let bind_addr = unsafe { &mut *core::ptr::addr_of_mut!(BIND_ADDR) };
-        *bind_addr = SockaddrIn::new(9000, Ipv4Address::new(0, 0, 0, 0));
+        *bind_addr = SockaddrIn::new(9000, Ipv4Address::UNSPECIFIED);
         let bind_result = sys_bind(
             receiver_fd,
-            bind_addr as *const SockaddrIn as u32,
+            core::ptr::from_ref::<SockaddrIn>(bind_addr) as u32,
             core::mem::size_of::<SockaddrIn>() as u32,
         );
         assert_eq!(bind_result, 0, "receiver bind must succeed");
@@ -1696,15 +1718,9 @@ mod tests {
         // send. Destination is the broadcast address so the interface
         // dispatches it immediately without needing ARP resolution.
         let sender_fd = sys_socket(AF_INET, SOCK_DGRAM, 0);
-        static mut DEST_ADDR: SockaddrIn = SockaddrIn {
-            sin_family: 0,
-            sin_port: 0,
-            sin_addr: 0,
-            sin_zero: [0u8; 8],
-        };
         // SAFETY: test-only static; single-threaded per test.
         let dest_addr = unsafe { &mut *core::ptr::addr_of_mut!(DEST_ADDR) };
-        *dest_addr = SockaddrIn::new(9000, Ipv4Address::new(255, 255, 255, 255));
+        *dest_addr = SockaddrIn::new(9000, Ipv4Address::BROADCAST);
 
         let payload = b"src-check";
         let send_result = sys_sendto(
@@ -1712,7 +1728,7 @@ mod tests {
             payload.as_ptr() as u32,
             payload.len() as u32,
             0,
-            dest_addr as *const SockaddrIn as u32,
+            core::ptr::from_ref::<SockaddrIn>(dest_addr) as u32,
             core::mem::size_of::<SockaddrIn>() as u32,
         );
         assert_eq!(
@@ -1745,15 +1761,8 @@ mod tests {
             stack.poll(smoltcp::time::Instant::from_millis(i64::from(step) * 10));
         }
 
-        static mut RECV_BUF: [u8; 32] = [0u8; 32];
         // SAFETY: test-only static; single-threaded per test.
         let recv_buf = unsafe { &mut *core::ptr::addr_of_mut!(RECV_BUF) };
-        static mut SRC_ADDR: SockaddrIn = SockaddrIn {
-            sin_family: 0,
-            sin_port: 0,
-            sin_addr: 0,
-            sin_zero: [0u8; 8],
-        };
         // SAFETY: test-only static; single-threaded per test.
         let src_addr = unsafe { &mut *core::ptr::addr_of_mut!(SRC_ADDR) };
 
@@ -1762,7 +1771,7 @@ mod tests {
             recv_buf.as_mut_ptr() as u32,
             recv_buf.len() as u32,
             0,
-            src_addr as *const SockaddrIn as u32,
+            core::ptr::from_ref::<SockaddrIn>(src_addr) as u32,
             0,
         );
         assert_eq!(
@@ -1783,7 +1792,7 @@ mod tests {
         // resolver validating which server answered) trusts this value.
         assert_eq!(
             src_addr.ipv4_addr(),
-            Ipv4Address::new(127, 0, 0, 1),
+            LOOPBACK_ADDR,
             "written-back source IP must match the real sender, not the broadcast destination"
         );
         assert_eq!(
@@ -1812,7 +1821,9 @@ mod tests {
     /// the new PCB's context.
     #[cfg(target_pointer_width = "32")]
     fn isolation_test_entry() -> ! {
-        loop {}
+        loop {
+            core::hint::spin_loop();
+        }
     }
 
     /// ISOLATION (CRITICAL): a different process must not be able to name
@@ -1825,6 +1836,19 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn socket_isolation_cross_process_ops_return_ebadf() {
+        static mut ADDR: SockaddrIn = SockaddrIn {
+            sin_family: 0,
+            sin_port: 0,
+            sin_addr: 0,
+            sin_zero: [0u8; 8],
+        };
+        static mut RECV_BUF: [u8; 4] = [0u8; 4];
+        static mut ADDR2: SockaddrIn = SockaddrIn {
+            sin_family: 0,
+            sin_port: 0,
+            sin_addr: 0,
+            sin_zero: [0u8; 8],
+        };
         // SAFETY: test-only; setup_test_network resets global state.
         unsafe {
             setup_test_network();
@@ -1833,18 +1857,12 @@ mod tests {
         let fd = sys_socket(AF_INET, SOCK_DGRAM, 0);
         assert!(fd < MAX_FDS as u32);
 
-        static mut ADDR: SockaddrIn = SockaddrIn {
-            sin_family: 0,
-            sin_port: 0,
-            sin_addr: 0,
-            sin_zero: [0u8; 8],
-        };
         // SAFETY: test-only static; single-threaded per test.
         let addr = unsafe { &mut *core::ptr::addr_of_mut!(ADDR) };
-        *addr = SockaddrIn::new(9001, Ipv4Address::new(0, 0, 0, 0));
+        *addr = SockaddrIn::new(9001, Ipv4Address::UNSPECIFIED);
         let bind_result = sys_bind(
             fd,
-            addr as *const SockaddrIn as u32,
+            core::ptr::from_ref::<SockaddrIn>(addr) as u32,
             core::mem::size_of::<SockaddrIn>() as u32,
         );
         assert_eq!(bind_result, 0, "proc0 must be able to bind its own socket");
@@ -1863,7 +1881,6 @@ mod tests {
             "a different process must not be able to sendto proc0's socket fd number"
         );
 
-        static mut RECV_BUF: [u8; 4] = [0u8; 4];
         // SAFETY: test-only static; single-threaded per test.
         let recv_buf = unsafe { &mut *core::ptr::addr_of_mut!(RECV_BUF) };
         assert_eq!(
@@ -1872,19 +1889,13 @@ mod tests {
             "a different process must not be able to recvfrom proc0's socket fd number"
         );
 
-        static mut ADDR2: SockaddrIn = SockaddrIn {
-            sin_family: 0,
-            sin_port: 0,
-            sin_addr: 0,
-            sin_zero: [0u8; 8],
-        };
         // SAFETY: test-only static; single-threaded per test.
         let addr2 = unsafe { &mut *core::ptr::addr_of_mut!(ADDR2) };
-        *addr2 = SockaddrIn::new(9002, Ipv4Address::new(0, 0, 0, 0));
+        *addr2 = SockaddrIn::new(9002, Ipv4Address::UNSPECIFIED);
         assert_eq!(
             sys_bind(
                 fd,
-                addr2 as *const SockaddrIn as u32,
+                core::ptr::from_ref::<SockaddrIn>(addr2) as u32,
                 core::mem::size_of::<SockaddrIn>() as u32,
             ),
             fd::EBADF,

--- a/crates/thumos/src/telephony.rs
+++ b/crates/thumos/src/telephony.rs
@@ -113,10 +113,11 @@ impl core::fmt::Display for TelephonyError {
 // ---------------------------------------------------------------------------
 
 /// Parsed AT response from the modem.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub enum AtResponse {
     /// Command succeeded.
+    #[default]
     Ok,
     /// Generic error (no code).
     Error,
@@ -126,14 +127,8 @@ pub enum AtResponse {
     CmsError(u32),
 }
 
-impl Default for AtResponse {
-    fn default() -> Self {
-        Self::Ok
-    }
-}
-
 /// Unsolicited result code from the modem.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Urc {
     /// Incoming call (RING).
@@ -777,11 +772,8 @@ impl<T: ModemTransport> Telephony<T> {
                 self.modem_state = ModemState::Error(TelephonyError::ParseError);
                 return Err(TelephonyError::ParseError);
             }
-            Ok((AtResponse::CmeError(code), _, _)) => {
-                self.modem_state = ModemState::Error(TelephonyError::CmeError(code));
-                return Err(TelephonyError::CmeError(code));
-            }
-            Ok((AtResponse::CmsError(code), _, _)) => {
+            // WHY: see dial() below -- CmsError collapses into CmeError.
+            Ok((AtResponse::CmeError(code) | AtResponse::CmsError(code), _, _)) => {
                 self.modem_state = ModemState::Error(TelephonyError::CmeError(code));
                 return Err(TelephonyError::CmeError(code));
             }
@@ -807,12 +799,12 @@ impl<T: ModemTransport> Telephony<T> {
 
         // Step 6: Query operator name.
         let cops_result = send_with_info(&mut self.transport, "AT+COPS?", 5000);
-        if let Ok((AtResponse::Ok, ref info_line, info_len)) = cops_result {
-            if info_len > 0 {
-                let line = &info_line[..info_len];
-                if let Some(len) = parse_cops_response(line, &mut self.operator_name) {
-                    self.operator_len = len;
-                }
+        if let Ok((AtResponse::Ok, ref info_line, info_len)) = cops_result
+            && info_len > 0
+        {
+            let line = &info_line[..info_len];
+            if let Some(len) = parse_cops_response(line, &mut self.operator_name) {
+                self.operator_len = len;
             }
         }
         self.init_step = 6;
@@ -1008,11 +1000,12 @@ impl<T: ModemTransport> Telephony<T> {
                 Ok(())
             }
             AtResponse::Error => Err(TelephonyError::ModemError),
-            AtResponse::CmeError(code) => Err(TelephonyError::CmeError(code)),
             // WHY: +CMS ERROR is SMS-specific and not expected on a voice
             // dial, but AtResponse is exhaustively matched here; surface it
             // through the same numeric-code channel as CME errors.
-            AtResponse::CmsError(code) => Err(TelephonyError::CmeError(code)),
+            AtResponse::CmeError(code) | AtResponse::CmsError(code) => {
+                Err(TelephonyError::CmeError(code))
+            }
         }
     }
 
@@ -1033,8 +1026,10 @@ impl<T: ModemTransport> Telephony<T> {
                 Ok(())
             }
             AtResponse::Error => Err(TelephonyError::ModemError),
-            AtResponse::CmeError(code) => Err(TelephonyError::CmeError(code)),
-            AtResponse::CmsError(code) => Err(TelephonyError::CmeError(code)),
+            // WHY: see dial() above -- CmsError collapses into CmeError.
+            AtResponse::CmeError(code) | AtResponse::CmsError(code) => {
+                Err(TelephonyError::CmeError(code))
+            }
         }
     }
 
@@ -1043,9 +1038,8 @@ impl<T: ModemTransport> Telephony<T> {
     /// Sends `ATH` and transitions to Idle state.
     pub fn hangup(&mut self) -> Result<(), TelephonyError> {
         // Allow hangup from any active call state.
-        match &self.call_state {
-            CallState::Idle => return Err(TelephonyError::InvalidState),
-            _ => {}
+        if self.call_state == CallState::Idle {
+            return Err(TelephonyError::InvalidState);
         }
 
         let result = send_simple(&mut self.transport, "ATH", 10_000)?;
@@ -1060,8 +1054,10 @@ impl<T: ModemTransport> Telephony<T> {
                 self.call_state = CallState::Idle;
                 Ok(())
             }
-            AtResponse::CmeError(code) => Err(TelephonyError::CmeError(code)),
-            AtResponse::CmsError(code) => Err(TelephonyError::CmeError(code)),
+            // WHY: see dial() above -- CmsError collapses into CmeError.
+            AtResponse::CmeError(code) | AtResponse::CmsError(code) => {
+                Err(TelephonyError::CmeError(code))
+            }
         }
     }
 
@@ -1453,7 +1449,7 @@ mod tests {
         // Verify the ATD command was sent.
         let last_cmd = tel.transport.sent_commands.last();
         assert_eq!(
-            last_cmd.map(|c| c.as_slice()),
+            last_cmd.map(alloc::vec::Vec::as_slice),
             Some(b"ATD+15551234567;" as &[u8]),
             "ATD command must be formatted correctly"
         );
@@ -1824,7 +1820,10 @@ mod tests {
             "refuse_2g must SET lte_only=true on OK response"
         );
         assert_eq!(
-            tel.transport.sent_commands.last().map(|c| c.as_slice()),
+            tel.transport
+                .sent_commands
+                .last()
+                .map(alloc::vec::Vec::as_slice),
             Some(b"AT+COPS=0,,,7" as &[u8]),
             "refuse_2g must send AT+COPS=0,,,7"
         );

--- a/crates/thumos/src/usb.rs
+++ b/crates/thumos/src/usb.rs
@@ -25,8 +25,9 @@ use core::sync::atomic::{AtomicBool, Ordering};
 
 use crate::irq;
 
-/// MUSB OTG controller base address on MT6739.
-/// Source: MT6739 device tree `usb0: usb@11210000`.
+// MUSB OTG controller base address (`MUSB_BASE`) lives in `board::m7` --
+// see its doc comment there for the device-tree source and the open
+// GIC-INTID question (#676).
 
 // ---------------------------------------------------------------------------
 // Common register offsets (relative to MUSB_BASE)
@@ -540,7 +541,7 @@ impl SetupPacket {
     #[must_use]
     pub(crate) fn from_bytes(b: &[u8; 8]) -> Self {
         Self {
-            bm_request_type: b.get(0).copied().unwrap_or_default(),
+            bm_request_type: b.first().copied().unwrap_or_default(),
             b_request: b.get(1).copied().unwrap_or_default(),
             w_value: u16::from_le_bytes([
                 b.get(2).copied().unwrap_or_default(),
@@ -610,7 +611,7 @@ impl LineCoding {
     pub(crate) fn to_bytes(self) -> [u8; 7] {
         let r = self.dw_dte_rate.to_le_bytes();
         [
-            r.get(0).copied().unwrap_or_default(),
+            r.first().copied().unwrap_or_default(),
             r.get(1).copied().unwrap_or_default(),
             r.get(2).copied().unwrap_or_default(),
             r.get(3).copied().unwrap_or_default(),
@@ -625,7 +626,7 @@ impl LineCoding {
     pub(crate) fn from_bytes(b: &[u8; 7]) -> Self {
         Self {
             dw_dte_rate: u32::from_le_bytes([
-                b.get(0).copied().unwrap_or_default(),
+                b.first().copied().unwrap_or_default(),
                 b.get(1).copied().unwrap_or_default(),
                 b.get(2).copied().unwrap_or_default(),
                 b.get(3).copied().unwrap_or_default(),
@@ -1016,7 +1017,14 @@ impl UsbController {
     ///
     /// Returns the number of bytes copied. Returns 0 if the ring buffer is
     /// empty. Does not block.
-    pub(crate) fn read_serial(&mut self, buf: &mut [u8]) -> usize {
+    ///
+    /// WHY: no `self` parameter -- the ring is deliberately NOT a
+    /// `UsbController` field (see [`SerialRxRing`]'s doc comment: it must
+    /// stay reachable from the ISR under its own lock, independent of
+    /// whatever borrow of the controller instance is live). An associated
+    /// function says that honestly instead of taking a `self` the body
+    /// never reads.
+    pub(crate) fn read_serial(buf: &mut [u8]) -> usize {
         with_serial_rx(|r| r.drain(buf))
     }
 
@@ -1029,7 +1037,7 @@ impl UsbController {
     ///
     /// [`read_serial`]: UsbController::read_serial
     #[must_use]
-    pub(crate) fn rx_dropped_bytes(&self) -> u32 {
+    pub(crate) fn rx_dropped_bytes() -> u32 {
         with_serial_rx(|r| r.dropped_bytes())
     }
 
@@ -1042,7 +1050,7 @@ impl UsbController {
     /// finding 4) -- see [`rx_dropped_bytes`].
     ///
     /// [`rx_dropped_bytes`]: UsbController::rx_dropped_bytes
-    fn ring_push(&mut self, byte: u8) -> bool {
+    fn ring_push(byte: u8) -> bool {
         with_serial_rx(|r| r.push(byte))
     }
 
@@ -1404,7 +1412,7 @@ impl UsbController {
                 let byte = core::ptr::read_volatile(fifo as *const u8);
                 // Ring-full bytes are counted, not silently dropped -- see
                 // ring_push / rx_dropped_bytes (issue #282 finding 4).
-                self.ring_push(byte);
+                Self::ring_push(byte);
             }
 
             // Clear RxPktRdy to signal we've consumed the packet.
@@ -1453,7 +1461,7 @@ impl UsbController {
     /// # Safety
     ///
     /// `offset` must be a valid 8-bit MUSB register offset.
-    #[inline(always)]
+    #[inline]
     unsafe fn read8(&self, offset: usize) -> u8 {
         // SAFETY: caller verifies offset is a valid 8-bit MUSB register within the MUSB address space at 0x1121_0000. Volatile access is required for hardware registers.
         unsafe { core::ptr::read_volatile((self.base + offset) as *const u8) }
@@ -1464,7 +1472,7 @@ impl UsbController {
     /// # Safety
     ///
     /// `offset` must be a valid 8-bit MUSB register offset.
-    #[inline(always)]
+    #[inline]
     unsafe fn write8(&self, offset: usize, val: u8) {
         // SAFETY: caller verifies offset is a valid 8-bit MUSB register within the MUSB address space at 0x1121_0000. Volatile access is required for hardware registers.
         unsafe { core::ptr::write_volatile((self.base + offset) as *mut u8, val) }
@@ -1475,7 +1483,7 @@ impl UsbController {
     /// # Safety
     ///
     /// `offset` must be a valid 16-bit MUSB register, 2-byte aligned.
-    #[inline(always)]
+    #[inline]
     unsafe fn read16(&self, offset: usize) -> u16 {
         // SAFETY: caller verifies offset is a valid 2-byte-aligned 16-bit MUSB register within the MUSB address space at 0x1121_0000. Volatile access is required for hardware registers.
         unsafe { core::ptr::read_volatile((self.base + offset) as *const u16) }
@@ -1486,7 +1494,7 @@ impl UsbController {
     /// # Safety
     ///
     /// `offset` must be a valid 16-bit MUSB register, 2-byte aligned.
-    #[inline(always)]
+    #[inline]
     unsafe fn write16(&self, offset: usize, val: u16) {
         // SAFETY: caller verifies offset is a valid 2-byte-aligned 16-bit MUSB register within the MUSB address space at 0x1121_0000. Volatile access is required for hardware registers.
         unsafe { core::ptr::write_volatile((self.base + offset) as *mut u16, val) }
@@ -1734,7 +1742,7 @@ mod tests {
             "device descriptor must be exactly 18 bytes per USB 2.0 spec §9.6.1"
         );
         assert_eq!(
-            DEVICE_DESCRIPTOR.get(0).copied().unwrap_or_default(),
+            DEVICE_DESCRIPTOR.first().copied().unwrap_or_default(),
             18,
             "bLength must equal 18"
         );
@@ -2007,15 +2015,13 @@ mod tests {
 
     #[test]
     fn read_serial_empty() {
-        let mut ctrl = UsbController::new();
         let mut buf = [0u8; 16];
-        let n = ctrl.read_serial(&mut buf);
+        let n = UsbController::read_serial(&mut buf);
         assert_eq!(n, 0, "read FROM empty ring buffer must return 0");
     }
 
     #[test]
     fn read_serial_partial() {
-        let mut ctrl = UsbController::new();
         // Prime the shared ring with 3 bytes through the locked push path.
         with_serial_rx(|r| {
             *r = SerialRxRing::new();
@@ -2025,14 +2031,13 @@ mod tests {
         });
 
         let mut buf = [0u8; 8];
-        let n = ctrl.read_serial(&mut buf);
+        let n = UsbController::read_serial(&mut buf);
         assert_eq!(n, 3, "must read exactly 3 bytes");
         assert_eq!(&buf[..3], b"ABC", "bytes must match what was written");
     }
 
     #[test]
     fn ring_push_drops_and_counts_overflow_when_ring_is_full() {
-        let mut ctrl = UsbController::new();
         // SERIAL_RX_BUF_LEN - 1 slots occupied is "full" for a
         // head==tail-means-empty ring.
         with_serial_rx(|r| {
@@ -2040,12 +2045,12 @@ mod tests {
             r.head = SERIAL_RX_BUF_LEN - 1;
             r.tail = 0;
         });
-        assert_eq!(ctrl.rx_dropped_bytes(), 0, "no drops yet");
+        assert_eq!(UsbController::rx_dropped_bytes(), 0, "no drops yet");
 
-        let accepted = ctrl.ring_push(b'X');
+        let accepted = UsbController::ring_push(b'X');
         assert!(!accepted, "ring at capacity must reject the push");
         assert_eq!(
-            ctrl.rx_dropped_bytes(),
+            UsbController::rx_dropped_bytes(),
             1,
             "a dropped byte must be counted, not silently discarded (issue #282 finding 4)"
         );
@@ -2053,18 +2058,20 @@ mod tests {
 
     #[test]
     fn ring_push_accepts_when_space_available() {
-        let mut ctrl = UsbController::new();
         with_serial_rx(|r| {
             *r = SerialRxRing::new();
         });
-        let accepted = ctrl.ring_push(b'Y');
+        let accepted = UsbController::ring_push(b'Y');
         assert!(accepted, "ring with free space must accept the push");
-        assert_eq!(ctrl.rx_dropped_bytes(), 0, "an accepted push is not a drop");
+        assert_eq!(
+            UsbController::rx_dropped_bytes(),
+            0,
+            "an accepted push is not a drop"
+        );
     }
 
     #[test]
     fn ring_push_and_read_wrap_indices_around_buffer_end() {
-        let mut ctrl = UsbController::new();
         // WHY: position the (empty) ring two slots from the buffer end so the
         // third push crosses SERIAL_RX_BUF_LEN - 1 and must wrap the head
         // index back to 0 rather than index past the end of the buffer.
@@ -2075,15 +2082,15 @@ mod tests {
         });
 
         assert!(
-            ctrl.ring_push(b'A'),
+            UsbController::ring_push(b'A'),
             "push into a non-full ring must be accepted"
         );
         assert!(
-            ctrl.ring_push(b'B'),
+            UsbController::ring_push(b'B'),
             "push into a non-full ring must be accepted"
         );
         assert!(
-            ctrl.ring_push(b'C'),
+            UsbController::ring_push(b'C'),
             "push that crosses the buffer end must still be accepted"
         );
 
@@ -2101,7 +2108,7 @@ mod tests {
         });
 
         let mut buf = [0u8; 3];
-        let n = ctrl.read_serial(&mut buf);
+        let n = UsbController::read_serial(&mut buf);
         assert_eq!(
             n, 3,
             "read_serial must drain all 3 bytes across the wrap boundary"


### PR DESCRIPTION
Burns down the 157 clippy findings in #672's structural backlog for `socket.rs`, `ccci.rs`, `ccci_logger.rs`, `usb.rs`, `emmc.rs`, `telephony.rs`, `sim.rs`, `lfs.rs`, and `ramfs.rs` — no other kernel source file touched.

## Counts per class

| class | sites |
|---|---|
| adding items after statements | 18 |
| reference as raw pointer | 16 |
| accessing first element (`.get(0)` → `.first()`) | 13 |
| `let...else` | 13 |
| identical match arms | 12 |
| lint expectation unfulfilled | 10 |
| long literal lacking separators | 10 |
| hand-coded well-known IP address | 10 |
| unused `#[must_use]` `FirewallVerdict` | 8 |
| unused `self` argument | 6 |
| `#[inline(always)]` on a bad candidate | 5 |
| redundant / unnecessary closure | 5 |
| `if` statement can be collapsed | 4 |
| variables usable directly in `format!` | 3 |
| `assert_eq!` with a literal bool | 2 |
| unnecessary boolean not | 2 |
| only a `panic!` in `if`-then | 2 |
| `to_*` methods should take `self` by value | 2 |
| same item pushed into a `Vec` repeatedly | 2 |
| push immediately after creation → `vec!` | 2 |
| match for single pattern → `if let` | 1 |
| match for equality check → `if` | 1 |
| `Default` impl that can be derived | 1 |
| OR pattern rewritten as a range | 1 |
| argument passed by value but not consumed | 1 |
| argument more efficient passed by value | 1 |
| loop variable used only to index | 1 |
| manual `Debug` impl missing a field | 1 |
| empty `loop {}` wastes CPU cycles | 1 |
| empty lines after doc comment | 1 |
| all fields share the same prefix | 1 |

**Total 157.**

## Where clippy's suggestion needed adaptation, not blind application

- **usb.rs / ccci.rs unused-self** (`read_serial`/`rx_dropped_bytes`/`ring_push`, `start_addr`, `copy_from_shared`): converted to associated functions rather than silenced. All call sites are local; `ring_push`'s one production caller and every test call site updated to `UsbController::method(...)`/`Self::method(...)`.
- **ccci.rs `WdtStatus::is_triggered`**: `WdtStatus` is `Copy` and exactly 4 bytes (the flagged limit) — took `self` by value instead of `&self`.
- **telephony.rs `Urc`**: added `Copy` (every variant field already is) so `handle_urc`'s single caller no longer needs to pass by value needlessly; more idiomatic than rewriting the match to borrow.
- **emmc.rs's 10 `lint expectation is unfulfilled`**: each is a register offset now covered by a `#[test]` (`emmc_register_offsets_match_spec` and the bus-width test) — used under `--tests`, still genuinely dead in production. Wrapped in `cfg_attr(not(test), expect(...))` rather than deleting the expectation, matching the existing `kinit_plan.rs` precedent for the same class (#528).
- **socket.rs hand-coded IPs**: smoltcp's `Ipv4Address` has no `LOCALHOST` (unlike `core::net::Ipv4Addr`, which is what clippy's `ip_constant` message assumes). Added one named `LOOPBACK_ADDR` const (the sole remaining literal, under a scoped `#[allow(clippy::ip_constant)]` + WHY) and reused smoltcp's own `Ipv4Address::UNSPECIFIED`/`BROADCAST` for the 0.0.0.0 / 255.255.255.255 sites — 9 of 10 sites now need no allow at all.
- **socket.rs `SockaddrIn`**: `#[allow(clippy::struct_field_names)]` — the `sin_*` prefix is the actual POSIX `struct sockaddr_in` field naming this struct exists to mirror; renaming would decouple the names from the ABI they document.
- **lfs.rs 48 KiB test payload**: `Box::new([0xAB; N])` does NOT clear clippy's `large_stack_arrays` — the array literal is still built as a stack temporary before the move into the box. Switched to `alloc::vec![elem; N]`, which allocates directly on the heap.

## reference-as-raw-pointer (16, all socket.rs)

Every site is `&T`/`&mut T` → `*const T`/`*mut T` of the **same** `T` (no reinterpretation): 15 are `&mut SockaddrIn → *const SockaddrIn → u32` test-harness address encodings, converted to `core::ptr::from_ref::<SockaddrIn>(x) as u32`; the 16th is the `sys_connect` split-borrow (`&mut NETWORK_STACK` field access), converted to `core::ptr::from_mut::<SocketNetworkStack>(s)`. No provenance or alignment change at any site; existing `SAFETY:` comments already cover the surrounding unsafe blocks and are unchanged.

## `let...else` / items-after-statements

All mechanical, behaviour-preserving control-flow reshapes. socket.rs's 18 items-after-statements sites are function-local `static mut` fixture declarations that clippy wants hoisted to the top of their function (static items have no execution-order dependency) — moved, with no change to what each test exercises.

## Test count

socket, ccci, ccci_logger, usb, emmc, telephony, sim, lfs, ramfs: `#[test]` count identical to `origin/main` for all nine files (24/77/42/32/42/38/20/49/35). No test added, removed, or renamed into a collision.

## Verification

- `cargo fmt --all --check`: clean
- `cargo fmt --manifest-path crates/thumos/Cargo.toml --check`: clean
- `scripts/check-board-seam.sh`, `check-doc-inventory.sh`, `check-lockfile-manifest.sh`, `check-wiring-inventory.sh --no-log`, `check-witness-extraction.sh`, `check-target-test-ledger.sh`: all pass
- `cargo clippy --bin thumos --tests --target i686-unknown-linux-gnu -- -D warnings`: zero findings in all nine target files (720-file-scoped total fell from 720 to 523; the remainder is backlog outside this file set)
- `Cargo.lock`: kernel-crate-local lockfile refresh only (path-dependency versions 0.1.18 → 0.2.2, matching the already-merged #682 release) — no dependency graph change

Touched only the nine assigned files. Not run: the full nextest suite (explicitly out of scope for local verification) and the QEMU boot witness (needs `boot.log`, not produced locally).

Refs #672