### PR TITLE
fix(scripts): strict mode, bracket form, and silent-true across the witness and gate scripts

### DIFF
--- a/scripts/check-board-seam.sh
+++ b/scripts/check-board-seam.sh
@@ -24,7 +24,7 @@ rc=0
 hits=$(grep -rn 'MT6739_[A-Z0-9_]\+' "$SRC" --include='*.rs' \
     | grep -v '/board/m7.rs:' \
     | grep -v '/ccci.rs:' | grep -v '/ccci_logger.rs:' || true)
-if [ -n "$hits" ]; then
+if [[ -n "$hits" ]]; then
     echo "SEAM DRIFT: MT6739_* identifier outside board::m7 (kernel core must name the board seam, not the SoC):" >&2
     echo "$hits" >&2
     rc=1
@@ -38,7 +38,7 @@ for hex in 0x1800_0000 0x180F_0000 0x1123_0000 0x1121_0000 0x1400_0000 \
            0x1100_3000 0x77EE_0000 0x1100_2000 0x0C00_0000 0x0C00_2000; do
     hits=$(grep -rn "const [A-Z0-9_]*: usize = $hex" "$SRC" --include='*.rs' \
         | grep -v '/board/' || true)
-    if [ -n "$hits" ]; then
+    if [[ -n "$hits" ]]; then
         echo "SEAM DRIFT: board MMIO value $hex re-declared as a const outside board/:" >&2
         echo "$hits" >&2
         rc=1

--- a/scripts/check-board-seam.sh
+++ b/scripts/check-board-seam.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # check-board-seam.sh — the #534 standing invariant, enforced as source
 # structure rather than prose. Fails when:
 #   (a) an `MT6739_*` identifier appears anywhere in the kernel crate outside
@@ -11,7 +13,6 @@
 #       are allowed.
 # Board constants live only under board::*; board selection happens once, in
 # board/mod.rs.
-set -uo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 SRC="$REPO_ROOT/crates/thumos/src"

--- a/scripts/check-convergence.sh
+++ b/scripts/check-convergence.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # check-convergence.sh — the #545 convergence ratchet. Fails when:
 #   (a) a [[pair]] row lacks disposition/canonical/owner, or names a file
 #       that no longer exists;
@@ -7,7 +9,6 @@
 #       recorded ratchet values (convergence only ever burns down);
 #   (d) any lib.rs still points at closed #126 (the pointer must be the
 #       live ledger, not a closed issue).
-set -uo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 LEDGER="$REPO_ROOT/docs/convergence.toml"

--- a/scripts/check-doc-inventory.sh
+++ b/scripts/check-doc-inventory.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # check-doc-inventory.sh — crate-roster and docs/ manifest drift check.
 # Fails when:
 #   (a) the crate roster derived from Cargo.toml [workspace] members (plus
@@ -11,7 +13,6 @@
 # Cargo.toml is the SSOT for what crates exist; docs/MANIFEST.toml is the
 # SSOT for what files live in docs/. No doc may hand-restate either count —
 # this script is the only thing allowed to know the number.
-set -uo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 

--- a/scripts/check-kernel-lockfile-versions.sh
+++ b/scripts/check-kernel-lockfile-versions.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # check-kernel-lockfile-versions.sh — the kernel lockfile's first-party crates
 # must carry the workspace version.
 #
@@ -17,7 +19,6 @@
 #
 # WHY `thumos` is exempt: its 0.1.0 in crates/thumos/Cargo.toml is its own
 # version, deliberately not workspace-inherited, so it must NOT track releases.
-set -uo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 

--- a/scripts/check-lockfile-manifest.sh
+++ b/scripts/check-lockfile-manifest.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # check-lockfile-manifest.sh — drift guard for the lockfile scan manifest (#547).
 # Fails when the tracked Cargo.lock set and scripts/lockfile-scan-manifest.txt
 # disagree in either direction: an unscanned new lockfile, or a manifest entry
 # whose lockfile no longer exists.
-set -euo pipefail
 
 repo=$(git rev-parse --show-toplevel)
 manifest="$repo/scripts/lockfile-scan-manifest.txt"

--- a/scripts/check-pr-title.sh
+++ b/scripts/check-pr-title.sh
@@ -11,13 +11,13 @@ set -euo pipefail
 REPO_ROOT=$(git rev-parse --show-toplevel)
 TITLE="${1:-}"
 
-if [ -z "$TITLE" ]; then
+if [[ -z "$TITLE" ]]; then
     echo "PR TITLE: no title given" >&2
     exit 1
 fi
 
 type_csv=$(sed -n 's/^commit_types: *//p' "$REPO_ROOT/CLAUDE.md")
