### PR TITLE
feat(kernel): consume one-time keys from inbound Olm pre-key messages

### DIFF
--- a/crates/thumos/src/harmostes.rs
+++ b/crates/thumos/src/harmostes.rs
@@ -2707,4 +2707,134 @@ mod tests {
         );
         assert_eq!(claimed_key_algorithm("no-colon-here"), "no-colon-here");
     }
+
+    // -- Inbound to-device / Olm pre-key receive-path tests (#437) --
+    //
+    // #437 remnant 3: consume_one_time_key has zero production call sites.
+    // This is the falsifier -- an inbound to_device Olm pre-key message must
+    // cause the matching local one-time key to leave the pool and a session
+    // to be established. process_sync_response does not yet look at
+    // `to_device` at all, so this must fail until that wiring lands.
+
+    /// Encode this kernel's pre-key body layout (`base_key || one_time_key`,
+    /// see `OLM_PREKEY_BODY_LEN`) as the hex string a `content.ciphertext.
+    /// <key>.body` field carries on the wire.
+    fn prekey_body_hex(base_key: &[u8; KEY_SIZE], one_time_key: &[u8; KEY_SIZE]) -> String {
+        let mut s = hex_encode_bytes(base_key);
+        s.push_str(&hex_encode_bytes(one_time_key));
+        s
+    }
+
+    /// Write a single `m.room.encrypted` to-device event onto an open
+    /// [`JsonWriter`] context, matching the real Matrix `to_device.events[]`
+    /// shape (spec: "Extensions to /sync", `m.olm.v1.curve25519-aes-sha2`).
+    fn write_olm_prekey_event(
+        w: &mut JsonWriter,
+        sender: &str,
+        algorithm: &str,
+        sender_key: &str,
+        recipient_identity_key: &str,
+        msg_type: i64,
+        body: &str,
+    ) {
+        w.object_start();
+        w.key("sender");
+        w.string_value(sender);
+        w.key("type");
+        w.string_value("m.room.encrypted");
+        w.key("content");
+        w.object_start();
+        w.key("algorithm");
+        w.string_value(algorithm);
+        w.key("sender_key");
+        w.string_value(sender_key);
+        w.key("ciphertext");
+        w.object_start();
+        w.key(recipient_identity_key);
+        w.object_start();
+        w.key("type");
+        w.number_value(msg_type);
+        w.key("body");
+        w.string_value(body);
+        w.end(); // ciphertext entry
+        w.end(); // ciphertext
+        w.end(); // content
+        w.end(); // event
+    }
+
+    /// Build a full `/sync` response body carrying one `to_device` Olm
+    /// pre-key event, for the end-to-end wiring test.
+    fn build_to_device_sync_response(
+        next_batch: &str,
+        sender: &str,
+        algorithm: &str,
+        sender_key: &str,
+        recipient_identity_key: &str,
+        msg_type: i64,
+        body: &str,
+    ) -> String {
+        let mut w = JsonWriter::new();
+        w.object_start();
+        w.key("next_batch");
+        w.string_value(next_batch);
+        w.key("to_device");
+        w.object_start();
+        w.key("events");
+        w.array_start();
+        write_olm_prekey_event(
+            &mut w,
+            sender,
+            algorithm,
+            sender_key,
+            recipient_identity_key,
+            msg_type,
+            body,
+        );
+        w.end(); // events
+        w.end(); // to_device
+        w.end(); // root
+        w.finish()
+    }
+
+    #[test]
+    fn sync_processes_to_device_olm_prekey_and_establishes_session() {
+        let mut client = matrix_client_with_test_credentials();
+        let otk = client
+            .crypto_mut()
+            .generate_one_time_keys(1)
+            .expect("seeding must succeed")[0];
+        let our_key = client.crypto().device_keys().curve25519_key;
+
+        let sender_identity_key = [0x11u8; KEY_SIZE];
+        let base_key = [0x22u8; KEY_SIZE];
+        let sync_json = build_to_device_sync_response(
+            "batch_prekey",
+            "@alice:matrix.example.com",
+            matrix_crypto::OLM_ALGORITHM,
+            &hex_encode_bytes(&sender_identity_key),
+            &hex_encode_bytes(&our_key),
+            0,
+            &prekey_body_hex(&base_key, &otk),
+        );
+
+        let result = client
+            .sync(&mock_response(200, &sync_json), 100)
+            .expect("a well-formed to-device pre-key event must not fail the sync");
+        assert_eq!(
+            result.rooms_updated, 0,
+            "this fixture carries no room events"
+        );
+
+        assert_eq!(
+            client.crypto().olm_sessions().len(),
+            1,
+            "an inbound Olm pre-key message via to_device must establish a session -- \
+             process_sync_response does not yet read to_device at all"
+        );
+        assert!(
+            !client.crypto().one_time_keys().contains(&otk),
+            "the named one-time key must leave this device's own pool -- the \
+             production call site for consume_one_time_key (#437)"
+        );
+    }
 }

--- a/crates/thumos/src/harmostes.rs
+++ b/crates/thumos/src/harmostes.rs
@@ -139,6 +139,26 @@ pub enum MatrixError {
     /// A `/keys/claim` response's matching key entry was not a string, or
     /// did not decode to a well-formed key (#437).
     MalformedClaimedKey,
+    /// An inbound to-device `m.room.encrypted` event's `content.algorithm`
+    /// was not [`matrix_crypto::OLM_ALGORITHM`] (#437). Distinct from a
+    /// to-device event whose `type` is not `m.room.encrypted` at all --
+    /// this client has no opinion on other to-device event types and
+    /// skips them without error; an event that DOES present itself as
+    /// `m.room.encrypted` is held to this contract.
+    UnsupportedToDeviceAlgorithm,
+    /// An inbound to-device `m.room.encrypted` event's `content.ciphertext`
+    /// map carried no entry addressed to this device's own Curve25519
+    /// identity key (#437). The homeserver already targets `to_device`
+    /// delivery per-recipient-device, so a genuine message always carries
+    /// our own entry; its absence means a relay defect or a malicious peer.
+    ToDeviceKeyMissing,
+    /// An inbound to-device `m.room.encrypted` event was structurally
+    /// malformed: missing `content`/`content.sender_key`, a `sender_key`
+    /// that did not decode to a well-formed key, a matched ciphertext
+    /// entry whose `type` was not `0` (pre-key -- this client does not yet
+    /// decrypt an established session's `type: 1` messages), or a `body`
+    /// that failed to decode (#437).
+    MalformedToDeviceEvent,
 }
 
 impl fmt::Display for MatrixError {
@@ -170,6 +190,19 @@ impl fmt::Display for MatrixError {
             Self::MalformedClaimedKey => {
                 write!(f, "keys/claim response key value is malformed")
             }
+            Self::UnsupportedToDeviceAlgorithm => {
+                write!(
+                    f,
+                    "to-device event used an unsupported encryption algorithm"
+                )
+            }
+            Self::ToDeviceKeyMissing => {
+                write!(
+                    f,
+                    "to-device event carried no ciphertext entry for this device"
+                )
+            }
+            Self::MalformedToDeviceEvent => write!(f, "to-device event is malformed"),
         }
     }
 }
