### PR TITLE
feat(kernel): make a dev grant unbuildable in production and enforce metaxu capability before transmit

### DIFF
--- a/crates/thumos/src/main.rs
+++ b/crates/thumos/src/main.rs
@@ -195,18 +195,17 @@ mod lock_screen;
 mod matrix_crypto;
 mod memguard;
 mod meshtastic;
-// WHY (#544 step 1): the metaxu-core authenticated request/response
+// WHY (#544 on-device leg): the metaxu-core authenticated request/response
 // exchange over board::UART1_BASE, gated ITEM-BY-ITEM inside the module
-// rather than at this declaration: the self-issued dev identity is
-// `#[cfg(feature = "qemu")]` (never in `production` -- see the
+// rather than at this declaration (#544 steps 1-2): the self-issued dev
+// identity is `#[cfg(feature = "qemu")]` (never in `production` -- see the
 // compile_error!s above AND the one restated inside the module beside the
-// identity material), and the UART transport is `#[cfg(all(not(test),
-// feature = "metaxu-probe"))]` (host test builds use `uart_stub`, which has
-// no `at()` constructor). Un-gated from this mod declaration (previously
-// `all(not(test), feature = "metaxu-probe")` here) so a later local
-// capability check (#544 step 2) can live in this file as a plain,
-// host-testable function -- item-level cfg, not a whole-module exclusion,
-// is what makes that possible.
+// identity material), the UART transport is `#[cfg(all(not(test), feature
+// = "metaxu-probe"))]` (host test builds use `uart_stub`, which has no
+// `at()` constructor), and the local capability decision
+// (`evaluate_submission`) is UNGATED -- generic over its inputs, no
+// qemu/UART dependency, host-testable in every build (see the module's own
+// `tests`).
 mod metaxu_bridge;
 mod mic_audit;
 mod mmio;

--- a/crates/thumos/src/main.rs
+++ b/crates/thumos/src/main.rs
@@ -195,12 +195,18 @@ mod lock_screen;
 mod matrix_crypto;
 mod memguard;
 mod meshtastic;
-// WHY (#544 on-device leg): the metaxu-core authenticated request/response
-// exchange over board::UART1_BASE -- feature-gated (never in `production`
-// or the M7 build, see the compile_error!s above) AND test-gated (host
-// test builds use `uart_stub`, which has no `at()` constructor; this
-// module is integration-only glue, not unit-tested on the host target).
-#[cfg(all(not(test), feature = "metaxu-probe"))]
+// WHY (#544 step 1): the metaxu-core authenticated request/response
+// exchange over board::UART1_BASE, gated ITEM-BY-ITEM inside the module
+// rather than at this declaration: the self-issued dev identity is
+// `#[cfg(feature = "qemu")]` (never in `production` -- see the
+// compile_error!s above AND the one restated inside the module beside the
+// identity material), and the UART transport is `#[cfg(all(not(test),
+// feature = "metaxu-probe"))]` (host test builds use `uart_stub`, which has
+// no `at()` constructor). Un-gated from this mod declaration (previously
+// `all(not(test), feature = "metaxu-probe")` here) so a later local
+// capability check (#544 step 2) can live in this file as a plain,
+// host-testable function -- item-level cfg, not a whole-module exclusion,
+// is what makes that possible.
 mod metaxu_bridge;
 mod mic_audit;
 mod mmio;

--- a/crates/thumos/src/metaxu_bridge.rs
+++ b/crates/thumos/src/metaxu_bridge.rs
@@ -32,7 +32,12 @@
 //! re-deriving those checks, and is generic over its grant/device/task
 //! inputs -- no qemu or dev-key dependency of its own -- so it is
 //! host-testable unconditionally (see the `tests` module below, which
-//! exercises it without the `qemu` feature).
+//! exercises it without the `qemu` feature). Every failure path (bad
+//! signature, wrong device, expired, capability absent) collapses to the
+//! SAME [`METAXU_DENIED_LOCALLY`] outcome: no variant is treated as
+//! "probably fine" (this repo already fixed three fail-open defects
+//! elsewhere; this path stays fail-closed by construction rather than by
+//! enumerating cases it must remember to deny).
 //!
 //! Split into two syscalls (`MetaxuSubmit`, `MetaxuPoll`) rather than one
 //! blocking call: an SVC handler runs with IRQs masked (`ticks()` frozen --
