### PR TITLE
feat(kernel): add the Matrix /keys/claim request builder and a claim-response handler that cannot touch the local key pool

### DIFF
--- a/crates/thumos/src/harmostes.rs
+++ b/crates/thumos/src/harmostes.rs
@@ -2427,4 +2427,274 @@ mod tests {
         let bad = alloc::format!("zz{}", "aa".repeat(31));
         assert_eq!(hex_decode_32_bytes(&bad), None);
     }
+
+    // -- /keys/claim (#437) --
+
+    /// Helper: build a minimal `/keys/claim` response body. `key_id` is the
+    /// `"<algorithm>:<id>"` string under the target device (e.g.
+    /// `"curve25519:AAAAAQ"`); `key_value` is the raw value at that key
+    /// (hex or base64, or deliberately neither for malformed-payload tests).
+    fn build_claim_response(
+        user_id: &str,
+        device_id: &str,
+        key_id: &str,
+        key_value: &str,
+    ) -> String {
+        let mut w = JsonWriter::new();
+        w.object_start();
+        w.key("failures");
+        w.object_start();
+        w.end();
+        w.key("one_time_keys");
+        w.object_start();
+        w.key(user_id);
+        w.object_start();
+        w.key(device_id);
+        w.object_start();
+        w.key(key_id);
+        w.string_value(key_value);
+        w.end(); // key map
+        w.end(); // device
+        w.end(); // user
+        w.end(); // one_time_keys
+        w.end(); // root
+        w.finish()
+    }
+
+    #[test]
+    fn claim_keys_request_builds_correct_path_and_body() {
+        let client = matrix_client_with_test_credentials();
+        let user_id = "@alice:matrix.example.com";
+        let device_id = "ALICEDEVICE";
+
+        let req = client
+            .build_claim_keys_request(user_id, device_id)
+            .expect("a well-formed target must build a request");
+
+        assert!(req.path.contains("/keys/claim"));
+
+        let has_auth = req
+            .headers
+            .iter()
+            .any(|(k, v)| k == "Authorization" && v.contains("Bearer"));
+        assert!(has_auth);
+
+        let body_bytes = req.body.as_deref().unwrap_or(&[]);
+        let body_str = core::str::from_utf8(body_bytes).unwrap_or("");
+        assert!(body_str.contains(user_id), "body must key on the user id");
+        assert!(
+            body_str.contains(device_id),
+            "body must nest the device id under the user"
+        );
+        assert!(
+            body_str.contains(matrix_crypto::ONE_TIME_KEY_ALGORITHM),
+            "body must declare the claimed algorithm"
+        );
+    }
+
+    #[test]
+    fn claim_keys_request_rejects_invalid_user_id() {
+        let client = matrix_client_with_test_credentials();
+        let result = client.build_claim_keys_request("not-a-user-id", "DEVICE1");
+        assert!(
+            matches!(result, Err(MatrixError::InvalidId(_))),
+            "a user id missing the '@' sigil must be rejected before it reaches the request body, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn claim_keys_request_rejects_invalid_device_id() {
+        let client = matrix_client_with_test_credentials();
+        // #373: a CRLF-bearing device id must not reach JSON-key interpolation.
+        let result = client
+            .build_claim_keys_request("@alice:matrix.example.com", "EVIL\r\nX-Injected: evil");
+        assert!(matches!(result, Err(MatrixError::InvalidId(_))));
+    }
+
+    #[test]
+    fn claim_response_happy_path_consumes_matching_local_key() {
+        // The single-use tracking this remnant wires is grounded in
+        // consume_one_time_key's existing pool -- seed a known key the same
+        // way consume_one_time_key_frees_capacity_for_regeneration (in
+        // matrix_crypto.rs) does, then verify the claim response round trip
+        // extracts and consumes that exact key.
+        let mut client = matrix_client_with_test_credentials();
+        let key = client
+            .crypto_mut()
+            .generate_one_time_keys(1)
+            .expect("seeding one key must succeed")[0];
+        let user_id = "@alice:matrix.example.com";
+        let device_id = "ALICEDEVICE";
+        let key_hex = hex_encode_bytes(&key);
+        let body = build_claim_response(user_id, device_id, "curve25519:AAAAAQ", &key_hex);
+        let response = mock_response(200, &body);
+
+        let result = client.process_claim_keys_response(user_id, device_id, &response);
+        assert_eq!(result, Ok(key));
+        assert!(
+            !client.crypto().one_time_keys().contains(&key),
+            "a successfully claimed key must be removed from the local pool"
+        );
+    }
+
+    #[test]
+    fn claim_response_rejects_double_consumption_of_same_key() {
+        // The security property this remnant exists for: a one-time key
+        // claimed once must never be usable a second time.
+        let mut client = matrix_client_with_test_credentials();
+        let key = client
+            .crypto_mut()
+            .generate_one_time_keys(1)
+            .expect("seeding one key must succeed")[0];
+        let user_id = "@alice:matrix.example.com";
+        let device_id = "ALICEDEVICE";
+        let key_hex = hex_encode_bytes(&key);
+        let body = build_claim_response(user_id, device_id, "curve25519:AAAAAQ", &key_hex);
+
+        let first =
+            client.process_claim_keys_response(user_id, device_id, &mock_response(200, &body));
+        assert_eq!(
+            first,
+            Ok(key),
+            "the first consumption of a fresh key must succeed"
+        );
+
+        let second =
+            client.process_claim_keys_response(user_id, device_id, &mock_response(200, &body));
+        assert_eq!(
+            second,
+            Err(MatrixError::OneTimeKeyAlreadyConsumed),
+            "a second consumption of the identical key must fail closed, not silently succeed"
+        );
+    }
+
+    #[test]
+    fn claim_response_missing_device_fails_closed() {
+        let mut client = matrix_client_with_test_credentials();
+        let user_id = "@alice:matrix.example.com";
+        // Response carries a key, but for a DIFFERENT device than requested.
+        let body = build_claim_response(
+            user_id,
+            "OTHERDEVICE",
+            "curve25519:AAAAAQ",
+            &"11".repeat(32),
+        );
+        let result =
+            client.process_claim_keys_response(user_id, "ALICEDEVICE", &mock_response(200, &body));
+        assert_eq!(result, Err(MatrixError::ClaimedKeyMissing));
+    }
+
+    #[test]
+    fn claim_response_empty_key_map_fails_closed() {
+        let mut client = matrix_client_with_test_credentials();
+        let user_id = "@alice:matrix.example.com";
+        let device_id = "ALICEDEVICE";
+
+        let mut w = JsonWriter::new();
+        w.object_start();
+        w.key("one_time_keys");
+        w.object_start();
+        w.key(user_id);
+        w.object_start();
+        w.key(device_id);
+        w.object_start();
+        w.end(); // empty key map -- homeserver had nothing to hand out
+        w.end();
+        w.end();
+        w.end();
+        w.end();
+        let body = w.finish();
+
+        let result =
+            client.process_claim_keys_response(user_id, device_id, &mock_response(200, &body));
+        assert_eq!(result, Err(MatrixError::ClaimedKeyMissing));
+    }
+
+    #[test]
+    fn claim_response_unsupported_algorithm_fails_closed() {
+        // A homeserver returning only `signed_curve25519` (this simplified
+        // client neither signs nor verifies signed one-time keys) must be
+        // rejected, not misread as a raw key.
+        let mut client = matrix_client_with_test_credentials();
+        let user_id = "@alice:matrix.example.com";
+        let device_id = "ALICEDEVICE";
+        let body = build_claim_response(
+            user_id,
+            device_id,
+            "signed_curve25519:AAAAAQ",
+            &"11".repeat(32),
+        );
+        let result =
+            client.process_claim_keys_response(user_id, device_id, &mock_response(200, &body));
+        assert_eq!(result, Err(MatrixError::UnsupportedKeyAlgorithm));
+    }
+
+    #[test]
+    fn claim_response_malformed_key_value_fails_closed() {
+        let mut client = matrix_client_with_test_credentials();
+        let user_id = "@alice:matrix.example.com";
+        let device_id = "ALICEDEVICE";
+        let body = build_claim_response(
+            user_id,
+            device_id,
+            "curve25519:AAAAAQ",
+            "not-a-valid-key-encoding",
+        );
+        let result =
+            client.process_claim_keys_response(user_id, device_id, &mock_response(200, &body));
+        assert_eq!(result, Err(MatrixError::MalformedClaimedKey));
+    }
+
+    #[test]
+    fn claim_response_non_object_key_value_fails_closed() {
+        // The matching key entry's value must be a string; a JSON number
+        // (or any non-string) must not be coerced or silently skipped past.
+        let mut client = matrix_client_with_test_credentials();
+        let user_id = "@alice:matrix.example.com";
+        let device_id = "ALICEDEVICE";
+
+        let mut w = JsonWriter::new();
+        w.object_start();
+        w.key("one_time_keys");
+        w.object_start();
+        w.key(user_id);
+        w.object_start();
+        w.key(device_id);
+        w.object_start();
+        w.key("curve25519:AAAAAQ");
+        w.number_value(12345);
+        w.end();
+        w.end();
+        w.end();
+        w.end();
+        w.end();
+        let body = w.finish();
+
+        let result =
+            client.process_claim_keys_response(user_id, device_id, &mock_response(200, &body));
+        assert_eq!(result, Err(MatrixError::MalformedClaimedKey));
+    }
+
+    #[test]
+    fn claim_response_server_error_propagates() {
+        let mut client = matrix_client_with_test_credentials();
+        let body = "{\"errcode\":\"M_NOT_FOUND\",\"error\":\"device not found\"}";
+        let response = mock_response(404, body);
+        let result = client.process_claim_keys_response(
+            "@alice:matrix.example.com",
+            "ALICEDEVICE",
+            &response,
+        );
+        assert!(matches!(result, Err(MatrixError::ServerError { .. })));
+    }
+
+    #[test]
+    fn claimed_key_algorithm_splits_on_colon() {
+        assert_eq!(claimed_key_algorithm("curve25519:AAAAAQ"), "curve25519");
+        assert_eq!(
+            claimed_key_algorithm("signed_curve25519:AAAAAQ"),
+            "signed_curve25519"
+        );
+        assert_eq!(claimed_key_algorithm("no-colon-here"), "no-colon-here");
+    }
 }

