### PR TITLE
fix(kernel): make screen dispatch exhaustive so an unreachable screen cannot render as Home

### DIFF
--- a/crates/thumos/src/kardia.rs
+++ b/crates/thumos/src/kardia.rs
@@ -51,6 +51,7 @@ use crate::screen_home::{HomeScreen, HomeScreenState, OperatingMode};
 use crate::screen_messages::MessagesScreen;
 use crate::screen_search::SearchScreen;
 use crate::screen_settings::SettingsMenuScreen;
+use crate::screen_unimplemented::UnimplementedScreen;
 use crate::security::KEY_SIZE;
 use crate::security_mode::ModeManager;
 use crate::sim::SimManager;
@@ -58,7 +59,7 @@ use crate::sms::SmsManager;
 use crate::status_bar::{KernelStatusBar, NetworkService, StatusBarState};
 use crate::telephony::{BootModemTransport, RadioAccessTech, RatGeneration, Telephony};
 use crate::uart::Uart;
-use crate::ui::{Screen, ScreenId, UiManager};
+use crate::ui::{Screen, ScreenId, ScreenKind, UiManager, screen_kind};
 
 /// Timer ticks per wall-clock second (exceptions.rs `TICK_MS` = 10).
 const TICKS_PER_SECOND: u64 = 100;