@@ -195,12 +200,12 @@ fn harmless_task(device: [u8; 32]) -> TaskRequest {
 ///
 /// Reuses [`SignedGrant::verify`] (via [`AuthenticatedSession::open`]) for
 /// the device+expiry check -- no parallel check that could drift from it.
-///
-/// WHY (commit sequencing, #544): this commit wires the device+expiry half
-/// only -- a grant that verifies but lacks the requested capability still
-/// proceeds to encoding. `tests::capability_absent_denies_locally_without_transmitting`
-/// below is written against the FULL contract and is expected to fail
-/// until the next commit adds the capability-presence check.
+/// Capability presence is checked against the grant's OWN verified
+/// capability list (never a self-claimed one) and only once the grant has
+/// already verified. Fail closed: every rejection path -- bad signature,
+/// wrong device, expired, capability absent -- returns the SAME
+/// [`METAXU_DENIED_LOCALLY`], so there is no case this function can forget
+/// to deny.
 ///
 /// This function has no reference to `uart`/`board`/the transport
 /// anywhere in its body. [`submit`] writes a frame ONLY on this function's
@@ -216,6 +221,14 @@ fn evaluate_submission(
     let Ok(session) = AuthenticatedSession::open(signed_grant, device, now_ms) else {
         return Err(METAXU_DENIED_LOCALLY); // bad signature, wrong device, or expired
     };
+    if !session
+        .grant()
+        .grant
+        .capabilities
+        .contains(&task.required_capability())
+    {
+        return Err(METAXU_DENIED_LOCALLY);
+    }
     metaxu_core::session::encode_authenticated_request(&session, task)
         .map_err(|_| METAXU_TRANSPORT_ERROR)
 }

--- a/crates/thumos/src/metaxu_bridge.rs
+++ b/crates/thumos/src/metaxu_bridge.rs
@@ -1,10 +1,17 @@
 //! The `metaxu-probe` on-device bridge (#544): the kernel-side half of the
-//! second-UART round trip criterion 3 exercises.
+//! second-UART round trip criterion 3 exercises, gated on the local
+//! capability check criterion 4 requires before any frame reaches the wire.
 //!
-//! Builds a harmless `SendSms` task under a self-issued dev grant, sends it
-//! through `metaxu-core`'s authenticated session/envelope framing over the
-//! second PL011 (`board::UART1_BASE`, the on-device transport), and
-//! verifies the `pylon-bridge` host process's signed response.
+//! Builds a harmless `SendSms` task, sends it through `metaxu-core`'s
+//! authenticated session/envelope framing over the second PL011
+//! (`board::UART1_BASE`, the on-device transport), and verifies the
+//! `pylon-bridge` host process's signed response -- but ONLY after
+//! [`evaluate_submission`] confirms the request is locally authorized. A
+//! local denial never reaches the transport: [`submit`] calls
+//! [`write_frame`] exclusively on the `Ok` arm of [`evaluate_submission`]'s
+//! result, and that function has no reference to `uart`/`board`/the
+//! transport anywhere in its body -- a denied request has no code path to
+//! a written byte.
 //!
 //! Dev-only, single-shot, wire-compatible: [`dev_identity`] signs with the
 //! SAME well-known dev seeds `metaxu`'s own witness and `pylon-bridge` use
@@ -12,13 +19,20 @@
 //! deliberately public, non-secret, matching `keys/dev/boot-dev.*`'s
 //! convention. It never ships in a `production` build: confined to
 //! `#[cfg(feature = "qemu")]`, itself already mutually exclusive with
-//! `production` crate-wide (main.rs `compile_error!`, mirrors
-//! `kfault-probe`/`crashloop-probe`); [`dev_identity`] restates that
-//! exclusion locally, beside the identity material, so a `production`
-//! build cannot contain this dev grant even if the crate-wide gate were
-//! ever relaxed. It never substitutes for a live Aletheia runtime's grant
-//! issuance -- see the PR body for exactly what remains before this leg is
-//! production-real.
+//! `production` crate-wide (main.rs `compile_error!`); [`dev_identity`]
+//! restates that exclusion locally, beside the identity material, so a
+//! `production` build cannot contain this dev grant even if the crate-wide
+//! gate were ever relaxed. It never substitutes for a live Aletheia
+//! runtime's grant issuance -- see the PR body for exactly what remains
+//! before this leg is production-real.
+//!
+//! [`evaluate_submission`] is the ONE place the local authorization
+//! decision is made. It reuses `SignedGrant::verify` (via
+//! `AuthenticatedSession::open`) for device binding + expiry rather than
+//! re-deriving those checks, and is generic over its grant/device/task
+//! inputs -- no qemu or dev-key dependency of its own -- so it is
+//! host-testable unconditionally (see the `tests` module below, which
+//! exercises it without the `qemu` feature).
 //!
 //! Split into two syscalls (`MetaxuSubmit`, `MetaxuPoll`) rather than one
 //! blocking call: an SVC handler runs with IRQs masked (`ticks()` frozen --
@@ -29,10 +43,15 @@
 //! the SAME poll-with-sleep idiom `init.rs`'s fork/forkexec/guard harnesses
 //! already use.
 
+use alloc::vec::Vec;
+
+use compact_str::CompactString;
+use metaxu_core::grants::SignedGrant;
 #[cfg(all(not(test), feature = "metaxu-probe"))]
 use metaxu_core::protocol::TaskStatus;
-#[cfg(all(not(test), feature = "metaxu-probe"))]
+use metaxu_core::protocol::{DeviceIdentityRef, IdentityKind, TaskRequest};
 use metaxu_core::session::AuthenticatedSession;
+use ulid::Ulid;
 
 #[cfg(all(not(test), feature = "metaxu-probe"))]
 use crate::board::UART1_BASE;
@@ -54,6 +73,13 @@ pub(crate) const METAXU_MISMATCH: u32 = 3;
 /// Status: the outgoing frame could not be encoded, or the declared
 /// incoming length exceeds this probe's fixed response buffer.
 pub(crate) const METAXU_TRANSPORT_ERROR: u32 = 4;
+/// Status: this device's local capability check denied the request BEFORE
+/// any frame was written. Distinct from [`METAXU_REJECTED`] (a policy
+/// reason FROM the peer) on purpose (#544 step 2): a local refusal must
+/// never read, in the audit trail, as if the peer had seen and rejected the
+/// request -- one is a control on this device, the other a claim about the
+/// peer.
+pub(crate) const METAXU_DENIED_LOCALLY: u32 = 5;
 
 // WHY (#544 step 1): the self-issued dev grant stands in for two
 // independent identities (a runtime issuer and a subject device) until a
@@ -64,13 +90,11 @@ pub(crate) const METAXU_TRANSPORT_ERROR: u32 = 4;
 // that does not opt into the QEMU bring-up harness.
 #[cfg(feature = "qemu")]
 mod dev_identity {
-    use alloc::vec::Vec;
-
-    use compact_str::CompactString;
     use ed25519_dalek::SigningKey;
-    use metaxu_core::grants::{Grant, SignedGrant};
-    use metaxu_core::protocol::{Capability, DeviceIdentityRef, IdentityKind, TaskRequest};
-    use ulid::Ulid;
+    use metaxu_core::grants::Grant;
+    use metaxu_core::protocol::Capability;
+
+    use super::SignedGrant;
 
     // WHY: restates main.rs's crate-wide `qemu`+`production`
     // compile_error! immediately beside the identity material it protects
@@ -122,28 +146,6 @@ mod dev_identity {
             &runtime_signing(),
         )
     }
-
-    /// The harmless typed task (#544's done-when: "one harmless typed
-    /// task"). A fixed, non-randomized request id: this is a single-shot
-    /// dev probe, not a general facility, so there is no replay concern to
-    /// a nonce.
-    pub(super) fn harmless_task() -> TaskRequest {
-        TaskRequest::SendSms {
-            request_id: Ulid::from_bytes([0x54; 16]),
-            identity: DeviceIdentityRef::new(
-                IdentityKind::Device,
-                "thumos-metaxu-probe",
-                device_signing().verifying_key().to_bytes(),
-            ),
-            // WHY empty: the authenticated path authorizes from the
-            // VERIFIED SignedGrant only (session.grant().grant.
-            // capabilities), never this wire-legacy self-claimed list (see
-            // metaxu::BridgeClient::submit_authenticated's docs).
-            grants: Vec::new(),
-            to: CompactString::from("+15550000000"),
-            body: CompactString::from("thumos metaxu-probe: harmless typed task (#544)"),
-        }
-    }
 }
 
 /// Capacity for the response scratch buffer: 4-byte length prefix + the