@@ -218,6 +251,21 @@ pub struct SyncResult {
     /// safely — mirroring the `rooms_over_capacity` rationale (#358), because
     /// aborting the batch would permanently wedge sync on the bad key.
     pub rooms_malformed: u32,
+    /// Number of inbound `to_device` Olm pre-key messages that established
+    /// a new [`OlmSession`](crate::matrix_crypto::OlmSession) this sync
+    /// (#437) -- the production call site for
+    /// [`MatrixCrypto::consume_one_time_key`](crate::matrix_crypto::MatrixCrypto::consume_one_time_key).
+    pub olm_sessions_established: u32,
+    /// Number of inbound `to_device` `m.room.encrypted` events rejected this
+    /// sync (#437): unsupported algorithm, no ciphertext entry addressed to
+    /// this device, a malformed event, or a
+    /// [`process_to_device_event`](MatrixClient::process_to_device_event)
+    /// crypto failure (unknown/replayed one-time key, malformed pre-key
+    /// body, session capacity). Mirrors `rooms_over_capacity`/
+    /// `rooms_malformed`: the sync token still advances safely, because a
+    /// rejected to-device event cannot be recovered by retrying the same
+    /// batch, and aborting the batch would permanently wedge sync on it.
+    pub olm_prekeys_rejected: u32,
     /// The next batch token (opaque, stored for incremental sync).
     pub next_batch: String,
 }
@@ -226,11 +274,13 @@ impl fmt::Display for SyncResult {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "SyncResult({} messages, {} rooms updated, {} over capacity, {} malformed)",
+            "SyncResult({} messages, {} rooms updated, {} over capacity, {} malformed, {} olm sessions established, {} olm prekeys rejected)",
             self.new_messages.len(),
             self.rooms_updated,
             self.rooms_over_capacity,
             self.rooms_malformed,
+            self.olm_sessions_established,
+            self.olm_prekeys_rejected,
         )
     }
 }