@@ -135,8 +136,10 @@ pub(crate) struct KernelState {
     home: HomeScreen,
     /// The screens reachable from Home (#400). Each is dependency-free to
     /// construct; subsystem wirings later feed their content (#398 dialer,
-    /// #402 clock into home, etc.). Screens not held here fall back to Home in
-    /// the dispatch match until their subsystem PR adds the field + arm.
+    /// #402 clock into home, etc.). A `ScreenId` not held here as a field
+    /// classifies as [`ScreenKind::NotImplemented`] and renders through
+    /// [`Self::not_implemented`] until its subsystem PR adds the field + arm
+    /// (#730 -- this used to silently fall back to Home instead).
     messages: MessagesScreen,
     search: SearchScreen,
     dialer: DialerScreen,
@@ -149,6 +152,13 @@ pub(crate) struct KernelState {
     /// WMT backend binds on device.
     fm: FmRadio<BootFmHw>,
     fm_screen: FmScreen,
+    /// Fallback for any `ScreenId` [`screen_kind`] classifies as
+    /// [`ScreenKind::NotImplemented`] (#730): renders an unmistakable,
+    /// screen-naming "NOT IMPLEMENTED" state instead of the render
+    /// dispatch silently falling through to Home. `active_screen_mut` and
+    /// `render_if_dirty` both call `set_screen` on this before selecting
+    /// it, so the label always names the screen actually requested.
+    not_implemented: UnimplementedScreen,
     /// Cursor into the qemu synthetic-input script. Real keypad decode is
     /// hardware-gated + net-new (no KPD model on -machine virt, no decoder
     /// in-tree); #400 input dispatch is CI-verified via a scripted key sequence
@@ -265,6 +275,7 @@ impl KernelState {
             calendar: CalendarScreen::new(),
             fm: FmRadio::new(BootFmHw::new()),
             fm_screen: FmScreen::new(),
+            not_implemented: UnimplementedScreen::new(),
             fb,
             last_second: 0,
             #[cfg(feature = "qemu")]
@@ -273,18 +284,25 @@ impl KernelState {
     }
 
     /// The active screen as a `&mut dyn Screen`, for input dispatch (#400).
-    /// Screens not yet wired as fields fall back to Home (their subsystem PR
-    /// adds the field + arm); the qemu input script only navigates to wired
-    /// screens, so the fallback is never exercised in CI.
+    /// Classified through [`screen_kind`] -- the same table `render_if_dirty`
+    /// matches on -- so the input and render dispatches cannot silently
+    /// disagree about which `ScreenId`s are wired (#730: `FmRadio` used to
+    /// take input while Home stayed painted, because this match and the
+    /// render match were two independent, drifted tables).
     fn active_screen_mut(&mut self) -> &mut dyn Screen {
-        match self.ui.active_screen() {
-            ScreenId::Messages => &mut self.messages,
-            ScreenId::Search => &mut self.search,
-            ScreenId::Dialer => &mut self.dialer,
-            ScreenId::Settings => &mut self.settings,
-            ScreenId::Calendar => &mut self.calendar,
-            ScreenId::FmRadio => &mut self.fm_screen,
-            _ => &mut self.home,
+        let id = self.ui.active_screen();
+        match screen_kind(id) {
+            ScreenKind::Home => &mut self.home,
+            ScreenKind::Messages => &mut self.messages,
+            ScreenKind::Search => &mut self.search,
+            ScreenKind::Dialer => &mut self.dialer,
+            ScreenKind::Settings => &mut self.settings,
+            ScreenKind::Calendar => &mut self.calendar,
+            ScreenKind::FmRadio => &mut self.fm_screen,
+            ScreenKind::NotImplemented => {
+                self.not_implemented.set_screen(id);
+                &mut self.not_implemented
+            }
         }
     }
 
@@ -439,6 +457,11 @@ impl KernelState {
         // the fb borrow (both disjoint from self.fb). Cheap for the small event
         // set; keeps the screen current whenever it is the active render target.
         self.calendar.update(&self.heorte, self.wall_clock);
+        let active = self.ui.active_screen();
+        // #730: cheap regardless of whether the placeholder is actually the
+        // render target this pass -- mirrors the calendar.update() pattern
+        // above (feed screens their content before the fb borrow, unconditionally).
+        self.not_implemented.set_screen(active);
         let fb = self.fb.as_deref_mut()?;
         let status = StatusBarState {
             network,
@@ -459,13 +482,19 @@ impl KernelState {
         // navigation stack has selected, not just Home. Inlined (not
         // active_screen_mut) because fb already holds a &mut borrow of self.fb;
         // this immutable match over disjoint screen fields coexists with it.
-        let screen: &dyn Screen = match self.ui.active_screen() {
-            ScreenId::Messages => &self.messages,
-            ScreenId::Search => &self.search,
-            ScreenId::Dialer => &self.dialer,
-            ScreenId::Settings => &self.settings,
-            ScreenId::Calendar => &self.calendar,
-            _ => &self.home,
+        //
+        // Classified through the SAME [`screen_kind`] table `active_screen_mut`
+        // matches on (#730) -- this match has no catch-all, so a `ScreenId`
+        // with no arm here is a compile error, not a silent Home render.
+        let screen: &dyn Screen = match screen_kind(active) {
+            ScreenKind::Home => &self.home,
+            ScreenKind::Messages => &self.messages,
+            ScreenKind::Search => &self.search,
+            ScreenKind::Dialer => &self.dialer,
+            ScreenKind::Settings => &self.settings,
+            ScreenKind::Calendar => &self.calendar,
+            ScreenKind::FmRadio => &self.fm_screen,
+            ScreenKind::NotImplemented => &self.not_implemented,
         };
         self.ui
             .render(screen, |s| KernelStatusBar::draw(s, &status), fb);
@@ -745,19 +774,6 @@ impl KernelState {
             let _ = serial.write_str("[kardia] REFLEX incoming-ring\r\n"); // WHY: best-effort loop diagnostic; must not block on a failed UART write
             // TODO(#398)[deliberate-prudent]: ring UI + audio route via persisted telephony.
         }
-    }
-}
-
-/// Name a `ScreenId` for the #400 qemu navigation CI marker.
-#[cfg(feature = "qemu")]
-fn screen_id_name(id: ScreenId) -> &'static str {
-    match id {
-        ScreenId::Home => "Home",
-        ScreenId::Search => "Search",
-        ScreenId::Messages => "Messages",
-        ScreenId::Dialer => "Dialer",
-        ScreenId::Settings => "Settings",
-        _ => "Other",
     }
 }
 
@@ -1078,8 +1094,8 @@ pub(crate) fn service_loop(mut kernel: KernelState, mut serial: Uart) -> ! {
                     &mut serial,
                     format_args!(
                         "kardia: nav {} -> {}\r\n",
-                        screen_id_name(from),
-                        screen_id_name(to)
+                        crate::ui::screen_label(from),
+                        crate::ui::screen_label(to)
                     ),
                 );
             }

--- a/crates/thumos/src/main.rs
+++ b/crates/thumos/src/main.rs
@@ -239,6 +239,7 @@ mod screen_radio;
 mod screen_search;
 mod screen_settings;
 mod screen_threat;
+mod screen_unimplemented;
 mod secrets;
 mod secure_boot;
 mod security;

--- a/crates/thumos/src/screen_unimplemented.rs
+++ b/crates/thumos/src/screen_unimplemented.rs
@@ -1,0 +1,172 @@
+//! Not-implemented placeholder screen for the thumos kernel UI.
+//!
+//! `kardia.rs`'s input and render dispatches are exhaustive over
+//! `ScreenId` with no catch-all arm (#730): every `ScreenId` maps to either
+//! a real wired screen or this placeholder. A screen with no wired
+//! implementation therefore renders an unmistakable "NOT IMPLEMENTED"
+//! state naming itself, instead of silently falling through to Home --
+//! the fail-open shape #730 fixed (a user who opened Threat Monitor and
+//! saw Home would read that as "checked, nothing to report", not
+//! "unimplemented").
+
+use crate::ui::{
+    self, CHAR_HEIGHT, CONTENT_HEIGHT, Key, SCREEN_WIDTH, Screen, ScreenAction, ScreenId, color,
+};
+
+/// Border thickness (px) framing the placeholder. Part of what makes the
+/// state unmistakable at a glance, distinct from every real screen's
+/// content (none of which draws a full-frame colored border).
+const BORDER_PX: u16 = 3;
+
+/// Fallback screen for a `ScreenId` the kernel dispatch does not yet
+/// render.
+///
+/// INVARIANT: this is the ONLY fallback in `kardia.rs`'s render/input
+/// dispatches -- `kardia::screen_kind` routes every unhandled `ScreenId`
+/// here rather than to Home (#730). `kardia.rs` calls [`Self::set_screen`]
+/// with the current `ScreenId` before every dispatch, so the label always
+/// names whichever screen is actually active, not whichever was active
+/// when the placeholder was constructed.
+pub(crate) struct UnimplementedScreen {
+    /// The screen this stand-in currently represents.
+    id: ScreenId,
+}
+
+impl UnimplementedScreen {
+    /// Construct with an arbitrary initial id; `kardia.rs` overwrites it via
+    /// [`Self::set_screen`] before every render/input dispatch.
+    pub(crate) fn new() -> Self {
+        Self { id: ScreenId::Home }
+    }
+
+    /// Record which screen this stand-in is currently representing.
+    pub(crate) fn set_screen(&mut self, id: ScreenId) {
+        self.id = id;
+    }
+}
+
+impl Screen for UnimplementedScreen {
+    fn draw(&self, fb: &mut [u16]) {
+        let w = SCREEN_WIDTH;
+        let h = CONTENT_HEIGHT;
+        ui::fill_rect(fb, w, h, 0, 0, w, h, color::BLACK);
+        // Full-frame red border -- no real screen draws one, so this state
+        // reads as distinct even before the text is legible.
+        ui::fill_rect(fb, w, h, 0, 0, w, BORDER_PX, color::RED);
+        ui::fill_rect(fb, w, h, 0, h - BORDER_PX, w, BORDER_PX, color::RED);
+        ui::fill_rect(fb, w, h, 0, 0, BORDER_PX, h, color::RED);
+        ui::fill_rect(fb, w, h, w - BORDER_PX, 0, BORDER_PX, h, color::RED);
+        ui::draw_str_centered(
+            fb,
+            w,
+            0,
+            w,
+            h / 2 - CHAR_HEIGHT,
+            "NOT IMPLEMENTED",
+            color::RED,
+            color::BLACK,
+        );
+        ui::draw_str_centered(
+            fb,
+            w,
+            0,
+            w,
+            h / 2 + 4,
+            ui::screen_label(self.id),
+            color::WHITE,
+            color::BLACK,
+        );
+    }
+
+    fn on_key(&mut self, key: Key) -> ScreenAction {
+        match key {
+            Key::Rsk | Key::End => ScreenAction::Back,
+            _ => ScreenAction::None,
+        }
+    }
+
+    fn softkey_left(&self) -> &'static str {
+        ""
+    }
+
+    fn softkey_right(&self) -> &'static str {
+        "BACK"
+    }
+
+    fn title(&self) -> &'static str {
+        "Not Implemented"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec::Vec;
+
+    use super::*;
+
+    /// Every `ScreenId` this screen might be asked to stand in for, so the
+    /// tests below cover the whole enum rather than one hand-picked example.
+    const ALL_SCREEN_IDS: [ScreenId; 20] = [
+        ScreenId::Home,
+        ScreenId::Dialer,
+        ScreenId::Messages,
+        ScreenId::Contacts,
+        ScreenId::Settings,
+        ScreenId::Search,
+        ScreenId::Calendar,
+        ScreenId::InCall,
+        ScreenId::Timer,
+        ScreenId::Stopwatch,
+        ScreenId::Alarms,
+        ScreenId::FmRadio,
+        ScreenId::WifiSettings,
+        ScreenId::BtSettings,
+        ScreenId::Privacy,
+        ScreenId::RadioControl,
+        ScreenId::About,
+        ScreenId::Battery,
+        ScreenId::Nous,
+        ScreenId::ThreatMonitor,
+    ];
+
+    #[test]
+    fn draw_renders_visible_content_for_every_screen_id() {
+        for id in ALL_SCREEN_IDS {
+            let mut screen = UnimplementedScreen::new();
+            screen.set_screen(id);
+            let mut fb = alloc::vec![0u16; SCREEN_WIDTH as usize * CONTENT_HEIGHT as usize];
+            screen.draw(&mut fb);
+            assert!(
+                fb.iter().any(|&px| px != 0),
+                "{id:?} not-implemented render must paint visible content, not stay blank"
+            );
+        }
+    }
+
+    #[test]
+    fn on_key_back_returns_to_previous_screen() {
+        let mut screen = UnimplementedScreen::new();
+        assert_eq!(screen.on_key(Key::Rsk), ScreenAction::Back);
+        assert_eq!(screen.on_key(Key::End), ScreenAction::Back);
+    }
+
+    #[test]
+    fn on_key_other_keys_do_not_navigate() {
+        let mut screen = UnimplementedScreen::new();
+        assert_eq!(screen.on_key(Key::Ok), ScreenAction::None);
+    }
+
+    #[test]
+    fn screen_label_is_distinct_and_nonempty_per_id() {
+        // A collision would let two different not-implemented screens read
+        // as the same one; an empty label would render as a blank second
+        // line, undermining the "must name the screen" requirement (#730).
+        let mut seen: Vec<&str> = Vec::new();
+        for id in ALL_SCREEN_IDS {
+            let label = ui::screen_label(id);
+            assert!(!label.is_empty(), "{id:?} has an empty label");
+            assert!(!seen.contains(&label), "label '{label}' reused for {id:?}");
+            seen.push(label);
+        }
+    }
+}

--- a/crates/thumos/src/screen_unimplemented.rs
+++ b/crates/thumos/src/screen_unimplemented.rs
@@ -79,9 +79,10 @@ impl Screen for UnimplementedScreen {
     }
 
     fn on_key(&mut self, key: Key) -> ScreenAction {
-        match key {
-            Key::Rsk | Key::End => ScreenAction::Back,
-            _ => ScreenAction::None,
+        if matches!(key, Key::Rsk | Key::End) {
+            ScreenAction::Back
+        } else {
+            ScreenAction::None
         }
     }
 

--- a/crates/thumos/src/ui.rs
+++ b/crates/thumos/src/ui.rs
@@ -606,6 +606,119 @@ pub enum ScreenId {
     ThreatMonitor,
 }
 
+/// Human-readable name for a `ScreenId`. SSOT for screen naming: the
+/// not-implemented placeholder screen (`screen_unimplemented.rs`) uses this
+/// to name the screen it is standing in for, and the qemu navigation CI
+/// witness (`kardia.rs`) uses it to label the `from`/`to` screens in its
+/// marker line.
+///
+/// Exhaustive over `ScreenId` with NO catch-all: adding a variant without a
+/// label here is a compile error, so a screen can never go silently
+/// unnamed (#730).
+pub(crate) const fn screen_label(id: ScreenId) -> &'static str {
+    match id {
+        ScreenId::Home => "Home",
+        ScreenId::Dialer => "Dialer",
+        ScreenId::Messages => "Messages",
+        ScreenId::Contacts => "Contacts",
+        ScreenId::Settings => "Settings",
+        ScreenId::Search => "Search",
+        ScreenId::Calendar => "Calendar",
+        ScreenId::InCall => "In Call",
+        ScreenId::Timer => "Timer",
+        ScreenId::Stopwatch => "Stopwatch",
+        ScreenId::Alarms => "Alarms",
+        ScreenId::FmRadio => "FM Radio",
+        ScreenId::WifiSettings => "WiFi Settings",
+        ScreenId::BtSettings => "Bluetooth Settings",
+        ScreenId::Privacy => "Privacy",
+        ScreenId::RadioControl => "Radio Control",
+        ScreenId::About => "About",
+        ScreenId::Battery => "Battery",
+        ScreenId::Nous => "Nous",
+        ScreenId::ThreatMonitor => "Threat Monitor",
+    }
+}
+
+/// Which concrete screen family a `ScreenId` maps to -- the SINGLE
+/// classification table `kardia.rs`'s `KernelState::active_screen_mut`
+/// (input dispatch) and `KernelState::render_if_dirty` (render dispatch)
+/// both match on, so the two dispatches can no longer drift apart
+/// independently. That drift is exactly what #730 found: `FmRadio` was in
+/// the input match's arm list but missing from the render match's, so the
+/// FM screen took every keypress while the framebuffer kept showing Home,
+/// and twelve `screen_search.rs` entries had no render arm at all, silently
+/// painting Home when selected.
+///
+/// Lives here (not in `kardia.rs`) because `kardia`'s `mod` declaration is
+/// `#[cfg(not(test))]` (it is the runtime continuation of the hardware boot
+/// path, #420/#528) -- classification logic that must itself be
+/// host-testable cannot live inside a module the host test build never
+/// compiles.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ScreenKind {
+    /// Home/idle screen.
+    Home,
+    /// Message list.
+    Messages,
+    /// Function search ("everything launcher").
+    Search,
+    /// Phone dialer.
+    Dialer,
+    /// Settings menu.
+    Settings,
+    /// Calendar.
+    Calendar,
+    /// FM Radio.
+    FmRadio,
+    /// No screen is wired into `KernelState` for this `ScreenId` yet. Both
+    /// dispatches route this to the not-implemented placeholder screen
+    /// (`screen_unimplemented.rs`), which renders an unmistakable state
+    /// naming the requested screen -- never Home.
+    NotImplemented,
+}
+
+/// Classify a `ScreenId` into its [`ScreenKind`] (#730).
+///
+/// Exhaustive over `ScreenId` with NO catch-all: adding a `ScreenId`
+/// variant fails this match at compile time until it is classified here,
+/// which then fails BOTH of `kardia.rs`'s dispatches at compile time (their
+/// matches over `ScreenKind` have no catch-all either) until each handles
+/// the new kind. That double exhaustiveness is the property the issue
+/// asked for: the divergence between the two dispatches is now a compile
+/// error, not a silent runtime fallback.
+pub(crate) fn screen_kind(id: ScreenId) -> ScreenKind {
+    match id {
+        ScreenId::Home => ScreenKind::Home,
+        ScreenId::Messages => ScreenKind::Messages,
+        ScreenId::Search => ScreenKind::Search,
+        ScreenId::Dialer => ScreenKind::Dialer,
+        ScreenId::Settings => ScreenKind::Settings,
+        ScreenId::Calendar => ScreenKind::Calendar,
+        ScreenId::FmRadio => ScreenKind::FmRadio,
+        // Compiled screens with no route into KernelState yet (#145 tracks
+        // wiring each in): Alarms/Timer/Stopwatch (screen_alarm.rs),
+        // InCall (screen_call.rs), Contacts (screen_contacts.rs),
+        // Nous (screen_nous.rs), Privacy (screen_privacy.rs),
+        // RadioControl (screen_radio.rs), ThreatMonitor (screen_threat.rs),
+        // WifiSettings/BtSettings/About (screen_settings.rs). Battery has no
+        // screen implementation at all yet.
+        ScreenId::Contacts
+        | ScreenId::InCall
+        | ScreenId::Timer
+        | ScreenId::Stopwatch
+        | ScreenId::Alarms
+        | ScreenId::WifiSettings
+        | ScreenId::BtSettings
+        | ScreenId::Privacy
+        | ScreenId::RadioControl
+        | ScreenId::About
+        | ScreenId::Battery
+        | ScreenId::Nous
+        | ScreenId::ThreatMonitor => ScreenKind::NotImplemented,
+    }
+}
+
 /// What the active screen wants the UI manager to do after handling input.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
@@ -1256,5 +1369,64 @@ mod tests {
         let softkey_start = content_end;
         let any_softkey = fb[softkey_start..].iter().any(|&px| px != 0);
         assert!(any_softkey, "softkey zone must contain visible pixels");
+    }
+
+    /// #730: every `ScreenId` with no wired screen must classify as
+    /// `NotImplemented`, never as `Home` -- the exact defect this
+    /// classifier exists to make impossible (`FmRadio` input-wired/
+    /// render-missing, plus the twelve `screen_search.rs` entries with no
+    /// render arm at all, all fell through to the render match's old
+    /// `_ => &self.home` catch-all).
+    #[test]
+    fn unwired_screens_are_not_implemented_not_home() {
+        const UNWIRED: [ScreenId; 13] = [
+            ScreenId::Contacts,
+            ScreenId::InCall,
+            ScreenId::Timer,
+            ScreenId::Stopwatch,
+            ScreenId::Alarms,
+            ScreenId::WifiSettings,
+            ScreenId::BtSettings,
+            ScreenId::Privacy,
+            ScreenId::RadioControl,
+            ScreenId::About,
+            ScreenId::Battery,
+            ScreenId::Nous,
+            ScreenId::ThreatMonitor,
+        ];
+        for id in UNWIRED {
+            let kind = screen_kind(id);
+            assert_eq!(
+                kind,
+                ScreenKind::NotImplemented,
+                "{id:?} has no wired screen; it must classify as NotImplemented rather than fall through to Home"
+            );
+            assert_ne!(
+                kind,
+                ScreenKind::Home,
+                "{id:?} must never be silently indistinguishable from Home (#730)"
+            );
+        }
+    }
+
+    /// Every screen genuinely wired into `KernelState` keeps its own,
+    /// distinct classification. This is the SSOT both of `kardia.rs`'s
+    /// dispatches derive from, so a wired screen accidentally grouped into
+    /// the not-implemented arm list -- or `FmRadio`'s #730 regression in
+    /// reverse -- is caught here.
+    #[test]
+    fn wired_screens_keep_distinct_classification() {
+        const WIRED: [(ScreenId, ScreenKind); 7] = [
+            (ScreenId::Home, ScreenKind::Home),
+            (ScreenId::Messages, ScreenKind::Messages),
+            (ScreenId::Search, ScreenKind::Search),
+            (ScreenId::Dialer, ScreenKind::Dialer),
+            (ScreenId::Settings, ScreenKind::Settings),
+            (ScreenId::Calendar, ScreenKind::Calendar),
+            (ScreenId::FmRadio, ScreenKind::FmRadio),
+        ];
+        for (id, expect) in WIRED {
+            assert_eq!(screen_kind(id), expect, "{id:?} classification drifted");
+        }
     }
 }

