### PR TITLE
fix(kernel): guard the QEMU semihosting asm by target_arch so the host lint pass can compile it

### DIFF
--- a/crates/thumos/src/qemu.rs
+++ b/crates/thumos/src/qemu.rs
@@ -6,21 +6,35 @@
 //!
 //! Exit-code contract (asserted by CI): 0 = boot-complete, 1 = panic,
 //! 2 = data abort, 3 = prefetch abort, 4 = undefined instruction.
+//!
+//! WHY(#692): the semihosting trap below binds `r0`/`r1` as explicit asm
+//! operands, which is AArch32-only -- `r0`/`r1` are not registers on the
+//! i686 host target `scripts/kernel-clippy.sh` lints this module against
+//! under `--features qemu`. Every function is therefore split
+//! `target_arch = "arm"` / `not(target_arch = "arm")`, so the public API
+//! (`request_exit`, `write0`) type-checks identically on both targets while
+//! only the ARM half ever performs a real semihosting call. See each
+//! host-target fn's own WHY for why panicking, not a silent no-op, is the
+//! correct fallback.
 
 /// SYS_EXIT_EXTENDED semihosting operation.
 ///
 /// WHY: plain SYS_EXIT (0x18) on AArch32 takes the reason code directly in
 /// r1 and cannot carry an exit status; the extended form takes a
 /// [reason, status] block, so pass/fail/abort codes reach the runner.
+#[cfg(target_arch = "arm")]
 const SYS_EXIT_EXTENDED: u32 = 0x20;
 
 /// SYS_WRITE0 semihosting operation (write NUL-terminated string).
+#[cfg(target_arch = "arm")]
 const SYS_WRITE0: u32 = 0x04;
 
 /// ADP_Stopped_ApplicationExit reason code.
+#[cfg(target_arch = "arm")]
 const ADP_STOPPED_APPLICATION_EXIT: u32 = 0x2_0026;
 
 /// Terminate the guest; `status` becomes the QEMU process exit code.
+#[cfg(target_arch = "arm")]
 fn exit(status: u32) -> ! {
     let params = [ADP_STOPPED_APPLICATION_EXIT, status];
     // SAFETY: `svc #0x123456` is the architecturally-defined A32 semihosting
@@ -35,6 +49,20 @@ fn exit(status: u32) -> ! {
             options(noreturn, nostack),
         );
     }
+}
+
+/// Host-target stand-in for [`exit`].
+///
+/// WHY(#692): semihosting exit has no host-target equivalent -- there is no
+/// QEMU guest to terminate and no `r0`/`r1` on `i686/x86_64`. This arm exists
+/// only so `--features qemu` lint/check passes on the host target (see the
+/// module WHY); `kernel-build.sh` only ever links `armv7a-none-eabi`
+/// artifacts, so this function is unreachable in every real boot. It
+/// panics rather than returning so a hypothetical host call fails loudly
+/// instead of reporting a fabricated QEMU exit status.
+#[cfg(not(target_arch = "arm"))]
+fn exit(status: u32) -> ! {
+    unreachable!("semihosting exit (status={status}) is ARM-only; unreachable on the host target")
 }
 
 /// Unit-typed wrapper over [`exit`].
@@ -52,6 +80,7 @@ pub(crate) fn request_exit(status: u32) {
 ///
 /// Works before UART/MMU init -- the only dependency is the semihosting
 /// trap, so it is the earliest available boot instrumentation.
+#[cfg(target_arch = "arm")]
 pub(crate) fn write0(msg: &core::ffi::CStr) {
     // SAFETY: msg is NUL-terminated (CStr invariant) and lives in mapped
     // kernel memory; QEMU reads it host-side up to the NUL. r0 carries the
@@ -64,4 +93,16 @@ pub(crate) fn write0(msg: &core::ffi::CStr) {
             options(nostack, readonly),
         );
     }
+}
+
+/// Host-target stand-in for [`write0`].
+///
+/// WHY(#692): see [`exit`]'s host-target stand-in -- same architecture
+/// mismatch, same reasoning. A silent no-op would let a caller believe the
+/// host console write happened when nothing was ever emitted; panicking
+/// keeps that failure visible instead of manufacturing success.
+#[cfg(not(target_arch = "arm"))]
+pub(crate) fn write0(msg: &core::ffi::CStr) {
+    let _ = msg;
+    unreachable!("semihosting write0 is ARM-only; unreachable on the host target")
 }


