### PR TITLE
fix(release): upload the attested artefacts, and assert the release carries them

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -203,6 +203,44 @@ jobs:
         with:
           subject-path: thumos-*.tar.gz
           sbom-path: sbom-kernel.cdx.json
+      # WHY (#705): attestation binds a signature to an artefact DIGEST; it does
+      # not publish the artefact. Without this upload the tarball and both SBOMs
+      # exist only inside the runner and are discarded when it terminates, so
+      # `gh attestation verify` -- which requires the file -- has nothing to
+      # check and the release carries zero assets. v0.2.5 is the proof: the job
+      # went green for the first time and the release was still empty.
+      # INVARIANT: every artefact named as an attestation subject-path or
+      # sbom-path above must appear here, or it is signed and undistributed.
+      - name: Upload attested artefacts to the release
+        if: ${{ env.IS_RELEASE == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          gh release upload "$TAG" \
+            thumos-"$TAG".tar.gz \
+            sbom-workspace.cdx.json \
+            sbom-kernel.cdx.json \
+            --repo "$GITHUB_REPOSITORY" --clobber
+      # WHY (#705): asserts the release actually carries what was just attested,
+      # rather than trusting that the upload above did anything. A green job that
+      # leaves the release empty is exactly the failure this issue was reopened
+      # for, and it is invisible without this check.
+      - name: Verify the release carries the attested artefacts
+        if: ${{ env.IS_RELEASE == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          names=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name')
+          for want in "thumos-$TAG.tar.gz" sbom-workspace.cdx.json sbom-kernel.cdx.json; do
+            printf '%s\n' "$names" | grep -qxF "$want" || {
+              echo "FAIL: release $TAG is missing attested artefact '$want'" >&2
+              echo "carries: $names" >&2
+              exit 1
+            }
+          done
+          echo "release $TAG carries all three attested artefacts"
       # WHY (#705): a red release-attest run reports to nobody who is
       # looking -- it fires after the tag is already published, is not a
       # required check, and cannot become one. Files a tracked issue only on


### PR DESCRIPTION
## What

`release-attest` succeeded for the first time ever on v0.2.5 — [run 31414543111](https://github.com/forkwright/thumos/actions/runs/31414543111), both jobs green — and **v0.2.5 carries zero assets**.

```
gh release view v0.2.5 --repo forkwright/thumos --json assets   ->   []
```

Attestation binds a signature to an artefact **digest**; it does not publish the artefact. The source tarball and both SBOMs existed only inside the runner and were discarded when it terminated. `gh attestation verify` requires the file, so the attestation certifies something no consumer can obtain.

Nothing in the workflow ever uploaded them — verified: no `gh release upload`, no `softprops`, no `files:` anywhere in the file.

## Why this got through

This is the third distinct cause on the same job across nine releases, and each one passed whatever check existed at the time:

1. `cargo package --workspace` against a `publish=false` workspace with a path dependency (v0.1.6–v0.1.8, rewritten under #536)
2. `cargo cyclonedx --output-file`, a flag that does not exist (#708)
3. this — everything generated, validated, signed, and never published

#708 added a glob assertion that the SBOM files match what the attest step expects. That check passed, correctly: the files *were* on disk with the right names. It just never asked whether they left the runner.

## The fix, and the assertion that matters more

The upload is three lines. The second step is the point: it reads the release back and fails unless all three artefact names are present.

A green job that leaves the release empty is precisely the failure being fixed, and nothing else makes it visible — `release-attest` runs after the tag is already published, is not a required check, and cannot become one. The invariant worth enforcing is not "the upload command ran" but **"the release carries what was signed"**.

An `INVARIANT` comment records the coupling: every artefact named as an attestation `subject-path` or `sbom-path` must also appear in the upload, or it is signed and undistributed.

## v0.2.5

Left as-is. It is tagged, published, and unattested-in-practice. Retro-uploading assets to it would attach files whose attestation was produced in a different run, which is a weaker claim than it appears — and the dispatch path deliberately cannot sign, so there is no honest way to reconstruct it. v0.2.6 will be the first release carrying verifiable provenance.

Refs: #705, #536