--- a/docs/capability-inventory.toml
+++ b/docs/capability-inventory.toml
@@ -106,15 +106,15 @@ notes = "Olm/Megolm + HTTP/JSON surfaces compiled, including the /keys/claim req
 
 [[capability]]
 id = "screens-extended"
-modules = ["screen_search", "screen_settings", "screen_dialer", "screen_calendar", "screen_alarm", "screen_messages", "screen_fm"]
+modules = ["screen_search", "screen_settings", "screen_dialer", "screen_calendar", "screen_messages", "screen_fm", "screen_unimplemented"]
 tier = "kernel-wired"
-notes = "screen_calendar renders via the heorte witness; screen_fm is fed by fm-radio's smoke witness; the rest are routed but unwitnessed."
+notes = "screen_calendar renders via the heorte witness; screen_fm is fed by fm-radio's smoke witness and (#730) is now routed for BOTH input and render (previously input-only, so the FM screen took keypresses while the framebuffer kept showing Home); screen_unimplemented is the exhaustive not-implemented fallback ui.rs's screen_kind classifier routes every currently-unwired ScreenId through (matched identically by both of kardia.rs's dispatches), naming the requested screen instead of silently rendering Home (#730); search/settings/dialer/messages are routed but unwitnessed. screen_settings also holds WifiSettingsScreen/BtSettingsScreen/AboutScreen, which -- like screen_alarm below -- are compiled but not routed; this module-level tier reflects that SettingsMenuScreen itself is genuinely wired, not that every screen type in the file is."
 
 [[capability]]
 id = "screens-compiled-only"