--- a/crates/thumos/src/harmostes.rs
+++ b/crates/thumos/src/harmostes.rs
@@ -46,7 +46,8 @@ use alloc::vec::Vec;
 use crate::http_client::{self, HttpError, HttpRequest, HttpResponse};
 use crate::json_mini::{JsonError, JsonParser, JsonValue, JsonWriter};
 use crate::matrix_crypto::{self, CryptoError, MatrixCrypto};
-use crate::matrix_ids::{MatrixEventId, MatrixRoomId};
+use crate::matrix_ids::{MatrixDeviceId, MatrixEventId, MatrixRoomId, MatrixUserId};
+use crate::security::KEY_SIZE;
 use crate::security_mode::SecurityMode;
 
 // ---------------------------------------------------------------------------
@@ -123,8 +124,26 @@ pub enum MatrixError {
     RoomCapacityReached,
     /// The outbox has reached [`MAX_OUTBOX_MESSAGES`] pending messages (#365).
     OutboxFull,
-    /// A Matrix identifier (room/event) failed format validation (#373).
+    /// A Matrix identifier (room/event/user/device) failed format validation
+    /// (#373).
     InvalidId(crate::matrix_ids::MatrixIdError),
+    /// A `/keys/claim` response carried no one-time key for the requested
+    /// (`user_id`, `device_id`) -- absent user, absent device, or an empty
+    /// key map (#437).
+    ClaimedKeyMissing,
+    /// None of a `/keys/claim` response's key entries for the requested
+    /// device used [`matrix_crypto::ONE_TIME_KEY_ALGORITHM`] (#437) -- e.g. a
+    /// homeserver returning only `signed_curve25519`, which this simplified
+    /// client does not verify.
+    UnsupportedKeyAlgorithm,
+    /// A `/keys/claim` response's matching key entry was not a string, or
+    /// did not decode to a well-formed key (#437).
+    MalformedClaimedKey,
+    /// A `/keys/claim` response's extracted key was already removed from the
+    /// local one-time-key pool by an earlier claim (#437) -- the single-use
+    /// property a one-time key exists to provide. Fails closed rather than
+    /// treating a replayed/duplicate claim response as reusable.
+    OneTimeKeyAlreadyConsumed,
 }
 
 impl fmt::Display for MatrixError {
@@ -144,6 +163,21 @@ impl fmt::Display for MatrixError {
             Self::RoomCapacityReached => write!(f, "room capacity reached"),
             Self::OutboxFull => write!(f, "outbox capacity reached"),
             Self::InvalidId(e) => write!(f, "invalid Matrix identifier: {e}"),
+            Self::ClaimedKeyMissing => {
+                write!(
+                    f,
+                    "keys/claim response carried no key for the requested device"
+                )
+            }
+            Self::UnsupportedKeyAlgorithm => {
+                write!(f, "keys/claim response used an unsupported key algorithm")
+            }
+            Self::MalformedClaimedKey => {
+                write!(f, "keys/claim response key value is malformed")
+            }
+            Self::OneTimeKeyAlreadyConsumed => {
+                write!(f, "claimed one-time key was already consumed")
+            }
         }
     }
 }