@@ -164,28 +166,79 @@ static mut RESPONSE_BUF: [u8; RESPONSE_BUF_CAP] = [0; RESPONSE_BUF_CAP];
 #[cfg(all(not(test), feature = "metaxu-probe"))]
 static mut RESPONSE_LEN: usize = 0;
 
-/// `Syscall::MetaxuSubmit`: build + sign the request and write it to
+/// The harmless typed task (#544's done-when: "one harmless typed task").
+/// Takes the presenting device's identity bytes as a parameter rather than
+/// deriving them internally: this constructor carries no qemu/dev-key
+/// dependency of its own, so it compiles and runs in every build.
+/// [`submit`]/[`poll`] pass `dev_identity::device_signing()`'s key -- the
+/// probe's own identity; tests pass an arbitrary fixture device.
+///
+/// A fixed, non-randomized request id: this is a single-shot dev probe, not
+/// a general facility, so there is no replay concern to a nonce.
+fn harmless_task(device: [u8; 32]) -> TaskRequest {
+    TaskRequest::SendSms {
+        request_id: Ulid::from_bytes([0x54; 16]),
+        identity: DeviceIdentityRef::new(IdentityKind::Device, "thumos-metaxu-probe", device),
+        // WHY empty: the authenticated path authorizes from the VERIFIED
+        // SignedGrant only (session.grant().grant.capabilities), never
+        // this wire-legacy self-claimed list (see
+        // metaxu::BridgeClient::submit_authenticated's docs).
+        grants: Vec::new(),
+        to: CompactString::from("+15550000000"),
+        body: CompactString::from("thumos metaxu-probe: harmless typed task (#544)"),
+    }
+}
+
+/// Local authorization for a submission (#544 step 2): the requested
+/// capability must be present in a grant that verifies -- device-bound,
+/// unexpired -- BEFORE any bytes are prepared for the wire.
+///
+/// Reuses [`SignedGrant::verify`] (via [`AuthenticatedSession::open`]) for
+/// the device+expiry check -- no parallel check that could drift from it.
+///
+/// WHY (commit sequencing, #544): this commit wires the device+expiry half
+/// only -- a grant that verifies but lacks the requested capability still
+/// proceeds to encoding. `tests::capability_absent_denies_locally_without_transmitting`
+/// below is written against the FULL contract and is expected to fail
+/// until the next commit adds the capability-presence check.
+///
+/// This function has no reference to `uart`/`board`/the transport
+/// anywhere in its body. [`submit`] writes a frame ONLY on this function's
+/// `Ok` arm, so a local denial has no code path to the wire -- provable by
+/// reading this function, not merely by observing that a byte counter
+/// stayed at zero.
+fn evaluate_submission(
+    signed_grant: SignedGrant,
+    device: &[u8; 32],
+    now_ms: u64,
+    task: &TaskRequest,
+) -> Result<Vec<u8>, u32> {
+    let Ok(session) = AuthenticatedSession::open(signed_grant, device, now_ms) else {
+        return Err(METAXU_DENIED_LOCALLY); // bad signature, wrong device, or expired
+    };
+    metaxu_core::session::encode_authenticated_request(&session, task)
+        .map_err(|_| METAXU_TRANSPORT_ERROR)
+}
+
+/// `Syscall::MetaxuSubmit`: enforce the local capability check FIRST (#544
+/// step 2 -- see [`evaluate_submission`]), then write the resulting frame to
 /// [`UART1_BASE`]. Returns [`METAXU_ACCEPTED`] once the frame is ON THE