-modules = ["screen_call", "screen_contacts", "screen_nous", "screen_privacy", "screen_radio", "screen_threat"]
+modules = ["screen_alarm", "screen_call", "screen_contacts", "screen_nous", "screen_privacy", "screen_radio", "screen_threat"]
 tier = "compiled-only"
-notes = "No route/input path reaches them today (#400 routing only covers the wired set). Threat screen waits on #555's calibrated scores; nous/privacy/radio screens wait on their owning subsystems."
+notes = "No route/input path reaches them today -- selecting their ScreenId renders the screen_unimplemented placeholder instead (#730). screen_alarm was previously (incorrectly) listed under screens-extended as 'routed but unwitnessed'; no route to it exists in kardia.rs at all, which is the drift #730 found and this entry corrects. Threat screen waits on #555's calibrated scores; alarm/nous/privacy/radio/call/contacts screens wait on their owning subsystems (#145)."
 
 [[capability]]
 id = "fm-radio"

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -556,6 +556,11 @@ tests = 18
 mechanism = "host"
 
 [[module]]
+name = "screen_unimplemented"
+tests = 4
+mechanism = "host"
+
+[[module]]
 name = "secure_boot"
 tests = 28
 mechanism = "both"
@@ -687,7 +692,7 @@ mechanism = "host"
 
 [[module]]
 name = "ui"
