### PR TITLE
fix(board): point MUSB_BASE at the controller the MT6739 vendor DT actually declares

### DIFF
--- a/crates/thumos/src/board/m7.rs
+++ b/crates/thumos/src/board/m7.rs
@@ -63,10 +63,30 @@ pub(crate) const LFS_PREAMBLE_SECTORS: u64 = 1;
 // USB
 // ---------------------------------------------------------------------------
 
-/// MUSB OTG USB controller MMIO base (device-tree node `usb@11210000`).
-/// NOTE: the pre-#534 device registry carried a stale `0x1120_0000` entry
-/// for `musb-hdrc`; the DT node and the usb.rs driver agree on this value.
-pub(crate) const MUSB_BASE: usize = 0x1121_0000;
+/// MUSB OTG USB controller MMIO base, from the `MediaTek` MT6739 vendor
+/// device tree's `usb0@11200000` node: `compatible = "mediatek,mt6739-usb20"`,
+/// `reg = <0 0x11200000 0 0x10000>, <0 0x11CC0000 0 0x10000>`. Two
+/// independently hosted copies agree byte-for-byte
+/// (github.com/fukehan/kernel-4.4,
+/// github.com/iscle/OrangePi_4G-IOT_Android_8.1_BSP), and `0x11210000`
+/// appears nowhere in either 2499-line tree.
+///
+/// WHY this replaced `0x1121_0000` (#676): that address is real in this SoC
+/// family but belongs to a different device. Mainline
+/// `arch/arm/boot/dts/mediatek/mt2701.dtsi` splits the pair explicitly --
+/// `usb@11200000` is the `mtk-musb` controller, `t-phy@11210000` is the
+/// T-PHY, whose registers are PHY tuning and carry no FADDR/POWER/INTRTX or
+/// EP CSRs. MT6739 breaks the family's controller+0x10000 pattern by moving
+/// its second region to `0x11CC0000`, so following that pattern lands on
+/// nothing. `usb.rs` drives MUSB-core operations, so it needs the controller.
+///
+/// WARNING: source-resolved, NOT hardware-confirmed. `usb::init_controller`'s
+/// `POWER` readback (`UsbInitError::NotResponding`) is the falsifier, and it
+/// reads a register inside the byte range `usb.rs` gets right -- test this
+/// base alone before concluding anything about #724's register-map
+/// divergence, or a failure downstream of `POWER` gets misattributed back
+/// to this value.
+pub(crate) const MUSB_BASE: usize = 0x1120_0000;
 
 /// MUSB OTG controller GIC interrupt (raw GIC INTID, the form
 /// `gic::enable_irq` and the IRQ-dispatch comparison in `exceptions.rs`
@@ -80,12 +100,14 @@ pub(crate) const MUSB_BASE: usize = 0x1121_0000;
 /// (github.com/fukehan/kernel-4.4, github.com/iscle/OrangePi_4G-IOT_Android_8.1_BSP)
 /// carry a `usb0@11200000` node -- `compatible = "mediatek,mt6739-usb20"`,
 /// `interrupts = <GIC_SPI 73 IRQ_TYPE_LEVEL_LOW>` (INTID 32+73 = 105) -- but
-/// that node's `reg` base is `0x1120_0000`, not the `0x1121_0000` `MUSB_BASE`
-/// carries above. `MUSB_BASE`'s own doc comment attributes `0x1121_0000` to
-/// "the DT node", and the #534 PR that moved it here repeats that claim,
-/// but neither cites a source beyond the other -- there is no artifact in
-/// this repo's history that independently confirms either address against
-/// real AGM M7 hardware or an authoritative MT6739 datasheet. Wiring a real
+/// `MUSB_BASE` above now carries that same node's `reg` base, so the address
+/// conflict this comment was written against is resolved by source (#676).
+/// What is still missing is a hardware artifact: nothing confirms INTID 105
+/// on real AGM M7 silicon, and a vendor DT is the same evidence class that
+/// carried the wrong base for two releases -- right about the base, unproven
+/// about this. The asymmetry is deliberate: a wrong base fails loudly and
+/// detectably at the `POWER` readback, while a wrongly-enabled IRQ wedges the
+/// interrupt path in ways that are far harder to attribute. Wiring a real
 /// GIC INTID into a live `enable_irq` call on that contested foundation
 /// would be a fabricated fact wearing a hardware-verified constant's
 /// clothes, not an engineering shortcut -- so this stays `None` (a

