### PR TITLE
fix(asphaleia): deny unrecognized IP protocols instead of classifying them as the allow-all wildcard

### DIFF
--- a/crates/asphaleia/src/filter.rs
+++ b/crates/asphaleia/src/filter.rs
@@ -2,7 +2,8 @@
 //!
 //! [`Filter`] combines a [`RuleSet`] with an optional [`DnsBlocklist`] to
 //! evaluate raw IP packets. DNS queries to blocked domains are denied before
-//! rule evaluation. Parse failures default to deny.
+//! rule evaluation. Parse failures and unrecognized IP protocol numbers
+//! default to deny.
 
 use crate::dns::{DNS_PORT, DnsBlocklist};
 use crate::packet::{IpHeader, PROTO_ICMP, PROTO_TCP, PROTO_UDP, TcpHeader, UdpHeader};
@@ -56,7 +57,8 @@ impl Filter {
     /// Evaluate a raw IPv4 packet in the given `direction` and return the
     /// action to take.
     ///
-    /// Packets that fail to parse are denied (fail-closed).
+    /// Packets that fail to parse, and packets carrying an unrecognized IP
+    /// protocol number, are denied (fail-closed).
     pub fn evaluate(&mut self, packet: &[u8], direction: Direction) -> Action {
         let action = self.classify(packet, direction);
         self.record(action);
@@ -99,7 +101,16 @@ impl Filter {
                 (Protocol::Udp, Some(udp.src_port), Some(udp.dst_port))
             }
             PROTO_ICMP => (Protocol::Icmp, None, None),
-            _ => (Protocol::Any, None, None),
+            // INVARIANT: an IP protocol number this filter does not
+            // recognize must deny, not classify as `Protocol::Any`.
+            // `Protocol::Any` is the rule-side wildcard ("match every
+            // protocol this filter understands") -- feeding it a packet
+            // whose protocol was never identified would let an allow-all
+            // rule admit traffic the filter has no basis to judge. This
+            // mirrors the kernel's `parse_packet` (firewall.rs), which
+            // returns `None` for the same case and is denied by its
+            // caller.
+            _ => return Action::Deny,
         };
 
         let info = PacketInfo {
@@ -181,6 +192,20 @@ mod tests {
         pkt[24] = ul_bytes[0];
         pkt[25] = ul_bytes[1];
         pkt[28..].copy_from_slice(udp_payload);
+        pkt
+    }
+
+    /// Build a bare IPv4 packet (no layer-4 payload) carrying `protocol`.
+    /// Used for protocols whose branch never parses past the IP header
+    /// (ICMP, and any unrecognized protocol number).
+    fn make_ip_only(protocol: u8, src: [u8; 4], dst: [u8; 4]) -> Vec<u8> {
+        let mut pkt = vec![0u8; 20];
+        pkt[0] = 0x45;
+        pkt[2] = 0x00;
+        pkt[3] = 20;
+        pkt[9] = protocol;
+        pkt[12..16].copy_from_slice(&src);
+        pkt[16..20].copy_from_slice(&dst);
         pkt
     }
 
@@ -272,6 +297,74 @@ mod tests {
             f.evaluate(&garbage, Direction::In),
             Action::Deny,
             "unparseable packet must be denied even with allow-all rule"
+        );
+    }
+
+    #[test]
+    fn unrecognized_protocol_is_denied_despite_allow_all_rule() {
+        // GRE (IANA protocol 47) -- representative of the ~250 IP protocol
+        // numbers this filter does not classify (anything outside
+        // TCP/UDP/ICMP).
+        const PROTO_GRE: u8 = 47;
+
+        let mut f = Filter::new();
+        f.ruleset_mut().add_rule(Rule {
+            direction: Direction::In,
+            protocol: Protocol::Any,
+            src_addr: AddressMatch::any(),
+            dst_addr: AddressMatch::any(),
+            src_port: PortMatch::Any,
+            dst_port: PortMatch::Any,
+            action: Action::Allow,
+        });
+        let pkt = make_ip_only(PROTO_GRE, [1, 2, 3, 4], [10, 0, 0, 1]);
+        assert_eq!(
+            f.evaluate(&pkt, Direction::In),
+            Action::Deny,
+            "an unrecognized IP protocol number must be denied even when an \
+             allow-all (Protocol::Any) rule is installed -- Any is the \
+             rule-side wildcard for protocols this filter understands, not \
+             a signal that classification succeeded"
+        );
+    }
+
+    #[test]
+    fn icmp_protocol_permitted_by_matching_rule() {
+        let mut f = Filter::new();
+        f.ruleset_mut().add_rule(Rule {
+            direction: Direction::In,
+            protocol: Protocol::Icmp,
+            src_addr: AddressMatch::any(),
+            dst_addr: AddressMatch::any(),
+            src_port: PortMatch::Any,
+            dst_port: PortMatch::Any,
+            action: Action::Allow,
+        });
+        let pkt = make_ip_only(PROTO_ICMP, [1, 2, 3, 4], [10, 0, 0, 1]);
+        assert_eq!(
+            f.evaluate(&pkt, Direction::In),
+            Action::Allow,
+            "ICMP packet must still be permitted by an explicit ICMP allow rule"
+        );
+    }
+
+    #[test]
+    fn udp_protocol_permitted_by_matching_rule() {
+        let mut f = Filter::new();
+        f.ruleset_mut().add_rule(Rule {
+            direction: Direction::In,
+            protocol: Protocol::Udp,
+            src_addr: AddressMatch::any(),
+            dst_addr: AddressMatch::any(),
+            src_port: PortMatch::Any,
+            dst_port: PortMatch::Single(4500),
+            action: Action::Allow,
+        });
+        let pkt = make_ip_udp([1, 2, 3, 4], [10, 0, 0, 1], 54321, 4500, &[]);
+        assert_eq!(
+            f.evaluate(&pkt, Direction::In),
+            Action::Allow,
+            "UDP packet must still be permitted by an explicit UDP allow rule"
         );
     }
 

--- a/crates/thumos/Cargo.toml
+++ b/crates/thumos/Cargo.toml
@@ -59,10 +59,13 @@ aes = { version = "0.8", default-features = false }
 # band boundaries) live in sema-core, shared with the workspace `sema` crate
 # — one implementation, no drifted duplicate in screen_threat.
 sema-core = { path = "../sema-core", default-features = false }
-# WHY (#545): the canonical packet-parse + DNS-surveillance-policy semantics
-# (IPv4/TCP/UDP header fields, QNAME extraction, the blocklist domain list and
-# its suffix-matching rule) live in asphaleia-core, shared with the workspace
-# `asphaleia` crate — one implementation, no drifted duplicate in firewall.rs.
+# WHY (#545): the canonical DNS-surveillance-policy semantics (QNAME
+# extraction, the blocklist domain list, and its suffix-matching rule) live
+# in asphaleia-core, shared with the workspace `asphaleia` crate -- one
+# implementation, no drifted duplicate in firewall.rs. IPv4/TCP/UDP header
+# parsing is NOT yet converged: firewall.rs::parse_packet still does its own
+# header arithmetic (see docs/convergence.toml's "firewall" pair for the
+# tracked disposition).
 asphaleia-core = { path = "../asphaleia-core", default-features = false }
 # WHY (#545, #662): the canonical GSM-7 codec, SMS-PDU byte primitives, and
 # the silent-SMS/WAP-Push classification live in klesis-core, shared with the


### PR DESCRIPTION
## What

`asphaleia`'s packet filter classified any IP protocol number it did not recognise as `Protocol::Any` and let it continue into rule evaluation. `Protocol::Any` is the **rule-side wildcard** — it means "match every protocol this filter understands". Feeding it a packet whose protocol was never identified inverts its meaning, so an allow-all rule admitted traffic the filter had no basis to judge.

The unrecognised arm now denies immediately, before a `PacketInfo` is ever constructed.

## Blast radius, stated plainly

Any IP protocol other than TCP (6), UDP (17), or ICMP (1) is now denied unconditionally at classification — GRE, ESP, AH, IGMP, SCTP, and the ~250 other IANA numbers — **even against an explicit allow-all rule**. That is the intended semantics of a firewall default-deny, but it is a real behavioural change and worth naming rather than burying.

Nothing in this repo relied on the fail-open path: `asphaleia` is a library at `alpha` maturity with no `[[bin]]`, no CLI consumer, and no default ruleset. This is a pre-release correctness fix, not a regression against running traffic. TCP/UDP/ICMP are untouched — still explicitly matched, same rule-evaluation path.

## Scope of the sweep

The whole decision path was audited rather than just the cited line. No other `_ => Allow`, permissive `unwrap_or(true)`, or `Option`-to-permit site exists across `asphaleia::{filter,rules,dns}` or `thumos::firewall`.

Two things the sweep established that are worth recording:

- **The kernel copy was already correct.** `thumos::firewall::parse_packet` returns `None` for unrecognised protocols and its caller denies on `None`; the kernel's `Protocol` has no `Any` variant at all, so this conflation was structurally impossible there. The divergence was one-sided — same shape as #685, where the kernel was also the correct copy.
- **`asphaleia::dns` already fails closed** on undecodable queries (`is_none_or`).

The drop is counted: `classify` returns into `evaluate`, which calls `record`, incrementing `packets_denied` — the same path a malformed packet already took. No new telemetry mechanism was invented.

## Also corrected

`crates/thumos/Cargo.toml:62-68` carried a WHY comment claiming the two filters share header parsing. They do not. The comment now states the actual state; `docs/convergence.toml`'s `firewall` pair already records the non-convergence and its live port marker. The convergence itself remains #545's work and is deliberately not attempted here.

## Verification

Test fails before the fix and passes after — demonstrated by reverting only the fix line and keeping the test:

```
thread 'filter::tests::unrecognized_protocol_is_denied_despite_allow_all_rule' panicked
assertion `left == right` failed: an unrecognized IP protocol number must be denied
even when an allow-all (Protocol::Any) rule is installed
  left: Allow
 right: Deny
test result: FAILED. 0 passed; 1 failed
```

New tests also confirm each supported protocol still passes (`icmp_protocol_permitted_by_matching_rule`, `udp_protocol_permitted_by_matching_rule`) — a fail-closed change is only correct if it did not close on legitimate traffic.

With the fix: asphaleia 39/39, workspace `nextest` 865/865, CI-exact kernel host tests exit 0 (2420/2420 then 2424/2424 with `debug-console`), `fmt --check` clean on both the workspace and the excluded kernel crate, `clippy --all-targets -D warnings` zero warnings with no `#[allow]` added, `check-convergence.sh` holding at 9 pairs.

Closes #686