@@ -613,7 +663,8 @@ impl MatrixClient {
     /// Process a `/sync` HTTP response and update internal state.
     ///
     /// Extracts timeline events from joined rooms, updates the room list
-    /// and message caches, and advances the sync token.
+    /// and message caches, processes inbound `to_device` Olm pre-key
+    /// messages (#437), and advances the sync token.
     ///
     /// # Errors
     ///
@@ -646,8 +697,41 @@ impl MatrixClient {
             rooms_updated: 0,
             rooms_over_capacity: 0,
             rooms_malformed: 0,
+            olm_sessions_established: 0,
+            olm_prekeys_rejected: 0,
             next_batch: String::from(next_batch),
         };
+
+        // Extract to_device.events (#437). Processed independently of, and
+        // before, the `rooms` block below: `rooms` is absent from plenty of
+        // real sync responses (nothing joined yet, or this batch carries only
+        // to-device traffic), and the early returns in the `rooms` block must
+        // not skip to-device processing when that happens.
+        //
+        // WHY (count-and-skip, not abort): self.sync_token was already
+        // advanced above. A single malformed/hostile to-device event cannot
+        // be recovered by retrying the same batch, so propagating an Err
+        // here would leave the token advanced while wedging every OTHER
+        // event in the batch behind it — the same rationale already applied
+        // to rooms_over_capacity/rooms_malformed.
+        if let Some(events) = root
+            .get("to_device")
+            .and_then(|td| td.get("events"))
+            .and_then(JsonValue::as_array)
+        {
+            for event in events {
+                match self.process_to_device_event(event) {
+                    Ok(true) => {
+                        result.olm_sessions_established =
+                            result.olm_sessions_established.saturating_add(1);
+                    }
+                    Ok(false) => {}
+                    Err(_) => {
+                        result.olm_prekeys_rejected = result.olm_prekeys_rejected.saturating_add(1);
+                    }
+                }
+            }
+        }
 
         // Extract joined rooms from rooms.join.
         let Some(rooms_obj) = root.get("rooms") else {
@@ -1093,14 +1177,11 @@ impl MatrixClient {
     ///
     /// [`MatrixCrypto::consume_one_time_key`] belongs to the *receive* side
     /// of key exchange instead: it removes one of this device's own
-    /// uploaded keys once something reports it was claimed by a peer (a
-    /// dropping `device_one_time_keys_count` on `/sync`, or an inbound Olm
-    /// pre-key message naming the key). Neither exists in this tree yet
-    /// (#437 remainder): `/sync` here reads only `rooms.join.*.timeline`,
-    /// and there is no inbound Olm pre-key handler -- `OlmSession` is
-    /// declared but never constructed anywhere. Wiring
-    /// `consume_one_time_key` belongs at that future receive-side call
-    /// site, not here.
+    /// uploaded keys once something reports it was claimed by a peer. That
+    /// receive side is [`process_to_device_event`](Self::process_to_device_event),
+    /// reached from [`process_sync_response`](Self::process_sync_response)'s
+    /// `to_device.events` handling -- an inbound Olm pre-key message names
+    /// the local key a peer already claimed and used (#437).
     ///
     /// # Errors
     ///
@@ -1152,6 +1233,110 @@ impl MatrixClient {
             matrix_crypto::decode_base64_key(key_value).ok_or(MatrixError::MalformedClaimedKey)?;
 
         Ok(key)
+    }
+
+    // -----------------------------------------------------------------------
+    // Inbound to-device / Olm pre-key receive (#437)
+    // -----------------------------------------------------------------------
+
+    /// Process a single `to_device.events[]` entry from a `/sync` response.
+    ///
+    /// A to-device event whose `type` is not `m.room.encrypted` is outside
+    /// this client's scope (key-verification requests, dummy events, secret
+    /// sharing, ...) and is skipped, returning `Ok(false)` -- that is not
+    /// "successfully handled", only "nothing here this function is
+    /// responsible for rejecting". An event that DOES present itself as
+    /// `m.room.encrypted` is held to the full fail-closed contract: every
+    /// failure below is a typed [`MatrixError`], never a silent skip.
+    ///
+    /// On success, decodes the pre-key body naming this device's own
+    /// consumed one-time key and calls
+    /// [`MatrixCrypto::process_olm_prekey_message`], which performs the
+    /// actual consume-and-establish -- this is the production call site for
+    /// [`MatrixCrypto::consume_one_time_key`] (#437). Returns `Ok(true)` iff
+    /// a session was established.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MatrixError::UnsupportedToDeviceAlgorithm`] if
+    /// `content.algorithm` is present but not
+    /// [`matrix_crypto::OLM_ALGORITHM`].
+    /// Returns [`MatrixError::MalformedToDeviceEvent`] if `content`,
+    /// `content.sender_key`, or `content.ciphertext` is missing or
+    /// malformed, if the matched ciphertext entry's `type` is not `0`
+    /// (pre-key), or if its `body` fails to decode.
+    /// Returns [`MatrixError::ToDeviceKeyMissing`] if no `ciphertext` entry
+    /// is addressed to this device's own Curve25519 identity key.
+    /// Returns [`MatrixError::ServerError`] (via [`crypto_error`]) if
+    /// [`MatrixCrypto::process_olm_prekey_message`] rejects the decoded
+    /// pre-key: malformed body length, a one-time key this device does not
+    /// hold (never generated, or already consumed by an earlier delivery of
+    /// this same pre-key -- the replay case, since [`consume_one_time_key`]
+    /// removes a key from the pool on its first successful use), or Olm
+    /// session capacity.
+    ///
+    /// [`consume_one_time_key`]: crate::matrix_crypto::MatrixCrypto::consume_one_time_key
+    pub(crate) fn process_to_device_event(
+        &mut self,
+        event: &JsonValue,
+    ) -> Result<bool, MatrixError> {
+        if event.get("type").and_then(JsonValue::as_str) != Some("m.room.encrypted") {
+            return Ok(false);
+        }
+
+        let content = event
+            .get("content")
+            .ok_or(MatrixError::MalformedToDeviceEvent)?;
+
+        let algorithm = content.get("algorithm").and_then(JsonValue::as_str);
+        if algorithm != Some(matrix_crypto::OLM_ALGORITHM) {
+            return Err(MatrixError::UnsupportedToDeviceAlgorithm);
+        }
+
+        let sender_key_str = content
+            .get("sender_key")
+            .and_then(JsonValue::as_str)
+            .ok_or(MatrixError::MalformedToDeviceEvent)?;
+        let sender_identity_key = matrix_crypto::decode_base64_key(sender_key_str)
+            .ok_or(MatrixError::MalformedToDeviceEvent)?;
+
+        let ciphertext_map = content
+            .get("ciphertext")
+            .and_then(JsonValue::as_object)
+            .ok_or(MatrixError::MalformedToDeviceEvent)?;
+
+        let our_identity_key = self.crypto.device_keys().curve25519_key;
+        let matched_entry = ciphertext_map
+            .iter()
+            .find_map(|(key_str, entry)| {
+                if matrix_crypto::decode_base64_key(key_str) == Some(our_identity_key) {
+                    Some(entry)
+                } else {
+                    None
+                }
+            })
+            .ok_or(MatrixError::ToDeviceKeyMissing)?;
+
+        // WHY: only ciphertext `type: 0` (pre-key message) is handled --
+        // `type: 1` (an established session's ratcheted message) needs a
+        // session lookup + double-ratchet decrypt this client does not yet
+        // implement. Rejecting rather than skipping: an event that reached
+        // this point IS addressed to us and DOES claim OLM_ALGORITHM, so an
+        // unhandled type is a real gap, not background noise.
+        if matched_entry.get("type").and_then(JsonValue::as_i64) != Some(0) {
+            return Err(MatrixError::MalformedToDeviceEvent);
+        }
+
+        let body_str = matched_entry
+            .get("body")
+            .and_then(JsonValue::as_str)
+            .ok_or(MatrixError::MalformedToDeviceEvent)?;
+        let body = hex_decode_bytes(body_str).ok_or(MatrixError::MalformedToDeviceEvent)?;
+
+        self.crypto
+            .process_olm_prekey_message(&sender_identity_key, &body)
+            .map_err(|e| crypto_error(&e))?;
+        Ok(true)
     }
 
     // -----------------------------------------------------------------------
@@ -2820,21 +3005,254 @@ mod tests {
         let result = client
             .sync(&mock_response(200, &sync_json), 100)
             .expect("a well-formed to-device pre-key event must not fail the sync");
-        assert_eq!(
-            result.rooms_updated, 0,
-            "this fixture carries no room events"
-        );
 
+        assert_eq!(
+            result.olm_sessions_established, 1,
+            "the production call site must report exactly one established session"
+        );
+        assert_eq!(result.olm_prekeys_rejected, 0);
         assert_eq!(
             client.crypto().olm_sessions().len(),
             1,
-            "an inbound Olm pre-key message via to_device must establish a session -- \
-             process_sync_response does not yet read to_device at all"
+            "the session must actually land in olm_sessions, not just be reported"
         );
         assert!(
             !client.crypto().one_time_keys().contains(&otk),
             "the named one-time key must leave this device's own pool -- the \
              production call site for consume_one_time_key (#437)"
+        );
+    }
+
+    /// Build a single `m.room.encrypted` to-device event as a standalone
+    /// JSON object, for tests that call [`MatrixClient::process_to_device_event`]
+    /// directly rather than through a full sync response.
+    fn build_olm_prekey_event(
+        sender: &str,
+        algorithm: &str,
+        sender_key: &str,
+        recipient_identity_key: &str,
+        msg_type: i64,
+        body: &str,
+    ) -> JsonValue {
+        let mut w = JsonWriter::new();
+        write_olm_prekey_event(
+            &mut w,
+            sender,
+            algorithm,
+            sender_key,
+            recipient_identity_key,
+            msg_type,
+            body,
+        );
+        JsonParser::parse(w.finish().as_bytes()).expect("test fixture must be valid JSON")
+    }
+
+    #[test]
+    fn to_device_non_olm_event_is_skipped_without_error() {
+        // A real to-device event type this client has no opinion on (e.g.
+        // a key-sharing request) must not be treated as a rejection --
+        // only events that present themselves as m.room.encrypted are held
+        // to the Olm pre-key contract.
+        let mut client = matrix_client_with_test_credentials();
+        let mut w = JsonWriter::new();
+        w.object_start();
+        w.key("sender");
+        w.string_value("@alice:matrix.example.com");
+        w.key("type");
+        w.string_value("m.room_key_request");
+        w.key("content");
+        w.object_start();
+        w.key("action");
+        w.string_value("request");
+        w.end();
+        w.end();
+        let event = JsonParser::parse(w.finish().as_bytes()).expect("valid JSON");
+
+        let result = client.process_to_device_event(&event);
+        assert_eq!(result, Ok(false));
+        assert!(client.crypto().olm_sessions().is_empty());
+    }
+
+    #[test]
+    fn to_device_prekey_unsupported_algorithm_is_rejected() {
+        let mut client = matrix_client_with_test_credentials();
+        let our_key = client.crypto().device_keys().curve25519_key;
+        let event = build_olm_prekey_event(
+            "@alice:matrix.example.com",
+            "m.some.other.algorithm",
+            &hex_encode_bytes(&[0x11u8; KEY_SIZE]),
+            &hex_encode_bytes(&our_key),
+            0,
+            &prekey_body_hex(&[0x22u8; KEY_SIZE], &[0x33u8; KEY_SIZE]),
+        );
+
+        let result = client.process_to_device_event(&event);
+        assert_eq!(result, Err(MatrixError::UnsupportedToDeviceAlgorithm));
+        assert!(client.crypto().olm_sessions().is_empty());
+    }
+
+    #[test]
+    fn to_device_prekey_missing_addressed_key_is_rejected() {
+        // The ciphertext map carries an entry, but keyed by a device that
+        // is not this one -- a real homeserver only relays to-device events
+        // to their addressed recipient, so this shape means a relay defect,
+        // not a legitimate "nothing for us here".
+        let mut client = matrix_client_with_test_credentials();
+        let someone_elses_key = [0x99u8; KEY_SIZE];
+        let event = build_olm_prekey_event(
+            "@alice:matrix.example.com",
+            matrix_crypto::OLM_ALGORITHM,
+            &hex_encode_bytes(&[0x11u8; KEY_SIZE]),
+            &hex_encode_bytes(&someone_elses_key),
+            0,
+            &prekey_body_hex(&[0x22u8; KEY_SIZE], &[0x33u8; KEY_SIZE]),
+        );
+
+        let result = client.process_to_device_event(&event);
+        assert_eq!(result, Err(MatrixError::ToDeviceKeyMissing));
+        assert!(client.crypto().olm_sessions().is_empty());
+    }
+
+    #[test]
+    fn to_device_prekey_wrong_message_type_is_rejected() {
+        // type: 1 (an established session's ratcheted message) is not
+        // implemented -- this must fail closed, not be treated as a pre-key.
+        let mut client = matrix_client_with_test_credentials();
+        let otk = client
+            .crypto_mut()
+            .generate_one_time_keys(1)
+            .expect("seeding must succeed")[0];
+        let our_key = client.crypto().device_keys().curve25519_key;
+        let event = build_olm_prekey_event(
+            "@alice:matrix.example.com",
+            matrix_crypto::OLM_ALGORITHM,
+            &hex_encode_bytes(&[0x11u8; KEY_SIZE]),
+            &hex_encode_bytes(&our_key),
+            1,
+            &prekey_body_hex(&[0x22u8; KEY_SIZE], &otk),
+        );
+
+        let result = client.process_to_device_event(&event);
+        assert_eq!(result, Err(MatrixError::MalformedToDeviceEvent));
+        assert!(client.crypto().olm_sessions().is_empty());
+        assert!(
+            client.crypto().one_time_keys().contains(&otk),
+            "an unhandled message type must not consume any key"
+        );
+    }
+
+    #[test]
+    fn to_device_prekey_missing_sender_key_is_rejected() {
+        let mut client = matrix_client_with_test_credentials();
+        let our_key = client.crypto().device_keys().curve25519_key;
+
+        let mut w = JsonWriter::new();
+        w.object_start();
+        w.key("sender");
+        w.string_value("@alice:matrix.example.com");
+        w.key("type");
+        w.string_value("m.room.encrypted");
+        w.key("content");
+        w.object_start();
+        w.key("algorithm");
+        w.string_value(matrix_crypto::OLM_ALGORITHM);
+        w.key("ciphertext");
+        w.object_start();
+        w.key(&hex_encode_bytes(&our_key));
+        w.object_start();
+        w.key("type");
+        w.number_value(0);
+        w.key("body");
+        w.string_value(&prekey_body_hex(&[0x22u8; KEY_SIZE], &[0x33u8; KEY_SIZE]));
+        w.end();
+        w.end();
+        w.end(); // content (no sender_key)
+        w.end(); // event
+        let event = JsonParser::parse(w.finish().as_bytes()).expect("valid JSON");
+
+        let result = client.process_to_device_event(&event);
+        assert_eq!(result, Err(MatrixError::MalformedToDeviceEvent));
+    }
+
+    #[test]
+    fn to_device_prekey_malformed_body_hex_is_rejected() {
+        let mut client = matrix_client_with_test_credentials();
+        let our_key = client.crypto().device_keys().curve25519_key;
+        let event = build_olm_prekey_event(
+            "@alice:matrix.example.com",
+            matrix_crypto::OLM_ALGORITHM,
+            &hex_encode_bytes(&[0x11u8; KEY_SIZE]),
+            &hex_encode_bytes(&our_key),
+            0,
+            "not-valid-hex!!",
+        );
+
+        let result = client.process_to_device_event(&event);
+        assert_eq!(result, Err(MatrixError::MalformedToDeviceEvent));
+        assert!(client.crypto().olm_sessions().is_empty());
+    }
+
+    #[test]
+    fn to_device_prekey_unknown_key_is_rejected() {
+        // The named one-time key was never generated by this device.
+        let mut client = matrix_client_with_test_credentials();
+        let our_key = client.crypto().device_keys().curve25519_key;
+        let never_ours = [0x55u8; KEY_SIZE];
+        let event = build_olm_prekey_event(
+            "@alice:matrix.example.com",
+            matrix_crypto::OLM_ALGORITHM,
+            &hex_encode_bytes(&[0x11u8; KEY_SIZE]),
+            &hex_encode_bytes(&our_key),
+            0,
+            &prekey_body_hex(&[0x22u8; KEY_SIZE], &never_ours),
+        );
+
+        let result = client.process_to_device_event(&event);
+        assert_eq!(
+            result,
+            Err(crypto_error(&CryptoError::UnknownOneTimeKey)),
+            "an unknown one-time key must fail closed via the crypto error path"
+        );
+        assert!(client.crypto().olm_sessions().is_empty());
+    }
+
+    #[test]
+    fn to_device_prekey_replay_is_rejected() {
+        // #437: a one-time key is consumed exactly once. The SAME pre-key
+        // message delivered twice (a homeserver-level or attacker-level
+        // replay) must establish a session on the first delivery and be
+        // rejected on the second -- consume_one_time_key already removed
+        // the key from the pool, so the replay finds it gone.
+        let mut client = matrix_client_with_test_credentials();
+        let otk = client
+            .crypto_mut()
+            .generate_one_time_keys(1)
+            .expect("seeding must succeed")[0];
+        let our_key = client.crypto().device_keys().curve25519_key;
+        let event = build_olm_prekey_event(
+            "@alice:matrix.example.com",
+            matrix_crypto::OLM_ALGORITHM,
+            &hex_encode_bytes(&[0x11u8; KEY_SIZE]),
+            &hex_encode_bytes(&our_key),
+            0,
+            &prekey_body_hex(&[0x22u8; KEY_SIZE], &otk),
+        );
+
+        let first = client.process_to_device_event(&event);
+        assert_eq!(first, Ok(true));
+        assert_eq!(client.crypto().olm_sessions().len(), 1);
+
+        let replay = client.process_to_device_event(&event);
+        assert_eq!(
+            replay,
+            Err(crypto_error(&CryptoError::UnknownOneTimeKey)),
+            "a replayed pre-key naming an already-consumed key must be rejected with the same \
+             disposition as a never-valid key -- the pool is the only record of \"used\""
+        );
+        assert_eq!(
+            client.crypto().olm_sessions().len(),
+            1,
+            "a rejected replay must not establish a second session"
         );
     }
 }

--- a/crates/thumos/src/matrix_crypto.rs
+++ b/crates/thumos/src/matrix_crypto.rs
@@ -24,23 +24,22 @@
 //! - AES-CBC: NIST SP 800-38A
 
 // WHY: Matrix crypto created in Phase 09 Wave 3, full integration pending.
-// #437 remnant 3: `harmostes` builds the /keys/claim request and validates
-// + returns the peer's claimed key (the send side of key exchange -- that
-// key belongs to the remote device, never to this device's own
-// `one_time_keys` pool). `consume_one_time_key` belongs to the RECEIVE
-// side instead: it removes one of THIS device's own uploaded keys once
-// something reports it was claimed by a peer (a dropping
-// `device_one_time_keys_count` on `/sync`, or an inbound Olm pre-key
-// message naming the key). Neither exists in this tree -- `/sync` here
-// reads only room timeline events, and there is no inbound Olm pre-key
-// handler (`OlmSession` is declared, never constructed). Wiring
-// `consume_one_time_key` there is what remains open; without it the
-// one_time_keys pool deadlocks at MAX_ONE_TIME_KEYS once that receive path
-// exists (#282 finding 8). This module stays unreachable until Phase-09
-// messaging integration lands.
+// #437: `harmostes` builds the /keys/claim request and validates + returns
+// the peer's claimed key (the send side of key exchange -- that key
+// belongs to the remote device, never to this device's own
+// `one_time_keys` pool). `consume_one_time_key`'s production call site is
+// on the RECEIVE side instead, and now lives there:
+// `harmostes::MatrixClient::process_to_device_event` extracts the local
+// one-time key an inbound Olm pre-key message names and calls
+// [`MatrixCrypto::process_olm_prekey_message`], which consumes it and
+// establishes the resulting `OlmSession`. `process_sync_response` reaches
+// that path via a `to_device.events` block. This module stays unreachable
+// from `kernel_main` regardless -- `MatrixClient` itself is not yet
+// constructed anywhere outside tests, a separate, broader integration
+// (#145) this issue does not close.
 #![expect(
     dead_code,
-    reason = "Matrix crypto unreachable pending Phase-09 messaging integration; consume_one_time_key's receive-side call site does not exist yet (#437)"
+    reason = "MatrixClient (and therefore MatrixCrypto) is not yet constructed from kernel_main; unreachable pending Phase-09 unified-inbox integration (#145)"
 )]
 
 extern crate alloc;