--- a/crates/thumos/src/board/m7.rs
+++ b/crates/thumos/src/board/m7.rs
@@ -71,7 +71,7 @@ pub(crate) const LFS_PREAMBLE_SECTORS: u64 = 1;
 /// github.com/iscle/OrangePi_4G-IOT_Android_8.1_BSP), and `0x11210000`
 /// appears nowhere in either 2499-line tree.
 ///
-/// WHY this replaced `0x1121_0000` (#676): that address is real in this SoC
+/// WHY this replaced `0x1121_0000` (#676): that address is real in this `SoC`
 /// family but belongs to a different device. Mainline
 /// `arch/arm/boot/dts/mediatek/mt2701.dtsi` splits the pair explicitly --
 /// `usb@11200000` is the `mtk-musb` controller, `t-phy@11210000` is the


### PR DESCRIPTION
Resolves the research half of #676. The address question is answered from source; hardware confirmation is a smaller, separate step.

## The claimed provenance does not exist

`MUSB_BASE` carried `0x1121_0000` with a doc comment asserting it came from a device-tree node `usb@11210000`.

**That node does not exist.** The MT6739 vendor tree declares:

```dts
usb0@11200000 {
    compatible = "mediatek,mt6739-usb20";
    reg = <0 0x11200000 0 0x10000>, <0 0x11CC0000 0 0x10000>;
    interrupts = <GIC_SPI 73 IRQ_TYPE_LEVEL_LOW>;
};
```

Two independently hosted copies agree byte-for-byte (`fukehan/kernel-4.4`, `iscle/OrangePi_4G-IOT_Android_8.1_BSP`), and `0x11210000` appears **nowhere** in either 2499-line tree.

## What that address actually is

`0x1121_0000` is a real MediaTek address belonging to a different device. Mainline `arch/arm/boot/dts/mediatek/mt2701.dtsi` splits the pair explicitly:

```dts
usb2:   usb@11200000   { compatible = "mediatek,mt2701-musb", "mediatek,mtk-musb"; ... };
u2phy0: t-phy@11210000 { compatible = "mediatek,mt2701-tphy"; ... };
```

It is the **T-PHY** — PHY tuning registers, no `FADDR`/`POWER`/`INTRTX`, no EP CSRs. The MT6735/MT6753 family puts both regions on one node, and a vendor header names the second directly: `#define U2PHYDTM1 (USB_SIF_BASE+0x800+0x6c)`.

MT6739 **breaks** the family's controller+`0x10000` pattern by moving its second region to `0x11CC0000`. Following that pattern lands on nothing — which is the most likely way the wrong value was derived.

`usb.rs` drives MUSB-core operations (enumeration, EP0 SETUP/DataIn/DataOut, `SET_ADDRESS`, bulk FIFO I/O), not PHY tuning. It needs the controller.

## The doc comment was the load-bearing defect

A wrong value with honest provenance invites checking. One labelled "the DT node" does not — which is how this survived #534 and #666 while the neighbouring `MUSB_IRQ` block was independently documenting the conflict and correctly refusing to act on it.

The new comment cites the actual node text and states plainly that it is source-resolved, not hardware-confirmed.

## Necessary, not sufficient

**#724**: `usb.rs`'s register map diverges from the MT6739 vendor driver from `MUSB_FRAME` onward, and addresses endpoints as per-endpoint blocks at `0x110`+ rather than MUSB's `INDEX`-selected window at `0x10`. With the correct base and that map, the driver still cannot drive the controller.

One consequence is recorded in the code, because it will otherwise cost a hardware session: `init_controller`'s `POWER` readback (`UsbInitError::NotResponding`) is a clean base-address falsifier **and it reads a register inside the twelve bytes `usb.rs` gets right**. Test the base alone first — a failure downstream of `POWER` otherwise gets attributed to the base, and the base gets flipped back.

## MUSB_IRQ stays None

Its caution is narrowed, not lifted. The address conflict it was written against is resolved, but INTID 105 still has no hardware artifact, and a vendor DT is the same evidence class that carried the wrong base for two releases — right about the base, unproven about this.

The asymmetry is deliberate and now stated in the comment: a wrong base fails loudly and detectably at the `POWER` readback, while a wrongly-enabled IRQ wedges the interrupt path in ways that are far harder to attribute.

## Risk

USB init failure is non-fatal at boot (`kinit.rs:1358` logs a WARN and continues), and QEMU models no MUSB at either address, so nothing regresses. The repo is pre-hardware. "Untestable" does not favour the status quo here: the old value has *no* provenance, the new one has two chip-exact sources.

Refs: #676, #724, #666, #534