@@ -1017,6 +1051,112 @@ impl MatrixClient {
     }
 
     // -----------------------------------------------------------------------
+    // Key claim (#437)
+    // -----------------------------------------------------------------------
+
+    /// Build a `/keys/claim` HTTP request for a one-time key from a single
+    /// target device.
+    ///
+    /// Uses POST `/_matrix/client/v3/keys/claim` with a
+    /// `{"one_time_keys": {user_id: {device_id: algorithm}}}` body -- the
+    /// Matrix CS API's device→algorithm map, nested under the requested
+    /// user.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MatrixError::InvalidId`] if `user_id` or `device_id` fails
+    /// identifier validation (#373: rejects a CRLF/NUL-bearing target before
+    /// it is written into the request body).
+    pub(crate) fn build_claim_keys_request(
+        &self,
+        user_id: &str,
+        device_id: &str,
+    ) -> Result<HttpRequest, MatrixError> {
+        MatrixUserId::new(user_id)?;
+        MatrixDeviceId::new(device_id)?;
+
+        let mut path = String::from(API_PREFIX);
+        path.push_str("/keys/claim");
+
+        let json_body = build_claim_keys_body(user_id, device_id);
+        let mut req = http_client::post_json(&self.homeserver, &path, json_body.as_bytes());
+        http_client::with_auth(&mut req, &self.access_token);
+        Ok(req)
+    }
+
+    /// Process a `/keys/claim` HTTP response for the `(user_id, device_id)`
+    /// target requested via [`build_claim_keys_request`].
+    ///
+    /// Extracts the claimed one-time key and marks it consumed via
+    /// [`MatrixCrypto::consume_one_time_key`] -- the structural single-use
+    /// gate this remnant exists to wire (#437, closing #282 finding 8: a
+    /// claimed key that is never consumed permanently counts against
+    /// `MAX_ONE_TIME_KEYS`). A key value no longer present in the local
+    /// pool -- already removed by an earlier claim, or never registered --
+    /// is rejected rather than treated as reusable: `consume_one_time_key`'s
+    /// find-then-remove-once mechanics make a second consumption of the
+    /// same key value structurally impossible, not merely checked.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MatrixError::ServerError`] on a non-2xx response.
+    /// Returns [`MatrixError::Json`] if the body is not valid JSON.
+    /// Returns [`MatrixError::ClaimedKeyMissing`] if the response carries no
+    /// key for `user_id`/`device_id` (absent user, absent device, or an
+    /// empty key map).
+    /// Returns [`MatrixError::UnsupportedKeyAlgorithm`] if none of the
+    /// returned key entries for that device use
+    /// [`matrix_crypto::ONE_TIME_KEY_ALGORITHM`].
+    /// Returns [`MatrixError::MalformedClaimedKey`] if the matching entry's
+    /// value is not a string, or does not decode to a well-formed key.
+    /// Returns [`MatrixError::OneTimeKeyAlreadyConsumed`] if the extracted
+    /// key was already removed from the local pool by an earlier claim.
+    pub(crate) fn process_claim_keys_response(
+        &mut self,
+        user_id: &str,
+        device_id: &str,
+        response: &HttpResponse,
+    ) -> Result<[u8; KEY_SIZE], MatrixError> {
+        if !response.is_success() {
+            return Err(parse_error_response(response));
+        }
+
+        let body_str = response
+            .body_as_str()
+            .ok_or(MatrixError::MalformedClaimedKey)?;
+        let root = JsonParser::parse(body_str.as_bytes())?;
+
+        let device_map = root
+            .get("one_time_keys")
+            .and_then(|otk| otk.get(user_id))
+            .and_then(|dev| dev.get(device_id))
+            .ok_or(MatrixError::ClaimedKeyMissing)?;
+
+        let entries = device_map
+            .as_object()
+            .ok_or(MatrixError::ClaimedKeyMissing)?;
+        if entries.is_empty() {
+            return Err(MatrixError::ClaimedKeyMissing);
+        }
+
+        let Some((_, value)) = entries.iter().find(|(key_id, _)| {
+            claimed_key_algorithm(key_id) == matrix_crypto::ONE_TIME_KEY_ALGORITHM
+        }) else {
+            return Err(MatrixError::UnsupportedKeyAlgorithm);
+        };
+
+        let key_value = value.as_str().ok_or(MatrixError::MalformedClaimedKey)?;
+        let key =
+            matrix_crypto::decode_base64_key(key_value).ok_or(MatrixError::MalformedClaimedKey)?;
+
+        if !self.crypto.consume_one_time_key(&key) {
+            return Err(MatrixError::OneTimeKeyAlreadyConsumed);
+        }
+
+        Ok(key)
+    }
+
+    // -----------------------------------------------------------------------
     // Internal helpers
     // -----------------------------------------------------------------------
 