@@ -98,6 +97,17 @@ const ED25519_SIGNATURE_LEN: usize = 64;
 /// Maximum number of Olm sessions tracked simultaneously.
 const MAX_OLM_SESSIONS: usize = 64;
 
+/// Byte length of this kernel's inbound Olm pre-key message body once
+/// hex-decoded: `base_key (32) || one_time_key (32)`. Matrix does not
+/// standardize the *contents* of an Olm ciphertext body -- that is the
+/// sending/receiving Olm implementations' own wire format, invisible to the
+/// homeserver that merely relays it -- and this module's device keys are
+/// HKDF-derived values rather than real Curve25519 points (module docs), so
+/// there is no libolm TLV encoding to interoperate with here; this is a
+/// kernel-internal format for talking to a future encrypt side of this same
+/// implementation (#437).
+const OLM_PREKEY_BODY_LEN: usize = KEY_SIZE * 2;
+
 /// Maximum number of outbound Megolm sessions (one per room).
 const MAX_MEGOLM_OUTBOUND: usize = 32;
 
@@ -117,6 +127,16 @@ const MAX_GENERATED_KEYS: usize = 50;
 /// `/keys/claim` request/response so the algorithm string exists in exactly
 /// one place.
 pub(crate) const ONE_TIME_KEY_ALGORITHM: &str = "curve25519";