-/// WIRE (not once it is answered -- call [`poll`] for the outcome), or
-/// [`METAXU_TRANSPORT_ERROR`] if it could not be built.
+/// WIRE (not once it is answered -- call [`poll`] for the outcome),
+/// [`METAXU_DENIED_LOCALLY`] if the local grant does not verify or lacks
+/// the capability (nothing is written), or [`METAXU_TRANSPORT_ERROR`] if
+/// the frame could not be encoded.
 #[cfg(all(not(test), feature = "metaxu-probe"))]
 pub(crate) fn submit() -> u32 {
     let now_ms = crate::exceptions::uptime_ms();
-    let Ok(session) = AuthenticatedSession::open(
-        dev_identity::dev_grant(),
-        &dev_identity::device_signing().verifying_key().to_bytes(),
-        now_ms,
-    ) else {
-        return METAXU_TRANSPORT_ERROR; // INVARIANT: the freshly self-issued dev grant always verifies against its own subject before DEV_GRANT_EXPIRES_AT_MS; unreachable in practice
-    };
-    let Ok(frame) = metaxu_core::session::encode_authenticated_request(
-        &session,
-        &dev_identity::harmless_task(),
-    ) else {
-        return METAXU_TRANSPORT_ERROR; // INVARIANT: the fixed harmless_task() always encodes under the envelope's MAX_AUTH_REQUEST_PAYLOAD ceiling
-    };
-    write_frame(&frame);
-    METAXU_ACCEPTED
+    let device = dev_identity::device_signing().verifying_key().to_bytes();
+    let task = harmless_task(device);
+    match evaluate_submission(dev_identity::dev_grant(), &device, now_ms, &task) {
+        Ok(frame) => {
+            write_frame(&frame);
+            METAXU_ACCEPTED
+        }
+        Err(denied_or_error) => denied_or_error,
+    }
 }
 
 /// `Syscall::MetaxuPoll`: non-blocking. Drains whatever bytes
