### PR TITLE
refactor(kernel): resolve structural clippy findings across the syscall/process/fd/elf core

### DIFF
--- a/crates/thumos/Cargo.lock
+++ b/crates/thumos/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "asphaleia-core"
-version = "0.1.18"
+version = "0.2.2"
 
 [[package]]
 name = "bitflags"
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "haphe"
-version = "0.1.18"
+version = "0.2.2"
 
 [[package]]
 name = "hash32"
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "klesis-core"
-version = "0.1.18"
+version = "0.2.2"
 
 [[package]]
 name = "libc"
@@ -369,7 +369,7 @@ checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "metaxu-core"
-version = "0.1.18"
+version = "0.2.2"
 dependencies = [
  "compact_str",
  "ed25519-dalek",
@@ -479,7 +479,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sema-core"
-version = "0.1.18"
+version = "0.2.2"
 dependencies = [
  "serde",
 ]
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "topos-core"
-version = "0.1.18"
+version = "0.2.2"
 
 [[package]]
 name = "typenum"

--- a/crates/thumos/src/elf.rs
+++ b/crates/thumos/src/elf.rs
@@ -55,6 +55,10 @@ pub(crate) fn flags_to_prot(p_flags: u32) -> u32 {
 /// packed)] binary compatibility.
 #[repr(C, packed)]
 #[derive(Clone, Copy)]
+// WHY: field names mirror the ELF32 spec's own `e_*` names verbatim, so a
+// reader cross-referencing the spec matches fields by name; stripping the
+// shared prefix would decouple this struct from the spec it exists to mirror.
+#[allow(clippy::struct_field_names)]
 struct Elf32Ehdr {
     // kanon:ignore RUST/struct-too-many-fields -- ELF32 spec layout; see doc comment
     e_ident: [u8; 16],
@@ -76,6 +80,9 @@ struct Elf32Ehdr {
 /// ELF32 program header.
 #[repr(C, packed)]
 #[derive(Clone, Copy)]
+// WHY: field names mirror the ELF32 spec's own `p_*` names verbatim; see
+// Elf32Ehdr's identical rationale above.
+#[allow(clippy::struct_field_names)]
 struct Elf32Phdr {
     p_type: u32,
     p_offset: u32,
@@ -238,20 +245,18 @@ fn validate(data: &[u8]) -> Result<(usize, ValidatedElf), ElfError> {
         // fields; plain addition/multiplication can wrap a 32-bit usize
         // target and bypass the bounds check below. checked_mul/checked_add
         // reject a header that would wrap instead of silently admitting it.
-        let offset = match i
+        let Some(offset) = i
             .checked_mul(phentsize)
             .and_then(|stride| stride.checked_add(phoff))
-        {
-            Some(o) => o,
-            None => return Err(ElfError::InvalidSegment),
+        else {
+            return Err(ElfError::InvalidSegment);
         };
         // WHY (#317): bounds-check against PHDR_SIZE (the bytes actually
         // read below), not phentsize (the attacker-controlled stride) — a
         // phentsize >= PHDR_SIZE is enforced above, but the read width
         // itself must never depend on the untrusted field.
-        let offset_end = match offset.checked_add(PHDR_SIZE) {
-            Some(e) => e,
-            None => return Err(ElfError::InvalidSegment),
+        let Some(offset_end) = offset.checked_add(PHDR_SIZE) else {
+            return Err(ElfError::InvalidSegment);
         };
         if offset_end > data.len() {
             return Err(ElfError::InvalidSegment);
@@ -275,9 +280,8 @@ fn validate(data: &[u8]) -> Result<(usize, ValidatedElf), ElfError> {
 
         // WHY (#316): file_offset/filesz are attacker-controlled; checked_add
         // rejects a wrap instead of letting it bypass this guard.
-        let file_end = match file_offset.checked_add(filesz) {
-            Some(e) => e,
-            None => return Err(ElfError::InvalidSegment),
+        let Some(file_end) = file_offset.checked_add(filesz) else {
+            return Err(ElfError::InvalidSegment);
         };
         if file_end > data.len() {
             return Err(ElfError::InvalidSegment);
@@ -297,12 +301,11 @@ fn validate(data: &[u8]) -> Result<(usize, ValidatedElf), ElfError> {
         // total across all segments, via checked arithmetic (memsz +
         // PAGE_SIZE - 1 can itself overflow a 32-bit usize) before any page
         // is allocated.
-        let seg_pages = match memsz
+        let Some(seg_pages) = memsz
             .checked_add(page::PAGE_SIZE - 1)
             .map(|rounded| rounded / page::PAGE_SIZE)
-        {
-            Some(n) => n,
-            None => return Err(ElfError::InvalidSegment),
+        else {
+            return Err(ElfError::InvalidSegment);
         };
         segments.total_pages = match segments.total_pages.checked_add(seg_pages) {
             Some(t) if t <= MAX_ELF_PAGES => t,
@@ -511,7 +514,7 @@ fn load_impl(data: &[u8], placement: Option<(usize, usize)>) -> Result<LoadedElf
         // performed for this same memsz while building validated.total_pages
         // (#327) — if it did not overflow there, it cannot overflow here —
         // so plain arithmetic is safe without re-deriving the check.
-        let num_pages = (memsz + page::PAGE_SIZE - 1) / page::PAGE_SIZE;
+        let num_pages = memsz.div_ceil(page::PAGE_SIZE);
         for p in 0..num_pages {
             pages_used += 1;
 
@@ -578,9 +581,9 @@ fn load_impl(data: &[u8], placement: Option<(usize, usize)>) -> Result<LoadedElf
     // Carry per-segment (vaddr, memsz, p_flags) so spawn_user can map each
     // segment PL0-accessible with W^X permissions (#482).
     let mut segments = [(0usize, 0usize, 0u32); 16];
-    for i in 0..validated.count {
+    for (i, seg) in segments.iter_mut().enumerate().take(validated.count) {
         let (vaddr, memsz, _, _, flags) = validated.segments[i];
-        segments[i] = (vaddr, memsz, flags);
+        *seg = (vaddr, memsz, flags);
     }
     Ok(LoadedElf {
         entry,
@@ -945,7 +948,7 @@ mod tests {
         // WHY no unsafe: addr_of_mut! only forms the static's address; it
         // does not dereference it, so this line needs no unsafe block —
         // only reading/writing through the resulting pointer would.
-        let vaddr = core::ptr::addr_of_mut!(BUF) as *mut u8 as usize;
+        let vaddr = core::ptr::addr_of_mut!(BUF).cast::<u8>() as usize;
 
         let mut data = [0u8; ELF32_EHDR_SIZE + ELF32_PHDR_SIZE + 4];
         let h = make_valid_ehdr();
@@ -1012,7 +1015,7 @@ mod tests {
         // (fail-before-destroy), so a boot/exec image can never write into
         // page-allocator RAM or escape the exec revocation surface.
         static mut BUF: [u8; 16] = [0xEE; 16];
-        let vaddr = core::ptr::addr_of_mut!(BUF) as *mut u8 as usize;
+        let vaddr = core::ptr::addr_of_mut!(BUF).cast::<u8>() as usize;
 
         let mut data = [0u8; ELF32_EHDR_SIZE + ELF32_PHDR_SIZE + 4];
         let h = make_valid_ehdr();
@@ -1073,7 +1076,7 @@ mod tests {
         // WHY no unsafe: addr_of_mut! only forms the static's address; it
         // does not dereference it, so this line needs no unsafe block —
         // only reading/writing through the resulting pointer would.
-        let vaddr = core::ptr::addr_of_mut!(BUF) as *mut u8 as usize;
+        let vaddr = core::ptr::addr_of_mut!(BUF).cast::<u8>() as usize;
 
         let mut data = [0u8; ELF32_EHDR_SIZE + ELF32_PHDR_SIZE];
         let h = make_valid_ehdr();

--- a/crates/thumos/src/fd.rs
+++ b/crates/thumos/src/fd.rs
@@ -181,9 +181,8 @@ impl FileDescriptor {
         // SAFETY: MOUNT_TABLE is a static mut; single-core cooperative
         // kernel ensures exclusive access during syscall handling.
         let mt_opt = unsafe { &*core::ptr::addr_of!(MOUNT_TABLE) };
-        let mt = match mt_opt.as_ref() {
-            Some(t) => t,
-            None => return 0,
+        let Some(mt) = mt_opt.as_ref() else {
+            return 0;
         };
         match mt.get(self.mount_idx as usize) {
             Some(fs) => match fs.stat(self.inode_id) {
@@ -419,7 +418,7 @@ pub(crate) fn fork_table(parent: &FdTable) -> FdTable {
 /// exit/fault (#267): close every fd -- drain the table, unref each OFD.
 /// Idempotent: a drained table is a no-op.
 pub(crate) fn close_all(table: &mut FdTable) {
-    for slot in table.entries.iter_mut() {
+    for slot in &mut table.entries {
         if let Some(entry) = slot.take() {
             ofd_unref(entry.ofd);
         }
@@ -429,11 +428,11 @@ pub(crate) fn close_all(table: &mut FdTable) {
 /// execve (#267): close every fd with `FD_CLOEXEC` set. Called only after
 /// the last execve failure point (POSIX: fds close on SUCCESSFUL exec).
 pub(crate) fn close_cloexec(table: &mut FdTable) {
-    for slot in table.entries.iter_mut() {
-        if slot.map(|e| e.cloexec).unwrap_or(false) {
-            if let Some(entry) = slot.take() {
-                ofd_unref(entry.ofd);
-            }
+    for slot in &mut table.entries {
+        if slot.map(|e| e.cloexec).unwrap_or(false)
+            && let Some(entry) = slot.take()
+        {
+            ofd_unref(entry.ofd);
         }
     }
 }
@@ -574,19 +573,16 @@ pub unsafe fn init_ramfs(fs: crate::ramfs::RamFs) {
     unsafe {
         let mt_opt = &mut *core::ptr::addr_of_mut!(MOUNT_TABLE);
 
-        match mt_opt {
-            Some(mt) => {
-                // Only mount root if not already mounted (init_vfs may have been called first)
-                if mt.lookup("/").is_none() {
-                    let _ = mt.mount("/", Box::new(fs)); // WHY: legacy init shim; mount failure leaves table unpopulated and later syscalls fail
-                }
-            }
-            None => {
-                // init_vfs was never called; create a new mount table with just ramfs.
-                let mut mt = MountTable::new();
+        if let Some(mt) = mt_opt {
+            // Only mount root if not already mounted (init_vfs may have been called first)
+            if mt.lookup("/").is_none() {
                 let _ = mt.mount("/", Box::new(fs)); // WHY: legacy init shim; mount failure leaves table unpopulated and later syscalls fail
-                *mt_opt = Some(mt);
             }
+        } else {
+            // init_vfs was never called; create a new mount table with just ramfs.
+            let mut mt = MountTable::new();
+            let _ = mt.mount("/", Box::new(fs)); // WHY: legacy init shim; mount failure leaves table unpopulated and later syscalls fail
+            *mt_opt = Some(mt);
         }
     }
 }
@@ -637,9 +633,8 @@ pub unsafe fn ramfs_find(path: &str) -> Option<&'static [u8]> {
     unsafe {
         let mt = get_mount_table()?;
 
-        let (mount_idx, inode_id) = match vfs::resolve_path(mt, path) {
-            Ok(r) => r,
-            Err(_) => return None,
+        let Ok((mount_idx, inode_id)) = vfs::resolve_path(mt, path) else {
+            return None;
         };
 
         let fs = mt.get(mount_idx)?;
@@ -677,14 +672,13 @@ pub unsafe fn ramfs_find(path: &str) -> Option<&'static [u8]> {
                 let leaked = buf.leak();
 
                 let cache = &mut *core::ptr::addr_of_mut!(ELF_CACHE);
-                let slot_idx = match cache.iter().position(|s| s.is_none()) {
-                    Some(idx) => idx,
-                    None => {
-                        let next = &mut *core::ptr::addr_of_mut!(ELF_CACHE_NEXT);
-                        let idx = *next % ELF_CACHE_SLOTS;
-                        *next = (*next + 1) % ELF_CACHE_SLOTS;
-                        idx
-                    }
+                let slot_idx = if let Some(idx) = cache.iter().position(Option::is_none) {
+                    idx
+                } else {
+                    let next = &mut *core::ptr::addr_of_mut!(ELF_CACHE_NEXT);
+                    let idx = *next % ELF_CACHE_SLOTS;
+                    *next = (*next + 1) % ELF_CACHE_SLOTS;
+                    idx
                 };
                 cache[slot_idx] = Some(ElfCacheEntry {
                     mount_idx: mount_idx_u8,
@@ -728,15 +722,13 @@ pub(crate) fn sys_open(path_ptr: u32, path_len: u32, flags: u32) -> u32 {
     // SAFETY: validate_user_buffer confirmed [path_ptr, path_ptr+len) lies
     // within user-accessible DRAM.
     let path_slice = unsafe { core::slice::from_raw_parts(path_ptr as *const u8, len) };
-    let path = match core::str::from_utf8(path_slice) {
-        Ok(s) => s,
-        Err(_) => return EINVAL,
+    let Ok(path) = core::str::from_utf8(path_slice) else {
+        return EINVAL;
     };
 
     // SAFETY: init_vfs has been called during kernel init.
-    let mt = match unsafe { get_mount_table() } {
-        Some(t) => t,
-        None => return ENOENT,
+    let Some(mt) = (unsafe { get_mount_table() }) else {
+        return ENOENT;
     };
 
     let (mount_idx, inode_id) = match vfs::resolve_path(mt, path) {
@@ -763,14 +755,13 @@ pub(crate) fn sys_open(path_ptr: u32, path_len: u32, flags: u32) -> u32 {
     };
     let installed =
         crate::process::with_current_fds(|t| t.alloc(FdEntry { ofd, cloexec })).flatten();
-    match installed {
-        Some(n) => n as u32,
-        None => {
-            // Absent PCB or per-process table full: roll the OFD back --
-            // never leave an orphaned description (fail closed).
-            ofd_unref(ofd);
-            EMFILE
-        }
+    if let Some(n) = installed {
+        n as u32
+    } else {
+        // Absent PCB or per-process table full: roll the OFD back --
+        // never leave an orphaned description (fail closed).
+        ofd_unref(ofd);
+        EMFILE
     }
 }
 
@@ -818,13 +809,11 @@ pub(crate) fn sys_read(fd: u32, buf_ptr: u32, count: u32) -> u32 {
     // required so devfs can serve /dev/urandom via Filesystem::read_mut()
     // (its PRNG needs &mut self); every other filesystem's read_mut()
     // defaults to its immutable read() (see vfs.rs).
-    let mt = match unsafe { get_mount_table_mut() } {
-        Some(t) => t,
-        None => return EBADF,
+    let Some(mt) = (unsafe { get_mount_table_mut() }) else {
+        return EBADF;
     };
-    let fs = match mt.get_mut(mount_idx) {
-        Some(f) => f,
-        None => return EBADF,
+    let Some(fs) = mt.get_mut(mount_idx) else {
+        return EBADF;
     };
 
     // SAFETY: buf_ptr + count validated by validate_user_buffer above
@@ -888,13 +877,11 @@ pub(crate) fn sys_write(fd: u32, buf_ptr: u32, count: u32) -> u32 {
 
     // SAFETY: init_vfs has been called during kernel init.
     // Mutable access needed for write.
-    let mt = match unsafe { get_mount_table_mut() } {
-        Some(t) => t,
-        None => return EBADF,
+    let Some(mt) = (unsafe { get_mount_table_mut() }) else {
+        return EBADF;
     };
-    let fs = match mt.get_mut(mount_idx) {
-        Some(f) => f,
-        None => return EBADF,
+    let Some(fs) = mt.get_mut(mount_idx) else {
+        return EBADF;
     };
 
     // SAFETY: buf_ptr + count validated by validate_user_buffer above
@@ -966,25 +953,21 @@ pub(crate) fn sys_stat(path_ptr: u32, path_len: u32, stat_buf_ptr: u32) -> u32 {
     // SAFETY: validate_user_buffer confirmed [path_ptr, path_ptr+len) lies
     // within user-accessible DRAM.
     let path_slice = unsafe { core::slice::from_raw_parts(path_ptr as *const u8, len) };
-    let path = match core::str::from_utf8(path_slice) {
-        Ok(s) => s,
-        Err(_) => return EINVAL,
+    let Ok(path) = core::str::from_utf8(path_slice) else {
+        return EINVAL;
     };
 
     // SAFETY: init_vfs has been called during kernel init.
-    let mt = match unsafe { get_mount_table() } {
-        Some(t) => t,
-        None => return ENOENT,
+    let Some(mt) = (unsafe { get_mount_table() }) else {
+        return ENOENT;
     };
 
-    let (mount_idx, inode_id) = match vfs::resolve_path(mt, path) {
-        Ok(r) => r,
-        Err(_) => return ENOENT,
+    let Ok((mount_idx, inode_id)) = vfs::resolve_path(mt, path) else {
+        return ENOENT;
     };
 
-    let fs = match mt.get(mount_idx) {
-        Some(f) => f,
-        None => return ENOENT,
+    let Some(fs) = mt.get(mount_idx) else {
+        return ENOENT;
     };
 
     let inode_stat = match fs.stat(inode_id) {
@@ -1049,35 +1032,29 @@ pub(crate) fn sys_fstat(fd: u32, stat_buf_ptr: u32) -> u32 {
     }
 
     // SAFETY: init_vfs has been called during kernel init.
-    let mt = match unsafe { get_mount_table() } {
-        Some(t) => t,
-        None => {
-            // Mount table not initialized — return minimal stat.
-            let stat = StatBuf {
-                size: 0,
-                file_type: S_IFREG,
-            };
-            unsafe {
-                let dst = stat_buf_ptr as *mut StatBuf;
-                core::ptr::write(dst, stat);
-            }
-            return 0;
+    let Some(mt) = (unsafe { get_mount_table() }) else {
+        // Mount table not initialized — return minimal stat.
+        let stat = StatBuf {
+            size: 0,
+            file_type: S_IFREG,
+        };
+        unsafe {
+            let dst = stat_buf_ptr as *mut StatBuf;
+            core::ptr::write(dst, stat);
         }
+        return 0;
     };
-    let fs = match mt.get(entry.mount_idx as usize) {
-        Some(f) => f,
-        None => {
-            // Pipe fd or no filesystem — return minimal stat
-            let stat = StatBuf {
-                size: 0,
-                file_type: S_IFREG,
-            };
-            unsafe {
-                let dst = stat_buf_ptr as *mut StatBuf;
-                core::ptr::write(dst, stat);
-            }
-            return 0;
+    let Some(fs) = mt.get(entry.mount_idx as usize) else {
+        // Pipe fd or no filesystem — return minimal stat
+        let stat = StatBuf {
+            size: 0,
+            file_type: S_IFREG,
+        };
+        unsafe {
+            let dst = stat_buf_ptr as *mut StatBuf;
+            core::ptr::write(dst, stat);
         }
+        return 0;
     };
 
     let inode_stat = match fs.stat(entry.inode_id) {
@@ -1120,6 +1097,9 @@ pub(crate) fn sys_fstat(fd: u32, stat_buf_ptr: u32) -> u32 {
 /// # Returns
 /// New file offset on success, negative error code on failure.
 pub(crate) fn sys_lseek(fd: u32, offset: u32, whence: u32) -> u32 {
+    // The syscall ABI reports the result in r0 as a signed i32 (0 =
+    // success); the representable non-error domain is 0..=i32::MAX.
+    const MAX_REPRESENTABLE_POS: i64 = 0x7FFF_FFFF;
     let fd_idx = fd as usize;
 
     let Some(ofd_idx) = resolve_fd(fd_idx) else {
@@ -1157,10 +1137,7 @@ pub(crate) fn sys_lseek(fd: u32, offset: u32, whence: u32) -> u32 {
         _ => return EINVAL,
     };
 
-    // The syscall ABI reports the result in r0 as a signed i32 (0 =
-    // success); the representable non-error domain is 0..=i32::MAX.
-    const MAX_REPRESENTABLE_POS: i64 = 0x7FFF_FFFF;
-    if new_pos < 0 || new_pos > MAX_REPRESENTABLE_POS {
+    if !(0..=MAX_REPRESENTABLE_POS).contains(&new_pos) {
         return EINVAL;
     }
 
@@ -1449,9 +1426,8 @@ pub(crate) fn sys_mkdir(path_ptr: u32, path_len: u32) -> u32 {
     // SAFETY: validate_user_buffer confirmed [path_ptr, path_ptr+len) lies
     // within user-accessible DRAM.
     let path_slice = unsafe { core::slice::from_raw_parts(path_ptr as *const u8, len) };
-    let path = match core::str::from_utf8(path_slice) {
-        Ok(s) => s,
-        Err(_) => return EINVAL,
+    let Ok(path) = core::str::from_utf8(path_slice) else {
+        return EINVAL;
     };
 
     vfs_mkdir(path)
@@ -1462,15 +1438,13 @@ pub(crate) fn sys_mkdir(path_ptr: u32, path_len: u32) -> u32 {
 /// Splits the path into parent and final component, resolves the parent
 /// directory, then creates the directory entry.
 pub(crate) fn vfs_mkdir(path: &str) -> u32 {
-    let (parent_path, name) = match split_parent_name(path) {
-        Some(r) => r,
-        None => return EINVAL,
+    let Some((parent_path, name)) = split_parent_name(path) else {
+        return EINVAL;
     };
 
     // SAFETY: init_vfs has been called during kernel init.
-    let mt = match unsafe { get_mount_table_mut() } {
-        Some(t) => t,
-        None => return VfsError::NotFound.to_errno(),
+    let Some(mt) = (unsafe { get_mount_table_mut() }) else {
+        return VfsError::NotFound.to_errno();
     };
 
     let (mount_idx, parent_inode) = match vfs::resolve_path(mt, parent_path) {
@@ -1478,9 +1452,8 @@ pub(crate) fn vfs_mkdir(path: &str) -> u32 {
         Err(e) => return e.to_errno(),
     };
 
-    let fs = match mt.get_mut(mount_idx) {
-        Some(f) => f,
-        None => return VfsError::NotFound.to_errno(),
+    let Some(fs) = mt.get_mut(mount_idx) else {
+        return VfsError::NotFound.to_errno();
     };
 
     match fs.create(parent_inode, name, InodeType::Directory) {
@@ -1514,9 +1487,8 @@ pub(crate) fn sys_unlink(path_ptr: u32, path_len: u32) -> u32 {
     // SAFETY: validate_user_buffer confirmed [path_ptr, path_ptr+len) lies
     // within user-accessible DRAM.
     let path_slice = unsafe { core::slice::from_raw_parts(path_ptr as *const u8, len) };
-    let path = match core::str::from_utf8(path_slice) {
-        Ok(s) => s,
-        Err(_) => return EINVAL,
+    let Ok(path) = core::str::from_utf8(path_slice) else {
+        return EINVAL;
     };
 
     vfs_unlink(path)
@@ -1524,15 +1496,13 @@ pub(crate) fn sys_unlink(path_ptr: u32, path_len: u32) -> u32 {
 
 /// Remove a file or directory via VFS path resolution.
 pub(crate) fn vfs_unlink(path: &str) -> u32 {
-    let (parent_path, name) = match split_parent_name(path) {
-        Some(r) => r,
-        None => return EINVAL,
+    let Some((parent_path, name)) = split_parent_name(path) else {
+        return EINVAL;
     };
 
     // SAFETY: init_vfs has been called during kernel init.
-    let mt = match unsafe { get_mount_table_mut() } {
-        Some(t) => t,
-        None => return VfsError::NotFound.to_errno(),
+    let Some(mt) = (unsafe { get_mount_table_mut() }) else {
+        return VfsError::NotFound.to_errno();
     };
 
     let (mount_idx, parent_inode) = match vfs::resolve_path(mt, parent_path) {
@@ -1540,9 +1510,8 @@ pub(crate) fn vfs_unlink(path: &str) -> u32 {
         Err(e) => return e.to_errno(),
     };
 
-    let fs = match mt.get_mut(mount_idx) {
-        Some(f) => f,
-        None => return VfsError::NotFound.to_errno(),
+    let Some(fs) = mt.get_mut(mount_idx) else {
+        return VfsError::NotFound.to_errno();
     };
 
     match fs.unlink(parent_inode, name) {
@@ -1576,9 +1545,8 @@ pub(crate) fn sys_chdir(path_ptr: u32, path_len: u32) -> u32 {
     // SAFETY: validate_user_buffer confirmed [path_ptr, path_ptr+len) lies
     // within user-accessible DRAM.
     let path_slice = unsafe { core::slice::from_raw_parts(path_ptr as *const u8, len) };
-    let path = match core::str::from_utf8(path_slice) {
-        Ok(s) => s,
-        Err(_) => return EINVAL,
+    let Ok(path) = core::str::from_utf8(path_slice) else {
+        return EINVAL;
     };
 
     vfs_chdir(path)
@@ -1589,9 +1557,8 @@ pub(crate) fn sys_chdir(path_ptr: u32, path_len: u32) -> u32 {
 /// Verifies the path resolves to a directory, then updates the global CWD.
 pub(crate) fn vfs_chdir(path: &str) -> u32 {
     // SAFETY: init_vfs has been called during kernel init.
-    let mt = match unsafe { get_mount_table() } {
-        Some(t) => t,
-        None => return VfsError::NotFound.to_errno(),
+    let Some(mt) = (unsafe { get_mount_table() }) else {
+        return VfsError::NotFound.to_errno();
     };
 
     let (mount_idx, inode_id) = match vfs::resolve_path(mt, path) {
@@ -1599,9 +1566,8 @@ pub(crate) fn vfs_chdir(path: &str) -> u32 {
         Err(e) => return e.to_errno(),
     };
 
-    let fs = match mt.get(mount_idx) {
-        Some(f) => f,
-        None => return VfsError::NotFound.to_errno(),
+    let Some(fs) = mt.get(mount_idx) else {
+        return VfsError::NotFound.to_errno();
     };
 
     // Verify it's a directory
@@ -1944,6 +1910,13 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn read_file_contents() {
+        // WHY function-local `static mut`: sys_read now validates buf_ptr via
+        // validate_user_buffer before dereferencing it. This binary's PIE
+        // image (hence any `static`) loads inside
+        // [board::KERNEL_END, board::RAM_END) on this host toolchain;
+        // a stack array does not (verified: glibc places the per-test-thread
+        // stack near the top of the 32-bit address space, above RAM_END).
+        static mut BUF: [u8; 64] = [0u8; 64];
         // SAFETY: test-only.
         unsafe {
             setup_test_vfs();
@@ -1952,13 +1925,6 @@ mod tests {
         let fd = sys_open(path.as_ptr() as u32, path.len() as u32, 0);
         assert_eq!(fd, 0);
 
-        // WHY function-local `static mut`: sys_read now validates buf_ptr via
-        // validate_user_buffer before dereferencing it. This binary's PIE
-        // image (hence any `static`) loads inside
-        // [board::KERNEL_END, board::RAM_END) on this host toolchain;
-        // a stack array does not (verified: glibc places the per-test-thread
-        // stack near the top of the 32-bit address space, above RAM_END).
-        static mut BUF: [u8; 64] = [0u8; 64];
         // SAFETY: test-only static; single-threaded per test.
         let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUF) };
         let bytes_read = sys_read(fd, buf.as_mut_ptr() as u32, 64);
@@ -1974,6 +1940,7 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn read_at_eof_returns_zero() {
+        static mut BUF: [u8; 64] = [0u8; 64];
         // SAFETY: test-only.
         unsafe {
             setup_test_vfs();
@@ -1981,7 +1948,6 @@ mod tests {
         let path = b"/test.txt";
         let fd = sys_open(path.as_ptr() as u32, path.len() as u32, 0);
 
-        static mut BUF: [u8; 64] = [0u8; 64];
         // SAFETY: test-only static; single-threaded per test.
         let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUF) };
         let _ = sys_read(fd, buf.as_mut_ptr() as u32, 64);
@@ -1999,6 +1965,7 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn close_then_read_returns_ebadf() {
+        static mut BUF: [u8; 64] = [0u8; 64];
         // SAFETY: test-only.
         unsafe {
             setup_test_vfs();
@@ -2007,7 +1974,6 @@ mod tests {
         let fd = sys_open(path.as_ptr() as u32, path.len() as u32, 0);
         assert_eq!(sys_close(fd), 0);
 
-        static mut BUF: [u8; 64] = [0u8; 64];
         // SAFETY: test-only static; single-threaded per test.
         let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUF) };
         let result = sys_read(fd, buf.as_mut_ptr() as u32, 64);
@@ -2022,6 +1988,7 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn lseek_set_then_read() {
+        static mut BUF: [u8; 32] = [0u8; 32];
         // SAFETY: test-only.
         unsafe {
             setup_test_vfs();
@@ -2033,7 +2000,6 @@ mod tests {
         let new_pos = sys_lseek(fd, 7, SEEK_SET);
         assert_eq!(new_pos, 7);
 
-        static mut BUF: [u8; 32] = [0u8; 32];
         // SAFETY: test-only static; single-threaded per test.
         let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUF) };
         let bytes_read = sys_read(fd, buf.as_mut_ptr() as u32, 32);
@@ -2049,6 +2015,7 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn lseek_end_positions_at_eof() {
+        static mut BUF: [u8; 32] = [0u8; 32];
         // SAFETY: test-only.
         unsafe {
             setup_test_vfs();
@@ -2059,7 +2026,6 @@ mod tests {
         let new_pos = sys_lseek(fd, 0, SEEK_END);
         assert_eq!(new_pos, 14);
 
-        static mut BUF: [u8; 32] = [0u8; 32];
         // SAFETY: test-only static; single-threaded per test.
         let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUF) };
         let bytes_read = sys_read(fd, buf.as_mut_ptr() as u32, 32);
@@ -2077,6 +2043,11 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn dup_shares_offset_with_original() {
+        // Read from fd0 — the dup SHARES the OFD, so fd1's offset advances too.
+        static mut BUF: [u8; 5] = [0u8; 5];
+        // fd1 must continue from the offset fd0 just advanced to (5), not
+        // restart from 0.
+        static mut BUF2: [u8; 7] = [0u8; 7];
         // SAFETY: test-only.
         unsafe {
             setup_test_vfs();
@@ -2088,17 +2059,12 @@ mod tests {
         let fd1 = sys_dup(fd0);
         assert_eq!(fd1, 1, "dup should return lowest available fd");
 
-        // Read from fd0 — the dup SHARES the OFD, so fd1's offset advances too.
-        static mut BUF: [u8; 5] = [0u8; 5];
         // SAFETY: test-only static; single-threaded per test.
         let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUF) };
         let n = sys_read(fd0, buf.as_mut_ptr() as u32, 5);
         assert_eq!(n, 5);
         assert_eq!(&*buf, b"Hello");
 
-        // fd1 must continue from the offset fd0 just advanced to (5), not
-        // restart from 0.
-        static mut BUF2: [u8; 7] = [0u8; 7];
         // SAFETY: test-only static; single-threaded per test.
         let buf2 = unsafe { &mut *core::ptr::addr_of_mut!(BUF2) };
         let bytes = sys_read(fd1, buf2.as_mut_ptr() as u32, 7);
@@ -2117,6 +2083,7 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn dup2_replaces_target_fd() {
+        static mut BUF: [u8; 5] = [0u8; 5];
         // SAFETY: test-only.
         unsafe {
             setup_test_vfs();
@@ -2131,7 +2098,6 @@ mod tests {
         let result = sys_dup2(fd0, fd1);
         assert_eq!(result, 1);
 
-        static mut BUF: [u8; 5] = [0u8; 5];
         // SAFETY: test-only static; single-threaded per test.
         let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUF) };
         let bytes = sys_read(1, buf.as_mut_ptr() as u32, 5);
@@ -2147,21 +2113,21 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn stat_existing_file() {
+        static mut STAT: StatBuf = StatBuf {
+            size: 0,
+            file_type: 0,
+        };
         // SAFETY: test-only.
         unsafe {
             setup_test_vfs();
         }
         let path = b"/test.txt";
-        static mut STAT: StatBuf = StatBuf {
-            size: 0,
-            file_type: 0,
-        };
         // SAFETY: test-only static; single-threaded per test.
         let stat = unsafe { &mut *core::ptr::addr_of_mut!(STAT) };
         let result = sys_stat(
             path.as_ptr() as u32,
             path.len() as u32,
-            stat as *mut StatBuf as u32,
+            core::ptr::from_mut::<StatBuf>(stat) as u32,
         );
         assert_eq!(result, 0);
         assert_eq!(stat.size, 14);
@@ -2176,21 +2142,21 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn stat_nonexistent_returns_enoent() {
+        static mut STAT: StatBuf = StatBuf {
+            size: 0,
+            file_type: 0,
+        };
         // SAFETY: test-only.
         unsafe {
             setup_test_vfs();
         }
         let path = b"/nope";
-        static mut STAT: StatBuf = StatBuf {
-            size: 0,
-            file_type: 0,
-        };
         // SAFETY: test-only static; single-threaded per test.
         let stat = unsafe { &mut *core::ptr::addr_of_mut!(STAT) };
         let result = sys_stat(
             path.as_ptr() as u32,
             path.len() as u32,
-            stat as *mut StatBuf as u32,
+            core::ptr::from_mut::<StatBuf>(stat) as u32,
         );
         assert_eq!(result, ENOENT);
     }
@@ -2203,6 +2169,10 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn fstat_open_fd() {
+        static mut STAT: StatBuf = StatBuf {
+            size: 0,
+            file_type: 0,
+        };
         // SAFETY: test-only.
         unsafe {
             setup_test_vfs();
@@ -2211,13 +2181,9 @@ mod tests {
         let fd = sys_open(path.as_ptr() as u32, path.len() as u32, 0);
         assert_eq!(fd, 0);
 
-        static mut STAT: StatBuf = StatBuf {
-            size: 0,
-            file_type: 0,
-        };
         // SAFETY: test-only static; single-threaded per test.
         let stat = unsafe { &mut *core::ptr::addr_of_mut!(STAT) };
-        let result = sys_fstat(fd, stat as *mut StatBuf as u32);
+        let result = sys_fstat(fd, core::ptr::from_mut::<StatBuf>(stat) as u32);
         assert_eq!(result, 0);
         assert_eq!(stat.size, 6);
         assert_eq!(stat.file_type, S_IFREG);
@@ -2225,17 +2191,17 @@ mod tests {
 
     #[test]
     fn fstat_closed_fd_returns_ebadf() {
-        // SAFETY: test-only.
-        unsafe {
-            setup_test_vfs();
-        }
         static mut STAT: StatBuf = StatBuf {
             size: 0,
             file_type: 0,
         };
+        // SAFETY: test-only.
+        unsafe {
+            setup_test_vfs();
+        }
         // SAFETY: test-only static; single-threaded per test.
         let stat = unsafe { &mut *core::ptr::addr_of_mut!(STAT) };
-        let result = sys_fstat(99, stat as *mut StatBuf as u32);
+        let result = sys_fstat(99, core::ptr::from_mut::<StatBuf>(stat) as u32);
         assert_eq!(result, EBADF);
     }
 
@@ -2244,6 +2210,10 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn fstat_propagates_real_stat_error_instead_of_fabricating_success() {
+        static mut STAT: StatBuf = StatBuf {
+            size: 0,
+            file_type: 0,
+        };
         // SAFETY: test-only.
         unsafe {
             setup_test_vfs();
@@ -2251,13 +2221,9 @@ mod tests {
         let bogus = FileDescriptor::from_vfs(0, 9_999, 0);
         let fd = install_test_fd(bogus);
 
-        static mut STAT: StatBuf = StatBuf {
-            size: 0,
-            file_type: 0,
-        };
         // SAFETY: test-only static; single-threaded per test.
         let stat = unsafe { &mut *core::ptr::addr_of_mut!(STAT) };
-        let result = sys_fstat(fd, stat as *mut StatBuf as u32);
+        let result = sys_fstat(fd, core::ptr::from_mut::<StatBuf>(stat) as u32);
 
         assert_ne!(
             result, 0,
@@ -2273,11 +2239,11 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn getcwd_returns_root() {
+        static mut BUF: [u8; 16] = [0u8; 16];
         // SAFETY: test-only.
         unsafe {
             setup_test_vfs();
         }
-        static mut BUF: [u8; 16] = [0u8; 16];
         // SAFETY: test-only static; single-threaded per test.
         let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUF) };
         let result = sys_getcwd(buf.as_mut_ptr() as u32, 16);
@@ -2289,14 +2255,14 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn getcwd_buffer_too_small_returns_einval() {
-        // SAFETY: test-only.
-        unsafe {
-            setup_test_vfs();
-        }
         // The root cwd ("/") needs 2 bytes (1 char + NUL terminator); a
         // 1-byte buffer must be rejected, not truncated or overflowed
         // (issue #282 finding 14).
         static mut BUF: [u8; 1] = [0u8; 1];
+        // SAFETY: test-only.
+        unsafe {
+            setup_test_vfs();
+        }
         // SAFETY: test-only static; single-threaded per test.
         let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUF) };
         let result = sys_getcwd(buf.as_mut_ptr() as u32, 1);
@@ -2316,6 +2282,7 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn write_and_read_back_via_vfs() {
+        static mut BUF: [u8; 32] = [0u8; 32];
         // SAFETY: test-only.
         unsafe {
             setup_test_vfs();
@@ -2335,7 +2302,6 @@ mod tests {
         let fd = sys_open(path.as_ptr() as u32, path.len() as u32, 0);
         assert!(fd < MAX_FDS as u32, "open should succeed");
 
-        static mut BUF: [u8; 32] = [0u8; 32];
         // SAFETY: test-only static; single-threaded per test.
         let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUF) };
         let read = sys_read(fd, buf.as_mut_ptr() as u32, 32);
@@ -2368,6 +2334,7 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn read_dev_urandom_returns_random_bytes() {
+        static mut BUF: [u8; 32] = [0u8; 32];
         // SAFETY: test-only.
         unsafe {
             setup_test_vfs();
@@ -2376,7 +2343,6 @@ mod tests {
         let fd = sys_open(path.as_ptr() as u32, path.len() as u32, 0);
         assert!(fd < MAX_FDS as u32, "opening /dev/urandom should succeed");
 
-        static mut BUF: [u8; 32] = [0u8; 32];
         // SAFETY: test-only static; single-threaded per test.
         let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUF) };
         let read = sys_read(fd, buf.as_mut_ptr() as u32, 32);
@@ -2398,6 +2364,10 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn mkdir_and_verify() {
+        static mut STAT: StatBuf = StatBuf {
+            size: 0,
+            file_type: 0,
+        };
         // SAFETY: test-only.
         unsafe {
             setup_test_vfs();
@@ -2407,16 +2377,12 @@ mod tests {
 
         // Stat should show directory
         let path = b"/mydir";
-        static mut STAT: StatBuf = StatBuf {
-            size: 0,
-            file_type: 0,
-        };
         // SAFETY: test-only static; single-threaded per test.
         let stat = unsafe { &mut *core::ptr::addr_of_mut!(STAT) };
         let r = sys_stat(
             path.as_ptr() as u32,
             path.len() as u32,
-            stat as *mut StatBuf as u32,
+            core::ptr::from_mut::<StatBuf>(stat) as u32,
         );
         assert_eq!(r, 0);
         assert_eq!(stat.file_type, S_IFDIR);
@@ -2458,6 +2424,8 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn chdir_to_valid_directory() {
+        // getcwd should return "/subdir"
+        static mut BUF: [u8; 32] = [0u8; 32];
         // SAFETY: test-only.
         unsafe {
             setup_test_vfs();
@@ -2469,8 +2437,6 @@ mod tests {
         let result = vfs_chdir("/subdir");
         assert_eq!(result, 0);
 
-        // getcwd should return "/subdir"
-        static mut BUF: [u8; 32] = [0u8; 32];
         // SAFETY: test-only static; single-threaded per test.
         let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUF) };
         sys_getcwd(buf.as_mut_ptr() as u32, 32);
@@ -2668,6 +2634,7 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn write_dispatches_to_vfs_for_file_fds() {
+        static mut BUF: [u8; 32] = [0u8; 32];
         unsafe {
             setup_test_vfs();
         }
@@ -2678,7 +2645,7 @@ mod tests {
         let _file_id = fs
             .create(0, "writable.txt", InodeType::RegularFile)
             .expect("create");
-        drop(fs);
+        let _ = fs;
 
         let path = b"/writable.txt";
         let fd = sys_open(path.as_ptr() as u32, path.len() as u32, 0);
@@ -2694,7 +2661,6 @@ mod tests {
 
         // Read back
         let _ = sys_lseek(fd, 0, SEEK_SET);
-        static mut BUF: [u8; 32] = [0u8; 32];
         // SAFETY: test-only static; single-threaded per test.
         let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUF) };
         let read = sys_read(fd, buf.as_mut_ptr() as u32, 32);
@@ -2897,7 +2863,9 @@ mod tests {
     /// referenced as a function pointer to populate the new PCB's context.
     #[cfg(target_pointer_width = "32")]
     fn isolation_test_entry() -> ! {
-        loop {}
+        loop {
+            core::hint::spin_loop();
+        }
     }
 
     /// ISOLATION: a different process must not be able to name proc0's fd
@@ -2907,6 +2875,7 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn fd_isolation_cross_process_ops_return_ebadf() {
+        static mut BUF: [u8; 8] = [0u8; 8];
         // SAFETY: test-only.
         unsafe {
             setup_test_vfs();
@@ -2923,7 +2892,6 @@ mod tests {
             crate::process::set_current_for_test(other_pid);
         }
 
-        static mut BUF: [u8; 8] = [0u8; 8];
         // SAFETY: test-only static; single-threaded per test.
         let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUF) };
         assert_eq!(
@@ -2955,6 +2923,11 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn fork_shares_ofd_offset_advances_together() {
+        // Parent reads 5 bytes ("Hello") before forking.
+        static mut BUF: [u8; 5] = [0u8; 5];
+        // Child's fd 0 shares the SAME OFD -- offset continues at 5, not 0.
+        static mut BUF2: [u8; 7] = [0u8; 7];
+        static mut BUF3: [u8; 2] = [0u8; 2];
         // SAFETY: test-only.
         unsafe {
             setup_test_vfs();
@@ -2963,8 +2936,6 @@ mod tests {
         let fd = sys_open(path.as_ptr() as u32, path.len() as u32, 0);
         assert_eq!(fd, 0);
 
-        // Parent reads 5 bytes ("Hello") before forking.
-        static mut BUF: [u8; 5] = [0u8; 5];
         // SAFETY: test-only static; single-threaded per test.
         let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUF) };
         assert_eq!(sys_read(fd, buf.as_mut_ptr() as u32, 5), 5);
@@ -2976,8 +2947,6 @@ mod tests {
             crate::process::set_current_for_test(child_pid);
         }
 
-        // Child's fd 0 shares the SAME OFD -- offset continues at 5, not 0.
-        static mut BUF2: [u8; 7] = [0u8; 7];
         // SAFETY: test-only static; single-threaded per test.
         let buf2 = unsafe { &mut *core::ptr::addr_of_mut!(BUF2) };
         let n2 = sys_read(fd, buf2.as_mut_ptr() as u32, 7);
@@ -2999,7 +2968,6 @@ mod tests {
         unsafe {
             crate::process::set_current_for_test(child_pid);
         }
-        static mut BUF3: [u8; 2] = [0u8; 2];
         // SAFETY: test-only static; single-threaded per test.
         let buf3 = unsafe { &mut *core::ptr::addr_of_mut!(BUF3) };
         let n3 = sys_read(fd, buf3.as_mut_ptr() as u32, 2);
@@ -3016,6 +2984,10 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn fork_then_open_is_independent_ofd() {
+        // Parent advances its offset by reading 5 bytes.
+        static mut BUF: [u8; 5] = [0u8; 5];
+        static mut BUF2: [u8; 5] = [0u8; 5];
+        static mut BUF3: [u8; 2] = [0u8; 2];
         // SAFETY: test-only.
         unsafe {
             setup_test_vfs();
@@ -3024,8 +2996,6 @@ mod tests {
         let parent_fd = sys_open(path.as_ptr() as u32, path.len() as u32, 0);
         assert_eq!(parent_fd, 0);
 
-        // Parent advances its offset by reading 5 bytes.
-        static mut BUF: [u8; 5] = [0u8; 5];
         // SAFETY: test-only static; single-threaded per test.
         let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUF) };
         assert_eq!(sys_read(parent_fd, buf.as_mut_ptr() as u32, 5), 5);
@@ -3044,7 +3014,6 @@ mod tests {
             "child's fresh open lands on its own next-free slot (inherited fd 0 is taken)"
         );
 
-        static mut BUF2: [u8; 5] = [0u8; 5];
         // SAFETY: test-only static; single-threaded per test.
         let buf2 = unsafe { &mut *core::ptr::addr_of_mut!(BUF2) };
         let n = sys_read(child_fd, buf2.as_mut_ptr() as u32, 5);
@@ -3059,7 +3028,6 @@ mod tests {
         unsafe {
             crate::process::set_current_for_test(0);
         }
-        static mut BUF3: [u8; 2] = [0u8; 2];
         // SAFETY: test-only static; single-threaded per test.
         let buf3 = unsafe { &mut *core::ptr::addr_of_mut!(BUF3) };
         assert_eq!(sys_read(parent_fd, buf3.as_mut_ptr() as u32, 2), 2);
@@ -3092,7 +3060,7 @@ mod tests {
             crate::process::set_current_for_test(child_pid);
         }
         crate::process::with_current_cwd(|c| {
-            assert_eq!(c, b"/dev", "fork must inherit the parent's cwd")
+            assert_eq!(c, b"/dev", "fork must inherit the parent's cwd");
         })
         .expect("child process must exist");
 
@@ -3106,7 +3074,7 @@ mod tests {
             assert_eq!(
                 c, b"/dev",
                 "a chdir in the child must never leak into the parent (the global-CWD bug, #437)"
-            )
+            );
         })
         .expect("parent process must exist");
 
@@ -3120,13 +3088,15 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn getcwd_reports_the_current_process_cwd() {
+        static mut BUFCWD: [u8; 8] = [0u8; 8];
+        static mut BUFCWD2: [u8; 8] = [0u8; 8];
+        static mut BUFCWD3: [u8; 8] = [0u8; 8];
         // SAFETY: test-only.
         unsafe {
             setup_test_vfs();
         }
         assert_eq!(vfs_chdir("/dev"), 0);
 
-        static mut BUFCWD: [u8; 8] = [0u8; 8];
         // SAFETY: test-only static; single-threaded per test.
         let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUFCWD) };
         assert_eq!(sys_getcwd(buf.as_mut_ptr() as u32, 8), 0);
@@ -3138,7 +3108,6 @@ mod tests {
             crate::process::set_current_for_test(child_pid);
         }
         assert_eq!(vfs_chdir("/"), 0);
-        static mut BUFCWD2: [u8; 8] = [0u8; 8];
         // SAFETY: test-only static; single-threaded per test.
         let buf2 = unsafe { &mut *core::ptr::addr_of_mut!(BUFCWD2) };
         assert_eq!(sys_getcwd(buf2.as_mut_ptr() as u32, 8), 0);
@@ -3148,7 +3117,6 @@ mod tests {
         unsafe {
             crate::process::set_current_for_test(0);
         }
-        static mut BUFCWD3: [u8; 8] = [0u8; 8];
         // SAFETY: test-only static; single-threaded per test.
         let buf3 = unsafe { &mut *core::ptr::addr_of_mut!(BUFCWD3) };
         assert_eq!(sys_getcwd(buf3.as_mut_ptr() as u32, 8), 0);
@@ -3164,6 +3132,7 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn close_cloexec_sweeps_only_cloexec_fds_dup_clears_flag() {
+        static mut BUF: [u8; 4] = [0u8; 4];
         // SAFETY: test-only.
         unsafe {
             setup_test_vfs();
@@ -3198,7 +3167,6 @@ mod tests {
         let swept = crate::process::with_current_fds(close_cloexec);
         assert!(swept.is_some(), "current process must exist");
 
-        static mut BUF: [u8; 4] = [0u8; 4];
         // SAFETY: test-only static; single-threaded per test.
         let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUF) };
         assert_eq!(
@@ -3229,6 +3197,7 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn close_all_frees_both_ofds_on_exit() {
+        static mut BUF: [u8; 1] = [0u8; 1];
         // SAFETY: test-only.
         unsafe {
             setup_test_vfs();
@@ -3258,7 +3227,6 @@ mod tests {
             "exit-path close_all must free the second OFD"
         );
 
-        static mut BUF: [u8; 1] = [0u8; 1];
         // SAFETY: test-only static; single-threaded per test.
         let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUF) };
         assert_eq!(
@@ -3275,6 +3243,9 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn dup_shares_ofd_offset_and_status_flags() {
+        // Reading via the dup must advance the ORIGINAL's shared offset.
+        static mut BUF: [u8; 5] = [0u8; 5];
+        static mut BUF2: [u8; 2] = [0u8; 2];
         // SAFETY: test-only.
         unsafe {
             setup_test_vfs();
@@ -3285,14 +3256,11 @@ mod tests {
         let fd1 = sys_dup(fd0);
         assert_eq!(fd1, 1);
 
-        // Reading via the dup must advance the ORIGINAL's shared offset.
-        static mut BUF: [u8; 5] = [0u8; 5];
         // SAFETY: test-only static; single-threaded per test.
         let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUF) };
         assert_eq!(sys_read(fd1, buf.as_mut_ptr() as u32, 5), 5);
         assert_eq!(&*buf, b"Hello");
 
-        static mut BUF2: [u8; 2] = [0u8; 2];
         // SAFETY: test-only static; single-threaded per test.
         let buf2 = unsafe { &mut *core::ptr::addr_of_mut!(BUF2) };
         let n = sys_read(fd0, buf2.as_mut_ptr() as u32, 2);

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -221,19 +221,18 @@ fn boot_verify_loop(
                     crate::ui::Key::Hash => {
                         let mut primary_out = None;
                         let result = lock.submit_passphrase_with(tick, |entered| {
-                            let primary =
-                                match crate::key_manager::KeyManager::derive_from_passphrase(
+                            let Ok(primary) =
+                                crate::key_manager::KeyManager::derive_from_passphrase(
                                     entered, &salt,
-                                ) {
-                                    Ok(p) => p,
-                                    Err(_) => return false,
-                                };
-                            let candidate =
-                                match crate::key_manager::KeyManager::derive_boot_verifier(&primary)
-                                {
-                                    Ok(v) => v,
-                                    Err(_) => return false,
-                                };
+                                )
+                            else {
+                                return false;
+                            };
+                            let Ok(candidate) =
+                                crate::key_manager::KeyManager::derive_boot_verifier(&primary)
+                            else {
+                                return false;
+                            };
                             let matches =
                                 crate::lock_screen::constant_time_eq(&candidate, &verifier);
                             if matches {
@@ -243,10 +242,10 @@ fn boot_verify_loop(
                         });
                         match result {
                             crate::lock_screen::UnlockResult::Success => {
-                                if let Some(primary) = primary_out {
-                                    if key_manager.derive_partition_keys(&primary).is_ok() {
-                                        return true;
-                                    }
+                                if let Some(primary) = primary_out
+                                    && key_manager.derive_partition_keys(&primary).is_ok()
+                                {
+                                    return true;
                                 }
                                 // A verified passphrase that cannot derive
                                 // partition keys is a crypto fault, not a
@@ -318,26 +317,10 @@ fn boot_setup_loop(
                     crate::ui::Key::Star => lock.backspace_passphrase(),
                     crate::ui::Key::Hash => {
                         let entered_len = lock.passphrase_len() as usize;
-                        if !confirming {
-                            if entered_len >= crate::kinit_plan::MIN_BOOT_PASSPHRASE_LEN as usize {
-                                first[..entered_len].copy_from_slice(lock.passphrase_bytes());
-                                first_len = entered_len;
-                                lock.clear_passphrase();
-                                confirming = true;
-                                serial.log(" Confirm passphrase\r\n");
-                            } else {
-                                serial.log(" Passphrase too short (6+ digits)\r\n");
-                            }
-                        } else {
+                        if confirming {
                             let matches = entered_len == first_len
                                 && lock.passphrase_bytes() == &first[..first_len];
-                            if !matches {
-                                serial.log(" Mismatch -- start over\r\n");
-                                lock.clear_passphrase();
-                                confirming = false;
-                                crate::key_manager::volatile_zero(&mut first);
-                                first_len = 0;
-                            } else {
+                            if matches {
                                 let mut salt = [0u8; crate::secrets::SALT_LEN];
                                 if crate::csprng::kernel_random_bytes(&mut salt).is_err() {
                                     serial.log(" CRIT CSPRNG unavailable -- cannot provision\r\n");
@@ -350,23 +333,19 @@ fn boot_setup_loop(
                                         lock.passphrase_bytes(),
                                         &salt,
                                     )
-                                {
-                                    if let Ok(verifier) =
+                                    && let Ok(verifier) =
                                         crate::key_manager::KeyManager::derive_boot_verifier(
                                             &primary,
                                         )
-                                    {
-                                        if crate::secrets::store_boot_verifier(
-                                            preamble_view,
-                                            &salt,
-                                            &verifier,
-                                        )
-                                        .is_ok()
-                                            && key_manager.derive_partition_keys(&primary).is_ok()
-                                        {
-                                            ok = true;
-                                        }
-                                    }
+                                    && crate::secrets::store_boot_verifier(
+                                        preamble_view,
+                                        &salt,
+                                        &verifier,
+                                    )
+                                    .is_ok()
+                                    && key_manager.derive_partition_keys(&primary).is_ok()
+                                {
+                                    ok = true;
                                 }
                                 lock.clear_passphrase();
                                 crate::key_manager::volatile_zero(&mut first);
@@ -377,6 +356,20 @@ fn boot_setup_loop(
                                 serial.log(" CRIT Provisioning failed (derive/store)\r\n");
                                 return false;
                             }
+                            serial.log(" Mismatch -- start over\r\n");
+                            lock.clear_passphrase();
+                            confirming = false;
+                            crate::key_manager::volatile_zero(&mut first);
+                            first_len = 0;
+                        } else if entered_len >= crate::kinit_plan::MIN_BOOT_PASSPHRASE_LEN as usize
+                        {
+                            first[..entered_len].copy_from_slice(lock.passphrase_bytes());
+                            first_len = entered_len;
+                            lock.clear_passphrase();
+                            confirming = true;
+                            serial.log(" Confirm passphrase\r\n");
+                        } else {
+                            serial.log(" Passphrase too short (6+ digits)\r\n");
                         }
                     }
                     _ => {}
@@ -502,6 +495,16 @@ fn debug_console_gate(serial: &mut Uart, mode_mgr: &crate::security_mode::ModeMa
 ///
 /// Must be called exactly once, FROM the boot processor, with
 /// interrupts disabled.
+//
+// WHY the allow: this is the boot sequencer -- one linear, numbered "Step N"
+// narrative over ~20 subsystems, called from exactly one site, executed
+// exactly once, never reused or independently tested in isolation. Splitting
+// it into helper functions would thread `serial`/`state`/intermediate
+// hand-offs (e.g. the mounted LFS feeding the VFS step) through a growing set
+// of new `unsafe fn` boundaries -- each needing its own safety contract --
+// purely to satisfy a line count, while making the top-to-bottom boot order
+// this function exists to keep auditable harder to read in one pass.
+#[allow(clippy::too_many_lines)]
 pub unsafe fn run() -> ! {
     let mut serial = Uart::new();
     let mut state = BootState::new();
@@ -737,7 +740,10 @@ pub unsafe fn run() -> ! {
         unsafe {
             display.init(board::FB_BASE);
         }
-        if display.state() != crate::display::DisplayState::Uninitialized {
+        if display.state() == crate::display::DisplayState::Uninitialized {
+            serial.log(" WARN Display init incomplete\r\n");
+            serial.log(" Falling back to USB serial console only\r\n");
+        } else {
             serial.log(" Display pipeline active\r\n");
             boot_log!(serial, " Framebuffer @ {:#010x}\r\n", board::FB_BASE);
             devices.activate("gc9306-lcm");
@@ -745,9 +751,6 @@ pub unsafe fn run() -> ! {
             devices.activate("disp-rdma0");
             state.display_ok = true;
             DISPLAY_AVAILABLE.store(true, Ordering::Release);
-        } else {
-            serial.log(" WARN Display init incomplete\r\n");
-            serial.log(" Falling back to USB serial console only\r\n");
         }
     }
 
@@ -1268,6 +1271,12 @@ pub unsafe fn run() -> ! {
     // initramfs -- the /init ELF wrapped in a newc CPIO, built by build.rs into
     // the kernel image -- as the root so plan_userspace_spawn_from_vfs("/init")
     // resolves. A verified boot uses the LFS root instead (initramfs ignored).
+    //
+    // WHY the allow: hoisting to the top of `run()`'s ~900-line boot sequence
+    // would separate this declaration from its use two lines below by
+    // hundreds of lines, for the same audit-ability reason `run()` itself
+    // carries a `too_many_lines` allow above.
+    #[allow(clippy::items_after_statements)]
     static INITRAMFS: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/initramfs.cpio"));
     let boot_cpio = if lfs_root.is_none() {
         Some(INITRAMFS)
@@ -1510,8 +1519,7 @@ pub unsafe fn run() -> ! {
                             configured = true;
                             break;
                         }
-                        DhcpEvent::Deconfigured => {}
-                        DhcpEvent::None => {}
+                        DhcpEvent::Deconfigured | DhcpEvent::None => {}
                     }
                     // WHY: WFI yields until the next interrupt (the timer
                     // tick). WFE was the wrong primitive here: with no SEV
@@ -1662,16 +1670,16 @@ pub unsafe fn run() -> ! {
     // eMMC secure-boot gate. secure_boot_ok stays false here (no medium), so
     // every OTHER trust-dependent step (passphrase, audit, persistent decrypt)
     // remains fail-closed.
+    //
+    // WHY the allow: see `INITRAMFS`'s identical note above -- hoisting out of
+    // `run()`'s boot narrative to satisfy a line-position lint would separate
+    // this from its use three lines below by well over a thousand lines.
+    #[allow(clippy::items_after_statements)]
     static INITRAMFS_SIG: &[u8; 64] =
         include_bytes!(concat!(env!("OUT_DIR"), "/initramfs_sig.bin"));
     let userspace_image_verified =
         crate::secure_boot::verify_userspace_image(INITRAMFS, INITRAMFS_SIG);
-    if !(state.secure_boot_ok || userspace_image_verified) {
-        // Fail-closed: no verified medium AND no verified image-resident image.
-        serial.log(
-            " WARN Userspace spawn refused (no verified boot medium or image -- fail-closed)\r\n",
-        );
-    } else {
+    if state.secure_boot_ok || userspace_image_verified {
         if userspace_image_verified && !state.secure_boot_ok {
             serial.log(" Userspace: image-resident initramfs signature verified (boot anchor)\r\n");
         }
@@ -1809,6 +1817,11 @@ pub unsafe fn run() -> ! {
                 state.userspace_entries_missing
             );
         }
+    } else {
+        // Fail-closed: no verified medium AND no verified image-resident image.
+        serial.log(
+            " WARN Userspace spawn refused (no verified boot medium or image -- fail-closed)\r\n",
+        );
     }
 
     // Boot is complete; the boot context now becomes the idle loop. Enable

--- a/crates/thumos/src/pipe.rs
+++ b/crates/thumos/src/pipe.rs
@@ -163,10 +163,11 @@ unsafe fn get_pipe_mut(pipe_idx: usize) -> Option<&'static mut PipeBuffer> {
 fn maybe_free_pipe(pipe_idx: usize) {
     // SAFETY: single-core cooperative kernel; no concurrent mutation.
     let pool = unsafe { &mut *core::ptr::addr_of_mut!(PIPE_POOL) };
-    if let Some(ref buf) = pool[pipe_idx] {
-        if buf.write_closed && buf.read_closed {
-            pool[pipe_idx] = None;
-        }
+    if let Some(ref buf) = pool[pipe_idx]
+        && buf.write_closed
+        && buf.read_closed
+    {
+        pool[pipe_idx] = None;
     }
 }
 
@@ -234,6 +235,12 @@ pub(crate) fn is_write_end(flags: u32) -> bool {
 ///
 /// # Returns
 /// 0 on success, negative error code on failure.
+// WHY: `read_ofd`/`write_ofd` (open-file-description table indices) and
+// `read_fd`/`write_fd` (the per-process fd numbers derived from them) are
+// standard POSIX fd/ofd terminology naming two genuinely distinct values --
+// renaming either pair to defeat the Levenshtein check would decouple the
+// names from the concepts they name.
+#[allow(clippy::similar_names)]
 pub(crate) fn sys_pipe(fds_ptr: u32) -> u32 {
     if fds_ptr == 0 {
         return EFAULT;
@@ -242,9 +249,8 @@ pub(crate) fn sys_pipe(fds_ptr: u32) -> u32 {
     // Allocate a pipe buffer slot, capped per-process (MAX_PIPES_PER_PROCESS)
     // so one process cannot exhaust the entire pool.
     let owner_pid = crate::process::current_pid();
-    let pipe_idx = match alloc_pipe_slot(owner_pid) {
-        Some(i) => i,
-        None => return EMFILE,
+    let Some(pipe_idx) = alloc_pipe_slot(owner_pid) else {
+        return EMFILE;
     };
 
     // Two-level alloc (#267): one OFD per pipe end (refs=1 each), then
@@ -326,9 +332,8 @@ pub(crate) fn sys_pipe_read(pipe_idx: usize, buf_ptr: u32, count: u32) -> u32 {
     }
 
     // SAFETY: single-core cooperative kernel; no concurrent mutation of pipe pool.
-    let buf = match unsafe { get_pipe_mut(pipe_idx) } {
-        Some(b) => b,
-        None => return EBADF,
+    let Some(buf) = (unsafe { get_pipe_mut(pipe_idx) }) else {
+        return EBADF;
     };
 
     if buf.available() == 0 {
@@ -368,9 +373,8 @@ pub(crate) fn sys_pipe_write(pipe_idx: usize, buf_ptr: u32, count: u32, writer_p
     }
 
     // SAFETY: single-core cooperative kernel; no concurrent mutation.
-    let buf = match unsafe { get_pipe_mut(pipe_idx) } {
-        Some(b) => b,
-        None => return EBADF,
+    let Some(buf) = (unsafe { get_pipe_mut(pipe_idx) }) else {
+        return EBADF;
     };
 
     if buf.read_closed {
@@ -638,6 +642,8 @@ mod tests {
     #[cfg(target_pointer_width = "32")]
     #[test]
     fn dup_of_pipe_write_end_delays_eof_until_last_close() {
+        static mut FDS: [u32; 2] = [0, 0];
+        static mut BUF: [u8; 8] = [0u8; 8];
         reset_pool();
         // SAFETY: test-only; establishes a fresh current process for
         // sys_pipe/sys_dup/sys_close to install fds into.
@@ -645,7 +651,6 @@ mod tests {
             crate::fd::reset_fd_state_for_test();
         }
 
-        static mut FDS: [u32; 2] = [0, 0];
         let fds_ptr = core::ptr::addr_of_mut!(FDS) as u32;
         assert_eq!(sys_pipe(fds_ptr), 0, "pipe() should succeed");
         // SAFETY: test-only static; single-threaded per test.
@@ -669,7 +674,6 @@ mod tests {
         // ZERO, not at the first close of the write end.
         assert_eq!(crate::fd::sys_close(write_fd), 0);
 
-        static mut BUF: [u8; 8] = [0u8; 8];
         // SAFETY: test-only static; single-threaded per test.
         let buf = unsafe { &mut *core::ptr::addr_of_mut!(BUF) };
         assert_eq!(

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -306,8 +306,8 @@ pub unsafe fn init() {
             cwd: crate::fd::DEFAULT_CWD,
             cwd_len: 1,
         };
-        let procs = &mut *addr_of_mut!(PROCS);
-        procs[0] = Some(proc0);
+        let proc_table = &mut *addr_of_mut!(PROCS);
+        proc_table[0] = Some(proc0);
         CURRENT = 0;
     }
 }
@@ -321,7 +321,7 @@ pub(crate) fn spawn(entry_point: fn() -> !) -> Option<Pid> {
     unsafe {
         // Find a free slot
         let procs = &mut *addr_of_mut!(PROCS);
-        let slot = procs.iter().position(|p| p.is_none())?;
+        let slot = procs.iter().position(Option::is_none)?;
         let pid = slot as Pid;
 
         // Allocate new address space cloned FROM kernel table
@@ -336,16 +336,15 @@ pub(crate) fn spawn(entry_point: fn() -> !) -> Option<Pid> {
         // rollback exact regardless of fragmentation.
         let mut stack_pages_alloc: [usize; STACK_PAGES] = [0; STACK_PAGES];
         for i in 0..STACK_PAGES {
-            match page::alloc_page() {
-                Some(page) => stack_pages_alloc[i] = page,
-                None => {
-                    // OOM: roll back exactly the pages allocated so far.
-                    for j in 0..i {
-                        page::free_page(stack_pages_alloc[j]);
-                    }
-                    mmu::free_addr_space(new_pt);
-                    return None;
+            if let Some(page) = page::alloc_page() {
+                stack_pages_alloc[i] = page;
+            } else {
+                // OOM: roll back exactly the pages allocated so far.
+                for &p in &stack_pages_alloc[..i] {
+                    page::free_page(p);
                 }
+                mmu::free_addr_space(new_pt);
+                return None;
             }
         }
         let stack_base = stack_pages_alloc[0];
@@ -485,7 +484,13 @@ unsafe fn map_signal_trampoline(pt: usize) -> Option<usize> {
 /// host-covered in mmu.rs's own tests; the real grant is covered end-to-end
 /// by the QEMU signal witness. `Some(0)` keeps `spawn_user`'s rollback shape
 /// (`free_page` validates allocator range, so 0 is a safe no-op there).
+// WHY the allow: this host stub's signature must match the ARM
+// implementation above (`Option<usize>`, genuinely fallible there) --
+// callers are shared across both `cfg`s and are not split per-arch, so
+// unwrapping this stub to a bare `usize` would break the common call site
+// rather than the mapping being pointless here.
 #[cfg(not(target_arch = "arm"))]
+#[allow(clippy::unnecessary_wraps)]
 unsafe fn map_signal_trampoline(_pt: usize) -> Option<usize> {
     Some(0)
 }
@@ -551,7 +556,7 @@ pub(crate) fn spawn_user(loaded: &crate::elf::LoadedElf) -> Option<Pid> {
     // core, no concurrent access at spawn.
     unsafe {
         let procs = &mut *addr_of_mut!(PROCS);
-        let Some(slot) = procs.iter().position(|p| p.is_none()) else {
+        let Some(slot) = procs.iter().position(Option::is_none) else {
             free_unspawned_image(loaded); // process table full
             return None;
         };
@@ -788,6 +793,14 @@ unsafe fn fork_pl0(
 /// NOTE: unlike POSIX `fork()`, both parent and child continue FROM the next
 /// scheduler tick; the child resumes at the fork return (its ctx is seeded from
 /// the live trap frame) with r0 = 0, the parent with r0 = `child_pid`.
+//
+// WHY the allow: `parent_pid` and `parent_uid` name genuinely distinct
+// fields (which process, which user) -- dropping either the `parent_`
+// prefix or the field suffix to defeat the Levenshtein check would lose
+// which value each name holds. A statement-local allow does not suppress
+// this lint (clippy checks binding similarity over the whole function body),
+// so the allow lives here.
+#[allow(clippy::similar_names)]
 pub(crate) fn fork() -> Option<Pid> {
     // SAFETY: current process PCB pointer is valid; set by the scheduler on
     // context switch. addr_of_mut! avoids intermediate references to static mut.
@@ -796,13 +809,13 @@ pub(crate) fn fork() -> Option<Pid> {
         let procs = &mut *addr_of_mut!(PROCS);
 
         // Find a free process slot
-        let slot = procs.iter().position(|p| p.is_none())?;
+        let slot = procs.iter().position(Option::is_none)?;
         let child_pid = slot as Pid;
         let parent_pid = CURRENT;
 
         let parent_ref0 = procs[usize::from(parent_pid)].as_ref();
         let parent_pt = parent_ref0.map_or(0, |p| p.page_table_phys);
-        let parent_pcb_ctx = parent_ref0.map(|p| p.ctx).unwrap_or_else(Context::zero);
+        let parent_pcb_ctx = parent_ref0.map_or_else(Context::zero, |p| p.ctx);
 
         // #478: seed the child from the LIVE trap frame (the in-flight fork
         // SVC), not the PCB's stale switch-OUT snapshot; the child resumes at
@@ -843,17 +856,16 @@ pub(crate) fn fork() -> Option<Pid> {
         // assumed contiguity.
         let mut child_stack_pages_alloc: [usize; STACK_PAGES] = [0; STACK_PAGES];
         for i in 0..STACK_PAGES {
-            match page::alloc_page() {
-                Some(page) => child_stack_pages_alloc[i] = page,
-                None => {
-                    // OOM: roll back exactly the pages allocated so far, then
-                    // the child's address space.
-                    for j in 0..i {
-                        page::free_page(child_stack_pages_alloc[j]);
-                    }
-                    mmu::free_addr_space(child_pt);
-                    return None;
+            if let Some(page) = page::alloc_page() {
+                child_stack_pages_alloc[i] = page;
+            } else {
+                // OOM: roll back exactly the pages allocated so far, then
+                // the child's address space.
+                for &p in &child_stack_pages_alloc[..i] {
+                    page::free_page(p);
                 }
+                mmu::free_addr_space(child_pt);
+                return None;
             }
         }
         let stack_base = child_stack_pages_alloc[0];
@@ -1051,10 +1063,10 @@ pub(crate) fn reap_dead_children() -> usize {
         // waitpid reaps only a Dead child of CURRENT; live/non-child PIDs (and
         // PID 0 itself, whose parent is None) return None and are skipped.
         // MAX_PROCS (16) fits Pid (u8), so the cast is total.
-        if let Ok(p) = Pid::try_from(pid) {
-            if waitpid(p).is_some() {
-                reaped += 1;
-            }
+        if let Ok(p) = Pid::try_from(pid)
+            && waitpid(p).is_some()
+        {
+            reaped += 1;
         }
     }
     reaped
@@ -1265,10 +1277,10 @@ pub(crate) fn schedule() -> Pid {
         let procs_ro = &*core::ptr::addr_of!(PROCS);
         for offset in 1..MAX_PROCS {
             let idx = (cur + offset) % MAX_PROCS;
-            if let Some(ref proc) = procs_ro[idx] {
-                if proc.state == State::Ready {
-                    return proc.pid;
-                }
+            if let Some(ref proc) = procs_ro[idx]
+                && proc.state == State::Ready
+            {
+                return proc.pid;
             }
         }
         // No other ready process  -  stay on current
@@ -1493,7 +1505,7 @@ pub(crate) fn add_mapping(mapping: VmMapping) -> Option<usize> {
         let procs = &mut *addr_of_mut!(PROCS);
         let cur = usize::from(CURRENT);
         let proc = procs[cur].as_mut()?;
-        let slot = proc.mappings.iter().position(|m| m.is_none())?;
+        let slot = proc.mappings.iter().position(Option::is_none)?;
         proc.mappings[slot] = Some(mapping);
         Some(slot)
     }
@@ -1508,11 +1520,11 @@ pub(crate) fn remove_mapping(start_addr: usize) -> Option<VmMapping> {
         let procs = &mut *addr_of_mut!(PROCS);
         let cur = usize::from(CURRENT);
         let proc = procs[cur].as_mut()?;
-        for slot in proc.mappings.iter_mut() {
-            if let Some(m) = slot {
-                if m.start == start_addr {
-                    return slot.take();
-                }
+        for slot in &mut proc.mappings {
+            if let Some(m) = slot
+                && m.start == start_addr
+            {
+                return slot.take();
             }
         }
         None
@@ -1528,11 +1540,9 @@ pub(crate) fn find_mapping(start_addr: usize) -> Option<VmMapping> {
         let procs = &*core::ptr::addr_of!(PROCS);
         let cur = usize::from(CURRENT);
         let proc = procs[cur].as_ref()?;
-        for slot in &proc.mappings {
-            if let Some(m) = slot {
-                if m.start == start_addr {
-                    return Some(*m);
-                }
+        for m in proc.mappings.iter().flatten() {
+            if m.start == start_addr {
+                return Some(*m);
             }
         }
         None
@@ -1550,12 +1560,10 @@ pub(crate) fn update_mapping_prot(start_addr: usize, new_prot: u32) -> bool {
         let Some(proc) = procs[cur].as_mut() else {
             return false;
         };
-        for slot in proc.mappings.iter_mut() {
-            if let Some(m) = slot {
-                if m.start == start_addr {
-                    m.prot = new_prot;
-                    return true;
-                }
+        for m in proc.mappings.iter_mut().flatten() {
+            if m.start == start_addr {
+                m.prot = new_prot;
+                return true;
             }
         }
         false
@@ -1989,10 +1997,10 @@ pub unsafe fn clear_any_pending() {
     unsafe {
         let procs = &mut *addr_of_mut!(PROCS);
         let cur = usize::from(CURRENT);
-        if let Some(ref mut proc) = procs[cur] {
-            if let Some(sig) = proc.signal_state.next_pending() {
-                proc.signal_state.clear_pending(sig);
-            }
+        if let Some(ref mut proc) = procs[cur]
+            && let Some(sig) = proc.signal_state.next_pending()
+        {
+            proc.signal_state.clear_pending(sig);
         }
     }
 }
@@ -2191,20 +2199,24 @@ mod tests {
 
     /// Reset all global state before each test.
     unsafe fn reset_all() {
-        // Zero process table
-        let procs = &mut *core::ptr::addr_of_mut!(PROCS);
-        for p in procs.iter_mut() {
-            *p = None;
+        // SAFETY: delegated to this function's own contract (test-only,
+        // single-threaded, called fresh before each test).
+        unsafe {
+            // Zero process table
+            let procs = &mut *core::ptr::addr_of_mut!(PROCS);
+            for p in procs.iter_mut() {
+                *p = None;
+            }
+            CURRENT = 0;
+
+            // Reset address space pool
+            mmu::reset_addr_space_pool();
+
+            // Reset page allocator with a modest test pool
+            // WHY: 0x4000_0000..0x8000_0000 is DRAM; kernel_end just above base so
+            // pages FROM 0x4010_0000 onward are available.
+            page::init(0x4000_0000, 0x8000_0000, 0x4010_0000);
         }
-        CURRENT = 0;
-
-        // Reset address space pool
-        mmu::reset_addr_space_pool();
-
-        // Reset page allocator with a modest test pool
-        // WHY: 0x4000_0000..0x8000_0000 is DRAM; kernel_end just above base so
-        // pages FROM 0x4010_0000 onward are available.
-        page::init(0x4000_0000, 0x8000_0000, 0x4010_0000);
 
         // Reset IPC inboxes by re-initialising as process 0 and draining
         // (no direct reset API; we just reconstruct process 0 and let
@@ -2251,7 +2263,7 @@ mod tests {
             };
             let interrupted = frame;
 
-            trap_enter(&mut frame as *mut Context);
+            trap_enter(&raw mut frame);
             assert!(!trap_switched(), "trap_enter must reset the swapped flag");
             switch_to(1);
 
@@ -2282,7 +2294,7 @@ mod tests {
             set_trap_return(42); // must be a harmless no-op with no frame
 
             let mut frame = Context::zero();
-            trap_enter(&mut frame as *mut Context);
+            trap_enter(&raw mut frame);
             set_trap_return(0xABC);
             assert_eq!(frame.r[0], 0xABC, "return value deposited into frame r0");
             trap_leave();
@@ -2299,7 +2311,7 @@ mod tests {
             CURRENT = 0;
             let mut frame = Context::zero();
             frame.r[0] = 0x1234;
-            trap_enter(&mut frame as *mut Context);
+            trap_enter(&raw mut frame);
             switch_to(0);
             assert!(!trap_switched(), "self-switch must not flag a swap");
             assert_eq!(frame.r[0], 0x1234, "self-switch must not touch the frame");
@@ -2396,7 +2408,9 @@ mod tests {
     #[test]
     fn fault_exit_current_kills_notifies_and_swaps_to_successor() {
         fn fault_test_entry() -> ! {
-            loop {}
+            loop {
+                core::hint::spin_loop();
+            }
         }
         // The composed abort-path kill the ARM stubs rely on, end to end: Dead +
         // fault status + resource teardown + PID-0 IPC + frame swap.
@@ -2425,7 +2439,7 @@ mod tests {
                 cpsr: 0x10,
                 ..Context::zero()
             };
-            trap_enter(&mut frame as *mut Context);
+            trap_enter(&raw mut frame);
             fault_exit_current(FaultKind::DataAbort {
                 fault_addr: 0xDEAD_0000,
                 fault_status: 0x80D,
@@ -2582,7 +2596,7 @@ mod tests {
                 pc: 0x7FF0_0010,
                 cpsr: 0x10,
             };
-            trap_enter(&mut frame as *mut Context);
+            trap_enter(&raw mut frame);
             let child_pid = fork().expect("PL0 fork must deep-copy");
             trap_leave();
 
@@ -2634,7 +2648,7 @@ mod tests {
                 cpsr: 0x10,
                 ..Context::zero()
             };
-            trap_enter(&mut frame as *mut Context);
+            trap_enter(&raw mut frame);
             assert!(fork().is_none(), "fork must fail closed on OOM");
             trap_leave();
 
@@ -2677,7 +2691,7 @@ mod tests {
                 cpsr: 0x10,
                 ..Context::zero()
             };
-            trap_enter(&mut frame as *mut Context);
+            trap_enter(&raw mut frame);
             let cpid = fork().expect("PL0 fork");
             trap_leave();
 
@@ -2740,7 +2754,7 @@ mod tests {
                 cpsr: 0x10,
                 ..Context::zero()
             };
-            trap_enter(&mut frame as *mut Context);
+            trap_enter(&raw mut frame);
             let cpid = fork().expect("PL0 fork");
             trap_leave();
 
@@ -2933,7 +2947,9 @@ mod tests {
     #[test]
     fn spawn_oom_rollback_frees_exact_allocated_pages() {
         fn spawn_test_entry() -> ! {
-            loop {}
+            loop {
+                core::hint::spin_loop();
+            }
         }
         unsafe {
             reset_all();
@@ -3082,9 +3098,9 @@ mod tests {
             }
 
             let procs_ro = &*core::ptr::addr_of!(PROCS);
-            for pid in 1..MAX_PROCS {
+            for (pid, slot) in procs_ro.iter().enumerate().skip(1) {
                 assert!(
-                    procs_ro[pid].is_none(),
+                    slot.is_none(),
                     "reaped slot {pid} must be None, not a lingering Dead PCB"
                 );
             }
@@ -3255,7 +3271,7 @@ mod tests {
 
             // Saturate PID 0's inbox so ipc::send(0, ...) returns false.
             for _ in 0..20 {
-                ipc::send(0, ipc::Message::new(99, b"fill"));
+                let _ = ipc::send(0, ipc::Message::new(99, b"fill"));
             }
 
             // Must not panic even though the fault notification cannot be delivered.
@@ -3373,7 +3389,7 @@ mod tests {
             let procs_ro = &*core::ptr::addr_of!(PROCS);
             let proc = procs_ro[0].as_ref().unwrap();
             assert!(
-                proc.mappings.iter().all(|m| m.is_none()),
+                proc.mappings.iter().all(Option::is_none),
                 "mappings must be cleared"
             );
             assert_eq!(
@@ -3865,13 +3881,13 @@ mod tests {
     #[test]
     fn deliver_signal_to_rejects_pid_zero() {
         unsafe {
+            const EPERM: u32 = 0u32.wrapping_sub(1);
             reset_all();
             let procs = &mut *core::ptr::addr_of_mut!(PROCS);
             let pt = mmu::alloc_addr_space().unwrap();
             procs[0] = Some(test_process(pt));
             CURRENT = 0;
 
-            const EPERM: u32 = 0u32.wrapping_sub(1);
             let ret = deliver_signal_to(0, crate::signal::Signal::Sigkill);
             assert_eq!(ret, EPERM, "deliver_signal_to(0, ...) must return EPERM");
 
@@ -3954,13 +3970,13 @@ mod tests {
     #[test]
     fn sys_kill_rejects_pid_zero_even_for_self() {
         unsafe {
+            const EPERM: u32 = 0u32.wrapping_sub(1);
             reset_all();
             let procs = &mut *core::ptr::addr_of_mut!(PROCS);
             let pt = mmu::alloc_addr_space().unwrap();
             procs[0] = Some(test_process(pt));
             CURRENT = 0;
 
-            const EPERM: u32 = 0u32.wrapping_sub(1);
             let ret = crate::signal::sys_kill(0, crate::signal::Signal::Sigkill as u32);
             assert_eq!(
                 ret, EPERM,
@@ -3975,6 +3991,7 @@ mod tests {
     #[test]
     fn sys_kill_cross_process_denied_without_cap_kill() {
         unsafe {
+            const EPERM: u32 = 0u32.wrapping_sub(1);
             reset_all();
             let procs = &mut *core::ptr::addr_of_mut!(PROCS);
 
@@ -4000,7 +4017,6 @@ mod tests {
             });
             CURRENT = 1;
 
-            const EPERM: u32 = 0u32.wrapping_sub(1);
             let ret = crate::signal::sys_kill(2, crate::signal::Signal::Sigterm as u32);
             assert_eq!(
                 ret, EPERM,

--- a/crates/thumos/src/slab.rs
+++ b/crates/thumos/src/slab.rs
@@ -110,9 +110,8 @@ impl SlabClass {
 
         // SAFETY: page allocator is initialized before the slab allocator.
         let phys = unsafe { page_fn() };
-        let page_addr = match phys {
-            Some(a) => a,
-            None => return false,
+        let Some(page_addr) = phys else {
+            return false;
         };
 
         let page_ptr = page_addr as *mut u8;
@@ -135,6 +134,13 @@ impl SlabClass {
             // always a multiple of 4 -- `FreeNode`'s alignment requirement.
             // `.cast()` keeps that a type-checked reinterpretation rather
             // than a raw `as`.
+            //
+            // WHY the allow: `cast_ptr_alignment` fires on `.cast()` the same
+            // as on `as` -- it cannot see the page-alignment + size-class
+            // multiple-of-4 proof in the INVARIANT above, which is exactly
+            // what discharges the alignment obligation the lint exists to
+            // demand.
+            #[allow(clippy::cast_ptr_alignment)]
             let node_ptr = unsafe { page_ptr.add(i * self.obj_size).cast::<FreeNode>() };
             unsafe {
                 (*node_ptr).next = self.free_list;
@@ -197,6 +203,11 @@ impl SlabClass {
         // obj_size-multiple offset `refill` establishes (see that
         // function's comment) -- `.cast()` keeps the reinterpretation
         // type-checked instead of re-deriving alignment by hand.
+        //
+        // WHY the allow: see `refill`'s identical `cast_ptr_alignment` note
+        // -- the lint fires on `.cast()` too and cannot see the INVARIANT
+        // above that discharges it.
+        #[allow(clippy::cast_ptr_alignment)]
         let node = ptr.cast::<FreeNode>();
         unsafe {
             (*node).next = self.free_list;
@@ -268,33 +279,30 @@ impl SlabAllocator {
 
         let size = layout.size().max(layout.align());
 
-        match Self::class_for(size) {
-            Some(idx) => {
-                // SAFETY: delegated to alloc_obj's contract; page_fn is valid.
-                unsafe { self.classes[idx].alloc_obj(page_fn) }
-            }
-            None => {
-                // Large allocation: back it with whole pages from the page
-                // allocator.
-                let pages = (size + page::PAGE_SIZE - 1) / page::PAGE_SIZE;
-                let addr = if pages == 1 {
-                    // SAFETY: large_alloc_fn returns a page from an initialized
-                    // page allocator (injected so the single-page path stays
-                    // host-fakeable).
-                    unsafe { large_alloc_fn() }
-                } else {
-                    // WHY (#475): multi-page requests need a contiguous run;
-                    // the injected single-page fn cannot express that, so go
-                    // direct to the page allocator's contiguous path.
-                    page::alloc_contiguous(pages)
-                };
-                match addr {
-                    Some(a) => {
-                        self.large_alloc_count += 1;
-                        a as *mut u8
-                    }
-                    None => ptr::null_mut(),
+        if let Some(idx) = Self::class_for(size) {
+            // SAFETY: delegated to alloc_obj's contract; page_fn is valid.
+            unsafe { self.classes[idx].alloc_obj(page_fn) }
+        } else {
+            // Large allocation: back it with whole pages from the page
+            // allocator.
+            let pages = size.div_ceil(page::PAGE_SIZE);
+            let addr = if pages == 1 {
+                // SAFETY: large_alloc_fn returns a page from an initialized
+                // page allocator (injected so the single-page path stays
+                // host-fakeable).
+                unsafe { large_alloc_fn() }
+            } else {
+                // WHY (#475): multi-page requests need a contiguous run;
+                // the injected single-page fn cannot express that, so go
+                // direct to the page allocator's contiguous path.
+                page::alloc_contiguous(pages)
+            };
+            match addr {
+                Some(a) => {
+                    self.large_alloc_count += 1;
+                    a as *mut u8
                 }
+                None => ptr::null_mut(),
             }
         }
     }
@@ -317,27 +325,24 @@ impl SlabAllocator {
 
         let size = layout.size().max(layout.align());
 
-        match Self::class_for(size) {
-            Some(idx) => {
-                // SAFETY: delegated to dealloc_obj's contract.
-                unsafe { self.classes[idx].dealloc_obj(ptr) };
+        if let Some(idx) = Self::class_for(size) {
+            // SAFETY: delegated to dealloc_obj's contract.
+            unsafe { self.classes[idx].dealloc_obj(ptr) };
+        } else {
+            // ptr was returned by alloc_inner's large path, so it is a
+            // page-aligned base of `pages` whole pages.
+            let pages = size.div_ceil(page::PAGE_SIZE);
+            if pages == 1 {
+                // SAFETY: single-page large alloc came from large_alloc_fn.
+                unsafe { large_free_fn(ptr as usize) };
+            } else {
+                // WHY (#475): free the contiguous run alloc_contiguous
+                // handed out. The bool return is a validated no-op on a bad
+                // address (not an error to propagate).
+                // SAFETY: ptr/pages name the run from alloc_contiguous.
+                unsafe { page::free_contiguous(ptr as usize, pages) };
             }
-            None => {
-                // ptr was returned by alloc_inner's large path, so it is a
-                // page-aligned base of `pages` whole pages.
-                let pages = (size + page::PAGE_SIZE - 1) / page::PAGE_SIZE;
-                if pages == 1 {
-                    // SAFETY: single-page large alloc came from large_alloc_fn.
-                    unsafe { large_free_fn(ptr as usize) };
-                } else {
-                    // WHY (#475): free the contiguous run alloc_contiguous
-                    // handed out. The bool return is a validated no-op on a bad
-                    // address (not an error to propagate).
-                    // SAFETY: ptr/pages name the run from alloc_contiguous.
-                    unsafe { page::free_contiguous(ptr as usize, pages) };
-                }
-                self.large_free_count += 1;
-            }
+            self.large_free_count += 1;
         }
     }
 
@@ -416,8 +421,8 @@ unsafe impl GlobalAlloc for KernelAllocator {
                 layout,
                 // SAFETY: wrapping the free function: alloc_page returns None on
                 // exhaustion, never panics.
-                || page::alloc_page(),
-                || page::alloc_page(),
+                page::alloc_page,
+                page::alloc_page,
             )
         }
     }
@@ -427,7 +432,7 @@ unsafe impl GlobalAlloc for KernelAllocator {
         // returned by alloc_page.
         unsafe {
             let _g = LOCK.lock();
-            (*ptr::addr_of_mut!(SLAB)).dealloc_inner(ptr, layout, page::free_page)
+            (*ptr::addr_of_mut!(SLAB)).dealloc_inner(ptr, layout, page::free_page);
         }
     }
 }
@@ -474,7 +479,7 @@ mod tests {
             if TEST_NEXT_PAGE >= TEST_PAGES {
                 return None;
             }
-            let base = core::ptr::addr_of_mut!(TEST_POOL) as *mut u8 as usize;
+            let base = core::ptr::addr_of_mut!(TEST_POOL).cast::<u8>() as usize;
             let addr = base + TEST_NEXT_PAGE * page::PAGE_SIZE;
             TEST_NEXT_PAGE += 1;
             Some(addr)
@@ -593,15 +598,15 @@ mod tests {
     fn stress_test_no_leaks() {
         // Alloc + free 1000 objects; alloc_count must equal free_count.
         unsafe {
+            const N: usize = 1000;
             let mut sa = make_allocator();
             let layout = Layout::from_size_align(128, 8).unwrap();
-            const N: usize = 1000;
             let mut ptrs = [ptr::null_mut::<u8>(); N];
-            for p in ptrs.iter_mut() {
+            for p in &mut ptrs {
                 *p = sa.alloc_inner(layout, fake_alloc_page, fake_alloc_page);
                 assert!(!p.is_null());
             }
-            for &p in ptrs.iter() {
+            for &p in &ptrs {
                 sa.dealloc_inner(p, layout, fake_free_page);
             }
             let (allocs, frees) = sa.stats();
@@ -641,7 +646,7 @@ mod tests {
             if TEST_SCARCE_NEXT_PAGE >= TEST_SCARCE_PAGES {
                 return None;
             }
-            let base = core::ptr::addr_of_mut!(TEST_POOL) as *mut u8 as usize;
+            let base = core::ptr::addr_of_mut!(TEST_POOL).cast::<u8>() as usize;
             let addr = base + TEST_SCARCE_NEXT_PAGE * page::PAGE_SIZE;
             TEST_SCARCE_NEXT_PAGE += 1;
             Some(addr)

--- a/crates/thumos/src/syscall.rs
+++ b/crates/thumos/src/syscall.rs
@@ -440,6 +440,7 @@ pub(crate) fn dispatch(num: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> 
         }
         Syscall::Uptime => crate::exceptions::uptime_ms() as u32,
         Syscall::Sleep => {
+            const TICK_MS: u64 = 10;
             // WHY (#264): mirror sys_nanosleep's pattern instead of a bare
             // uptime_ms() busy-wait that never touched process state — mark
             // the process Sleeping with its wake tick before waiting so
@@ -447,7 +448,6 @@ pub(crate) fn dispatch(num: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> 
             // this process as blocked for the sleep window, not spuriously
             // Running.
             let ms = u64::from(arg0);
-            const TICK_MS: u64 = 10;
             let ticks_needed = ms.saturating_add(TICK_MS - 1) / TICK_MS;
             let wake_tick = crate::exceptions::ticks().saturating_add(ticks_needed);
             // Mark Sleeping and YIELD (#465/#477, mirrors sys_nanosleep): the
@@ -456,18 +456,18 @@ pub(crate) fn dispatch(num: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> 
             // the process at wake_tick; a later switch resumes it with r0=0.
             process::set_wake_tick(wake_tick);
             let next = process::schedule();
-            if next != process::current_pid() {
+            if next == process::current_pid() {
+                // No other process to yield to (or a zero-length sleep the
+                // scheduler re-woke at once): the sleep is a no-op -- restore
+                // Running rather than linger mis-marked Sleeping.
+                process::clear_wake_tick();
+            } else {
                 // WHY(#465): deposit the return value (0) before switching away.
                 process::set_trap_return(0);
                 // SAFETY: `next` is a valid Ready PID from schedule().
                 unsafe {
                     process::switch_to(next);
                 }
-            } else {
-                // No other process to yield to (or a zero-length sleep the
-                // scheduler re-woke at once): the sleep is a no-op -- restore
-                // Running rather than linger mis-marked Sleeping.
-                process::clear_wake_tick();
             }
             0
         }
@@ -520,10 +520,7 @@ pub(crate) fn dispatch(num: u32, arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> 
 
         // ---- Process management ----
         Syscall::Fork => match process::fork() {
-            Some(child_pid) => {
-                let pid_u32 = u32::from(child_pid);
-                pid_u32
-            }
+            Some(child_pid) => u32::from(child_pid),
             None => u32::MAX,
         },
         Syscall::Waitpid => {
@@ -642,9 +639,8 @@ fn sys_metaxu_poll_dispatch() -> u32 {
 /// `SYS_read`: dispatch to pipe or ramfs based on fd kind.
 fn sys_read_with_pipe(fd: u32, buf_ptr: u32, count: u32) -> u32 {
     let fd_idx = fd as usize;
-    let flags = match fd::current_fd_flags(fd_idx) {
-        Some(f) => f,
-        None => return fd::EBADF,
+    let Some(flags) = fd::current_fd_flags(fd_idx) else {
+        return fd::EBADF;
     };
 
     if pipe::is_pipe_fd(flags) {
@@ -734,6 +730,13 @@ const ENOEXEC: u32 = 0u32.wrapping_sub(8);
 /// `_envp_ptr` is accepted but ignored; environment variables are not yet
 /// supported.
 fn sys_execve(path_ptr: u32, argv_ptr: u32, _envp_ptr: u32) -> u32 {
+    // --- Step 4: allocate new stack ---
+    // WHY 4 pages (16 KB): matches spawn() stack size; sufficient for musl
+    // libc start-up (argc/argv + environ + aux vectors + initial stack frame).
+    const EXEC_STACK_PAGES: usize = 4;
+    // Collect argv strings from user space (cap at 16 args, 128 bytes each).
+    const MAX_ARGS: usize = 16;
+    const MAX_ARG_LEN: usize = 128;
     // --- Step 1: validate and read path ---
 
     // Cap at 256 bytes to bound the scan; longer paths are rejected.
@@ -771,9 +774,8 @@ fn sys_execve(path_ptr: u32, argv_ptr: u32, _envp_ptr: u32) -> u32 {
     // SAFETY: path_ptr is in user DRAM (validated above); path_len bytes
     // were just scanned without trapping. The slice lifetime is local.
     let path_bytes = unsafe { core::slice::from_raw_parts(path_ptr as *const u8, path_len) };
-    let path = match core::str::from_utf8(path_bytes) {
-        Ok(s) => s,
-        Err(_) => return ENOENT,
+    let Ok(path) = core::str::from_utf8(path_bytes) else {
+        return ENOENT;
     };
 
     // --- Step 2: locate the file in ramfs ---
@@ -793,10 +795,6 @@ fn sys_execve(path_ptr: u32, argv_ptr: u32, _envp_ptr: u32) -> u32 {
     // measured-boot chain (#480) is the primary guarantee: only signed ramfs
     // images ever reach here.
 
-    // --- Step 4: allocate new stack ---
-    // WHY 4 pages (16 KB): matches spawn() stack size; sufficient for musl
-    // libc start-up (argc/argv + environ + aux vectors + initial stack frame).
-    const EXEC_STACK_PAGES: usize = 4;
     // WHY contiguous (#489): the new stack must be a single run -- new_stack_top
     // arithmetic and exec_replace_context's map_user_stack both assume
     // `new_stack_base + i * PAGE_SIZE` names the i-th frame (the old alloc_page
@@ -817,9 +815,6 @@ fn sys_execve(path_ptr: u32, argv_ptr: u32, _envp_ptr: u32) -> u32 {
     // This layout matches the Linux/ARM AAPCS start-up convention consumed by
     // musl libc's __start_main.
 
-    // Collect argv strings from user space (cap at 16 args, 128 bytes each).
-    const MAX_ARGS: usize = 16;
-    const MAX_ARG_LEN: usize = 128;
     // WHY fixed-size arrays: avoids heap allocation in the execve path; size
     // is bounded so the combined frame always fits in the 16 KB stack.
     let mut arg_data: [[u8; MAX_ARG_LEN]; MAX_ARGS] = [[0u8; MAX_ARG_LEN]; MAX_ARGS];
@@ -869,7 +864,15 @@ fn sys_execve(path_ptr: u32, argv_ptr: u32, _envp_ptr: u32) -> u32 {
         new_stack_top - frame_aligned
     } else {
         // Pathological argv (too many/long args): fall back to argc=0 frame.
-        argc = 0;
+        // WHY the cfg: the only read of this reset is the ARM-only argv-frame
+        // write below (`#[cfg(target_arch = "arm")]`); on host the write never
+        // happens, so the assignment is genuinely dead there and not merely
+        // lint-noise -- gate it to match its one reader instead of writing a
+        // value host builds can never observe.
+        #[cfg(target_arch = "arm")]
+        {
+            argc = 0;
+        }
         new_stack_top - 8
     };
 
@@ -1183,7 +1186,9 @@ fn sys_brk(new_break_raw: u32) -> u32 {
 /// - arg2: prot flags (`PROT_READ` | `PROT_WRITE` | `PROT_EXEC`)
 /// - arg3: low 16 bits = flags, high 16 bits = fd (as i16, -1 = 0xFFFF)
 fn sys_mmap(arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> u32 {
-    let _addr_hint = arg0 as usize;
+    // arg0 (addr hint) is accepted for ABI shape only -- see the doc comment
+    // above (ignored for MAP_ANONYMOUS; we always pick the address).
+    let _ = arg0;
     let length = arg1 as usize;
     let prot_flags = arg2;
     let flags = arg3 & 0xFFFF;
@@ -1230,7 +1235,7 @@ fn sys_mmap(arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> u32 {
     }
 
     // Round length up to page boundary
-    let page_count = (length + page::PAGE_SIZE - 1) / page::PAGE_SIZE;
+    let page_count = length.div_ceil(page::PAGE_SIZE);
 
     let pt = process::current_page_table();
     if pt == 0 {
@@ -1415,7 +1420,9 @@ fn sys_mmap(arg0: u32, arg1: u32, arg2: u32, arg3: u32) -> u32 {
 /// Returns 0 on success, EINVAL if the mapping is not found.
 fn sys_munmap(arg0: u32, arg1: u32) -> u32 {
     let addr = arg0 as usize;
-    let _length = arg1 as usize;
+    // arg1 (length) is accepted for ABI shape only; the mapping is looked up
+    // and removed by addr alone below.
+    let _ = arg1;
 
     let pt = process::current_page_table();
     if pt == 0 {
@@ -1467,7 +1474,9 @@ fn sys_munmap(arg0: u32, arg1: u32) -> u32 {
 /// Returns 0 on success, EINVAL if the mapping is not found.
 fn sys_mprotect(arg0: u32, arg1: u32, arg2: u32) -> u32 {
     let addr = arg0 as usize;
-    let _length = arg1 as usize;
+    // arg1 (length) is accepted for ABI shape only; the mapping (and its page
+    // count) is looked up by addr alone below.
+    let _ = arg1;
     let new_prot = arg2;
 
     let pt = process::current_page_table();
@@ -1529,6 +1538,7 @@ mod tests {
     /// physical frames -- not just unmapping them (same class as #226).
     #[test]
     fn mmap_oom_rollback_frees_mapped_pages() {
+        const MAP_PAGES: u32 = 4;
         unsafe {
             setup_mm();
         }
@@ -1545,7 +1555,6 @@ mod tests {
         let free_before = page::free_count();
         assert_eq!(free_before, 2, "test setup must yield exactly 2 free pages");
 
-        const MAP_PAGES: u32 = 4;
         let flags_and_fd: u32 = MAP_ANONYMOUS | (0xFFFF << 16);
         let prot = mmu::prot::PROT_READ | mmu::prot::PROT_WRITE;
         let length = MAP_PAGES * u32::try_from(crate::page::PAGE_SIZE).unwrap_or_default();
@@ -1576,6 +1585,7 @@ mod tests {
     #[test]
     fn execve_returns_enoexec_for_bad_elf_magic() {
         unsafe {
+            static mut PATH: [u8; 5] = *b"/bin\0";
             process::reset_for_test();
 
             // Not a valid ELF file at all (bad magic) -- elf::load rejects this
@@ -1588,8 +1598,7 @@ mod tests {
             fs.add("bin", &garbage);
             fd::init_ramfs(fs);
 
-            static mut PATH: [u8; 5] = *b"/bin\0";
-            let path_ptr = core::ptr::addr_of!(PATH) as *const u8 as u32;
+            let path_ptr = core::ptr::addr_of!(PATH).cast::<u8>() as u32;
 
             let result = sys_execve(path_ptr, 0, 0);
             assert_eq!(
@@ -1742,10 +1751,13 @@ mod tests {
 
     #[test]
     fn syscall_count_at_least_35() {
-        assert!(
-            SYSCALL_COUNT >= 35,
-            "must define at least 35 syscalls, got {SYSCALL_COUNT}"
-        );
+        // WHY the const block: SYSCALL_COUNT is a compile-time constant, so
+        // this invariant can be (and now is) checked at build time -- a
+        // regression fails compilation, not just this test if it happens to
+        // run.
+        const {
+            assert!(SYSCALL_COUNT >= 35, "must define at least 35 syscalls");
+        }
     }
 
     #[test]
@@ -2096,7 +2108,7 @@ mod tests {
         );
         let addr = result as usize;
         assert!(
-            addr >= process::MMAP_BASE && addr < 0x3000_0000,
+            (process::MMAP_BASE..0x3000_0000).contains(&addr),
             "mmap address 0x{addr:08x} must be in user mmap range"
         );
     }
@@ -2431,9 +2443,11 @@ mod tests {
     #[test]
     fn write_dispatch_respects_dup2_redirected_stdout() {
         unsafe {
+            static mut FDS: [u32; 2] = [0, 0];
+            static mut MSG: [u8; 5] = *b"hello";
+            static mut BUF: [u8; 5] = [0u8; 5];
             fd::reset_fd_state_for_test();
 
-            static mut FDS: [u32; 2] = [0, 0];
             let fds_ptr = core::ptr::addr_of_mut!(FDS) as u32;
             let pipe_result = pipe::sys_pipe(fds_ptr);
             assert_eq!(pipe_result, 0, "pipe creation must succeed");
@@ -2447,7 +2461,6 @@ mod tests {
                 "dup2 must install the pipe write end at fd 1"
             );
 
-            static mut MSG: [u8; 5] = *b"hello";
             let msg_ptr = core::ptr::addr_of!(MSG) as u32;
             let written = sys_write_dispatch(1, msg_ptr, 5);
             assert_eq!(
@@ -2455,7 +2468,6 @@ mod tests {
                 "write(1, ...) after dup2 must report 5 bytes written"
             );
 
-            static mut BUF: [u8; 5] = [0u8; 5];
             let buf_ptr = core::ptr::addr_of_mut!(BUF) as u32;
             let read_result = sys_read_with_pipe(read_fd, buf_ptr, 5);
             assert_eq!(read_result, 5, "5 bytes must be read back from the pipe");
@@ -2538,9 +2550,9 @@ mod tests {
 
         for &variant in &Syscall::ALL {
             let n = variant.as_u32();
-            let is_implemented = IMPLEMENTED.iter().any(|&x| x == n);
-            let is_phase05 = PHASE05.iter().any(|&x| x == n);
-            let is_phase06 = PHASE06.iter().any(|&x| x == n);
+            let is_implemented = IMPLEMENTED.contains(&n);
+            let is_phase05 = PHASE05.contains(&n);
+            let is_phase06 = PHASE06.contains(&n);
             assert!(
                 is_implemented || is_phase05 || is_phase06,
                 "syscall {variant:?} (number {n}) has no documented status — \
@@ -2821,12 +2833,12 @@ mod tests {
     /// `mmap_munmap` cycles to exhaust the mapping table (`MAX_MAPPINGS` = 32).
     #[test]
     fn mmap_munmap_balance() {
+        const MAP_PAGES: u32 = 4;
         unsafe {
             setup_mm();
         }
         let free_before = page::free_count();
 
-        const MAP_PAGES: u32 = 4;
         let flags_and_fd: u32 = MAP_ANONYMOUS | (0xFFFF << 16);
         let prot = mmu::prot::PROT_READ | mmu::prot::PROT_WRITE;
         let length = MAP_PAGES * u32::try_from(crate::page::PAGE_SIZE).unwrap_or_default();
@@ -2865,8 +2877,6 @@ mod tests {
     #[test]
     fn execve_oom_rollback_frees_exact_stack_pages() {
         unsafe {
-            process::reset_for_test();
-
             // 52-byte header + one 32-byte PT_LOAD program header. e_entry
             // must fall inside a loaded segment (#384 finding 49), so the
             // segment covers the entry address. WHY a `static mut BUF`
@@ -2875,7 +2885,10 @@ mod tests {
             // address (this binary's static lands in user DRAM range) --
             // same pattern as elf::tests::load_does_not_leak_pages_on_success.
             static mut SEG_BUF: [u8; 16] = [0u8; 16];
-            let vaddr = core::ptr::addr_of_mut!(SEG_BUF) as *mut u8 as u32;
+            static mut PATH: [u8; 5] = *b"/bin\0";
+            process::reset_for_test();
+
+            let vaddr = core::ptr::addr_of_mut!(SEG_BUF).cast::<u8>() as u32;
             let mut elf = [0u8; 84];
             elf[0] = 0x7F;
             elf[1] = b'E';
@@ -2912,8 +2925,7 @@ mod tests {
             let free_before = page::free_count();
             assert_eq!(free_before, 2, "test setup must yield exactly 2 free pages");
 
-            static mut PATH: [u8; 5] = *b"/bin\0";
-            let path_ptr = core::ptr::addr_of!(PATH) as *const u8 as u32;
+            let path_ptr = core::ptr::addr_of!(PATH).cast::<u8>() as u32;
 
             let result = sys_execve(path_ptr, 0, 0);
             assert_eq!(
@@ -2969,7 +2981,7 @@ mod tests {
                 // WHY addr_of_mut!: avoids forming a reference to the mutable
                 // static. The wrapper's address equals its sole field's array
                 // address, and repr(align(4096)) guarantees page alignment.
-                let base = core::ptr::addr_of_mut!(POOL) as *mut u8 as usize;
+                let base = core::ptr::addr_of_mut!(POOL).cast::<u8>() as usize;
                 let addr = base + NEXT * crate::page::PAGE_SIZE;
                 NEXT += 1;
                 Some(addr)
@@ -2979,19 +2991,19 @@ mod tests {
 
         // SAFETY: sa is local; POOL/NEXT are test-only statics.
         unsafe {
+            const N: usize = 128;
             NEXT = 0;
             let mut sa = SlabAllocator::new();
             sa.init();
 
             let layout = Layout::from_size_align(64, 8).unwrap();
-            const N: usize = 128;
             let mut ptrs = [core::ptr::null_mut::<u8>(); N];
 
-            for p in ptrs.iter_mut() {
+            for p in &mut ptrs {
                 *p = sa.alloc_inner(layout, fake_alloc, fake_alloc);
                 assert!(!p.is_null(), "slab alloc must succeed");
             }
-            for &p in ptrs.iter() {
+            for &p in &ptrs {
                 sa.dealloc_inner(p, layout, fake_free);
             }
 


### PR DESCRIPTION
Structural clippy burn-down over `crates/thumos/src/{elf,fd,process,syscall,pipe,slab,kinit}.rs` -- the seven-file slice of #672's remaining structural backlog. All seven now report **zero** findings against the gate's own command:

```
cargo clippy --bin thumos --tests --target i686-unknown-linux-gnu -- -D warnings
```

## Counts fixed, by class (204 findings total in this slice)

| class | count |
|---|---|
| `items_after_statements` | 56 |
| `manual_let_else` | 37 |
| `collapsible_if` | 11 |
| `single_match_else` | 9 |
| `ptr_as_ptr` | 9 |
| `explicit_iter_loop` | 8 |
| `borrow_as_ptr` | 8 |
| `similar_names` | 6 |
| `ref_as_ptr` | 6 |
| `redundant_closure_for_method_calls` | 6 |
| `if_not_else` | 5 |
| `needless_range_loop` | 4 |
| `manual_div_ceil` | 4 |
| `E0133` (unsafe-block-required, edition 2024) | 3 |
| `semicolon_if_nothing_returned` | 3 |
| `no_effect_underscore_binding` | 3 |
| `manual_contains` | 3 |
| `empty_loop` | 3 |
| `struct_field_names` | 2 |
| `redundant_closure` | 2 |
| `match_same_arms` | 2 |
| `manual_range_contains` | 2 |
| `manual_flatten` | 2 |
| `cast_ptr_alignment` | 2 |
| `unused_must_use` | 1 |
| `unused_assignments` | 1 |
| `dropping_references` | 1 |
| `unnecessary_wraps` | 1 |
| `too_many_lines` | 1 |
| `map_unwrap_or` | 1 |
| `let_and_return` | 1 |
| `assertions_on_constants` | 1 |

Plus one `redundant_else` I introduced myself mid-pass (a `kinit.rs` branch swap made an `else` provably unreachable) and fixed in the same recheck cycle before it ever left my worktree -- not part of the original 204, mentioned for completeness.

## Pointer-cast sites (same family as #680)

- **9x `ptr_as_ptr`** (elf.rs x3, slab.rs x2, syscall.rs x4): all `X as *mut/const T as U` chains ending in `.cast::<T>()`. Every site narrows to `u8` (align 1) from a wider type, so alignment is trivially satisfied regardless of the source type's layout; provenance is unchanged (`.cast()` is the type-checked sibling of the `as` it replaces, same address, same operation at the machine level).
- **6x `ref_as_ptr`** (fd.rs, all `stat as *mut StatBuf as u32` -> `core::ptr::from_mut::<StatBuf>(stat) as u32`) and **8x `borrow_as_ptr`** (process.rs, all `&mut frame as *mut Context` -> `&raw mut frame`): same-type reference-to-pointer conversions, no reinterpretation, alignment trivially preserved (same type on both sides). No `SAFETY:`/`INVARIANT:` comment added at these sites -- `core::ptr::from_mut` is a safe fn and `&raw mut` is not an `unsafe` operation; there is no new invariant to discharge.
- **2x `cast_ptr_alignment`** (slab.rs, `refill`/`dealloc_obj`'s `.cast::<FreeNode>()` on a `*mut u8`): the ONE class here with a real alignment obligation. Both sites already carried a pre-existing `INVARIANT:` comment (from #680) tracing the guarantee to `page::alloc_page`'s page-aligned base plus `SLAB_SIZES` all being multiples of 4. The lint fires on `.cast()` exactly the same as on `as` -- it cannot see that proof -- so I added a site-local `#[allow(clippy::cast_ptr_alignment)]` at each with a `WHY:` pointing at the existing `INVARIANT:` rather than restating it.

## Sites where I judged clippy wrong (10 site-local allows total, each with a WHY)

- **elf.rs `Elf32Ehdr`/`Elf32Phdr`** (`struct_field_names`, 2x): field names mirror the ELF32 spec's own `e_*`/`p_*` names verbatim; stripping the shared prefix would decouple the struct from the spec it exists to mirror.
- **slab.rs `refill`/`dealloc_obj`** (`cast_ptr_alignment`, 2x): covered above.
- **kinit.rs `run()`** (`too_many_lines`, 889/800): the boot sequencer -- one linear, numbered "Step N" narrative over ~20 subsystems, called from exactly one site, executed exactly once, never reused or independently tested. Splitting it would thread `serial`/`state`/intermediate hand-offs through a growing set of new `unsafe fn` boundaries purely to satisfy a line count, while making the top-to-bottom boot order harder to audit in one pass.
- **kinit.rs `INITRAMFS`/`INITRAMFS_SIG`** (`items_after_statements`, 2x): both are used two-to-three lines below their declaration; hoisting to the top of `run()`'s ~900-line body would separate declaration from use by hundreds to well over a thousand lines, for the same reason `run()` itself carries the `too_many_lines` allow.
- **pipe.rs `sys_pipe`** (`similar_names`, fn-level): `read_ofd`/`write_ofd` (open-file-description indices) and `read_fd`/`write_fd` (the derived per-process fd numbers) are standard, distinct POSIX terminology, not a naming defect.
- **process.rs `fork()`** (`similar_names`, fn-level): `parent_pid` and `parent_uid` name genuinely distinct fields. Worth flagging: a statement-local `#[allow(clippy::similar_names)]` on just the `let` did **not** suppress this lint -- clippy checks binding similarity over the whole function body, not per-statement, so the allow has to live on the function item. First attempt left the finding still red; caught on recheck.
- **process.rs `map_signal_trampoline`'s host stub** (`unnecessary_wraps`): its signature must match the ARM implementation (`Option<usize>`, genuinely fallible there); callers are shared across both `cfg`s and are not split per-arch, so unwrapping the stub to a bare `usize` would break the common call site rather than the wrapper being pointless.

Where a rename was cleanly available instead of an allow, I used it: `process::init()`'s `procs` -> `proc_table` (colliding with `proc0`) needed no allow at all.

## Other judgment calls, not allows

- **syscall.rs `sys_execve`'s `argc = 0` (`unused_assignments`, a rustc lint, not clippy)**: genuinely dead on the `i686` host target the gate compiles, because its only reader is the `#[cfg(target_arch = "arm")]` argv-frame write further down -- code this gate's target never sees. Gated the assignment itself to `#[cfg(target_arch = "arm")]` to match its one reader, rather than writing a value host builds can never observe. ARM behaviour is byte-for-byte unchanged.
- **syscall.rs, 3x `no_effect_underscore_binding`** (`sys_mmap`'s addr hint, `sys_munmap`/`sys_mprotect`'s length): all three are ABI-shape-only parameters, already documented as intentionally unused in their function doc comments. Replaced the named-but-dead `let _foo = arg as T;` with a bare `let _ = arg;` plus an inline WHY -- keeps the acknowledgement, loses the lint's "you computed this and threw it away" complaint (a named underscore binding reads as "might be used later"; a bare `_` doesn't).
- **syscall.rs `syscall_count_at_least_35`** (`assertions_on_constants`): moved into a `const { assert!(...) }` block. `SYSCALL_COUNT` is a compile-time constant, so the invariant is now checked at build time rather than only when this specific test happens to run. The panic message drops its `{SYSCALL_COUNT}` interpolation because const-context panics can't format values.
- **process.rs's 3x `E0133`** (`reset_all()`): edition 2024 requires explicit `unsafe {}` inside an already-`unsafe fn` body (the implicit-unsafe-body carve-out from 2021 is gone). Wrapped the existing body in one `unsafe { }` block, matching the pattern already used elsewhere in this crate for the same shape (e.g. `fd::init_ramfs`). Not in the original 720-finding census -- it only surfaces under `--tests`, which is worth a note to the operator: if the census that produced #672's numbers didn't compile test code on every file, this class could recur in the other lanes' files (`mmu.rs`, `exceptions.rs`) once they add or touch test modules under edition 2024.

## Confirmed

- Touched only `crates/thumos/src/{elf,fd,process,syscall,pipe,slab,kinit}.rs` plus `crates/thumos/Cargo.lock` (a version sync 0.1.18 -> 0.2.2 that `cargo` rewrote on first invocation, stale since the 0.2.2 release commit; unrelated to this change but included since it was in the tree).
- `cargo fmt --all --check` and `cargo fmt --manifest-path crates/thumos/Cargo.toml --check` both pass.
- `./scripts/check-*.sh`: all pass except `check-pr-title.sh` (no PR existed yet locally) and `check-wiring-inventory.sh`'s default mode (needs a `boot.log` from an actual witness boot run, which I didn't run per "no heavy local builds"); `check-wiring-inventory.sh --no-log` passes (118 modules, 21 capabilities, 20 witness markers verified), confirming the inventory logic itself is unaffected.
- Did not run `scripts/kernel-host-tests.sh` locally (heavy) -- the decisive check on this PR is that stage reporting the same runnable-test count as `main`.
- No `allow` added crate-wide; all ten are site-local with a `WHY:`.
- `KCLIPPY` will stay red on the full gate -- the other three lanes' files are not in this slice.

Refs #672