+
+/// The Olm to-device encryption algorithm identifier (Matrix spec:
+/// `m.olm.v1.curve25519-aes-sha2`) -- the top-level `content.algorithm`
+/// value on an `m.room.encrypted` **to-device** event. Distinct from
+/// [`ONE_TIME_KEY_ALGORITHM`], which names the per-key algorithm inside a
+/// `/keys/claim` request/response, not the encrypted-payload algorithm.
+/// Shared between [`build_device_keys_json`]'s advertised algorithm list
+/// and `harmostes`'s inbound to-device filter (#437) so the string exists
+/// in exactly one place.
+pub(crate) const OLM_ALGORITHM: &str = "m.olm.v1.curve25519-aes-sha2";
 
 // ---------------------------------------------------------------------------
 // Error types
@@ -173,6 +193,19 @@ pub enum CryptoError {
     /// further would reuse a (key, IV) pair (issue #282 finding 9). The
     /// session must be rotated.
     MegolmIndexExhausted,
+    /// An inbound Olm pre-key message's body did not decode to the expected
+    /// `base_key || one_time_key` layout -- wrong length after decoding, or
+    /// not decodable at all (#437).
+    MalformedPreKeyMessage,
+    /// An inbound Olm pre-key message named a one-time key this device's
+    /// local pool does not currently hold. Covers BOTH a key this device
+    /// never generated AND a replay of a key an earlier pre-key message
+    /// already consumed (#437) -- deliberately the same disposition: the
+    /// pool itself is the only record of "used", so there is no separate
+    /// "already consumed" bookkeeping that could fall out of sync with it,
+    /// and a caller cannot distinguish "never valid" from "already spent"
+    /// by the error alone.
+    UnknownOneTimeKey,
 }
 
 impl From<csprng::CsprngError> for CryptoError {
@@ -230,6 +263,15 @@ impl fmt::Display for CryptoError {
                 write!(
                     f,
                     "Megolm session message index exhausted -- rotate the session"
+                )
+            }
+            Self::MalformedPreKeyMessage => {
+                write!(f, "Olm pre-key message body is malformed")
+            }
+            Self::UnknownOneTimeKey => {
+                write!(
+                    f,
+                    "Olm pre-key message named a one-time key not held locally"
                 )
             }
         }
