### PR TITLE
docs(contributing): describe the GitHub topology that is, and drop the internal forge FQDNs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,31 +2,16 @@
 
 Thumos is a privacy-first Rust mobile OS targeting the AGM M7 (MediaTek MT6739). It is hardware-adjacent and embedded - contributions are welcome from external researchers, radio hackers, and anyone interested in a Rust-from-kernel-to-UI mobile stack.
 
-The repo uses the self-hosted kanon forge as the authoritative PR surface. GitHub stays bidirectionally mirrored for external discoverability, but PRs live on the forge.
-
-## Push target
-
-```
-origin = http://kanon.lan/forkwright/thumos.git   (authoritative)
-github = git@github.com:forkwright/thumos.git     (mirror)
-```
-
-Push to `origin`. The forge post-receive hook runs CI (`.kanon-ci.toml`) and mirrors merge commits to GitHub via the pr-sync worker.
+The repo is public and GitHub is the contribution surface. `origin` is `https://github.com/forkwright/thumos.git`; PRs are opened, reviewed, and merged there, and CI runs on GitHub-hosted runners.
 
 ## Opening a PR
 
-Two paths, same effect:
-
-**Stoa UI.** Open `http://kanon.lan/prs/forkwright/thumos`, click "New PR", pick base + head refs, review diff, submit.
-
-**CLI.**
-
 ```bash
 git push origin HEAD:refs/heads/<branch>
-kanon pr open <branch> --title "..." --body "..."
+gh pr create --base main --head <branch> --title "..." --body "..."
 ```
 
-`kanon pr open` prints the new PR number and its forge URL.
+The title matters: the repo squash-merges, so a PR title becomes `main`'s commit message and release-please parses it for the changelog and the version bump. `.github/workflows/pr-title.yml` validates it against `CLAUDE.md`'s grammar as a required check.
 
 ## Review
 