@@ -1097,6 +1237,33 @@ fn build_encrypted_body(ciphertext: &[u8], session_id: &[u8; 32]) -> String {
     w.string_value(&hex_encode_bytes(session_id));
     w.end();
     w.finish()
+}
+
+/// Build the JSON body for `/_matrix/client/v3/keys/claim`.
+///
+/// ```json
+/// {"one_time_keys":{"@alice:example.com":{"DEVICEID":"curve25519"}}}
+/// ```
+fn build_claim_keys_body(user_id: &str, device_id: &str) -> String {
+    let mut w = JsonWriter::new();
+    w.object_start();
+    w.key("one_time_keys");
+    w.object_start();
+    w.key(user_id);
+    w.object_start();
+    w.key(device_id);
+    w.string_value(matrix_crypto::ONE_TIME_KEY_ALGORITHM);
+    w.end(); // device -> algorithm map
+    w.end(); // user -> device map
+    w.end(); // one_time_keys
+    w.end(); // root
+    w.finish()
+}
+
+/// Extract the algorithm portion of a `/keys/claim` response key id
+/// (`"<algorithm>:<key_id>"`, e.g. `"curve25519:AAAAAQ"`).
+fn claimed_key_algorithm(key_id: &str) -> &str {
+    key_id.split_once(':').map_or(key_id, |(algo, _)| algo)
 }
 
 /// Encode a byte slice as lowercase hex string.

--- a/crates/thumos/src/harmostes.rs
+++ b/crates/thumos/src/harmostes.rs
@@ -1072,8 +1072,11 @@ impl MatrixClient {
         user_id: &str,
         device_id: &str,
     ) -> Result<HttpRequest, MatrixError> {
-        MatrixUserId::new(user_id)?;
-        MatrixDeviceId::new(device_id)?;
+        // WHY: bind (not a bare `expr?;` statement) -- MatrixUserId/
+        // MatrixDeviceId are #[must_use]; discarding the validated value as
+        // a statement trips the must_use lint under -D warnings.
+        let _validated_user = MatrixUserId::new(user_id)?;
+        let _validated_device = MatrixDeviceId::new(device_id)?;
 
         let mut path = String::from(API_PREFIX);
         path.push_str("/keys/claim");

--- a/crates/thumos/src/harmostes.rs
+++ b/crates/thumos/src/harmostes.rs
@@ -139,11 +139,6 @@ pub enum MatrixError {
     /// A `/keys/claim` response's matching key entry was not a string, or
     /// did not decode to a well-formed key (#437).
     MalformedClaimedKey,
-    /// A `/keys/claim` response's extracted key was already removed from the
-    /// local one-time-key pool by an earlier claim (#437) -- the single-use
-    /// property a one-time key exists to provide. Fails closed rather than
-    /// treating a replayed/duplicate claim response as reusable.
-    OneTimeKeyAlreadyConsumed,
 }
 
 impl fmt::Display for MatrixError {
@@ -174,9 +169,6 @@ impl fmt::Display for MatrixError {
             }
             Self::MalformedClaimedKey => {
                 write!(f, "keys/claim response key value is malformed")
-            }
-            Self::OneTimeKeyAlreadyConsumed => {
-                write!(f, "claimed one-time key was already consumed")
             }
         }
     }
@@ -1088,17 +1080,27 @@ impl MatrixClient {
     }
 
     /// Process a `/keys/claim` HTTP response for the `(user_id, device_id)`
-    /// target requested via [`build_claim_keys_request`].
+    /// target requested via [`build_claim_keys_request`], validating and
+    /// returning the claimed one-time key.
     ///