@@ -496,6 +538,90 @@ impl MatrixCrypto {
         } else {
             false
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Olm pre-key receive path (#437)
+    // -----------------------------------------------------------------------
+
+    /// Process an inbound Olm **pre-key** message (`to_device` event type
+    /// `m.room.encrypted`, `content.algorithm ==` [`OLM_ALGORITHM`],
+    /// ciphertext `type: 0`) addressed to this device: extract the local
+    /// one-time key its sender used, consume it, and record the resulting
+    /// [`OlmSession`].
+    ///
+    /// This is the RECEIVE side of Matrix key exchange (#437): a
+    /// `/keys/claim` response (the send side, `harmostes`'s
+    /// `process_claim_keys_response`) carries a *remote* device's key and
+    /// never touches this pool. A pre-key message instead names one of
+    /// THIS device's own uploaded keys, reporting that a peer already
+    /// claimed and used it -- this is the only production call site for
+    /// [`consume_one_time_key`].
+    ///
+    /// `sender_identity_key` is the sending device's Curve25519 identity key
+    /// (the envelope's `content.sender_key`, already decoded by the caller).
+    /// `body` is the already-decoded bytes of the matching
+    /// `ciphertext.<our device key>.body` entry. Its layout is
+    /// `base_key (32) || one_time_key (32)` -- see [`OLM_PREKEY_BODY_LEN`]
+    /// for why this is a kernel-internal format rather than libolm's own
+    /// encoding.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CryptoError::MalformedPreKeyMessage`] if `body` is not
+    /// exactly [`OLM_PREKEY_BODY_LEN`] bytes.
+    /// Returns [`CryptoError::SessionCapacityReached`] if [`MAX_OLM_SESSIONS`]
+    /// is already reached -- checked BEFORE consuming the named one-time
+    /// key, so a session that cannot be recorded does not needlessly burn
+    /// real key material this device can never get back (unlike CSPRNG
+    /// output, a one-time key is not cheaply regenerable once a peer has
+    /// already claimed it from the homeserver).
+    /// Returns [`CryptoError::UnknownOneTimeKey`] if the named key is not
+    /// present in the local pool -- this is the structural single-use
+    /// enforcement: [`consume_one_time_key`] removes the key from the pool
+    /// on its first successful use, so a replayed pre-key naming the same
+    /// key finds the pool already empty of it and fails with the identical
+    /// error a never-valid key would, with no separate "already consumed"
+    /// state to go stale.
+    /// Returns [`CryptoError::KeyDerivationFailed`] if HKDF fails (defensive;
+    /// unreachable in practice at a 32-byte output length, mirroring
+    /// [`derive_megolm_message_keys`]'s identical guard).
+    ///
+    /// [`consume_one_time_key`]: Self::consume_one_time_key
+    pub(crate) fn process_olm_prekey_message(
+        &mut self,
+        sender_identity_key: &[u8; KEY_SIZE],
+        body: &[u8],
+    ) -> Result<(), CryptoError> {
+        if body.len() != OLM_PREKEY_BODY_LEN {
+            return Err(CryptoError::MalformedPreKeyMessage);
+        }
+        let mut base_key = [0u8; KEY_SIZE];
+        let mut one_time_key = [0u8; KEY_SIZE];
+        base_key.copy_from_slice(&body[..KEY_SIZE]);
+        one_time_key.copy_from_slice(&body[KEY_SIZE..]);
+
+        // WHY (capacity before consume): see the doc comment above -- a
+        // session we cannot record must not cost this device a one-time key
+        // it cannot recover.
+        if self.olm_sessions.len() >= MAX_OLM_SESSIONS {
+            return Err(CryptoError::SessionCapacityReached);
+        }
+
+        if !self.consume_one_time_key(&one_time_key) {
+            return Err(CryptoError::UnknownOneTimeKey);
+        }
+
+        let ratchet_key =
+            derive_olm_initial_ratchet_key(sender_identity_key, &base_key, &one_time_key)?;
+        let session_id = security::sha256(&ratchet_key);
+
+        self.olm_sessions.push(OlmSession {
+            session_id,
+            ratchet_key,
+            chain_index: 0,
+        });
+        Ok(())
     }
 
     // -----------------------------------------------------------------------
@@ -1011,6 +1137,37 @@ fn derive_megolm_message_keys(
     })
 }
 