@@ -230,7 +283,8 @@ pub(crate) fn poll() -> u32 {
     if !authenticated.verify(&dev_identity::dev_grant()) {
         return METAXU_MAC_FAILED;
     }
-    if authenticated.response.request_id != dev_identity::harmless_task().request_id() {
+    let device = dev_identity::device_signing().verifying_key().to_bytes();
+    if authenticated.response.request_id != harmless_task(device).request_id() {
         return METAXU_MISMATCH;
     }
     match authenticated.response.status {
@@ -273,5 +327,102 @@ fn drain_into_buffer() {
             RESPONSE_BUF[RESPONSE_LEN] = byte;
             RESPONSE_LEN += 1;
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests (#544 step 2): offline, no live bridge -- evaluate_submission has no
+// qemu/UART dependency, so these run in the default host test pass.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use ed25519_dalek::SigningKey;
+    use metaxu_core::grants::Grant;
+    use metaxu_core::protocol::Capability;
+
+    use super::{METAXU_DENIED_LOCALLY, SignedGrant, evaluate_submission, harmless_task};
+
+    // WHY inline key material, not `dev_identity::{runtime_signing,
+    // device_signing}`: these tests must run without the `qemu` feature (they
+    // exercise `evaluate_submission`, which has no qemu dependency of its
+    // own), so they cannot reference anything gated behind it. Arbitrary,
+    // non-secret bytes -- test fixtures only, never linked into a build that
+    // ships.
+    fn issuer_key() -> SigningKey {
+        SigningKey::from_bytes(&[7u8; 32])
+    }
+
+    fn device_key() -> [u8; 32] {
+        SigningKey::from_bytes(&[9u8; 32])
+            .verifying_key()
+            .to_bytes()
+    }
+
+    fn other_device_key() -> [u8; 32] {
+        SigningKey::from_bytes(&[0xEEu8; 32])
+            .verifying_key()
+            .to_bytes()
+    }
+
+    fn grant(
+        capabilities: alloc::vec::Vec<Capability>,
+        expires_at_ms: u64,
+        subject: [u8; 32],
+    ) -> SignedGrant {
+        SignedGrant::issue(
+            Grant {
+                issuer: issuer_key().verifying_key().to_bytes(),
+                subject,
+                capabilities,
+                issued_at_ms: 0,
+                expires_at_ms,
+                nonce: [0xA5; 16],
+            },
+            &issuer_key(),
+        )
+    }
+
+    #[test]
+    fn capability_present_and_valid_proceeds() {
+        let signed = grant(alloc::vec![Capability::SmsSend], 10_000, device_key());
+        let result =
+            evaluate_submission(signed, &device_key(), 5_000, &harmless_task(device_key()));
+        assert!(
+            result.is_ok(),
+            "a grant that verifies and carries the required capability must proceed to encoding, not deny"
+        );
+    }
+
+    #[test]
+    fn capability_absent_denies_locally_without_transmitting() {
+        let signed = grant(alloc::vec![Capability::CallDial], 10_000, device_key());
+        assert_eq!(
+            evaluate_submission(signed, &device_key(), 5_000, &harmless_task(device_key())),
+            Err(METAXU_DENIED_LOCALLY),
+            "a grant that verifies but never carries SmsSend must deny locally -- \
+             evaluate_submission's Err arm never calls write_frame, so this outcome \
+             has no code path to the transport"
+        );
+    }
+
+    #[test]
+    fn expired_grant_denies_locally_without_transmitting() {
+        let signed = grant(alloc::vec![Capability::SmsSend], 10_000, device_key());
+        assert_eq!(
+            evaluate_submission(signed, &device_key(), 10_000, &harmless_task(device_key())),
+            Err(METAXU_DENIED_LOCALLY),
+            "a grant past its expiry must deny locally even though it once carried the capability"
+        );
+    }
+
+    #[test]
+    fn wrong_device_denies_locally_without_transmitting() {
+        let signed = grant(alloc::vec![Capability::SmsSend], 10_000, other_device_key());
+        assert_eq!(
+            evaluate_submission(signed, &device_key(), 5_000, &harmless_task(device_key())),
+            Err(METAXU_DENIED_LOCALLY),
+            "a grant bound to a different device must deny locally"
+        );
     }
 }

--- a/crates/thumos/src/metaxu_bridge.rs
+++ b/crates/thumos/src/metaxu_bridge.rs
@@ -6,14 +6,19 @@
 //! second PL011 (`board::UART1_BASE`, the on-device transport), and
 //! verifies the `pylon-bridge` host process's signed response.
 //!
-//! Dev-only, single-shot, wire-compatible: this module signs with the SAME
-//! well-known dev seeds `metaxu`'s own witness and `pylon-bridge` use for
-//! the SAME roles (`[7u8; 32]` = runtime, `[9u8; 32]` = device) --
+//! Dev-only, single-shot, wire-compatible: [`dev_identity`] signs with the
+//! SAME well-known dev seeds `metaxu`'s own witness and `pylon-bridge` use
+//! for the SAME roles (`[7u8; 32]` = runtime, `[9u8; 32]` = device) --
 //! deliberately public, non-secret, matching `keys/dev/boot-dev.*`'s
-//! convention. It never ships in a `production` build (main.rs
-//! `compile_error`!, mirrors `kfault-probe`/`crashloop-probe`) and never
-//! substitutes for a live Aletheia runtime's grant issuance -- see the PR
-//! body for exactly what remains before this leg is production-real.
+//! convention. It never ships in a `production` build: confined to
+//! `#[cfg(feature = "qemu")]`, itself already mutually exclusive with
+//! `production` crate-wide (main.rs `compile_error!`, mirrors
+//! `kfault-probe`/`crashloop-probe`); [`dev_identity`] restates that
+//! exclusion locally, beside the identity material, so a `production`
+//! build cannot contain this dev grant even if the crate-wide gate were
+//! ever relaxed. It never substitutes for a live Aletheia runtime's grant
+//! issuance -- see the PR body for exactly what remains before this leg is
+//! production-real.
 //!
 //! Split into two syscalls (`MetaxuSubmit`, `MetaxuPoll`) rather than one
 //! blocking call: an SVC handler runs with IRQs masked (`ticks()` frozen --
@@ -24,20 +29,18 @@
 //! the SAME poll-with-sleep idiom `init.rs`'s fork/forkexec/guard harnesses
 //! already use.
 
-use alloc::vec::Vec;
-
-use compact_str::CompactString;
-use ed25519_dalek::SigningKey;
-use metaxu_core::grants::{Grant, SignedGrant};
-use metaxu_core::protocol::{Capability, DeviceIdentityRef, IdentityKind, TaskRequest, TaskStatus};
+#[cfg(all(not(test), feature = "metaxu-probe"))]
+use metaxu_core::protocol::TaskStatus;
+#[cfg(all(not(test), feature = "metaxu-probe"))]
 use metaxu_core::session::AuthenticatedSession;
-use ulid::Ulid;
 
+#[cfg(all(not(test), feature = "metaxu-probe"))]
 use crate::board::UART1_BASE;
 // WHY `crate::uart`, not `crate::uart_pl011`: main.rs path-swaps the
 // driver FILE under the `qemu` feature (`#[path = "uart_pl011.rs"] mod
 // uart;`) -- the MODULE name every caller in this kernel uses is `uart`
 // regardless of which file backs it.
+#[cfg(all(not(test), feature = "metaxu-probe"))]
 use crate::uart::Uart;
 
 /// Status: the authenticated request was accepted.
@@ -52,93 +55,133 @@ pub(crate) const METAXU_MISMATCH: u32 = 3;
 /// incoming length exceeds this probe's fixed response buffer.
 pub(crate) const METAXU_TRANSPORT_ERROR: u32 = 4;
 
+// WHY (#544 step 1): the self-issued dev grant stands in for two
+// independent identities (a runtime issuer and a subject device) until a
+// live Aletheia runtime provisions the real ones through the SAME boot
+// trust anchor `production` already requires (build.rs,
+// scripts/witness/trust-anchor.sh) -- never a second mechanism. Confined to
+// `#[cfg(feature = "qemu")]` so it is structurally absent from every build
+// that does not opt into the QEMU bring-up harness.
+#[cfg(feature = "qemu")]
+mod dev_identity {
+    use alloc::vec::Vec;
+
+    use compact_str::CompactString;
+    use ed25519_dalek::SigningKey;
+    use metaxu_core::grants::{Grant, SignedGrant};
+    use metaxu_core::protocol::{Capability, DeviceIdentityRef, IdentityKind, TaskRequest};
+    use ulid::Ulid;
+
+    // WHY: restates main.rs's crate-wide `qemu`+`production`
+    // compile_error! immediately beside the identity material it protects
+    // -- this module is already confined to `#[cfg(feature = "qemu")]`
+    // above, so `production` alone is the remaining half of the same
+    // condition. An adversarial diff review sees the enforcement at the
+    // point of risk rather than in a different file; the crate-wide gate
+    // already makes the combination unbuildable on its own, so this is a
+    // second, independent structural barrier around the SAME material, not
+    // the sole one.
+    #[cfg(feature = "production")]
+    compile_error!(
+        "qemu (and therefore the self-issued dev grant it gates here, metaxu_bridge::dev_identity) is mutually exclusive with production: a shipped image must never contain a dev grant standing in for a live Aletheia identity."
+    );
+
+    /// The dev "runtime" identity: the SAME well-known seed `metaxu`'s
+    /// witness and `pylon-bridge` pin for this role. Never a production
+    /// credential.
+    pub(super) fn runtime_signing() -> SigningKey {
+        SigningKey::from_bytes(&[7u8; 32])
+    }
+
+    /// The dev "device" identity this kernel presents.
+    pub(super) fn device_signing() -> SigningKey {
+        SigningKey::from_bytes(&[9u8; 32])
+    }
+
+    /// Grant expiry: a year-2100 epoch-ms sentinel, far past any witness run.
+    /// The grant is otherwise fully self-issued and fully deterministic (#544
+    /// dev-only simulation of what a live Aletheia runtime would provision out
+    /// of band); a real epoch source for this probe is out of scope here --
+    /// see the PR body for what remains.
+    pub(super) const DEV_GRANT_EXPIRES_AT_MS: u64 = 4_102_444_800_000;
+
+    /// Self-issue the SAME dev grant every call -- fully deterministic (fixed
+    /// seeds, fixed nonce, fixed expiry), so `submit` and `poll` need no
+    /// persisted session state between them: each can independently re-derive
+    /// the identical `SignedGrant` and its response key.
+    pub(super) fn dev_grant() -> SignedGrant {
+        SignedGrant::issue(
+            Grant {
+                issuer: runtime_signing().verifying_key().to_bytes(),
+                subject: device_signing().verifying_key().to_bytes(),
+                capabilities: alloc::vec![Capability::SmsSend],
+                issued_at_ms: 0,
+                expires_at_ms: DEV_GRANT_EXPIRES_AT_MS,
+                nonce: [0xA5; 16],
+            },
+            &runtime_signing(),
+        )
+    }
+
+    /// The harmless typed task (#544's done-when: "one harmless typed
+    /// task"). A fixed, non-randomized request id: this is a single-shot
+    /// dev probe, not a general facility, so there is no replay concern to
+    /// a nonce.
+    pub(super) fn harmless_task() -> TaskRequest {
+        TaskRequest::SendSms {
+            request_id: Ulid::from_bytes([0x54; 16]),
+            identity: DeviceIdentityRef::new(
+                IdentityKind::Device,
+                "thumos-metaxu-probe",
+                device_signing().verifying_key().to_bytes(),
+            ),
+            // WHY empty: the authenticated path authorizes from the
+            // VERIFIED SignedGrant only (session.grant().grant.
+            // capabilities), never this wire-legacy self-claimed list (see
+            // metaxu::BridgeClient::submit_authenticated's docs).
+            grants: Vec::new(),
+            to: CompactString::from("+15550000000"),
+            body: CompactString::from("thumos metaxu-probe: harmless typed task (#544)"),
+        }
+    }
+}
+
 /// Capacity for the response scratch buffer: 4-byte length prefix + the
 /// envelope header (22 B) + the `AuthenticatedResponse` postcard payload
 /// (a `TaskResponse` + 32 B MAC, comfortably under 256 B for this harmless
 /// task) -- generous headroom without approaching the envelope's own
 /// `MAX_AUTH_RESPONSE_PAYLOAD` (33 KiB) ceiling.
+#[cfg(all(not(test), feature = "metaxu-probe"))]
 const RESPONSE_BUF_CAP: usize = 512;
 
 /// SAFETY (single-core, SVC-serialized, #544): touched only from `poll`/
 /// `drain_into_buffer`, themselves reachable only via the serialized SVC
 /// dispatch path (`syscall::dispatch`) -- no concurrent access is possible
 /// on this kernel.
+#[cfg(all(not(test), feature = "metaxu-probe"))]
 static mut RESPONSE_BUF: [u8; RESPONSE_BUF_CAP] = [0; RESPONSE_BUF_CAP];
 /// SAFETY: see [`RESPONSE_BUF`].
+#[cfg(all(not(test), feature = "metaxu-probe"))]
 static mut RESPONSE_LEN: usize = 0;
-
-/// The dev "runtime" identity: the SAME well-known seed `metaxu`'s witness
-/// and `pylon-bridge` pin for this role. Never a production credential.
-fn runtime_signing() -> SigningKey {
-    SigningKey::from_bytes(&[7u8; 32])
-}
-
-/// The dev "device" identity this kernel presents.
-fn device_signing() -> SigningKey {
-    SigningKey::from_bytes(&[9u8; 32])
-}
-
-/// Grant expiry: a year-2100 epoch-ms sentinel, far past any witness run.
-/// The grant is otherwise fully self-issued and fully deterministic (#544
-/// dev-only simulation of what a live Aletheia runtime would provision out
-/// of band); a real epoch source for this probe is out of scope here --
-/// see the PR body for what remains.
-const DEV_GRANT_EXPIRES_AT_MS: u64 = 4_102_444_800_000;
-
-/// Self-issue the SAME dev grant every call -- fully deterministic (fixed
-/// seeds, fixed nonce, fixed expiry), so `submit` and `poll` need no
-/// persisted session state between them: each can independently re-derive
-/// the identical `SignedGrant` and its response key.
-fn dev_grant() -> SignedGrant {
-    SignedGrant::issue(
-        Grant {
-            issuer: runtime_signing().verifying_key().to_bytes(),
-            subject: device_signing().verifying_key().to_bytes(),
-            capabilities: alloc::vec![Capability::SmsSend],
-            issued_at_ms: 0,
-            expires_at_ms: DEV_GRANT_EXPIRES_AT_MS,
-            nonce: [0xA5; 16],
-        },
-        &runtime_signing(),
-    )
-}
-
-/// The harmless typed task (#544's done-when: "one harmless typed task").
-/// A fixed, non-randomized request id: this is a single-shot dev probe,
-/// not a general facility, so there is no replay concern to a nonce.
-fn harmless_task() -> TaskRequest {
-    TaskRequest::SendSms {
-        request_id: Ulid::from_bytes([0x54; 16]),
-        identity: DeviceIdentityRef::new(
-            IdentityKind::Device,
-            "thumos-metaxu-probe",
-            device_signing().verifying_key().to_bytes(),
-        ),
-        // WHY empty: the authenticated path authorizes from the VERIFIED
-        // SignedGrant only (session.grant().grant.capabilities), never
-        // this wire-legacy self-claimed list (see
-        // metaxu::BridgeClient::submit_authenticated's docs).
-        grants: Vec::new(),
-        to: CompactString::from("+15550000000"),
-        body: CompactString::from("thumos metaxu-probe: harmless typed task (#544)"),
-    }
-}
 
 /// `Syscall::MetaxuSubmit`: build + sign the request and write it to
 /// [`UART1_BASE`]. Returns [`METAXU_ACCEPTED`] once the frame is ON THE
 /// WIRE (not once it is answered -- call [`poll`] for the outcome), or
 /// [`METAXU_TRANSPORT_ERROR`] if it could not be built.
+#[cfg(all(not(test), feature = "metaxu-probe"))]
 pub(crate) fn submit() -> u32 {
     let now_ms = crate::exceptions::uptime_ms();
     let Ok(session) = AuthenticatedSession::open(
-        dev_grant(),
-        &device_signing().verifying_key().to_bytes(),
+        dev_identity::dev_grant(),
+        &dev_identity::device_signing().verifying_key().to_bytes(),
         now_ms,
     ) else {
         return METAXU_TRANSPORT_ERROR; // INVARIANT: the freshly self-issued dev grant always verifies against its own subject before DEV_GRANT_EXPIRES_AT_MS; unreachable in practice
     };
-    let Ok(frame) = metaxu_core::session::encode_authenticated_request(&session, &harmless_task())
-    else {
+    let Ok(frame) = metaxu_core::session::encode_authenticated_request(
+        &session,
+        &dev_identity::harmless_task(),
+    ) else {
         return METAXU_TRANSPORT_ERROR; // INVARIANT: the fixed harmless_task() always encodes under the envelope's MAX_AUTH_REQUEST_PAYLOAD ceiling
     };
     write_frame(&frame);
@@ -150,6 +193,7 @@ pub(crate) fn submit() -> u32 {
 /// until a complete framed response has arrived, then decodes + verifies
 /// it and returns a definitive [`METAXU_ACCEPTED`] / [`METAXU_REJECTED`] /
 /// [`METAXU_MAC_FAILED`] / [`METAXU_MISMATCH`].
+#[cfg(all(not(test), feature = "metaxu-probe"))]
 pub(crate) fn poll() -> u32 {
     drain_into_buffer();
     // SAFETY: see [`RESPONSE_BUF`].
@@ -183,10 +227,10 @@ pub(crate) fn poll() -> u32 {
     let Ok(authenticated) = metaxu_core::session::decode_authenticated_response(frame_bytes) else {
         return METAXU_TRANSPORT_ERROR;
     };
-    if !authenticated.verify(&dev_grant()) {
+    if !authenticated.verify(&dev_identity::dev_grant()) {
         return METAXU_MAC_FAILED;
     }
-    if authenticated.response.request_id != harmless_task().request_id() {
+    if authenticated.response.request_id != dev_identity::harmless_task().request_id() {
         return METAXU_MISMATCH;
     }
     match authenticated.response.status {
@@ -203,6 +247,7 @@ pub(crate) fn poll() -> u32 {
 /// Write a length-prefixed frame to `UART1_BASE`: a 4-byte LE length
 /// followed by `frame`'s bytes -- the SAME framing `pylon::serve_one` (the
 /// `pylon-bridge` process on the other end) already reads.
+#[cfg(all(not(test), feature = "metaxu-probe"))]
 fn write_frame(frame: &[u8]) {
     let uart = Uart::at(UART1_BASE);
     let Ok(len) = u32::try_from(frame.len()) else {
@@ -218,6 +263,7 @@ fn write_frame(frame: &[u8]) {
 
 /// Drain whatever bytes are currently ready on `UART1_BASE` into the
 /// response buffer (non-blocking, mirrors `Uart::getc`).
+#[cfg(all(not(test), feature = "metaxu-probe"))]
 fn drain_into_buffer() {
     let uart = Uart::at(UART1_BASE);
     // SAFETY: see [`RESPONSE_BUF`].

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -396,6 +396,11 @@ tests = 36
 mechanism = "host"
 
 [[module]]
+name = "metaxu_bridge"
+tests = 4
+mechanism = "host"
+
+[[module]]
 name = "mic_audit"
 tests = 18
 mechanism = "host"


### PR DESCRIPTION
## What

Steps 1 and 2 of the #544 design: make a dev grant structurally impossible in a production build, and enforce the capability locally before anything reaches the transport.

## Step 1 — a production image cannot contain a dev grant

`runtime_signing`, `device_signing`, `dev_grant`, and `DEV_GRANT_EXPIRES_AT_MS` (a grant expiring in 2100) are now confined to a `dev_identity` submodule gated on `#[cfg(feature = "qemu")]`, with the exclusion restated beside the material it protects:

```rust
#[cfg(feature = "qemu")]
mod dev_identity {
    #[cfg(feature = "production")]
    compile_error!("qemu (and therefore the self-issued dev grant it gates here ...) is mutually exclusive with production: a shipped image must never contain a dev grant standing in for a live Aletheia identity.");
}
```

The property is a **compile failure**, not a runtime check and not a lint.

The local restatement is deliberately redundant with the crate-wide `qemu`+`production` exclusion in `main.rs`, and the redundancy is load-bearing: `mod metaxu_bridge;` was un-gated from `all(not(test), feature = "metaxu-probe")` to unconditional, so this file no longer inherits protection from a whole-module exclusion. Without the local `compile_error!`, the guarantee would depend on a `cfg` several files away that nobody editing this one would see.

## Step 2 — capability enforced before transmit

`evaluate_submission` is the sole decision point, and it reuses `SignedGrant::verify` **through** `AuthenticatedSession::open` rather than duplicating the device and expiry checks:

```rust
let Ok(session) = AuthenticatedSession::open(signed_grant, device, now_ms) else {
    return Err(METAXU_DENIED_LOCALLY);
};
if !session.grant().grant.capabilities.contains(&task.required_capability()) {
    return Err(METAXU_DENIED_LOCALLY);
}
```

Every rejection path — bad signature, wrong device, expired grant, capability absent — collapses to a new `METAXU_DENIED_LOCALLY` (`= 5`), distinct from `METAXU_REJECTED`. That distinction is the point: a local policy refusal surfacing as `REJECTED` would be indistinguishable from a remote one in the audit trail, and the two mean opposite things about where trust failed.

`submit()` calls `write_frame` only on the `Ok` arm, and its body holds no reference to `uart` or `board` at all — a denial has **no code path to the transport by construction**, rather than a runtime guard that a later edit could bypass.

## Failing-before evidence

Scaffolding plus tests pushed one commit ahead of the implementation. CI run [31430078045](https://github.com/forkwright/thumos/actions/runs/31430078045) went red on exactly one test — `capability_absent_denies_locally_without_transmitting` — while the other three (valid, expired, wrong-device) passed, because `SignedGrant::verify` already covered those. That is the correct shape: only the genuinely new property failed.

[31430273887](https://github.com/forkwright/thumos/actions/runs/31430273887) is green with the check added, across both host-test feature passes, kernel clippy on all seven feature configurations, the ledger check, and the existing `#544` QEMU witness — confirming the refactor did not disturb the on-device happy path.

Tests are unconditional rather than `qemu`/`metaxu-probe`-gated, because `harmless_task` now takes the device identity instead of deriving it from the gated `dev_identity` module. They therefore run in the default `kernel-host-tests.sh` pass with no new CI wiring. `docs/target-test-ledger.toml` gains a `metaxu_bridge` row.

## Scope

Steps 3 and 4 of the design are not here. Step 3 (syscall pair + userspace program) turned out to be **already on `main`** — see the correction posted to #544.

Refs: #544, #545