-    /// Extracts the claimed one-time key and marks it consumed via
-    /// [`MatrixCrypto::consume_one_time_key`] -- the structural single-use
-    /// gate this remnant exists to wire (#437, closing #282 finding 8: a
-    /// claimed key that is never consumed permanently counts against
-    /// `MAX_ONE_TIME_KEYS`). A key value no longer present in the local
-    /// pool -- already removed by an earlier claim, or never registered --
-    /// is rejected rather than treated as reusable: `consume_one_time_key`'s
-    /// find-then-remove-once mechanics make a second consumption of the
-    /// same key value structurally impossible, not merely checked.
+    /// This is the send side of key exchange: the returned key belongs to
+    /// the remote device named by `user_id`/`device_id`, never to this
+    /// device's own [`MatrixCrypto::one_time_keys`] pool, so this function
+    /// does not touch `self` -- there is nothing here for it to consume
+    /// (`consume_one_time_key`'s pool holds only keys this device generated
+    /// and uploaded). Establishing an Olm session from the returned key
+    /// (X3DH) is not implemented; the caller receives raw key material.
+    ///
+    /// [`MatrixCrypto::consume_one_time_key`] belongs to the *receive* side
+    /// of key exchange instead: it removes one of this device's own
+    /// uploaded keys once something reports it was claimed by a peer (a
+    /// dropping `device_one_time_keys_count` on `/sync`, or an inbound Olm
+    /// pre-key message naming the key). Neither exists in this tree yet
+    /// (#437 remainder): `/sync` here reads only `rooms.join.*.timeline`,
+    /// and there is no inbound Olm pre-key handler -- `OlmSession` is
+    /// declared but never constructed anywhere. Wiring
+    /// `consume_one_time_key` belongs at that future receive-side call
+    /// site, not here.
     ///
     /// # Errors
     ///
