### PR TITLE
test(kernel): prove the required kernel check blocks a merge (#694, do not merge)

### DIFF
--- a/crates/thumos/src/telephony_parser.rs
+++ b/crates/thumos/src/telephony_parser.rs
@@ -661,3 +661,13 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod gate_proof_694 {
+    // WHY: deliberately failing test proving the kernel job blocks a merge
+    // once promoted to a required check. This branch is never merged.
+    #[test]
+    fn deliberately_failing_kernel_test() {
+        assert_eq!(1, 2, "intentional failure proving the required check blocks");
+    }
+}


### PR DESCRIPTION
Deliberately failing kernel test. This PR exists solely to exhibit that the newly-required `kernel (i686 tests + armv7a build)` context blocks a merge, per #694's acceptance criterion — proving the block rather than reading the settings page.

**Do not merge.** Will be closed and its branch deleted once the block is observed.

Refs: #694