+/// Derive a new Olm session's initial ratchet key from an inbound pre-key
+/// message's key material (#437).
+///
+/// A simplified X3DH substitute: this module's device/one-time keys are
+/// CSPRNG-derived values used directly as HKDF input rather than real
+/// Curve25519 points (module docs), so there are no DH outputs to combine --
+/// the three key values (sender identity, sender ephemeral, and the
+/// consumed local one-time key) are concatenated as HKDF input key material
+/// instead, matching this module's existing departure from full X3DH.
+///
+/// # Errors
+///
+/// Returns [`CryptoError::KeyDerivationFailed`] if HKDF fails (defensive;
+/// unreachable at this fixed 32-byte output length).
+fn derive_olm_initial_ratchet_key(
+    sender_identity_key: &[u8; KEY_SIZE],
+    base_key: &[u8; KEY_SIZE],
+    one_time_key: &[u8; KEY_SIZE],
+) -> Result<[u8; KEY_SIZE], CryptoError> {
+    const LABEL: &[u8] = b"olm-prekey-session";
+    let mut ikm = [0u8; KEY_SIZE * 3];
+    ikm[..KEY_SIZE].copy_from_slice(sender_identity_key);
+    ikm[KEY_SIZE..KEY_SIZE * 2].copy_from_slice(base_key);
+    ikm[KEY_SIZE * 2..].copy_from_slice(one_time_key);
+
+    let mut ratchet_key = [0u8; KEY_SIZE];
+    security::hkdf_sha256(&ikm, &[], LABEL, &mut ratchet_key)
+        .map_err(|_| CryptoError::KeyDerivationFailed)?;
+    Ok(ratchet_key)
+}
+
 // ---------------------------------------------------------------------------
 // JSON helpers
 // ---------------------------------------------------------------------------
@@ -1021,7 +1178,7 @@ fn build_device_keys_json(keys: &DeviceKeys) -> String {
     w.object_start();
     w.key("algorithms");
     w.array_start();
-    w.string_value("m.olm.v1.curve25519-aes-sha2");
+    w.string_value(OLM_ALGORITHM);
     w.string_value("m.megolm.v1.aes-sha2");
     w.end(); // algorithms
     w.key("keys");
@@ -1537,6 +1694,148 @@ mod tests {
             !crypto.consume_one_time_key(&claimed),
             "consuming an already-removed key must return false, not panic"
         );
+    }
+
+    // -- Olm pre-key receive-path tests (#437) --
+
+    /// Build a wire body matching this kernel's pre-key layout:
+    /// `base_key || one_time_key`.
+    fn prekey_body(base_key: &[u8; KEY_SIZE], one_time_key: &[u8; KEY_SIZE]) -> Vec<u8> {
+        let mut body = Vec::with_capacity(OLM_PREKEY_BODY_LEN);
+        body.extend_from_slice(base_key);
+        body.extend_from_slice(one_time_key);
+        body
+    }
+
+    #[test]
+    fn process_olm_prekey_message_consumes_named_key_and_establishes_session() {
+        setup_test_rng();
+        let mut crypto = MatrixCrypto::new().expect("test csprng seeded");
+        let otk = crypto
+            .generate_one_time_keys(1)
+            .expect("seeding must succeed")[0];
+
+        let sender_identity_key = [0x11u8; KEY_SIZE];
+        let base_key = [0x22u8; KEY_SIZE];
+        let body = prekey_body(&base_key, &otk);
+
+        let result = crypto.process_olm_prekey_message(&sender_identity_key, &body);
+        assert!(result.is_ok(), "a valid pre-key message must be accepted");
+        assert!(
+            !crypto.one_time_keys().contains(&otk),
+            "the claimed key must leave the local pool"
+        );
+        assert_eq!(
+            crypto.olm_sessions().len(),
+            1,
+            "a valid pre-key message must establish exactly one session"
+        );
+    }
+
+    #[test]
+    fn process_olm_prekey_message_rejects_replay() {
+        setup_test_rng();
+        let mut crypto = MatrixCrypto::new().expect("test csprng seeded");
+        let otk = crypto
+            .generate_one_time_keys(1)
+            .expect("seeding must succeed")[0];
+        let sender_identity_key = [0x33u8; KEY_SIZE];
+        let base_key = [0x44u8; KEY_SIZE];
+        let body = prekey_body(&base_key, &otk);
+
+        assert!(
+            crypto
+                .process_olm_prekey_message(&sender_identity_key, &body)
+                .is_ok(),
+            "the first delivery of a valid pre-key message must succeed"
+        );
+        assert_eq!(crypto.olm_sessions().len(), 1);
+
+        let replay = crypto.process_olm_prekey_message(&sender_identity_key, &body);
+        assert_eq!(
+            replay,
+            Err(CryptoError::UnknownOneTimeKey),
+            "a replayed pre-key message naming an already-consumed key must be rejected"
+        );
+        assert_eq!(
+            crypto.olm_sessions().len(),
+            1,
+            "a rejected replay must not establish a second session"
+        );
+    }
+
+    #[test]
+    fn process_olm_prekey_message_rejects_unknown_key() {
+        setup_test_rng();
+        let mut crypto = MatrixCrypto::new().expect("test csprng seeded");
+        // Never generated or uploaded by this device.
+        let never_ours = [0x55u8; KEY_SIZE];
+        let sender_identity_key = [0x66u8; KEY_SIZE];
+        let base_key = [0x77u8; KEY_SIZE];
+        let body = prekey_body(&base_key, &never_ours);
+
+        let result = crypto.process_olm_prekey_message(&sender_identity_key, &body);
+        assert_eq!(result, Err(CryptoError::UnknownOneTimeKey));
+        assert!(
+            crypto.olm_sessions().is_empty(),
+            "an unknown-key pre-key message must not establish a session"
+        );
+    }
+
+    #[test]
+    fn process_olm_prekey_message_rejects_malformed_body_length() {
+        setup_test_rng();
+        let mut crypto = MatrixCrypto::new().expect("test csprng seeded");
+        let sender_identity_key = [0x88u8; KEY_SIZE];
+
+        let short_body = alloc::vec![0u8; OLM_PREKEY_BODY_LEN - 1];
+        assert_eq!(
+            crypto.process_olm_prekey_message(&sender_identity_key, &short_body),
+            Err(CryptoError::MalformedPreKeyMessage)
+        );
+
+        let long_body = alloc::vec![0u8; OLM_PREKEY_BODY_LEN + 1];
+        assert_eq!(
+            crypto.process_olm_prekey_message(&sender_identity_key, &long_body),
+            Err(CryptoError::MalformedPreKeyMessage)
+        );
+
+        assert!(crypto.olm_sessions().is_empty());
+    }
+
+    #[test]
+    fn process_olm_prekey_message_enforces_session_capacity_without_burning_key() {
+        setup_test_rng();
+        let mut crypto = MatrixCrypto::new().expect("test csprng seeded");
+
+        for i in 0..MAX_OLM_SESSIONS {
+            let otk = crypto
+                .generate_one_time_keys(1)
+                .expect("filling below capacity must succeed")[0];
+            let sender_byte = u8::try_from(i).expect("MAX_OLM_SESSIONS fits in u8 range");
+            let sender_identity_key = [sender_byte; KEY_SIZE];
+            let base_key = [0xAAu8; KEY_SIZE];
+            let body = prekey_body(&base_key, &otk);
+            crypto
+                .process_olm_prekey_message(&sender_identity_key, &body)
+                .expect("filling below capacity must succeed");
+        }
+        assert_eq!(crypto.olm_sessions().len(), MAX_OLM_SESSIONS);
+
+        let overflow_otk = crypto
+            .generate_one_time_keys(1)
+            .expect("seeding must succeed")[0];
+        let before = crypto.one_time_keys().len();
+        let body = prekey_body(&[0xBBu8; KEY_SIZE], &overflow_otk);
+        let result = crypto.process_olm_prekey_message(&[0xFFu8; KEY_SIZE], &body);
+
+        assert_eq!(result, Err(CryptoError::SessionCapacityReached));
+        assert_eq!(
+            crypto.one_time_keys().len(),
+            before,
+            "a session that cannot be recorded must not consume the one-time key"
+        );
+        assert_eq!(crypto.olm_sessions().len(), MAX_OLM_SESSIONS);
     }
 
     // -- Encrypt/decrypt round-trip tests --

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -250,7 +250,7 @@ mechanism = "host"
 
 [[module]]
 name = "harmostes"