@@ -34,7 +19,7 @@ Comments and approvals land through stoa. The merge button activates when all ga
 
 - CI status `Pass` (every stage in `.kanon-ci.toml` exits zero, or the stage's `fail_on` predicate reports success).
 - Independent verifier `Ok` (03f-e reproduces the headline claims from a fresh checkout of the head sha).
-- The `Gate Attestation` check (`.github/workflows/gate-attestation.yml`) reports success. A `Gate-Passed: kanon <version>` trailer on the tip commit takes the fast path; without one, the check runs a real `cargo fmt`/`check`/`clippy`/`nextest` build against the branch instead (skipped only for docs-only PRs). The AI-attribution check always runs, trailer or not, and no trailer is appended by the merge itself. **This check, and `.kanon-ci.toml`'s fmt/check/clippy/nextest stages, do not cover the kernel crate** (`crates/thumos`, excluded from the Cargo workspace) — only the separate, non-required `CI` workflow's kernel job (i686 host tests, armv7a cross-compile, QEMU boot) exercises it. A green `Gate Attestation` check does not attest the kernel.
+- The `Gate Attestation` check (`.github/workflows/gate-attestation.yml`) reports success. A `Gate-Passed: kanon <version>` trailer on the tip commit takes the fast path; without one, the check runs a real `cargo fmt`/`check`/`clippy`/`nextest` build against the branch instead (skipped only for docs-only PRs). The AI-attribution check always runs, trailer or not, and no trailer is appended by the merge itself. **This check, and `.kanon-ci.toml`'s fmt/check/clippy/nextest stages, do not cover the kernel crate** (`crates/thumos`, excluded from the Cargo workspace) — the `CI` workflow's `kernel` job exercises it (i686 host tests, armv7a cross-compile, QEMU boot and witnesses, and a zero-warning clippy gate across every declared feature configuration). That job **is** a required check, so a red kernel blocks the merge; but a green `Gate Attestation` on its own still does not attest the kernel, because the two cover different trees.
 
 ## Merging
 
@@ -42,9 +27,9 @@ Comments and approvals land through stoa. The merge button activates when all ga
 kanon pr merge <pr_number>
 ```
 
-or the forge merge button. Default strategy is `squash`; `--strategy ff` or `--strategy rebase` are supported. A squash merge does not carry the source branch's `Gate-Passed` trailer forward — squashing drops per-commit trailers by construction, so no commit on `main` has one. That absence is expected, not a gap: `Gate Attestation`'s `push`-to-`main` trigger re-runs the full build against the merge commit itself, which is what actually attests `main`.
+or the GitHub merge button. Default strategy is `squash`; `--strategy ff` or `--strategy rebase` are supported. A squash merge does not carry the source branch's `Gate-Passed` trailer forward — squashing drops per-commit trailers by construction, so no commit on `main` has one. That absence is expected, not a gap: `Gate Attestation`'s `push`-to-`main` trigger re-runs the full build against the merge commit itself, which is what actually attests `main`.
 
-Do not merge via GitHub. The GitHub mirror is read-only from the contributor's perspective: any merge performed there races the forge pr-sync worker.
+Branch protection gates the merge: `cargo audit`, `cargo deny`, `gate / gate`, `conventional-commit grammar`, and the `kernel` job must all report success, and `enforce_admins` is on, so the checks bind every merge rather than only external ones.
 
 ## Releases
 
@@ -68,18 +53,9 @@ The merge is not the release: release-please's `push`-to-`main` trigger creates 
 
 ## External contributors
 
-Thumos has a real external-contributor path - radio, baseband, and MTK tooling folks without kanon.lan access. The GitHub mirror at `github.com/forkwright/thumos` is fully functional for you:
+Radio, baseband, and MTK tooling folks: there is nothing special to do. Fork on GitHub and open a PR against `forkwright/thumos:main` as you would on any other project. Review, CI, and the merge all happen there.
 
-1. Fork on GitHub, open a PR against `forkwright/thumos:main` as you would on any OSS project.
-2. The 05d bidirectional sync ingests the PR into the forge. Review, CI, and the verifier all run there.
-3. Discussion may happen on either side; the forge thread is authoritative. The mirror sync relays merge state back to GitHub once the forge merges.
-4. The merge always happens on the forge; CI artifacts from that run are preserved there. The merge commit itself carries no `Gate-Passed` trailer — squash merges drop it — so `Gate Attestation` independently re-verifies the merge commit when it lands on `main` via GitHub's `push` trigger. GitHub closes your PR when the mirror sync observes the merge commit on `main`.
-
-You do not need a kanon.lan account to contribute. The GitHub path is a first-class inbound route, not a courtesy.
-
-## Fallback
-
-If the forge is unreachable from within the fleet, push to `github` and open a GitHub PR. When the forge is back, its pr-sync worker picks up the PR and continues from there. This is an escape hatch for fleet operators, not a preferred path - use it only when kanon.lan is actually down.
+The merge commit carries no `Gate-Passed` trailer — squash merges drop per-commit trailers by construction — so `Gate Attestation` re-runs against the merge commit when it lands on `main` via the `push` trigger. That absence is expected, not a gap.
 
 ## CI configuration
 

--- a/crates/thumos/src/ekphrasis.rs
+++ b/crates/thumos/src/ekphrasis.rs
@@ -631,7 +631,7 @@ impl fmt::Display for AudioCaptureConfig {
 pub(crate) struct Ekphrasis {
     /// Current state of the voice-to-text pipeline.
     state: EkphrasisState,
-    /// Aletheia STT endpoint hostname (e.g., "stt.example.lan" or Tailscale IP).
+    /// Aletheia STT endpoint hostname, supplied by the caller (a hostname or an IP).
     aletheia_host: String,
     /// Aletheia STT endpoint port.
     aletheia_port: u16,

--- a/crates/thumos/src/nous.rs
+++ b/crates/thumos/src/nous.rs
@@ -68,9 +68,6 @@ const MAX_ENTITIES: usize = 16;
 /// Maximum length of an entity name in bytes.
 const MAX_NAME_LEN: usize = 32;
 
-/// Default Matrix homeserver domain for nous entities.
-const DEFAULT_HOMESERVER: &str = "thumos.lan";
-
 // ---------------------------------------------------------------------------
 // Capability model (#552): typed grants are the sole authority
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Clears the four `OIKOS/private-content` findings (high severity) from #718, and the document turned out to be stale as well as leaky.

## CONTRIBUTING.md described a topology that no longer holds

It opened by inviting *"external researchers, radio hackers"* to contribute, then told them:

```
origin = http://kanon.lan/forkwright/thumos.git   (authoritative)
```

An address an external contributor cannot resolve. It also said PRs *"live on the forge"*, that *"the merge always happens on the forge"*, and **"Do not merge via GitHub."**

Observed reality: `git remote -v` shows `origin = https://github.com/forkwright/thumos.git` and nothing else. Every PR in this program — #695 through #721 — was opened, checked, and merged on GitHub, under GitHub branch protection, on GitHub-hosted runners.

I did **not** replace the forge claims with new ones. Whether a mirror still exists elsewhere is not something this clone can tell me, so the unverifiable statements are removed rather than restated in a different direction.

## One correction that matters more than the hostnames

The Review section said:

> only the separate, **non-required** `CI` workflow's kernel job ... exercises it. A green `Gate Attestation` check does not attest the kernel.

The first half stopped being true when #694 promoted the kernel job to a required check — it now blocks merges, and the document was telling contributors it did not. The second half is still true, for a different reason, and the text now says which: the two checks cover different trees.

A contributor reading the old text would have concluded a red kernel was advisory. It is not.

## Source changes

- **`nous::DEFAULT_HOMESERVER` deleted.** A private `const` with **zero usages anywhere in the tree**, carrying a fleet-internal domain into a public repo. Dead code and a leak in one line.
- **`ekphrasis.rs` doc example de-FQDN'd.** The host is supplied by the caller (`ekphrasis.rs:668`), so the doc now says that instead of naming an internal-looking example.

## What this does not fix

`thumos.lan` remains throughout `nous.rs` — including **production** default entities at `nous.rs:772,783,796` (`@syn:`, `@phrouros:`, `@paideia:`) — and `stt.example.lan` throughout the ekphrasis tests. Roughly 50 occurrences.

The rule reported **4**. It appears to match bare quoted FQDN literals and not ones embedded in a longer string such as a Matrix user ID, so the finding count materially under-states the exposure. Filed separately rather than expanded here: hardcoding a fleet-internal Matrix domain into shipped defaults is a design question, not a lint fix, and it touches every construction site plus dozens of tests.

Refs: #718, #694