@@ -1112,10 +1114,7 @@ impl MatrixClient {
     /// [`matrix_crypto::ONE_TIME_KEY_ALGORITHM`].
     /// Returns [`MatrixError::MalformedClaimedKey`] if the matching entry's
     /// value is not a string, or does not decode to a well-formed key.
-    /// Returns [`MatrixError::OneTimeKeyAlreadyConsumed`] if the extracted
-    /// key was already removed from the local pool by an earlier claim.
     pub(crate) fn process_claim_keys_response(
-        &mut self,
         user_id: &str,
         device_id: &str,
         response: &HttpResponse,
@@ -1151,10 +1150,6 @@ impl MatrixClient {
         let key_value = value.as_str().ok_or(MatrixError::MalformedClaimedKey)?;
         let key =
             matrix_crypto::decode_base64_key(key_value).ok_or(MatrixError::MalformedClaimedKey)?;
-
-        if !self.crypto.consume_one_time_key(&key) {
-            return Err(MatrixError::OneTimeKeyAlreadyConsumed);
-        }
 
         Ok(key)
     }
@@ -2515,65 +2510,67 @@ mod tests {
     }
 
     #[test]
-    fn claim_response_happy_path_consumes_matching_local_key() {
-        // The single-use tracking this remnant wires is grounded in
-        // consume_one_time_key's existing pool -- seed a known key the same
-        // way consume_one_time_key_frees_capacity_for_regeneration (in
-        // matrix_crypto.rs) does, then verify the claim response round trip
-        // extracts and consumes that exact key.
-        let mut client = matrix_client_with_test_credentials();
-        let key = client
-            .crypto_mut()
-            .generate_one_time_keys(1)
-            .expect("seeding one key must succeed")[0];
+    fn claim_response_happy_path_returns_peer_key() {
+        // The claimed key belongs to the REMOTE device named in the
+        // request -- it is never drawn from this device's own pool, exactly
+        // as a real homeserver response would look (#437 rework: an earlier
+        // version of this test seeded the response from
+        // generate_one_time_keys, which made the fixture a shape a
+        // homeserver would never send).
+        let peer_key = [0xABu8; KEY_SIZE];
         let user_id = "@alice:matrix.example.com";
         let device_id = "ALICEDEVICE";
-        let key_hex = hex_encode_bytes(&key);
-        let body = build_claim_response(user_id, device_id, "curve25519:AAAAAQ", &key_hex);
+        let body = build_claim_response(
+            user_id,
+            device_id,
+            "curve25519:AAAAAQ",
+            &hex_encode_bytes(&peer_key),
+        );
         let response = mock_response(200, &body);
 
-        let result = client.process_claim_keys_response(user_id, device_id, &response);
-        assert_eq!(result, Ok(key));
-        assert!(
-            !client.crypto().one_time_keys().contains(&key),
-            "a successfully claimed key must be removed from the local pool"
-        );
+        let result = MatrixClient::process_claim_keys_response(user_id, device_id, &response);
+        assert_eq!(result, Ok(peer_key));
     }
 
     #[test]
-    fn claim_response_rejects_double_consumption_of_same_key() {
-        // The security property this remnant exists for: a one-time key
-        // claimed once must never be usable a second time.
+    fn claim_response_does_not_touch_this_devices_own_pool() {
+        // process_claim_keys_response takes no `self`, so it cannot reach
+        // this device's own one_time_keys pool by construction -- pinned
+        // here as a concrete regression guard, not just a type-signature
+        // argument. consume_one_time_key belongs to the receive side of key
+        // exchange (an inbound Olm pre-key message naming one of THIS
+        // device's own claimed keys), which does not exist in this tree yet.
         let mut client = matrix_client_with_test_credentials();
-        let key = client
+        let own_keys = client
             .crypto_mut()
-            .generate_one_time_keys(1)
-            .expect("seeding one key must succeed")[0];
-        let user_id = "@alice:matrix.example.com";
-        let device_id = "ALICEDEVICE";
-        let key_hex = hex_encode_bytes(&key);
-        let body = build_claim_response(user_id, device_id, "curve25519:AAAAAQ", &key_hex);
+            .generate_one_time_keys(3)
+            .expect("seeding must succeed");
 
-        let first =
-            client.process_claim_keys_response(user_id, device_id, &mock_response(200, &body));
-        assert_eq!(
-            first,
-            Ok(key),
-            "the first consumption of a fresh key must succeed"
+        let peer_key = [0xCDu8; KEY_SIZE];
+        let user_id = "@bob:matrix.example.com";
+        let device_id = "BOBDEVICE";
+        let body = build_claim_response(
+            user_id,
+            device_id,
+            "curve25519:AAAAAQ",
+            &hex_encode_bytes(&peer_key),
         );
+        let result = MatrixClient::process_claim_keys_response(
+            user_id,
+            device_id,
+            &mock_response(200, &body),
+        );
+        assert_eq!(result, Ok(peer_key));
 
-        let second =
-            client.process_claim_keys_response(user_id, device_id, &mock_response(200, &body));
         assert_eq!(
-            second,
-            Err(MatrixError::OneTimeKeyAlreadyConsumed),
-            "a second consumption of the identical key must fail closed, not silently succeed"
+            client.crypto().one_time_keys(),
+            own_keys.as_slice(),
+            "processing a claim response must never mutate this device's own pool"
         );
     }
 
     #[test]
     fn claim_response_missing_device_fails_closed() {
-        let mut client = matrix_client_with_test_credentials();
         let user_id = "@alice:matrix.example.com";
         // Response carries a key, but for a DIFFERENT device than requested.
         let body = build_claim_response(
@@ -2582,14 +2579,16 @@ mod tests {
             "curve25519:AAAAAQ",
             &"11".repeat(32),
         );
-        let result =
-            client.process_claim_keys_response(user_id, "ALICEDEVICE", &mock_response(200, &body));
+        let result = MatrixClient::process_claim_keys_response(
+            user_id,
+            "ALICEDEVICE",
+            &mock_response(200, &body),
+        );
         assert_eq!(result, Err(MatrixError::ClaimedKeyMissing));
     }
 
     #[test]
     fn claim_response_empty_key_map_fails_closed() {
-        let mut client = matrix_client_with_test_credentials();
         let user_id = "@alice:matrix.example.com";
         let device_id = "ALICEDEVICE";
 
@@ -2608,8 +2607,11 @@ mod tests {
         w.end();
         let body = w.finish();
 
-        let result =
-            client.process_claim_keys_response(user_id, device_id, &mock_response(200, &body));
+        let result = MatrixClient::process_claim_keys_response(
+            user_id,
+            device_id,
+            &mock_response(200, &body),
+        );
         assert_eq!(result, Err(MatrixError::ClaimedKeyMissing));
     }
 
@@ -2618,7 +2620,6 @@ mod tests {
         // A homeserver returning only `signed_curve25519` (this simplified
         // client neither signs nor verifies signed one-time keys) must be
         // rejected, not misread as a raw key.
-        let mut client = matrix_client_with_test_credentials();
         let user_id = "@alice:matrix.example.com";
         let device_id = "ALICEDEVICE";
         let body = build_claim_response(
@@ -2627,14 +2628,16 @@ mod tests {
             "signed_curve25519:AAAAAQ",
             &"11".repeat(32),
         );
-        let result =
-            client.process_claim_keys_response(user_id, device_id, &mock_response(200, &body));
+        let result = MatrixClient::process_claim_keys_response(
+            user_id,
+            device_id,
+            &mock_response(200, &body),
+        );
         assert_eq!(result, Err(MatrixError::UnsupportedKeyAlgorithm));
     }
 
     #[test]
     fn claim_response_malformed_key_value_fails_closed() {
-        let mut client = matrix_client_with_test_credentials();
         let user_id = "@alice:matrix.example.com";
         let device_id = "ALICEDEVICE";
         let body = build_claim_response(
@@ -2643,8 +2646,11 @@ mod tests {
             "curve25519:AAAAAQ",
             "not-a-valid-key-encoding",
         );
-        let result =
-            client.process_claim_keys_response(user_id, device_id, &mock_response(200, &body));
+        let result = MatrixClient::process_claim_keys_response(
+            user_id,
+            device_id,
+            &mock_response(200, &body),
+        );
         assert_eq!(result, Err(MatrixError::MalformedClaimedKey));
     }
 
@@ -2652,7 +2658,6 @@ mod tests {
     fn claim_response_non_object_key_value_fails_closed() {
         // The matching key entry's value must be a string; a JSON number
         // (or any non-string) must not be coerced or silently skipped past.
-        let mut client = matrix_client_with_test_credentials();
         let user_id = "@alice:matrix.example.com";
         let device_id = "ALICEDEVICE";
 
@@ -2673,17 +2678,19 @@ mod tests {
         w.end();
         let body = w.finish();
 
-        let result =
-            client.process_claim_keys_response(user_id, device_id, &mock_response(200, &body));
+        let result = MatrixClient::process_claim_keys_response(
+            user_id,
+            device_id,
+            &mock_response(200, &body),
+        );
         assert_eq!(result, Err(MatrixError::MalformedClaimedKey));
     }
 
     #[test]
     fn claim_response_server_error_propagates() {
-        let mut client = matrix_client_with_test_credentials();
         let body = "{\"errcode\":\"M_NOT_FOUND\",\"error\":\"device not found\"}";
         let response = mock_response(404, body);
-        let result = client.process_claim_keys_response(
+        let result = MatrixClient::process_claim_keys_response(
             "@alice:matrix.example.com",
             "ALICEDEVICE",
             &response,

--- a/crates/thumos/src/matrix_crypto.rs
+++ b/crates/thumos/src/matrix_crypto.rs
@@ -104,6 +104,14 @@ const MAX_ONE_TIME_KEYS: usize = 100;
 /// Maximum number of one-time keys generated in a single batch.
 const MAX_GENERATED_KEYS: usize = 50;
 
+/// The one-time-key algorithm identifier this device generates, uploads, and
+/// claims. Unsigned (raw Curve25519, not `signed_curve25519`) -- this
+/// simplified implementation does not sign one-time keys (#437). Shared
+/// between [`build_one_time_keys_json`] (upload) and `harmostes`'s
+/// `/keys/claim` request/response so the algorithm string exists in exactly
+/// one place.
+pub(crate) const ONE_TIME_KEY_ALGORITHM: &str = "curve25519";
+
 // ---------------------------------------------------------------------------
 // Error types
 // ---------------------------------------------------------------------------
@@ -1026,7 +1034,8 @@ fn build_one_time_keys_json(keys: &[[u8; KEY_SIZE]]) -> String {
     let mut w = JsonWriter::new();
     w.object_start();
     for (i, key) in keys.iter().enumerate() {
-        let mut key_name = String::from("curve25519:AAAAAA");
+        let mut key_name = String::from(ONE_TIME_KEY_ALGORITHM);
+        key_name.push_str(":AAAAAA");
         push_usize(&mut key_name, i);
         w.key(&key_name);
         w.string_value(&hex_encode(key));
@@ -1252,7 +1261,11 @@ fn base64_decode_bytes(s: &str) -> Option<Vec<u8>> {
 ///
 /// Returns `None` if the input doesn't decode to exactly 32 bytes.
 /// Tries hex first (64 chars = 32 bytes), then unpadded base64 (43 chars = 32 bytes).
-fn decode_base64_key(s: &str) -> Option<[u8; KEY_SIZE]> {
+///
+/// `pub(crate)`: also used by `harmostes`'s `/keys/claim` response handling
+/// to decode a claimed one-time key value (#437) -- the same key-encoding
+/// convention as `/keys/query` device keys, one decoder for both.
+pub(crate) fn decode_base64_key(s: &str) -> Option<[u8; KEY_SIZE]> {
     // Try hex decoding first (our own output format).
     if s.len() == 64 {
         return hex_decode_32(s);

--- a/crates/thumos/src/matrix_crypto.rs
+++ b/crates/thumos/src/matrix_crypto.rs
@@ -24,17 +24,23 @@
 //! - AES-CBC: NIST SP 800-38A
 
 // WHY: Matrix crypto created in Phase 09 Wave 3, full integration pending.
-// #437 remnant 3, explicitly re-confirmed deferred (2026-08-04): the
-// /keys/claim round-trip cannot land without the Olm session-establishment
-// path that consumes claimed keys, and X3DH is intentionally not
-// implemented here. Building the claim builder/parser alone would only
-// move the dead call site, not close it — this module stays unreachable
-// until Phase-09 messaging integration lands, at which point
-// `consume_one_time_key` MUST be wired into claimed-key receipt or the
-// one_time_keys pool deadlocks at MAX_ONE_TIME_KEYS (#282 finding 8).
+// #437 remnant 3: `harmostes` builds the /keys/claim request and validates
+// + returns the peer's claimed key (the send side of key exchange -- that
+// key belongs to the remote device, never to this device's own
+// `one_time_keys` pool). `consume_one_time_key` belongs to the RECEIVE
+// side instead: it removes one of THIS device's own uploaded keys once
+// something reports it was claimed by a peer (a dropping
+// `device_one_time_keys_count` on `/sync`, or an inbound Olm pre-key
+// message naming the key). Neither exists in this tree -- `/sync` here
+// reads only room timeline events, and there is no inbound Olm pre-key
+// handler (`OlmSession` is declared, never constructed). Wiring
+// `consume_one_time_key` there is what remains open; without it the
+// one_time_keys pool deadlocks at MAX_ONE_TIME_KEYS once that receive path
+// exists (#282 finding 8). This module stays unreachable until Phase-09
+// messaging integration lands.
 #![expect(
     dead_code,
-    reason = "Matrix crypto unreachable pending Phase-09 messaging integration; /keys/claim wiring explicitly deferred to that epic (#437)"
+    reason = "Matrix crypto unreachable pending Phase-09 messaging integration; consume_one_time_key's receive-side call site does not exist yet (#437)"
 )]
 
 extern crate alloc;

--- a/docs/capability-inventory.toml
+++ b/docs/capability-inventory.toml
@@ -102,7 +102,7 @@ hardware_reason = "WiFi TX/RX/scan, BT RF, GPS NMEA need the combo chip + antenn
 id = "comms-matrix"
 modules = ["matrix_crypto", "http_client", "json_mini", "harmostes", "matrix_ids"]
 tier = "kernel-wired"
-notes = "Olm/Megolm + HTTP/JSON surfaces compiled, including the /keys/claim request/response round trip and its consume_one_time_key single-use gate (#437); X3DH session establishment is not implemented, so nothing yet drives a claim from kinit/kardia."
+notes = "Olm/Megolm + HTTP/JSON surfaces compiled, including the /keys/claim request/response round trip that validates and returns a peer's key (#437). consume_one_time_key -- removing one of this device's OWN keys once a peer claims it -- stays unwired: that needs a receive-side signal (a dropping device_one_time_keys_count on /sync, or an inbound Olm pre-key message) that does not exist in this tree; X3DH session establishment is also not implemented. Nothing yet drives a claim from kinit/kardia."
 
 [[capability]]
 id = "screens-extended"

--- a/docs/capability-inventory.toml
+++ b/docs/capability-inventory.toml
@@ -102,7 +102,7 @@ hardware_reason = "WiFi TX/RX/scan, BT RF, GPS NMEA need the combo chip + antenn
 id = "comms-matrix"
 modules = ["matrix_crypto", "http_client", "json_mini", "harmostes", "matrix_ids"]
 tier = "kernel-wired"
-notes = "Olm/Megolm + HTTP/JSON surfaces compiled; /keys/claim consumption is #437 remnant 3."
+notes = "Olm/Megolm + HTTP/JSON surfaces compiled, including the /keys/claim request/response round trip and its consume_one_time_key single-use gate (#437); X3DH session establishment is not implemented, so nothing yet drives a claim from kinit/kardia."
 
 [[capability]]
 id = "screens-extended"

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -250,7 +250,7 @@ mechanism = "host"
 
 [[module]]
 name = "harmostes"
-tests = 36
+tests = 48
 mechanism = "host"
 
 [[module]]


### PR DESCRIPTION
## What

Adds the `/keys/claim` request builder and response handler for the Matrix E2E key-claim flow. **Does not close #437** — see below.

## A defect this PR caught in itself

The first version wired `consume_one_time_key` into the `/keys/claim` **response** handler. That is wrong, and wrong in a way CI could not see.

Per the Matrix CS spec, a `/keys/claim` response carries a **remote** device's one-time key — the peer whose session you are establishing. `consume_one_time_key` removes a key from **this device's own** pool. Against a real homeserver those two sets never intersect, so the lookup would fail and the handler would return `OneTimeKeyAlreadyConsumed` for **every legitimate claim**. The function could not succeed in production.

The test suite went green anyway, because it seeded our own pool and then built a claim response around that same value — a shape no homeserver sends. The tests certified the defect rather than catching it. Worth stating plainly: a full-green kernel job, including every QEMU witness, is not evidence of protocol correctness. The gate cannot witness what the spec says.

## The correct topology, now encoded

- `/keys/claim` is the **send** side. Its handler validates and returns the peer's key, and must not touch our pool.
- Our own one-time keys are consumed **server-side** when a peer claims them. We learn of it from `device_one_time_keys_count` on `/sync`, or from an inbound Olm **pre-key message** naming which of our keys the sender used.
- So `consume_one_time_key`'s real production call site is the **receive** path, not this one.

`process_claim_keys_response` now takes **no `self` at all** — it cannot reach `crypto.one_time_keys` by construction, not merely by omission. The `OneTimeKeyAlreadyConsumed` variant is gone from this path, since nothing here can raise it.

## Why #437 stays open

The receive-side path does not exist yet. Verified rather than assumed:

- `OlmSession` is declared (`matrix_crypto.rs:288`) and stored (`olm_sessions: Vec<OlmSession>`) but **never constructed** — the only matches for `OlmSession {` are its `Debug` and `Display` impls.
- `olm_sessions` is never pushed to. The `Vec` is permanently empty and its accessor returns an empty slice.
- No `to_device` handling in `process_sync_response`, no Olm decrypt function, no `device_one_time_keys_count` handling.

There is nothing to wire `consume_one_time_key` into. Inventing a receive handler to close an issue would produce exactly the shape this PR just removed: a call site that exists so a function has one. Remnant 3 stays open with a stated dependency.

## What lands

| | |
|---|---|
| `matrix_crypto.rs:110` | `ONE_TIME_KEY_ALGORITHM` constant, shared by upload and claim so the algorithm string exists once |
| `matrix_crypto.rs:1034` | `build_one_time_keys_json` derives its prefix from that constant instead of a literal |
| `matrix_crypto.rs:1261` | `decode_base64_key` widened to `pub(crate)` so the claim handler reuses the existing decoder rather than a second one |
| `harmostes.rs:1053` | `build_claim_keys_request` — POST `/_matrix/client/v3/keys/claim` |
| `harmostes.rs:1117` | `process_claim_keys_response` — validates and returns the peer key |
| `harmostes.rs:124` | fail-closed error variants |

Every failure mode fails closed, none falls through to a default or a placeholder key: absent user, absent device, empty key map → `ClaimedKeyMissing`; a non-`curve25519` algorithm (e.g. a homeserver returning only `signed_curve25519`, which this client neither signs nor verifies) → `UnsupportedKeyAlgorithm`; a non-string value or one that does not decode to 32 bytes → `MalformedClaimedKey`; non-2xx → existing `ServerError`.

`claim_response_does_not_touch_this_devices_own_pool` seeds our pool, processes an unrelated claim, and asserts the pool is byte-for-byte unchanged — a concrete regression guard layered on top of the structural one, because the structural guarantee is only as durable as the signature.

The double-consumption test was **deleted, not relocated**. That property still holds where it belongs, in `matrix_crypto.rs`'s pre-existing `consume_one_time_key_frees_capacity_for_regeneration`. Moving it to an invented site would have recreated the original error.

Also updated: `docs/target-test-ledger.toml` (`harmostes` 36 → 48, caught by a live CI drift failure rather than guessed) and `docs/capability-inventory.toml`, whose `comms-matrix` note still described `/keys/claim` as outstanding.

## Observation, not fixed here

`olm_sessions` is a `Vec` that is never populated, with a `pub(crate)` accessor returning a permanently empty slice, plus `Debug`/`Display` impls for a type never constructed. That is dead state carrying the appearance of capability. It belongs with the receive-side work rather than a drive-by deletion here.

Refs: #437