-tests = 21
+tests = 23
 mechanism = "both"
 witness = "boot.sh"
 


### PR DESCRIPTION
Closes #730. Twelve screens were selectable from the search launcher with no render arm, so choosing **Threat Monitor** silently painted Home — and `FmRadio` took input while Home stayed on the display.

## Why this was a trust defect

A user who selects Threat Monitor and lands on Home does not conclude "unimplemented". They conclude **"I checked, and there was nothing to show."** On a device whose stated purpose is telling you when you are being surveilled, silence that reads as a clean report is the worst available failure.

Five of the twelve were the counter-surveillance surfaces: `ThreatMonitor`, `Privacy`, `RadioControl`, `WifiSettings`, `BtSettings`.

Same shape as the fail-open defects fixed earlier in this program — #685 (an `OK` prefix accepted as success), #686 (a firewall admitting unrecognised protocols), #696 (`SIM PUK2` misread as a primary-SIM lock). In each, absence of a signal was indistinguishable from a good result.

## The fix is a compile error, not twelve patches

A `ScreenKind` enum and a single `screen_kind(ScreenId) -> ScreenKind` mapping (`ui.rs:659,690`). Both dispatches then match exhaustively over that small enum.

**`screen_kind` has no catch-all.** All twenty `ScreenId` variants are listed explicitly — seven to real screens, thirteen enumerated by name as `NotImplemented`:

```rust
ScreenId::Contacts
| ScreenId::InCall
| ScreenId::Timer
| ScreenId::Stopwatch
| ScreenId::Alarms
| ScreenId::WifiSettings
| ScreenId::BtSettings
| ScreenId::Privacy
| ScreenId::RadioControl
| ScreenId::About
| ScreenId::Battery
| ScreenId::Nous
| ScreenId::ThreatMonitor => ScreenKind::NotImplemented,
```

Adding a `ScreenId` variant now **fails to compile** until someone decides which kind it is. That is the property that would have prevented this, and it is stronger than two parallel exhaustive matches: one place owns the decision, and the unimplemented set is an auditable list rather than whatever fell through a wildcard.

## The placeholder says what it is

Unimplemented screens render a `screen_unimplemented` placeholder naming the screen, rather than routing to Home. An unimplemented screen that says it is unimplemented cannot be mistaken for a clean threat report — which is the entire point.

The alternative — having the search launcher list only working screens — was deliberately not taken. It hides the twelve rather than resolving them, and it loses the compile-time guarantee.

## Verification

CI [31518371752](https://github.com/forkwright/thumos/actions/runs/31518371752) green: rustfmt, workspace clippy + tests, and the full `kernel` job — i686 host tests, armv7a cross-compile, QEMU boot and witnesses, and the zero-warning clippy gate across all nine declared feature configurations.

Closes #730
Refs: #458
