### PR TITLE
refactor(kernel): convert allows to reasoned expects, and restore 27 suppressions the tautological rule mis-classified

### DIFF
--- a/crates/pteron/src/smp/pdu.rs
+++ b/crates/pteron/src/smp/pdu.rs
@@ -186,7 +186,10 @@ impl IoCapability {
 // each is independently meaningful and independently set/read against a
 // single wire byte; folding them into an enum would obscure that 1:1
 // mapping rather than clarify it.
-#[allow(clippy::struct_excessive_bools)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "mirrors Table 3.5's own bitfield layout; folding independently-meaningful fields into an enum would obscure the 1:1 mapping"
+)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub(crate) struct AuthReq {
@@ -243,7 +246,10 @@ impl AuthReq {
 /// distribute, once for what the responder will).
 // WHY: same rationale as `AuthReq` — this is Table 3.6's own bitfield
 // layout, not application state.
-#[allow(clippy::struct_excessive_bools)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "mirrors Table 3.6's own bitfield layout, same rationale as AuthReq"
+)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub(crate) struct KeyDistribution {

--- a/crates/pteron/src/smp/toolbox.rs
+++ b/crates/pteron/src/smp/toolbox.rs
@@ -53,7 +53,10 @@ fn aes_cmac(key: &[u8; 16], message: &[u8]) -> [u8; 16] {
 // WHY: parameter names deliberately match the spec's own U/V/X/Z notation
 // (Vol 3, Part H §2.2.6) — matching the formula verbatim is more
 // auditable than inventing longer names for four single-letter terms.
-#[allow(clippy::many_single_char_names)]
+#[expect(
+    clippy::many_single_char_names,
+    reason = "parameter names deliberately match Vol 3, Part H §2.2.6's own U/V/X/Z notation; matching the formula verbatim is more auditable than inventing longer names for four single-letter terms"
+)]
 pub(crate) fn f4(u: &[u8; 32], v: &[u8; 32], x: &[u8; 16], z: u8) -> [u8; 16] {
     let mut m = [0u8; 65];
     m[..32].copy_from_slice(u);
@@ -146,7 +149,10 @@ pub(crate) fn f6(
 /// convention closely enough that a future Numeric Comparison IO
 /// capability can reuse it directly.
 // WHY: same rationale as `f4` — U/V/X/Y match the spec's own notation.
-#[allow(clippy::many_single_char_names)]
+#[expect(
+    clippy::many_single_char_names,
+    reason = "same rationale as f4 -- U/V/X/Y match Vol 3, Part H §2.2.9's own notation"
+)]
 pub(crate) fn g2(u: &[u8; 32], v: &[u8; 32], x: &[u8; 16], y: &[u8; 16]) -> u32 {
     let mut m = [0u8; 80];
     m[0..32].copy_from_slice(u);

--- a/crates/pteron/src/smp/toolbox.rs
+++ b/crates/pteron/src/smp/toolbox.rs
@@ -53,7 +53,6 @@ fn aes_cmac(key: &[u8; 16], message: &[u8]) -> [u8; 16] {
 // WHY: parameter names deliberately match the spec's own U/V/X/Z notation
 // (Vol 3, Part H §2.2.6) — matching the formula verbatim is more
 // auditable than inventing longer names for four single-letter terms.
-#[allow(clippy::many_single_char_names)]
 pub(crate) fn f4(u: &[u8; 32], v: &[u8; 32], x: &[u8; 16], z: u8) -> [u8; 16] {
     let mut m = [0u8; 65];
     m[..32].copy_from_slice(u);
@@ -146,7 +145,6 @@ pub(crate) fn f6(
 /// convention closely enough that a future Numeric Comparison IO
 /// capability can reuse it directly.
 // WHY: same rationale as `f4` — U/V/X/Y match the spec's own notation.
-#[allow(clippy::many_single_char_names)]
 pub(crate) fn g2(u: &[u8; 32], v: &[u8; 32], x: &[u8; 16], y: &[u8; 16]) -> u32 {
     let mut m = [0u8; 80];
     m[0..32].copy_from_slice(u);

--- a/crates/pteron/src/smp/toolbox.rs
+++ b/crates/pteron/src/smp/toolbox.rs
@@ -53,6 +53,7 @@ fn aes_cmac(key: &[u8; 16], message: &[u8]) -> [u8; 16] {
 // WHY: parameter names deliberately match the spec's own U/V/X/Z notation
 // (Vol 3, Part H §2.2.6) — matching the formula verbatim is more
 // auditable than inventing longer names for four single-letter terms.
+#[allow(clippy::many_single_char_names)]
 pub(crate) fn f4(u: &[u8; 32], v: &[u8; 32], x: &[u8; 16], z: u8) -> [u8; 16] {
     let mut m = [0u8; 65];
     m[..32].copy_from_slice(u);
@@ -145,6 +146,7 @@ pub(crate) fn f6(
 /// convention closely enough that a future Numeric Comparison IO
 /// capability can reuse it directly.
 // WHY: same rationale as `f4` — U/V/X/Y match the spec's own notation.
+#[allow(clippy::many_single_char_names)]
 pub(crate) fn g2(u: &[u8; 32], v: &[u8; 32], x: &[u8; 16], y: &[u8; 16]) -> u32 {
     let mut m = [0u8; 80];
     m[0..32].copy_from_slice(u);

--- a/crates/thumos/src/audio_codec.rs
+++ b/crates/thumos/src/audio_codec.rs
@@ -263,7 +263,10 @@ pub(crate) trait AudioCodecOps {
 // power-gate flags that can be set in any combination, not a mutually
 // exclusive state machine — a bitflags/enum recast would not simplify
 // the per-flag read/write pattern used against the PMIC registers.
-#[allow(clippy::struct_excessive_bools)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "independent PMIC power-gate flags, not a state machine; a bitflags/enum recast would not simplify the per-flag register read/write pattern"
+)]
 #[cfg(not(any(test, feature = "qemu")))]
 pub(crate) struct Mt6357Codec {
     /// Whether the codec is powered on (LDO active).

--- a/crates/thumos/src/audio_codec.rs
+++ b/crates/thumos/src/audio_codec.rs
@@ -640,6 +640,10 @@ impl AudioCodecOps for Mt6357Codec {
 // WHY: powered/dac_enabled/adc_enabled/mic_bias mirror the independent
 // hardware power-gate flags of the real codec (see Mt6357Codec) — not a
 // state machine, so no bitflags/enum recast applies here either.
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "powered/dac_enabled/adc_enabled/mic_bias mirror the independent hardware power-gate flags of the real codec (see Mt6357Codec) -- not a state machine, so no bitflags/enum recast applies here either"
+)]
 #[cfg(test)]
 pub struct MockCodec {
     /// Whether the codec is powered on.
@@ -873,6 +877,10 @@ impl AudioCodecOps for MockCodec {
 // WHY: powered/dac_enabled/adc_enabled/mic_bias mirror the independent
 // hardware power-gate flags of the real codec (see Mt6357Codec) — not a
 // state machine, so no bitflags/enum recast applies here either.
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "powered/dac_enabled/adc_enabled/mic_bias mirror the independent hardware power-gate flags of the real codec (see Mt6357Codec) -- not a state machine, so no bitflags/enum recast applies here either"
+)]
 #[cfg(any(feature = "qemu", test))]
 pub(crate) struct NullCodec {
     powered: bool,

--- a/crates/thumos/src/audio_codec.rs
+++ b/crates/thumos/src/audio_codec.rs
@@ -640,7 +640,6 @@ impl AudioCodecOps for Mt6357Codec {
 // WHY: powered/dac_enabled/adc_enabled/mic_bias mirror the independent
 // hardware power-gate flags of the real codec (see Mt6357Codec) — not a
 // state machine, so no bitflags/enum recast applies here either.
-#[allow(clippy::struct_excessive_bools)]
 #[cfg(test)]
 pub struct MockCodec {
     /// Whether the codec is powered on.
@@ -874,7 +873,6 @@ impl AudioCodecOps for MockCodec {
 // WHY: powered/dac_enabled/adc_enabled/mic_bias mirror the independent
 // hardware power-gate flags of the real codec (see Mt6357Codec) — not a
 // state machine, so no bitflags/enum recast applies here either.
-#[allow(clippy::struct_excessive_bools)]
 #[cfg(any(feature = "qemu", test))]
 pub(crate) struct NullCodec {
     powered: bool,

--- a/crates/thumos/src/contacts.rs
+++ b/crates/thumos/src/contacts.rs
@@ -202,7 +202,10 @@ impl core::fmt::Display for Contact {
 // halves of what name_str()/number_str()/matrix_id_str() already decode --
 // dumping the raw arrays alongside the decoded strings would duplicate
 // the same content in a less readable form, not add information.
-#[allow(clippy::missing_fields_in_debug)]
+#[expect(
+    clippy::missing_fields_in_debug,
+    reason = "raw name/number/matrix_id arrays are redundant with the already-decoded name_str()/number_str()/matrix_id_str() fields shown; dumping both would duplicate content, not add it"
+)]
 impl core::fmt::Debug for Contact {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut s = f.debug_struct("Contact");

--- a/crates/thumos/src/csprng.rs
+++ b/crates/thumos/src/csprng.rs
@@ -495,7 +495,10 @@ mod tests {
     // to pin that literal within a sane range as a discoverable, individually
     // reportable host test (not a const-eval assert) so a future edit to the
     // constant fails a named test rather than a silent build-time check.
-    #[allow(clippy::assertions_on_constants)]
+    #[expect(
+        clippy::assertions_on_constants,
+        reason = "pins a compile-time constant to a sane range as a named, individually-reportable host test rather than a silent const-eval assert"
+    )]
     fn csprng_init_timeout_is_sane() {
         assert!(
             CSPRNG_INIT_TIMEOUT_MS >= 5_000,

--- a/crates/thumos/src/dhcp.rs
+++ b/crates/thumos/src/dhcp.rs
@@ -157,7 +157,10 @@ impl DhcpClient {
     // only a transitive dependency (via smoltcp), not a direct one this
     // crate can name. Adding it as a direct dependency just to spell a
     // method path is out of scope for a lint fix.
-    #[allow(clippy::redundant_closure_for_method_calls)]
+    #[expect(
+        clippy::redundant_closure_for_method_calls,
+        reason = "clippy's suggested Vec::clear names heapless::vec::Vec, a transitive smoltcp dependency this crate cannot name directly"
+    )]
     pub(crate) fn poll<D: Device>(&mut self, stack: &mut NetworkStack<D>) -> DhcpEvent {
         // WHY: Extract all data from the DHCP config *before* calling any
         // methods on `stack`, to avoid overlapping mutable borrows. The

--- a/crates/thumos/src/display.rs
+++ b/crates/thumos/src/display.rs
@@ -937,7 +937,6 @@ impl<L: LcmDriver> DisplayDriver<L> {
     // DisplayDriver instance-style via `display.state()`). Dropping
     // &mut self would turn a pipeline-instance method into a free
     // function and misrepresent the state precondition as global.
-    #[allow(clippy::unused_self)]
     pub unsafe fn write_framebuffer(&mut self, addr: usize, stride: u32) {
         debug_assert!(
             is_fb_addr_aligned(addr),

--- a/crates/thumos/src/display.rs
+++ b/crates/thumos/src/display.rs
@@ -937,6 +937,25 @@ impl<L: LcmDriver> DisplayDriver<L> {
     // DisplayDriver instance-style via `display.state()`). Dropping
     // &mut self would turn a pipeline-instance method into a free
     // function and misrepresent the state precondition as global.
+    // NOTE: cfg_attr split, not a bare expect (#718 trap) -- clippy's
+    // unused_self does not fire on this exact body under the qemu feature
+    // (verified: CI run 31499203998), so an unconditional #[expect] is
+    // unfulfilled there while fulfilled under every non-qemu kernel
+    // configuration.
+    #[cfg_attr(
+        not(feature = "qemu"),
+        expect(
+            clippy::unused_self,
+            reason = "the body only touches global MMIO today, but this is a documented instance method on the pipeline handle (its safety contract is stated in terms of self's Active state) meant to be called as display.write_framebuffer(..) alongside this same struct's other &mut self steps; dropping &mut self would turn a pipeline-instance method into a free function and misrepresent the state precondition as global"
+        )
+    )]
+    #[cfg_attr(
+        feature = "qemu",
+        allow(
+            clippy::unused_self,
+            reason = "same instance-method-parity rationale as the non-qemu expect above; clippy's unused_self does not fire on this body under qemu"
+        )
+    )]
     pub unsafe fn write_framebuffer(&mut self, addr: usize, stride: u32) {
         debug_assert!(
             is_fb_addr_aligned(addr),

--- a/crates/thumos/src/dns.rs
+++ b/crates/thumos/src/dns.rs
@@ -557,6 +557,10 @@ impl DnsResolver {
     // test exercises it that way (`resolver.build_query(..)` in a loop over
     // one `DnsResolver::new(..)` instance). Dropping &mut self would force
     // restructuring that test's instance shape for no functional benefit.
+    #[expect(
+        clippy::unused_self,
+        reason = "the body only calls free functions today, but this sits in DnsResolver's instance-method API alongside resolve/process_response/tick (all &mut self); its own test exercises it instance-style (resolver.build_query(..)) -- dropping &mut self would force restructuring that test's instance shape for no functional benefit"
+    )]
     pub(crate) fn build_query(&mut self, hostname: &str) -> Result<(Vec<u8>, u16), DnsError> {
         let txid = random_txid();
         let packet = build_dns_query(hostname, txid)?;

--- a/crates/thumos/src/dns.rs
+++ b/crates/thumos/src/dns.rs
@@ -557,7 +557,6 @@ impl DnsResolver {
     // test exercises it that way (`resolver.build_query(..)` in a loop over
     // one `DnsResolver::new(..)` instance). Dropping &mut self would force
     // restructuring that test's instance shape for no functional benefit.
-    #[allow(clippy::unused_self)]
     pub(crate) fn build_query(&mut self, hostname: &str) -> Result<(Vec<u8>, u16), DnsError> {
         let txid = random_txid();
         let packet = build_dns_query(hostname, txid)?;

--- a/crates/thumos/src/elf.rs
+++ b/crates/thumos/src/elf.rs
@@ -58,6 +58,10 @@ pub(crate) fn flags_to_prot(p_flags: u32) -> u32 {
 // WHY: field names mirror the ELF32 spec's own `e_*` names verbatim, so a
 // reader cross-referencing the spec matches fields by name; stripping the
 // shared prefix would decouple this struct from the spec it exists to mirror.
+#[expect(
+    clippy::struct_field_names,
+    reason = "field names mirror the ELF32 spec's own e_* names verbatim, so a reader cross-referencing the spec matches fields by name; stripping the shared prefix would decouple this struct from the spec it exists to mirror"
+)]
 struct Elf32Ehdr {
     // kanon:ignore RUST/struct-too-many-fields -- ELF32 spec layout; see doc comment
     e_ident: [u8; 16],
@@ -81,6 +85,10 @@ struct Elf32Ehdr {
 #[derive(Clone, Copy)]
 // WHY: field names mirror the ELF32 spec's own `p_*` names verbatim; see
 // Elf32Ehdr's identical rationale above.
+#[expect(
+    clippy::struct_field_names,
+    reason = "field names mirror the ELF32 spec's own p_* names verbatim; see Elf32Ehdr's identical rationale above"
+)]
 struct Elf32Phdr {
     p_type: u32,
     p_offset: u32,

--- a/crates/thumos/src/elf.rs
+++ b/crates/thumos/src/elf.rs
@@ -58,7 +58,6 @@ pub(crate) fn flags_to_prot(p_flags: u32) -> u32 {
 // WHY: field names mirror the ELF32 spec's own `e_*` names verbatim, so a
 // reader cross-referencing the spec matches fields by name; stripping the
 // shared prefix would decouple this struct from the spec it exists to mirror.
-#[allow(clippy::struct_field_names)]
 struct Elf32Ehdr {
     // kanon:ignore RUST/struct-too-many-fields -- ELF32 spec layout; see doc comment
     e_ident: [u8; 16],
@@ -82,7 +81,6 @@ struct Elf32Ehdr {
 #[derive(Clone, Copy)]
 // WHY: field names mirror the ELF32 spec's own `p_*` names verbatim; see
 // Elf32Ehdr's identical rationale above.
-#[allow(clippy::struct_field_names)]
 struct Elf32Phdr {
     p_type: u32,
     p_offset: u32,

--- a/crates/thumos/src/kardia.rs
+++ b/crates/thumos/src/kardia.rs
@@ -728,6 +728,10 @@ impl KernelState {
     // routes UI + audio via self's persisted telephony. Called instance-style
     // (`kernel.handle_reflex(..)`) from the production run loop; dropping
     // &mut self now would just be re-added when those TODOs land.
+    #[expect(
+        clippy::unused_self,
+        reason = "all three arms are TODO stubs today, but two are explicitly documented to need self once implemented -- the duress arm (#404) transitions via self.mode + wipe policy, the incoming-ring arm (#398) routes UI + audio via self's persisted telephony; called instance-style (kernel.handle_reflex(..)) from the production run loop"
+    )]
     pub(crate) fn handle_reflex(&mut self, pending: reflex::Pending, serial: &mut Uart) {
         if pending.panic_wipe {
             let _ = serial.write_str("[kardia] REFLEX panic-wipe\r\n"); // WHY: best-effort loop diagnostic; must not block on a failed UART write

--- a/crates/thumos/src/kardia.rs
+++ b/crates/thumos/src/kardia.rs
@@ -728,7 +728,6 @@ impl KernelState {
     // routes UI + audio via self's persisted telephony. Called instance-style
     // (`kernel.handle_reflex(..)`) from the production run loop; dropping
     // &mut self now would just be re-added when those TODOs land.
-    #[allow(clippy::unused_self)]
     pub(crate) fn handle_reflex(&mut self, pending: reflex::Pending, serial: &mut Uart) {
         if pending.panic_wipe {
             let _ = serial.write_str("[kardia] REFLEX panic-wipe\r\n"); // WHY: best-effort loop diagnostic; must not block on a failed UART write

--- a/crates/thumos/src/keypad.rs
+++ b/crates/thumos/src/keypad.rs
@@ -183,7 +183,6 @@ impl BootKeypad {
     // self, but kinit.rs (out of this change's scope) calls this as
     // `keypad.init()` alongside the rest of BootKeypad's per-instance API --
     // dropping &self would require a matching kinit.rs call-site edit.
-    #[allow(clippy::unused_self)]
     pub(crate) fn init(&self) {
         for &pin in &board::KEYPAD_ROW_PINS {
             let (dir_addr, dir_mask) = gpio_reg(board::GPIO_DIR_BASE, pin);

--- a/crates/thumos/src/keypad.rs
+++ b/crates/thumos/src/keypad.rs
@@ -183,6 +183,25 @@ impl BootKeypad {
     // self, but kinit.rs (out of this change's scope) calls this as
     // `keypad.init()` alongside the rest of BootKeypad's per-instance API --
     // dropping &self would require a matching kinit.rs call-site edit.
+    // NOTE: cfg_attr split, not a bare expect (#718 trap) -- clippy's
+    // unused_self does not fire on this body under the qemu feature
+    // (verified: CI run 31499203998), so an unconditional #[expect] is
+    // unfulfilled there while fulfilled under every non-qemu, non-test
+    // kernel configuration.
+    #[cfg_attr(
+        not(feature = "qemu"),
+        expect(
+            clippy::unused_self,
+            reason = "the body only touches board:: constants and MMIO registers, not self, but kinit.rs calls this as keypad.init() alongside the rest of BootKeypad's per-instance API -- dropping &self would require a matching kinit.rs call-site edit"
+        )
+    )]
+    #[cfg_attr(
+        feature = "qemu",
+        allow(
+            clippy::unused_self,
+            reason = "same instance-method-parity rationale as the non-qemu expect above; clippy's unused_self does not fire on this body under qemu"
+        )
+    )]
     pub(crate) fn init(&self) {
         for &pin in &board::KEYPAD_ROW_PINS {
             let (dir_addr, dir_mask) = gpio_reg(board::GPIO_DIR_BASE, pin);

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -498,7 +498,6 @@ fn debug_console_gate(serial: &mut Uart, mode_mgr: &crate::security_mode::ModeMa
 // of new `unsafe fn` boundaries -- each needing its own safety contract --
 // purely to satisfy a line count, while making the top-to-bottom boot order
 // this function exists to keep auditable harder to read in one pass.
-#[allow(clippy::too_many_lines)]
 pub unsafe fn run() -> ! {
     let mut serial = Uart::new();
     let mut state = BootState::new();
@@ -1270,7 +1269,6 @@ pub unsafe fn run() -> ! {
     // would separate this declaration from its use two lines below by
     // hundreds of lines, for the same audit-ability reason `run()` itself
     // carries a `too_many_lines` allow above.
-    #[allow(clippy::items_after_statements)]
     static INITRAMFS: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/initramfs.cpio"));
     let boot_cpio = if lfs_root.is_none() {
         Some(INITRAMFS)
@@ -1668,7 +1666,6 @@ pub unsafe fn run() -> ! {
     // WHY the allow: see `INITRAMFS`'s identical note above -- hoisting out of
     // `run()`'s boot narrative to satisfy a line-position lint would separate
     // this from its use three lines below by well over a thousand lines.
-    #[allow(clippy::items_after_statements)]
     static INITRAMFS_SIG: &[u8; 64] =
         include_bytes!(concat!(env!("OUT_DIR"), "/initramfs_sig.bin"));
     let userspace_image_verified =

--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -498,6 +498,10 @@ fn debug_console_gate(serial: &mut Uart, mode_mgr: &crate::security_mode::ModeMa
 // of new `unsafe fn` boundaries -- each needing its own safety contract --
 // purely to satisfy a line count, while making the top-to-bottom boot order
 // this function exists to keep auditable harder to read in one pass.
+#[expect(
+    clippy::too_many_lines,
+    reason = "the boot sequencer -- one linear, numbered Step-N narrative over ~20 subsystems, called from exactly one site, executed exactly once, never reused or independently tested in isolation; splitting into helpers would thread serial/state/intermediate hand-offs through a growing set of new unsafe fn boundaries purely to satisfy a line count, making the top-to-bottom boot order this function exists to keep auditable harder to read in one pass"
+)]
 pub unsafe fn run() -> ! {
     let mut serial = Uart::new();
     let mut state = BootState::new();
@@ -1269,6 +1273,10 @@ pub unsafe fn run() -> ! {
     // would separate this declaration from its use two lines below by
     // hundreds of lines, for the same audit-ability reason `run()` itself
     // carries a `too_many_lines` allow above.
+    #[expect(
+        clippy::items_after_statements,
+        reason = "hoisting to the top of run()'s ~900-line boot sequence would separate this declaration from its use two lines below by hundreds of lines, for the same audit-ability reason run() itself carries a too_many_lines expect above"
+    )]
     static INITRAMFS: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/initramfs.cpio"));
     let boot_cpio = if lfs_root.is_none() {
         Some(INITRAMFS)
@@ -1666,6 +1674,10 @@ pub unsafe fn run() -> ! {
     // WHY the allow: see `INITRAMFS`'s identical note above -- hoisting out of
     // `run()`'s boot narrative to satisfy a line-position lint would separate
     // this from its use three lines below by well over a thousand lines.
+    #[expect(
+        clippy::items_after_statements,
+        reason = "see INITRAMFS's identical note above -- hoisting out of run()'s boot narrative to satisfy a line-position lint would separate this from its use three lines below by well over a thousand lines"
+    )]
     static INITRAMFS_SIG: &[u8; 64] =
         include_bytes!(concat!(env!("OUT_DIR"), "/initramfs_sig.bin"));
     let userspace_image_verified =

--- a/crates/thumos/src/kinit_plan.rs
+++ b/crates/thumos/src/kinit_plan.rs
@@ -252,6 +252,10 @@ pub(crate) const fn passphrase_skip_reason(
 // boot-success flags read individually by the panic handler and degradation
 // logic, not a state machine -- an enum or bitflags wouldn't remove any of
 // the axes, just rename how each is read.
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "mmu_ok/heap_ok/gic_ok/... are independent, unrelated per-subsystem boot-success flags read individually by the panic handler and degradation logic, not a state machine -- an enum or bitflags wouldn't remove any of the axes, just rename how each is read"
+)]
 pub(crate) struct BootState {
     // kanon:ignore RUST/struct-too-many-fields -- one bool per boot subsystem; grouping would obscure the per-subsystem degradation model
     pub(crate) mmu_ok: bool,

--- a/crates/thumos/src/kinit_plan.rs
+++ b/crates/thumos/src/kinit_plan.rs
@@ -252,7 +252,6 @@ pub(crate) const fn passphrase_skip_reason(
 // boot-success flags read individually by the panic handler and degradation
 // logic, not a state machine -- an enum or bitflags wouldn't remove any of
 // the axes, just rename how each is read.
-#[allow(clippy::struct_excessive_bools)]
 pub(crate) struct BootState {
     // kanon:ignore RUST/struct-too-many-fields -- one bool per boot subsystem; grouping would obscure the per-subsystem degradation model
     pub(crate) mmu_ok: bool,

--- a/crates/thumos/src/lfs_checkpoint.rs
+++ b/crates/thumos/src/lfs_checkpoint.rs
@@ -271,6 +271,10 @@ fn validate_header_geometry(header: &CheckpointHeader, device_blocks: u64) -> Re
 // WHY: slot_a_block/slot_b_block mirror this module's own "slot A / slot B"
 // dual-checkpoint terminology (see the module doc comment) — renaming either
 // would obscure which physical slot each argument identifies.
+#[expect(
+    clippy::similar_names,
+    reason = "slot_a_block/slot_b_block mirror this module's own slot-A/slot-B dual-checkpoint terminology (see the module doc comment) -- renaming either would obscure which physical slot each argument identifies"
+)]
 pub(crate) fn pick_latest(
     dev: &mut dyn BlockDevice,
     cache: &mut BlockCache,

--- a/crates/thumos/src/lfs_checkpoint.rs
+++ b/crates/thumos/src/lfs_checkpoint.rs
@@ -271,7 +271,6 @@ fn validate_header_geometry(header: &CheckpointHeader, device_blocks: u64) -> Re
 // WHY: slot_a_block/slot_b_block mirror this module's own "slot A / slot B"
 // dual-checkpoint terminology (see the module doc comment) — renaming either
 // would obscure which physical slot each argument identifies.
-#[allow(clippy::similar_names)]
 pub(crate) fn pick_latest(
     dev: &mut dyn BlockDevice,
     cache: &mut BlockCache,

--- a/crates/thumos/src/net.rs
+++ b/crates/thumos/src/net.rs
@@ -292,7 +292,10 @@ impl<H: WifiHwOps> WifiDevice<H> {
     // (`wifi_device.kind()`) alongside `.data_path_ready()` in
     // NetworkReadiness::from_device -- dropping &self would need a matching
     // kinit.rs call-site edit this PR cannot make.
-    #[allow(clippy::unused_self)]
+    #[expect(
+        clippy::unused_self,
+        reason = "kind() is called instance-style (wifi_device.kind()) alongside data_path_ready() in NetworkReadiness::from_device; dropping &self would need a matching call-site edit out of this change's scope"
+    )]
     pub(crate) const fn kind(&self) -> NetworkDeviceKind {
         NetworkDeviceKind::Wifi
     }

--- a/crates/thumos/src/nous.rs
+++ b/crates/thumos/src/nous.rs
@@ -267,7 +267,10 @@ impl CapabilityPreset {
     // state lives on the entity, not derivable from the enum variant
     // alone -- see the arm's own comment below). Merging the arms with `|`
     // would erase that distinction for a future reader.
-    #[allow(clippy::match_same_arms)]
+    #[expect(
+        clippy::match_same_arms,
+        reason = "Off and Custom both evaluate to CapabilitySet::NONE for different reasons -- Off is the real documented empty grant, Custom is an unrepresentable placeholder; merging the arms would erase that distinction"
+    )]
     pub(crate) const fn grants(self) -> CapabilitySet {
         const RS: u32 = 1 << NousCapability::ReadState as u32;
         const RCM: u32 = 1 << NousCapability::ReadContactsMetadata as u32;
@@ -432,7 +435,10 @@ pub(crate) struct ActionRequirement {
 // adjacent allowlist edit). Each pair is conceptually distinct and may
 // diverge independently on a future design-table update -- merging the
 // arms with `|` would erase that independence.
-#[allow(clippy::match_same_arms)]
+#[expect(
+    clippy::match_same_arms,
+    reason = "each shared-binding pair shares a requirement for unrelated reasons and may diverge independently on a future design-table update; merging with | would erase that independence"
+)]
 pub(crate) fn action_requirement(action: &str) -> Option<ActionRequirement> {
     use crate::ekphrasis::action_types as at;
     let req = |capability, confirmation| {

--- a/crates/thumos/src/pipe.rs
+++ b/crates/thumos/src/pipe.rs
@@ -240,6 +240,10 @@ pub(crate) fn is_write_end(flags: u32) -> bool {
 // standard POSIX fd/ofd terminology naming two genuinely distinct values --
 // renaming either pair to defeat the Levenshtein check would decouple the
 // names from the concepts they name.
+#[expect(
+    clippy::similar_names,
+    reason = "read_ofd/write_ofd (open-file-description table indices) and read_fd/write_fd (the per-process fd numbers derived from them) are standard POSIX fd/ofd terminology naming two genuinely distinct values -- renaming either pair to defeat the Levenshtein check would decouple the names from the concepts they name"
+)]
 pub(crate) fn sys_pipe(fds_ptr: u32) -> u32 {
     if fds_ptr == 0 {
         return EFAULT;

--- a/crates/thumos/src/pipe.rs
+++ b/crates/thumos/src/pipe.rs
@@ -240,7 +240,6 @@ pub(crate) fn is_write_end(flags: u32) -> bool {
 // standard POSIX fd/ofd terminology naming two genuinely distinct values --
 // renaming either pair to defeat the Levenshtein check would decouple the
 // names from the concepts they name.
-#[allow(clippy::similar_names)]
 pub(crate) fn sys_pipe(fds_ptr: u32) -> u32 {
     if fds_ptr == 0 {
         return EFAULT;

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -490,6 +490,10 @@ unsafe fn map_signal_trampoline(pt: usize) -> Option<usize> {
 // unwrapping this stub to a bare `usize` would break the common call site
 // rather than the mapping being pointless here.
 #[cfg(not(target_arch = "arm"))]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "this host stub's signature must match the ARM implementation above (Option<usize>, genuinely fallible there) -- callers are shared across both cfgs and are not split per-arch, so unwrapping this stub to a bare usize would break the common call site rather than the mapping being pointless here"
+)]
 unsafe fn map_signal_trampoline(_pt: usize) -> Option<usize> {
     Some(0)
 }
@@ -799,6 +803,10 @@ unsafe fn fork_pl0(
 // which value each name holds. A statement-local allow does not suppress
 // this lint (clippy checks binding similarity over the whole function body),
 // so the allow lives here.
+#[expect(
+    clippy::similar_names,
+    reason = "parent_pid and parent_uid name genuinely distinct fields (which process, which user) -- dropping either the parent_ prefix or the field suffix to defeat the Levenshtein check would lose which value each name holds; a statement-local allow does not suppress this lint since clippy checks binding similarity over the whole function body, so the expect lives here"
+)]
 pub(crate) fn fork() -> Option<Pid> {
     // SAFETY: current process PCB pointer is valid; set by the scheduler on
     // context switch. addr_of_mut! avoids intermediate references to static mut.

--- a/crates/thumos/src/process.rs
+++ b/crates/thumos/src/process.rs
@@ -490,7 +490,6 @@ unsafe fn map_signal_trampoline(pt: usize) -> Option<usize> {
 // unwrapping this stub to a bare `usize` would break the common call site
 // rather than the mapping being pointless here.
 #[cfg(not(target_arch = "arm"))]
-#[allow(clippy::unnecessary_wraps)]
 unsafe fn map_signal_trampoline(_pt: usize) -> Option<usize> {
     Some(0)
 }
@@ -800,7 +799,6 @@ unsafe fn fork_pl0(
 // which value each name holds. A statement-local allow does not suppress
 // this lint (clippy checks binding similarity over the whole function body),
 // so the allow lives here.
-#[allow(clippy::similar_names)]
 pub(crate) fn fork() -> Option<Pid> {
     // SAFETY: current process PCB pointer is valid; set by the scheduler on
     // context switch. addr_of_mut! avoids intermediate references to static mut.

--- a/crates/thumos/src/screen_radio.rs
+++ b/crates/thumos/src/screen_radio.rs
@@ -63,6 +63,10 @@ const PRESET_COUNT: usize = 3;
 // WHY: cellular/wifi/bluetooth/gps are four independent radio power flags,
 // not a state machine -- an enum or bitflags wouldn't remove any of the
 // four axes, just rename how each is read.
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "cellular/wifi/bluetooth/gps are four independent radio power flags, not a state machine -- an enum or bitflags wouldn't remove any of the four axes, just rename how each is read"
+)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RadioState {
     /// Cellular modem (voice + data).

--- a/crates/thumos/src/screen_radio.rs
+++ b/crates/thumos/src/screen_radio.rs
@@ -63,7 +63,6 @@ const PRESET_COUNT: usize = 3;
 // WHY: cellular/wifi/bluetooth/gps are four independent radio power flags,
 // not a state machine -- an enum or bitflags wouldn't remove any of the
 // four axes, just rename how each is read.
-#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RadioState {
     /// Cellular modem (voice + data).

--- a/crates/thumos/src/screen_threat.rs
+++ b/crates/thumos/src/screen_threat.rs
@@ -103,7 +103,6 @@ impl ThreatLevelScreenExt for ThreatLevel {
     // but for different reasons -- High is orange on its own merits, the
     // wildcard is a defensive "unknown future band renders as attention,
     // never fine". Merging them into one arm would blur that distinction.
-    #[allow(clippy::match_same_arms)]
     fn color(self) -> u16 {
         match self {
             Self::Low => color::GREEN,

--- a/crates/thumos/src/screen_threat.rs
+++ b/crates/thumos/src/screen_threat.rs
@@ -601,7 +601,10 @@ impl Screen for ThreatMonitor {
     // but the explicit Lsk arm documents that LSK is intentionally a no-op
     // (detail view pending, not a forgotten key) rather than silently
     // falling through the same as any unhandled key.
-    #[allow(clippy::match_same_arms)]
+    #[expect(
+        clippy::match_same_arms,
+        reason = "Key::Lsk's arm documents LSK as an intentional no-op (detail view pending) rather than silently falling through the wildcard like any unhandled key"
+    )]
     fn on_key(&mut self, key: Key) -> ScreenAction {
         match key {
             Key::Up => {

--- a/crates/thumos/src/screen_threat.rs
+++ b/crates/thumos/src/screen_threat.rs
@@ -103,6 +103,10 @@ impl ThreatLevelScreenExt for ThreatLevel {
     // but for different reasons -- High is orange on its own merits, the
     // wildcard is a defensive "unknown future band renders as attention,
     // never fine". Merging them into one arm would blur that distinction.
+    #[expect(
+        clippy::match_same_arms,
+        reason = "High and the non_exhaustive wildcard both resolve to COLOR_ORANGE, but for different reasons -- High is orange on its own merits, the wildcard is a defensive unknown-future-band-renders-as-attention-never-fine; merging them into one arm would blur that distinction"
+    )]
     fn color(self) -> u16 {
         match self {
             Self::Low => color::GREEN,

--- a/crates/thumos/src/security.rs
+++ b/crates/thumos/src/security.rs
@@ -326,7 +326,13 @@ fn sha1_compress(state: &mut [u32; 5], block: &[u8; SHA1_BLOCK_SIZE]) {
     // same buffer (i-3, i-8, i-14, i-16) while writing w[i] -- an iterator
     // rewrite would need split-borrow/windows tricks that add real
     // complexity to a hash compression function for no behavior change.
-    #[expect(
+    // NOTE: stays #[allow], not #[expect] -- clippy's needless_range_loop
+    // heuristic never flags this loop shape (a write at w[i] alongside
+    // multiple distinct read offsets w[i-3]/w[i-8]/w[i-14]/w[i-16]) in any
+    // of kernel-clippy.sh's declared feature configurations, so an
+    // #[expect] here is an unconditionally unfulfilled lint expectation
+    // (verified: CI run 31499203998, all 9 configs).
+    #[allow(
         clippy::needless_range_loop,
         reason = "FIPS 180-4's recurrence reads four different past offsets (i-3, i-8, i-14, i-16) of the same buffer while writing w[i]; an iterator rewrite needs split-borrow/windows tricks for no behavior change"
     )]
@@ -340,6 +346,10 @@ fn sha1_compress(state: &mut [u32; 5], block: &[u8; SHA1_BLOCK_SIZE]) {
     // selection via `match i` -- an iterator rewrite still needs i for the
     // match, so the container index would just move into an unused
     // .enumerate() binding for zero simplification.
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "i drives both the w[i] round input AND the (f, k) round-constant selection via match i -- an iterator rewrite still needs i for the match, so the container index would just move into an unused .enumerate() binding for zero simplification"
+    )]
     for i in 0..80 {
         let (f, k) = match i {
             0..=19 => ((wb & wc) | ((!wb) & wd), SHA1_K[0]),

--- a/crates/thumos/src/security.rs
+++ b/crates/thumos/src/security.rs
@@ -340,7 +340,6 @@ fn sha1_compress(state: &mut [u32; 5], block: &[u8; SHA1_BLOCK_SIZE]) {
     // selection via `match i` -- an iterator rewrite still needs i for the
     // match, so the container index would just move into an unused
     // .enumerate() binding for zero simplification.
-    #[allow(clippy::needless_range_loop)]
     for i in 0..80 {
         let (f, k) = match i {
             0..=19 => ((wb & wc) | ((!wb) & wd), SHA1_K[0]),

--- a/crates/thumos/src/security.rs
+++ b/crates/thumos/src/security.rs
@@ -326,7 +326,10 @@ fn sha1_compress(state: &mut [u32; 5], block: &[u8; SHA1_BLOCK_SIZE]) {
     // same buffer (i-3, i-8, i-14, i-16) while writing w[i] -- an iterator
     // rewrite would need split-borrow/windows tricks that add real
     // complexity to a hash compression function for no behavior change.
-    #[allow(clippy::needless_range_loop)]
+    #[expect(
+        clippy::needless_range_loop,
+        reason = "FIPS 180-4's recurrence reads four different past offsets (i-3, i-8, i-14, i-16) of the same buffer while writing w[i]; an iterator rewrite needs split-borrow/windows tricks for no behavior change"
+    )]
     for i in 16..80 {
         w[i] = (w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]).rotate_left(1);
     }

--- a/crates/thumos/src/slab.rs
+++ b/crates/thumos/src/slab.rs
@@ -140,6 +140,10 @@ impl SlabClass {
             // multiple-of-4 proof in the INVARIANT above, which is exactly
             // what discharges the alignment obligation the lint exists to
             // demand.
+            #[expect(
+                clippy::cast_ptr_alignment,
+                reason = "cast_ptr_alignment fires on .cast() the same as on as -- it cannot see the page-alignment + size-class multiple-of-4 proof in the INVARIANT above, which is exactly what discharges the alignment obligation the lint exists to demand"
+            )]
             let node_ptr = unsafe { page_ptr.add(i * self.obj_size).cast::<FreeNode>() };
             unsafe {
                 (*node_ptr).next = self.free_list;
@@ -206,6 +210,10 @@ impl SlabClass {
         // WHY the allow: see `refill`'s identical `cast_ptr_alignment` note
         // -- the lint fires on `.cast()` too and cannot see the INVARIANT
         // above that discharges it.
+        #[expect(
+            clippy::cast_ptr_alignment,
+            reason = "see refill's identical cast_ptr_alignment note -- the lint fires on .cast() too and cannot see the INVARIANT above that discharges it"
+        )]
         let node = ptr.cast::<FreeNode>();
         unsafe {
             (*node).next = self.free_list;

--- a/crates/thumos/src/slab.rs
+++ b/crates/thumos/src/slab.rs
@@ -140,7 +140,6 @@ impl SlabClass {
             // multiple-of-4 proof in the INVARIANT above, which is exactly
             // what discharges the alignment obligation the lint exists to
             // demand.
-            #[allow(clippy::cast_ptr_alignment)]
             let node_ptr = unsafe { page_ptr.add(i * self.obj_size).cast::<FreeNode>() };
             unsafe {
                 (*node_ptr).next = self.free_list;
@@ -207,7 +206,6 @@ impl SlabClass {
         // WHY the allow: see `refill`'s identical `cast_ptr_alignment` note
         // -- the lint fires on `.cast()` too and cannot see the INVARIANT
         // above that discharges it.
-        #[allow(clippy::cast_ptr_alignment)]
         let node = ptr.cast::<FreeNode>();
         unsafe {
             (*node).next = self.free_list;

--- a/crates/thumos/src/socket.rs
+++ b/crates/thumos/src/socket.rs
@@ -103,7 +103,6 @@ pub(crate) const FD_KIND_SOCKET: u32 = 0x0002;
 /// `core::net::Ipv4Addr`, which clippy's `ip_constant` lint otherwise
 /// steers callers toward. This is the one place the raw octets are
 /// spelled out; every other use in this file names this constant instead.
-#[allow(clippy::ip_constant)]
 pub(crate) const LOOPBACK_ADDR: Ipv4Address = Ipv4Address::new(127, 0, 0, 1);
 
 // ---------------------------------------------------------------------------
@@ -147,7 +146,6 @@ pub struct SocketInfo {
 // `sin_zero`) -- this struct exists to mirror that ABI layout field-for-
 // field; dropping the prefix would decouple the names from the spec they
 // document.
-#[allow(clippy::struct_field_names)]
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub struct SockaddrIn {

--- a/crates/thumos/src/socket.rs
+++ b/crates/thumos/src/socket.rs
@@ -103,6 +103,10 @@ pub(crate) const FD_KIND_SOCKET: u32 = 0x0002;
 /// `core::net::Ipv4Addr`, which clippy's `ip_constant` lint otherwise
 /// steers callers toward. This is the one place the raw octets are
 /// spelled out; every other use in this file names this constant instead.
+#[expect(
+    clippy::ip_constant,
+    reason = "smoltcp's Ipv4Address carries UNSPECIFIED/BROADCAST but no LOCALHOST -- unlike core::net::Ipv4Addr, which clippy's ip_constant lint otherwise steers callers toward; clippy's suggested Ipv4Address::LOCALHOST fixup does not exist on this type and would not compile. This is the one place the raw octets are spelled out; every other use in this file names this constant instead"
+)]
 pub(crate) const LOOPBACK_ADDR: Ipv4Address = Ipv4Address::new(127, 0, 0, 1);
 
 // ---------------------------------------------------------------------------
@@ -146,6 +150,10 @@ pub struct SocketInfo {
 // `sin_zero`) -- this struct exists to mirror that ABI layout field-for-
 // field; dropping the prefix would decouple the names from the spec they
 // document.
+#[expect(
+    clippy::struct_field_names,
+    reason = "the sin_* prefix on every field is the actual POSIX struct sockaddr_in field naming (sin_family, sin_port, sin_addr, sin_zero) -- this struct exists to mirror that ABI layout field-for-field; dropping the prefix would decouple the names from the spec they document"
+)]
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub struct SockaddrIn {

--- a/crates/thumos/src/status_bar.rs
+++ b/crates/thumos/src/status_bar.rs
@@ -64,7 +64,10 @@ impl NetworkService {
 // unrelated per-radio/per-condition display flags snapshotted each render
 // cycle, not a state machine -- collapsing them into an enum or bitflags
 // would not remove any of the four axes, just rename how each is read.
-#[allow(clippy::struct_excessive_bools)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "independent per-radio/per-condition display flags snapshotted each render cycle, not a state machine; collapsing to an enum or bitflags would not remove any axis"
+)]
 pub(crate) struct StatusBarState {
     /// Cellular network service level.
     pub network: NetworkService,

--- a/crates/thumos/src/uart_stub.rs
+++ b/crates/thumos/src/uart_stub.rs
@@ -26,9 +26,17 @@ impl Uart {
     // binding described above -- callers like console.rs/syscall.rs (out of
     // scope here) call `.putc(..)`/`.getc()` on whichever binding is active.
     // Dropping &self would break that parity.
+    #[expect(
+        clippy::unused_self,
+        reason = "this stub's whole purpose is API parity with uart.rs's real putc(&self, ..)/getc(&self) (both genuine MMIO-register accesses tied to the instance), via the parallel cfg(test)-gated path binding described above -- callers like console.rs/syscall.rs call .putc(..)/.getc() on whichever binding is active; dropping &self would break that parity"
+    )]
     pub(crate) fn putc(&self, _byte: u8) {}
 
     /// Host-test RX stub: no real UART, so no bytes are ever available.
+    #[expect(
+        clippy::unused_self,
+        reason = "same API-parity rationale as putc above -- dropping &self would break parity with uart.rs's real getc(&self)"
+    )]
     pub(crate) fn getc(&self) -> Option<u8> {
         None
     }

--- a/crates/thumos/src/uart_stub.rs
+++ b/crates/thumos/src/uart_stub.rs
@@ -26,11 +26,9 @@ impl Uart {
     // binding described above -- callers like console.rs/syscall.rs (out of
     // scope here) call `.putc(..)`/`.getc()` on whichever binding is active.
     // Dropping &self would break that parity.
-    #[allow(clippy::unused_self)]
     pub(crate) fn putc(&self, _byte: u8) {}
 
     /// Host-test RX stub: no real UART, so no bytes are ever available.
-    #[allow(clippy::unused_self)]
     pub(crate) fn getc(&self) -> Option<u8> {
         None
     }

--- a/crates/thumos/src/ui.rs
+++ b/crates/thumos/src/ui.rs
@@ -725,7 +725,10 @@ impl UiManager {
     // a different reason (documented per-arm below: real UI exit vs. a
     // privileged hardware action vs. yielding to the panic sequence).
     // Merging them into one arm would blur those distinct rationales.
-    #[allow(clippy::match_same_arms)]
+    #[expect(
+        clippy::match_same_arms,
+        reason = "Exit, KillModem, and Duress all return true for different reasons -- real UI exit vs. a privileged hardware action vs. yielding to the panic sequence; merging would blur those distinct rationales"
+    )]
     pub(crate) fn apply_action(&mut self, action: ScreenAction) -> bool {
         match action {
             ScreenAction::None => false,

--- a/crates/thumos/src/vfs.rs
+++ b/crates/thumos/src/vfs.rs
@@ -87,7 +87,10 @@ impl VfsError {
         // RequiresMut deliberately reuses it because no POSIX code fits
         // "wrong access mode used internally" (see RequiresMut's own doc
         // above). Keeping the arms separate documents both reasons in place.
-        #[allow(clippy::match_same_arms)]
+        #[expect(
+            clippy::match_same_arms,
+            reason = "IoError and RequiresMut both resolve to EIO for distinct reasons -- IoError is EIO's natural POSIX meaning, RequiresMut reuses it because no POSIX code fits an internal wrong-access-mode error; keeping the arms separate documents both"
+        )]
         let raw = match self {
             Self::NotFound => 2,
             Self::NotADirectory => 20,


### PR DESCRIPTION
Works the suppression-hygiene class of #718 — and the headline result is about the rule, not the code.

## `no-tautological-clippy-suppress` was wrong 27 times out of 27

The rule reports suppressions that suppress nothing. Every one of its 27 findings here was deleted, and **every deletion made a real clippy diagnostic fire.** All 27 are load-bearing. A 0% true-positive rate, at `high` severity.

Two were already known: `pteron/src/smp/toolbox.rs`'s `many_single_char_names` pair, found when a deletion turned the build red. The remaining 25 were established by mining a CI run's full log rather than its head — each site's actual diagnostic, per configuration.

That is the finding. Acting on this rule as written would have removed 27 working suppressions from a kernel that holds zero clippy findings, and every step would have looked like progress.

## Result

| rule | before | after |
|---|---|---|
| `RUST/prefer-expect-over-allow` | 41 | **0** |
| `RUST/allow-not-expect` | 37 | **1** (deliberate, below) |
| `RUST/no-tautological-clippy-suppress` | 27 | **0** |

All 27 restored, then converted to `#[expect(..., reason = "...")]` where the reason states why the code is correct — drawn from each site's own CI diagnostic and its pre-existing WHY comment, not invented.

## The multi-configuration trap, twice

`crates/thumos` is linted across **nine** declared kernel configurations and the `kernel` job is a required check, so an `#[expect]` fulfilled in one configuration and not another turns every merge in the repo red.

**Two sites needed `cfg_attr` gates**, both the same split — the lint fires under default/debug-console/production and is absent under all six qemu-inclusive configurations:

- `display.rs` — `write_framebuffer`, `unused_self`
- `keypad.rs` — `init`, `unused_self`

Determined by parsing the CI log per configuration, not by inference.

**One site stays `#[allow]` deliberately.** `security.rs:330`, `sha1_compress`'s FIPS 180-4 recurrence loop: the `#[expect]` an earlier commit added is **unconditionally unfulfilled** — `this lint expectation is unfulfilled` in all nine configurations, because clippy's `needless_range_loop` heuristic never flags this shape (a write at `w[i]` alongside reads at `i-3`, `i-8`, `i-14`, `i-16`). Reverted to `#[allow]` with a reason, and a NOTE recording why `#[expect]` is wrong there so the next sweep does not re-convert it. That is the one remaining `allow-not-expect` finding and it should stay.

## No genuine defects surfaced

One candidate was checked and dismissed on evidence: `socket.rs`'s suggestion to use `Ipv4Address::LOCALHOST` — smoltcp's `Ipv4Address` exposes only `UNSPECIFIED`/`BROADCAST` in this file, confirming the existing WHY comment rather than exposing a stale one.

## Verification

CI [31506156311](https://github.com/forkwright/thumos/actions/runs/31506156311) green at `244125c`: rustfmt, workspace clippy + tests, and the full `kernel` job — i686 host tests, armv7a cross-compile, the QEMU boot/fault/fork/exec/signal witnesses, and the zero-warning clippy gate across all nine configurations.

Follow-up filed against kanon for the rule itself.

Refs: #718
