### PR TITLE
chore(lint): extend the #130 ignore pattern to the crates that postdate it

### DIFF
--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -181,3 +181,45 @@ MANIFEST/package-workspace-inheritance:crates/thumos/Cargo.toml
 # consolidated CI file and does not see the sibling security workflow. The
 # check genuinely runs; it is just not duplicated in ci.yml.
 CI/no-deny-check:.github/workflows/ci.yml
+
+# =============================================================================
+# Post-#130 crates — same pattern, relocated code
+# =============================================================================
+#
+# WHY(#719): the #130 block above suppresses RUST/indexing-slicing for the
+# parser/encoder files that existed when it was written. The crates below
+# postdate it and carry the identical pattern. Two of them carry it because
+# convergence work MOVED the code: klesis/src/pdu.rs and klesis/src/gsm7.rs are
+# both ignored above, and #662/#700/#710 extracted their BCD framing, GSM-7
+# codec, and PDU primitives into klesis-core. The code did not change, only its
+# address. An extraction relocates code out from under its suppressions, and
+# nothing warns that it has.
+#
+# Each site was verified in-place before being listed here: every one is either
+# an index into a fixed-size array with a literal index (no runtime length
+# exists), an index after a length check earlier in the same function that
+# returns a typed error first, or a private helper whose every call site is
+# guarded. `smp/pdu.rs::decode` is representative -- its `expect(want)` tests
+# `body.len() == want`, exact equality, and every decode call sits directly
+# behind it.
+#
+# WHY files, not a `smp/**` glob: a glob would also silence a NEW file in these
+# directories, which nobody has read. Listing files means new code gets its own
+# review rather than inheriting this one.
+#
+# NOT a permanent position. kanon#3176 asks for the rule to resolve caller
+# guards and fixed-size arrays; if that lands, this whole block and #130's
+# should be deleted together rather than left as scar tissue.
+RUST/indexing-slicing:crates/klesis-core/src/lib.rs
+RUST/indexing-slicing:crates/metaxu-core/src/envelope.rs
+RUST/indexing-slicing:crates/metaxu-core/src/protocol.rs
+RUST/indexing-slicing:crates/pteron/src/smp/mod.rs
+RUST/indexing-slicing:crates/pteron/src/smp/pairing.rs
+RUST/indexing-slicing:crates/pteron/src/smp/pdu.rs
+RUST/indexing-slicing:crates/pteron/src/smp/toolbox.rs
+RUST/indexing-slicing:crates/topos-core/src/lib.rs
+
+# WHY(#719): same lib.rs-only heuristic as the TESTING/no-tests block above.
+# metaxu-core's lib.rs is module declarations and re-exports; its submodules
+# carry 19 tests (envelope.rs 10, grants.rs 6, protocol.rs 3).
+TESTING/no-tests:crates/metaxu-core/src/lib.rs


### PR DESCRIPTION
## Decision

#719 offered two options: extend the #130 ignore pattern, or wait for kanon#3176 to fix the rule upstream. **Extend**, and the reason is specific rather than expedient.

## The code did not change — its address did

`crates/klesis/src/pdu.rs` and `crates/klesis/src/gsm7.rs` are both already ignored under #130, with the rationale *"provably safe per-call but the lint can't see the bounds check."*

Today's convergence work (#662, #700, #710) extracted their BCD framing, GSM-7 codec, and PDU byte primitives into `klesis-core`. Identical code, new file, no suppression.

**An extraction relocates code out from under its suppressions, and nothing warns that it has.** That is the general shape, and it will recur with every future `-core` convergence. Declining to extend would mean the same bytes are judged differently based on which file they sit in — which is not a standard, it is an accident of when a sweep ran.

The rest (`pteron/src/smp/*`, `metaxu-core`, `topos-core`) simply postdate #130.

## Verified, not assumed

Every listed site was checked in place across two independent passes plus a spot check of the highest-exposure path. Each is one of:

- an index into a fixed-size array with a literal index — no runtime length exists
- an index after a same-function length check that returns a typed error first
- a private helper whose every call site is guarded

`smp/pdu.rs::decode` is representative: its `expect(want)` tests `body.len() == want` — **exact equality**, stricter than a lower bound — and both `PairingFeatures::decode` call sites sit directly behind it.

## Files, not a glob

`crates/pteron/src/smp/**` would have been shorter and would also silence a **new** file in that directory that nobody has read. Listing files means new code gets its own review rather than inheriting this one.

For the same reason `sema/src/cell.rs` (3) and `fuzz/` (2) are **left unsuppressed** — they were outside the verification scope, so suppressing them would be exactly the unexamined blanket this PR is trying not to be. They remain visible.

## Effect

`kanon lint . --summary` (the form `.kanon-ci.toml` gates on): **419 → 354**, `indexing-slicing` 84 → 5.

Also adds `TESTING/no-tests` for `metaxu-core/src/lib.rs` — the same lib.rs-only heuristic the existing block documents. Its submodules carry 19 tests (envelope 10, grants 6, protocol 3).

Deliberately **not** included: `RUST/file-too-long` on `klesis-core` (1650 lines), `topos-core` (1096), and `pteron/smp/{pairing,pdu}.rs`. Those are real signal about file size, tracked by #131, and want a decision rather than a suppression.

## Not permanent

kanon#3176 asks the rule to resolve caller guards and fixed-size arrays. If that lands, this block and #130's should be **deleted together** rather than left as scar tissue. The comment says so in the file.

Closes #719
Refs: #130, #718, kanon#3176