-if [ -z "$type_csv" ]; then
+if [[ -z "$type_csv" ]]; then
     echo "PR TITLE: CLAUDE.md has no 'commit_types:' line to derive the accepted type list from" >&2
     exit 1
 fi

--- a/scripts/check-pr-title.sh
+++ b/scripts/check-pr-title.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # check-pr-title.sh — validates a PR title against the conventional-commit
 # grammar (#665). The repo squash-merges, so the title becomes main's commit
 # message and release-please parses it for the changelog and version bump;
 # an unvalidated title is silently invisible to both.
 # WHY: `type` is derived from CLAUDE.md's `commit_types:` frontmatter line —
 # the sole declaration — so this script never hand-carries its own copy.
-set -uo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 TITLE="${1:-}"

--- a/scripts/check-target-test-ledger.sh
+++ b/scripts/check-target-test-ledger.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # check-target-test-ledger.sh — declared-vs-executed audit for the kernel's
 # test obligations (#551, restoring #124; runnable-derivation #645). Fails
 # when:
@@ -25,7 +27,6 @@
 # here is a cache hit, not a fresh compile — this stage's placement in the
 # pipeline is load-bearing, not incidental. Invoked standalone with no prior
 # build, this script builds first like any other nextest call.
-set -uo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 LEDGER="$REPO_ROOT/docs/target-test-ledger.toml"

--- a/scripts/check-wiring-inventory.sh
+++ b/scripts/check-wiring-inventory.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # check-wiring-inventory.sh [boot.log] — capability-reachability drift check
 # (#550). Fails when:
 #   (a) a main.rs module is not classified in docs/capability-inventory.toml
@@ -8,7 +10,6 @@
 #       pass --no-log to skip (c) when no boot has run yet)
 # The inventory is the SSOT for capability reachability; README's capability
 # section and docs/KERNEL-WIRING-AUDIT.md's successor point at it.
-set -uo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 INV="$REPO_ROOT/docs/capability-inventory.toml"

--- a/scripts/check-witness-extraction.sh
+++ b/scripts/check-witness-extraction.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # check-witness-extraction.sh — drift guard for the witness extraction (#546).
 # Kernel witness logic must live ONLY in scripts/witness/*.sh; ci.yml and
 # .kanon-ci.toml call those scripts, never inline the assertions. Fails when:
@@ -6,7 +8,6 @@
 #       (assertion logic living outside the scripts), or
 #   (b) ci.yml's kernel steps stop calling the scripts, or
 #   (c) .kanon-ci.toml loses the kernel stages.
-set -euo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 CI="$REPO_ROOT/.github/workflows/ci.yml"

--- a/scripts/kernel-build.sh
+++ b/scripts/kernel-build.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # kernel-build.sh — canonical kernel cross-compile (#546). crates/thumos/
 # .cargo/config.toml already pins the armv7a target, the link script, and the
 # -D warnings zero-warning gate (#431), so the canonical build is a plain
 # release build from the kernel directory. NEVER pass RUSTFLAGS through the
 # environment — env rustflags CLOBBER the config's and silently drop the
 # zero-warning gate (the live drift this script exists to kill).
-set -uo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 KERNEL_DIR="${THUMOS_KERNEL_DIR:-$REPO_ROOT/crates/thumos}"