### PR DESCRIPTION
## What

`crates/thumos/src/qemu.rs` used ARM semihosting inline assembly with explicit `r0`/`r1` register operands and no `target_arch` guard. The kernel's lint and test passes run against the i686 host target, where those register names do not exist, so rustc emitted four hard `invalid register` **errors**.

`exit()` and `write0()` are now split on `#[cfg(target_arch = "arm")]`. The ARM arm is byte-identical to the original semihosting code; the host arm keeps the same signature so every caller (`exceptions.rs`, `kinit.rs`, `kardia.rs`, `main.rs`) still typechecks on i686.

The host arm panics via `unreachable!()` rather than returning normally. `kernel-build.sh` only ever links `armv7a-none-eabi` artifacts, so it is unreachable in any real boot — and a silent no-op would let a caller believe a QEMU exit or console write happened when nothing was emitted. That is the failure mode worth preventing here, so the host path is loud by construction.

## The number that matters, and why it goes up

These were not lint findings. They were rustc errors, and **a compile error aborts the unit before clippy analyses any of it**:

| pass | before | after |
|---|---|---|
| `invalid register` errors | 4 | **0** |
| `[qemu]` bin (non-test) | 7 | **164** |
| `[qemu]` bin-test | 29 | 29 |
| `[default]` bin / bin-test | 147 / 333 | 147 / 333 |

The 7 → 164 jump is the fix working, not a regression. Those four errors were hiding roughly 157 pre-existing findings across unrelated files, which have now become visible for the first time. Nothing was introduced; the instrument simply reached code it had never been able to see.

This is the third time this repo has hit that shape — `build.rs` (#668) hid the entire 1161-finding kernel backlog behind 18 errors, and #672 records the same mechanism. The general form: **an early hard failure in a lint pipeline hides everything behind it, and the failure looks like the whole result.** Any "clean" reading taken while a compile abort is upstream is unknown, not clean.

Consequence for #672: its remaining count is materially larger than the 393 the census reported, and its `[qemu]` half was never measurable until this landed. I have updated that issue with the corrected figures.

The one `qemu.rs`-attributed finding still present is a pre-existing `doc_markdown` lint on line 3; it belongs to #672 and is deliberately untouched here.

## Sweep for the same shape

`rg '(in|out|inout|inlateout|lateout)\("[a-zA-Z][0-9]*"\)' crates/thumos/src/` found explicit register-name operands **only** in `qemu.rs`. Every other `asm!`/`global_asm!` site in the crate — `timer.rs`, `exceptions.rs`, `uart.rs`, `uart_pl011.rs`, `csprng.rs`, `process.rs`, `power.rs`, `mmu.rs`, `irq.rs`, `ccci.rs`, `kinit.rs`, `console.rs`, `main.rs` — either uses generic register classes (`in(reg)`/`out(reg)`, which do not trip this class on any target) or operand-less instruction text, and is already `target_arch`- or `test`-gated where it matters. No other file needed the guard.

## Verification

`scripts/kernel-build.sh` (matches CI exactly, no `qemu` feature) passes clean under `-D warnings`. The real ARM semihosting path this change touches was exercised directly with `cargo build --release --features qemu` from `crates/thumos`, which targets `armv7a-none-eabi` via `.cargo/config.toml` — passes clean. `cargo fmt --manifest-path crates/thumos/Cargo.toml --all -- --check` clean.

Closes #692
