### PR TITLE
refactor(eidolon): port the crate to no_std + alloc

### DIFF
--- a/crates/eidolon/src/color.rs
+++ b/crates/eidolon/src/color.rs
@@ -3,7 +3,7 @@
 //! The `GC9306` DBI controller uses `RGB565` format: 5 red bits, 6 green bits, 5 blue bits
 //! packed INTO a 16-bit little-endian word.
 
-use std::fmt;
+use core::fmt;
 
 const RED_BITS: u8 = 5;
 const GREEN_BITS: u8 = 6;
@@ -59,6 +59,8 @@ impl fmt::Display for Rgb565 {
 
 #[cfg(test)]
 mod tests {
+    use alloc::format;
+
     use super::*;
 
     #[test]

--- a/crates/eidolon/src/framebuffer.rs
+++ b/crates/eidolon/src/framebuffer.rs
@@ -4,6 +4,9 @@
 //! All write operations are bounds-checked and silently ignore out-of-range coordinates,
 //! which is safe for clipped rendering on the 240×320 display.
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::color::Rgb565;
 
 const BYTES_PER_PIXEL: usize = 2;

--- a/crates/eidolon/src/lib.rs
+++ b/crates/eidolon/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 #![deny(missing_docs)]
 #![expect(
     dead_code,
@@ -14,6 +15,8 @@
 //! - [`status_bar`]: top status strip (signal, time, battery).
 //! - [`widget`]: [`widget::Widget`] and [`widget::Focusable`] traits for UI components.
 //! - [`widgets`]: concrete widget implementations (list, menu, dialog, dialer).
+
+extern crate alloc;
 
 pub mod color;
 pub mod font;

--- a/crates/eidolon/src/widgets/dialer.rs
+++ b/crates/eidolon/src/widgets/dialer.rs
@@ -4,6 +4,10 @@
 //! Call/End action buttons. Digit entry via [`Key`] events; backspace
 //! on the Left key; Call/End on the corresponding physical keys.
 
+use alloc::borrow::ToOwned;
+use alloc::format;
+use alloc::string::String;
+
 use haphe::input::{Key, TouchPoint};
 
 use crate::color::Rgb565;

--- a/crates/eidolon/src/widgets/dialog.rs
+++ b/crates/eidolon/src/widgets/dialog.rs
@@ -4,6 +4,10 @@
 //! buttons (OK, Cancel, Yes, No) at the bottom. The caller queries
 //! [`Dialog::take_result`] to learn which button was activated.
 
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+
 use haphe::input::{Key, TouchPoint};
 
 use crate::color::Rgb565;

--- a/crates/eidolon/src/widgets/list.rs
+++ b/crates/eidolon/src/widgets/list.rs
@@ -3,6 +3,9 @@
 //! [`TextList`] renders a bounded list of text items and tracks which item
 //! is selected. Navigation is via Up/Down keys or touch tap.
 
+use alloc::string::String;
+use alloc::vec::Vec;
+
 use haphe::input::{Key, TouchPoint};
 
 use crate::color::Rgb565;
@@ -236,6 +239,8 @@ impl Focusable for TextList {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::ToString;
+
     use super::*;
 
     fn make_list(items: &[&str]) -> TextList {

--- a/crates/eidolon/src/widgets/menu.rs
+++ b/crates/eidolon/src/widgets/menu.rs
@@ -5,6 +5,9 @@
 //! the caller uses to dispatch work. Navigation is by Up/Down/Select; the
 //! Left key (or a back-button item) pops the navigation stack.
 
+use alloc::string::String;
+use alloc::vec::Vec;
+
 use haphe::input::{Key, TouchPoint};
 
 use crate::color::Rgb565;
@@ -283,6 +286,8 @@ impl Focusable for Menu {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
+
     use super::*;
 
     fn root_items() -> Vec<MenuItem> {


### PR DESCRIPTION
Settles #731 empirically. **eidolon ports to `no_std` + `alloc` in 27 insertions and one deletion across 7 files.**

## The premise this disproves

`crates/thumos/src/ui.rs:21-22` states the reason the kernel duplicates eidolon's font table, colour type, and drawing primitives:

> The font module is duplicated here because eidolon depends on `std` (via `Vec`) and cannot be linked into the `#![no_std]` kernel.

`Vec` has never required `std` — it lives in `alloc`, which the kernel already links. `ui.rs:31` does `extern crate alloc` and `ui.rs:32` uses `alloc::vec::Vec`, nine lines below the comment claiming `Vec` forces `std`.

That justification has been load-bearing for the entire UI architecture, and it was wrong.

## What the port actually cost

```
crates/eidolon/src/color.rs           4 +++-
crates/eidolon/src/framebuffer.rs     3 +++
crates/eidolon/src/lib.rs             3 +++
crates/eidolon/src/widgets/dialer.rs  4 ++++
crates/eidolon/src/widgets/dialog.rs  4 ++++
crates/eidolon/src/widgets/list.rs    5 +++++
crates/eidolon/src/widgets/menu.rs    5 +++++
7 files changed, 27 insertions(+), 1 deletion(-)
```

`#![no_std]`, `extern crate alloc`, `String`/`Vec`/`format!`/`ToOwned` imported from `alloc`, and one `std::fmt` → `core::fmt`.

**No float maths** — so no `libm` dependency. **No `HashMap`** — so no `BTreeMap` migration. **No `cfg_attr(not(test), no_std)`.**

That last point is the one worth dwelling on. `#![no_std]` is unconditional, so the crate is genuinely `no_std` **including under test** — not the weaker variant that is only `no_std` when tests are compiled out. The whole test suite runs against the ported crate, which is what makes the result trustworthy rather than merely green.

## What this unblocks

eidolon is the touch-capable widget layer the kernel does not have:

```
crates/eidolon/src/widget.rs:40           fn on_touch(&mut self, point: TouchPoint) -> bool;
crates/eidolon/src/widgets/menu.rs:259    fn on_touch(...)
crates/eidolon/src/widgets/list.rs:217    fn on_touch(...)
crates/eidolon/src/widgets/dialer.rs:254  fn on_touch(...)
crates/eidolon/src/widgets/dialog.rs      fn on_touch(...)
```

The kernel's `Screen` trait (`ui.rs:633`) has exactly four methods — `draw`, `on_key`, `softkey_left`, `softkey_right`. No `on_touch`. `TouchPoint` and `InputEvent::Touch` have **zero** references anywhere in `crates/thumos/src`, and `kardia.rs:311` dispatches `on_key` only.

Meanwhile `crates/haphe/src/touch.rs` carries a real FT-series multi-touch driver with `X_MAX=239`/`Y_MAX=319` matching the panel exactly. The driver exists, the touch widgets exist and are tested, and they could not meet — because of a barrier that was not there.

## Deliberately not in this PR

No kernel link, no deletion of `ui.rs`'s duplicated font/colour/primitives, no `Keyboard` widget, no behaviour changes. This PR answers one question — *does it port, and at what cost* — and each follow-on deserves its own reviewable diff. Contaminating this one would have obscured the answer.

The linkage pattern is already proven: `sema-core`, `asphaleia-core`, `klesis-core`, `topos-core`, and `metaxu-core` all cross the workspace/kernel boundary as `{ path = "../x-core", default-features = false }` at `crates/thumos/Cargo.toml:79-134`.

## Verification

CI [31515732195](https://github.com/forkwright/thumos/actions/runs/31515732195) green: `rustfmt`, `workspace clippy + tests`, and the full `kernel` job — i686 host tests, armv7a cross-compile, QEMU boot and witnesses, and the zero-warning clippy gate across all nine declared feature configurations.

Closes #731
Refs: #458, #545