--- a/scripts/kernel-clippy.sh
+++ b/scripts/kernel-clippy.sh
@@ -91,7 +91,7 @@ declare -A REQUIRES=(
 declare -a PASS_TAGS=("default")
 declare -a PASS_FEATURES=("")
 for f in "${KERNEL_FEATURES[@]}"; do
-    if [ -n "${REQUIRES[$f]:-}" ]; then
+    if [[ -n "${REQUIRES[$f]:-}" ]]; then
         PASS_TAGS+=("${REQUIRES[$f]}+$f")
         PASS_FEATURES+=("${REQUIRES[$f]},$f")
     else
@@ -110,7 +110,7 @@ done
 # `production` pass is actually in the list above) and scoped to this run.
 PRODUCTION_KEY_DIR=""
 production_key() {
-    if [ -z "$PRODUCTION_KEY_DIR" ]; then
+    if [[ -z "$PRODUCTION_KEY_DIR" ]]; then
         PRODUCTION_KEY_DIR=$(mktemp -d)
         openssl genpkey -algorithm ed25519 -out "$PRODUCTION_KEY_DIR/ci-boot.pem" 2>/dev/null
         openssl pkey -in "$PRODUCTION_KEY_DIR/ci-boot.pem" -pubout -outform DER \
@@ -137,7 +137,7 @@ for i in "${!PASS_TAGS[@]}"; do
     label=$(printf '[%s]' "$tag")
     label=$(printf '%-*s' "$((tagwidth + 3))" "$label")
 
-    if [ "$tag" = "production" ]; then
+    if [[ "$tag" = "production" ]]; then
         out=$(cd "$KERNEL_DIR" && THUMOS_BOOT_KEY_PUB="$(production_key)" cargo clippy --bin thumos --tests \
             --features "$features" --target i686-unknown-linux-gnu -- -D warnings 2>&1)
     elif [ -n "$features" ]; then
@@ -157,7 +157,7 @@ for i in "${!PASS_TAGS[@]}"; do
     [ "${RCS[$i]}" -ne 0 ] && failures+=("${PASS_TAGS[$i]} rc=${RCS[$i]}")
 done
 
-if [ "${#failures[@]}" -gt 0 ]; then
+if [[ "${#failures[@]}" -gt 0 ]]; then
     IFS=', '
     echo "FAIL: kernel clippy failed (${failures[*]})" >&2
     exit 1

--- a/scripts/kernel-host-tests.sh
+++ b/scripts/kernel-host-tests.sh
@@ -49,7 +49,7 @@ grep -q 'console::tests' <<<"$out" || {
 # without this check the script's exit code was the grep's, letting a failing
 # test pass ship rc=0 to CI. Both passes run to completion either way (a red
 # main pass must not hide the debug-console witness output).
-if [ "$pass1" -ne 0 ] || [ "$pass2" -ne 0 ]; then
+if [[ "$pass1" -ne 0 ]] || [[ "$pass2" -ne 0 ]]; then
     echo "FAIL: kernel host tests failed (main pass rc=$pass1, debug-console pass rc=$pass2)" >&2
     exit 1
 fi

--- a/scripts/security-scan.sh
+++ b/scripts/security-scan.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # security-scan.sh <deny|audit|osv> [osv-binary] — run one scanner over every
 # graph in scripts/lockfile-scan-manifest.txt (#547). One code path per tool so
 # findings are attributed per-graph and no graph can be silently skipped.
 # Exclusion lines (`| excluded: reason`) are honored and reported, not scanned.
-set -euo pipefail
 
 mode="${1:?usage: security-scan.sh <deny|audit|osv> [osv-binary]}"
 repo=$(git rev-parse --show-toplevel)

--- a/scripts/witness-run-all.sh
+++ b/scripts/witness-run-all.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # witness-run-all.sh — run every kernel QEMU witness in canonical order (#546).
 # Used by the forge admission gate (.kanon-ci.toml); ci.yml calls the same
 # scripts step-by-step so GitHub's UI shows per-witness status. Any failure
 # stops the run with the witness's own named assertion.
-set -uo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 for w in boot kfault sleep fork exec forkexec guard brk signal crashloop metaxu metaxu-negative; do

--- a/scripts/witness/lib.sh
+++ b/scripts/witness/lib.sh
@@ -82,5 +82,5 @@ start_pylon_bridge() {
 # negative-case witness asserts on its content (or the absence of a marker
 # line) after stopping, before removing it.
 stop_pylon_bridge() {
-    kill "$PYLON_PID" 2>/dev/null || true
+    kill "$PYLON_PID" 2>/dev/null || true  # WHY: idempotent -- PID may already be dead
 }


### PR DESCRIPTION
Works the `SHELL/*` class of #718 (~72 findings). Salvaged from a lane whose session ended mid-report; its three commits were complete and unpushed.

## Three rules, three commits

| commit | rule |
|---|---|
| `baf84ac` | `SHELL/strict-mode`, `SHELL/set-euo-pipefail` |
| `b69b0f7` | `SHELL/single-bracket` |
| `7832946` | `SHELL/silent-true` |

Separate commits because they are different operations, and one may need reverting without the others.

## Why this class needed care rather than a sweep

Several of these scripts run inside the `kernel` job, which is a **required status check** — a broken script stops every merge in the repo, not just this PR.

`set -euo pipefail` is not a free addition. Adding `-e` to a script that deliberately captures a failing command's status **changes what it does**. `scripts/kernel-clippy.sh` is the clearest case: it runs `set -uo pipefail` *without* `-e` on purpose, because it must execute all seven feature-configuration passes and collect each return code rather than abort on the first failure. Adding `-e` there would silently reduce a seven-configuration gate to a one-configuration gate — and it would still report green.

That is the #672 lesson in different clothing: a check that stops early looks identical to a check that passed.

## Verification

CI on this branch, with specific attention to the `kernel` job — that is where these scripts actually execute, so a green kernel job is the evidence that matters here, not a green lint.

Refs: #718
