### PR TITLE
fix(klesis): match AT final result codes exactly rather than by prefix

### DIFF
--- a/crates/klesis/src/at.rs
+++ b/crates/klesis/src/at.rs
@@ -8,7 +8,7 @@ use nom::Parser;
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until, take_while1};
 use nom::character::complete::{char, digit1};
-use nom::combinator::{map, map_res, opt, value, verify};
+use nom::combinator::{all_consuming, map, map_res, opt, value, verify};
 use nom::sequence::{delimited, preceded};
 
 use crate::error::{Error, Result};
@@ -151,8 +151,19 @@ impl From<u8> for SignalStrength {
 // (variable whitespace, optional fields, interleaved URCs).
 
 /// Parse a final result code (OK, ERROR, +CME ERROR, +CMS ERROR).
+///
+/// SECURITY: 3GPP TS 27.007 final result codes are complete lines, not
+/// prefixes -- `OK` and `ERROR` terminate the response with no further
+/// bytes. `all_consuming` enforces that: a `nom::bytes::complete::tag`
+/// alone accepts any line merely *beginning* with the matched text (`"OK"`
+/// matches `"OKAY"`, an unsolicited line, or trailing framing debris the
+/// transport failed to strip), which would let the caller record a modem
+/// command as having succeeded when it did not. `+CME ERROR: `/`+CMS
+/// ERROR: ` remain legitimate prefixes -- they carry a numeric code after
+/// the tag -- but `all_consuming` still requires that code to account for
+/// every remaining byte on the line.
 pub fn parse_final_result(input: &str) -> IResult<&str, Response> {
-    alt((
+    all_consuming(alt((
         value(Response::Ok, tag("OK")),
         value(Response::Error, tag("ERROR")),
         map(
@@ -163,7 +174,7 @@ pub fn parse_final_result(input: &str) -> IResult<&str, Response> {
             preceded(tag("+CMS ERROR: "), map_res(digit1, str::parse::<u32>)),
             Response::CmsError,
         ),
-    ))
+    )))
     .parse(input)
 }
 
@@ -215,8 +226,14 @@ pub fn parse_creg(input: &str) -> IResult<&str, Urc> {
 }
 
 /// Parse a RING URC.
+///
+/// SECURITY: same prefix-vs-exact hazard as [`parse_final_result`] -- `RING`
+/// is a bare literal with no trailing payload (3GPP TS 27.007), so a plain
+/// `tag` would also accept `"RINGING"` or any other line merely beginning
+/// with it. `all_consuming` keeps this in parity with the kernel's
+/// `is_ring`, which already compares the whole line.
 pub fn parse_ring(input: &str) -> IResult<&str, Urc> {
-    value(Urc::Ring, tag("RING")).parse(input)
+    all_consuming(value(Urc::Ring, tag("RING"))).parse(input)
 }
 
 /// Maximum length accepted for a `+CMTI` storage-location name.
@@ -364,6 +381,43 @@ mod tests {
     }
 
     #[test]
+    fn parse_final_result_rejects_okay_as_success() {
+        // SECURITY (#685): a modem line beginning "OK" but carrying more
+        // bytes must not be accepted as command success. Before
+        // `all_consuming`, `tag("OK")` matched the prefix and returned
+        // Response::Ok with "AY" as unconsumed remainder that callers
+        // following the usual IResult idiom discard.
+        assert!(
+            parse_final_result("OKAY").is_err(),
+            "'OKAY' must not parse as a successful final result"
+        );
+    }
+
+    #[test]
+    fn parse_final_result_rejects_okk_prefix_collision() {
+        // SECURITY (#685): issue's exact near-miss case.
+        assert!(
+            parse_final_result("OKK").is_err(),
+            "'OKK' must not be classified as Response::Ok by prefix match"
+        );
+    }
+
+    #[test]
+    fn parse_final_result_rejects_ok_embedded_mid_string() {
+        // SECURITY (#685): a final result code is the whole line; "OK"
+        // occurring anywhere other than as the complete line must not
+        // classify as success.
+        assert!(
+            parse_final_result("PREFIX OK").is_err(),
+            "a line with OK embedded mid-string must not parse as a final result"
+        );
+        assert!(
+            parse_final_result("NOKIA").is_err(),
+            "a line merely containing the substring OK must not parse as a final result"
+        );
+    }
+
+    #[test]
     fn parse_final_result_bare_error() {
         let (_, resp) = parse_final_result("ERROR").unwrap_or_default();
         assert_eq!(
@@ -374,12 +428,34 @@ mod tests {
     }
 
     #[test]
+    fn parse_final_result_rejects_error_prefix_collision() {
+        // SECURITY (#685): same exactness requirement as OK -- ERROR is
+        // also a bare, no-payload final result code.
+        assert!(
+            parse_final_result("ERRORX").is_err(),
+            "'ERRORX' must not be classified as Response::Error by prefix match"
+        );
+    }
+
+    #[test]
     fn parse_cme_error() {
         let (_, resp) = parse_final_result("+CME ERROR: 10").unwrap_or_default();
         assert_eq!(
             resp,
             Response::CmeError(10),
             "CME error code 10 must be extracted"
+        );
+    }
+
+    #[test]
+    fn parse_cme_error_rejects_trailing_garbage() {
+        // WHY: +CME ERROR remains a legitimate prefix (it carries a code)
+        // -- this is NOT turned into an exact string match. `all_consuming`
+        // only requires that, once the code is extracted, no bytes are
+        // left unaccounted for on the line.
+        assert!(
+            parse_final_result("+CME ERROR: 10x").is_err(),
+            "trailing bytes after a CME error code must not be silently dropped"
         );
     }
 
@@ -463,6 +539,17 @@ mod tests {
     fn parse_ring_urc() {
         let (_, urc) = parse_ring("RING").unwrap_or_default();
         assert_eq!(urc, Urc::Ring, "RING must parse to Urc::Ring");
+    }
+
+    #[test]
+    fn parse_ring_rejects_prefix_collision() {
+        // SECURITY (#685, same class): RING is a bare no-payload URC token,
+        // just like OK/ERROR. The kernel's `is_ring` already compares the
+        // whole line; klesis must not diverge by accepting a mere prefix.
+        assert!(
+            parse_ring("RINGING").is_err(),
+            "'RINGING' must not be classified as Urc::Ring by prefix match"
+        );
     }
 
     #[test]

--- a/crates/klesis/src/transport.rs
+++ b/crates/klesis/src/transport.rs
@@ -19,7 +19,13 @@ use crate::error::{NotReadySnafu, ParseSnafu, Result, UnexpectedResponseSnafu};
 /// result code keeps `AtSession::send_command` looping forever and grows
 /// its `info` `Vec` without bound -- a heap-exhaustion `DoS`. Mirrors
 /// `wait_urc`'s `MAX_ATTEMPTS` below.
-const MAX_INFO_LINES: usize = 64;
+///
+/// WHY: matches the kernel's `telephony::MAX_RESPONSE_LINES`, which was
+/// deliberately narrowed from 64 (issue #282 finding 14) to shrink the
+/// worst-case block time a modem pacing junk lines just under a command's
+/// timeout can impose. A looser bound here would reopen that window on
+/// this side of the split AT-parsing path.
+const MAX_INFO_LINES: usize = 16;
 
 /// Maximum bytes buffered for a single AT line before giving up.
 ///
@@ -421,6 +427,29 @@ mod tests {
         assert!(
             result.is_err(),
             "send_command must error rather than buffer 1000 info lines"
+        );
+    }
+
+    #[test]
+    fn send_command_bounds_matches_kernel_hardened_limit() {
+        // WHY (#685): MAX_INFO_LINES was reconciled to the kernel's
+        // MAX_RESPONSE_LINES = 16 (deliberately narrowed from 64 there, per
+        // issue #282 finding 14, to shrink a modem's worst-case block-time
+        // window). This exercises the boundary directly: a response with
+        // one more info line than the hardened bound, followed by OK, must
+        // still fail -- against the pre-reconciliation bound of 64 this
+        // response fits comfortably and would have succeeded.
+        let mut data = Vec::new();
+        for _ in 0..17 {
+            data.extend_from_slice(b"+CSQ: 1,1\r\n");
+        }
+        data.extend_from_slice(b"OK\r\n");
+        let transport = MockTransport::with_response(&data);
+        let mut session = AtSession::new(transport);
+        let result = session.send_command("AT+CSQ");
+        assert!(
+            result.is_err(),
+            "17 info lines must exceed the hardened 16-line bound shared with the kernel"
         );
     }
 


### PR DESCRIPTION
## What

`klesis`'s AT final-result parser matched `OK` and `ERROR` by prefix. 3GPP TS 27.007 makes these complete final result lines, not prefixes — so `OKAY`, `OKK`, or any unsolicited line beginning with those bytes was accepted as confirmation that a modem command succeeded. On the modem control path a false success means the kernel believes it configured something it did not.

Wrapping the alternation in `nom::combinator::all_consuming` makes recognition exact. `+CME ERROR:` and `+CMS ERROR:` stay prefixes — they legitimately carry a numeric code — but trailing garbage after that code is now rejected too, since `all_consuming` wraps the outer alternation rather than each branch.

## Scope beyond the filed issue

Two things were found by sweeping for the same shape rather than fixing only the cited line:

- **`parse_ring` had the identical defect** (`at.rs:235`). `RING` is the same bare no-payload token, so `RINGING` parsed as `Urc::Ring`. Not named in #685; fixed here because it is the same class.
- **`MAX_INFO_LINES` reconciled 64 → 16** (`transport.rs:28`) to match the kernel's `telephony::MAX_RESPONSE_LINES`, deliberately narrowed to 16 under #282 finding 14 to bound the worst-case block time a modem pacing junk lines can impose. klesis retained the loose 64 and reopened that window on its side of the split AT path — a #545-shaped divergence.

  This one changes behaviour, so stating the bound explicitly: klesis issues `AT`, `AT+CSQ`, `AT+CPIN?`, `AT+CMGR=<index>`, and `AT+COPS` variants. None has a legitimate response exceeding 16 info lines. A future `AT+CMGL` or `AT+CPBR` — list-style commands that genuinely return dozens of lines — would need this raised on **both** sides, not just here.

## Kernel vs workspace

Only the workspace copy was affected. `crates/thumos/src/telephony_parser.rs:22,25` already compares whole lines (`line == b"OK"`), as do `is_ring` / `is_no_carrier` / `is_busy`. A genuine one-sided divergence: the kernel copy was correct and could not catch the workspace copy's bug, which is the failure mode #545 exists to eliminate.

## Verification

Tests fail before the fix and pass after — demonstrated by stashing only the three source lines and keeping the new tests:

```
failures:
    at::tests::parse_cme_error_rejects_trailing_garbage
    at::tests::parse_final_result_rejects_error_prefix_collision
    at::tests::parse_final_result_rejects_okay_as_success
    at::tests::parse_final_result_rejects_okk_prefix_collision
    at::tests::parse_ring_rejects_prefix_collision
    transport::tests::send_command_bounds_matches_kernel_hardened_limit
test result: FAILED. 83 passed; 6 failed
```

`parse_final_result_rejects_ok_embedded_mid_string` deliberately does **not** fail pre-fix — nom's `tag` anchors at offset 0, so a mid-string occurrence was never reachable through this bug. It is defence-in-depth, and its body says so rather than implying it caught something.

With the fix restored: klesis 89/89, workspace `nextest` 869/869, `clippy --workspace --all-targets -D warnings` clean, `fmt --check` clean, CI-exact kernel host tests 2420/2420 and 2424/2424 (exit 0), `check-convergence.sh` holds.

Closes #685