-tests = 48
+tests = 57
 mechanism = "host"
 
 [[module]]
@@ -377,7 +377,7 @@ fidelity = "module wiring only — the boot witness is its proof"
 
 [[module]]
 name = "matrix_crypto"
-tests = 37
+tests = 42
 mechanism = "host"
 
 [[module]]


### PR DESCRIPTION
Closes remnant 3 of #437: `consume_one_time_key` now has a production call site, and it is on the correct side of the protocol.

## The falsifier this issue recorded, and the evidence for it

#437 was reopened with a stated close condition: *an inbound Olm pre-key message makes the matching local key leave the pool, proven by a test that fails without the wiring* — explicitly **not** "the function gains a call site".

- **Red** — [31505977390](https://github.com/forkwright/thumos/actions/runs/31505977390) at `1438e99`, one integration test against pre-existing API surface, no new symbols:
  ```
  assertion `left == right` failed: an inbound Olm pre-key message via to_device
  must establish a session -- process_sync_response
  ```
  A behavioural failure, not a compile error. Everything else in the suite passed.
- **Green** — [31506789865](https://github.com/forkwright/thumos/actions/runs/31506789865) at `3719231`, implementation plus the remaining tests.

## The receive path

```
process_sync_response          harmostes.rs:723
  -> process_to_device_event   harmostes.rs:1279
    -> process_olm_prekey_message  matrix_crypto.rs:591
      -> consume_one_time_key      matrix_crypto.rs:611
```

`process_to_device_event` gates on the real Matrix envelope — `type == "m.room.encrypted"`, `content.algorithm == m.olm.v1.curve25519-aes-sha2`, `content.sender_key`, and a `content.ciphertext` entry addressed to *our* identity key.

`to_device.events` is read **before** the `rooms` block so it is not skipped when `rooms` is absent, and results aggregate into two counters (`olm_sessions_established`, `olm_prekeys_rejected`) following the existing `rooms_over_capacity`/`rooms_malformed` pattern — one bad to-device event does not wedge the rest of the sync batch.

## Why this is the correct side

An earlier attempt wired consumption into the `/keys/claim` **response**. That response carries a *remote* device's key while `consume_one_time_key` removes one of *ours*, so it would have failed every legitimate claim, and its tests passed only by fabricating a response no homeserver sends. #713 removed it and made `process_claim_keys_response` take no `self` at all.

Our keys are consumed server-side when a peer claims them; we learn of it from the inbound pre-key naming which key was used. That is this path.

## Single-use is structural

`consume_one_time_key` does `position()` then `swap_remove(idx)` — the key physically leaves the pool. There is no separate "consumed" flag that can drift out of sync with it. A replay naming the same key finds it absent and gets `CryptoError::UnknownOneTimeKey`, deliberately the same error a never-valid key produces, so the two are indistinguishable to a caller.

`to_device_prekey_replay_is_rejected` delivers the identical event twice and asserts the second fails while `olm_sessions().len()` stays at 1.

## olm_sessions is no longer dead state

`matrix_crypto.rs:619` pushes a real `OlmSession` on every successful pre-key. That `Vec` was previously **never pushed to** — an accessor and `Debug`/`Display` impls for a type never constructed, which #713's review flagged as capability-shaped dead state. `sync_processes_to_device_olm_prekey_and_establishes_session` asserts end to end that the session lands and the key leaves the pool.

## Every failure mode fails closed

| condition | error |
|---|---|
| unknown algorithm | `UnsupportedToDeviceAlgorithm` |
| no ciphertext addressed to our identity key | `ToDeviceKeyMissing` |
| missing `sender_key`, wrong ciphertext `type`, bad hex body | `MalformedToDeviceEvent` |
| unknown one-time key, replay, session capacity, bad pre-key length | `ServerError` wrapping the `CryptoError` |

A to-device event that is not `m.room.encrypted` at all (say `m.room_key_request`) returns `Ok(false)` — out of scope, deliberately distinct from a rejection.

## One judgment call worth a reviewer's eye

The pre-key **body**'s internal layout is read as `base_key(32) || one_time_key(32)`, hex-encoded, matching this file's own existing convention for its ciphertext bodies (`parse_timeline_event`'s `ciphertext_hex`/`hex_decode_bytes`) rather than base64.

Matrix standardizes the homeserver-facing envelope — `to_device`, `content.algorithm`, `content.sender_key`, the `content.ciphertext` map — which the fixtures match exactly. It does not standardize Olm ciphertext-body internals, and this module already documents its departure from real X3DH, so wire-fidelity to libolm is not achievable here regardless. Identity keys go through the existing `matrix_crypto::decode_base64_key`, the same decoder the `/keys/claim` path uses, which accepts both hex and base64.

If a future change makes this talk to a real libolm peer, that layout is the thing to revisit.

## Ledger

`docs/target-test-ledger.toml`: `harmostes` 48 -> 57, `matrix_crypto` 37 -> 42, matched to tests by name.

Closes #437
