### PR TITLE
fix(kernel): point the dead-code exemptions at a live tracker and gate the inventory on it

### DIFF
--- a/crates/thumos/src/screen_alarm.rs
+++ b/crates/thumos/src/screen_alarm.rs
@@ -14,7 +14,7 @@
 // frame and has no alarm/timer route/input path.
 #![expect(
     dead_code,
-    reason = "Alarm screen is not wired into the kinit UI route (#145)"
+    reason = "Alarm screen is not wired into the kinit UI route (#737)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/screen_calendar.rs
+++ b/crates/thumos/src/screen_calendar.rs
@@ -14,11 +14,12 @@
 //! before each render cycle, avoiding references to kernel globals across
 //! the render boundary.
 
-// WHY: renderable screen exists, but kinit currently renders only the home
-// frame and has no calendar route/input path.
+// WHY: CalendarScreen itself is routed for render and input via ui.rs's
+// screen_kind (#400/#516); selected_event_id is scaffolding for the OK-key
+// event-detail action, a future wave with no implementation yet.
 #![expect(
     dead_code,
-    reason = "Calendar screen is not wired into the kinit UI route (#145)"
+    reason = "Event-detail action (OK key) not yet implemented on the routed calendar screen, tracked under #737"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/screen_call.rs
+++ b/crates/thumos/src/screen_call.rs
@@ -16,7 +16,7 @@
 // WHY: call screen created in Phase 07 Wave 3, kinit wiring pending.
 #![expect(
     dead_code,
-    reason = "Call screen created in Phase 07 Wave 3, kinit wiring pending (#145)"
+    reason = "Call screen created in Phase 07 Wave 3, kinit wiring pending (#737)"
 )]
 
 use crate::ui::{

--- a/crates/thumos/src/screen_contacts.rs
+++ b/crates/thumos/src/screen_contacts.rs
@@ -20,7 +20,7 @@
 // WHY: contacts screen created in Phase 07 Wave 5, kinit wiring pending.
 #![expect(
     dead_code,
-    reason = "Contacts screen created in Phase 07 Wave 5, kinit wiring pending (#145)"
+    reason = "Contacts screen created in Phase 07 Wave 5, kinit wiring pending (#737)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/screen_nous.rs
+++ b/crates/thumos/src/screen_nous.rs
@@ -51,7 +51,7 @@
 // WHY: nous chat screen created in Phase 09 Wave 8, full integration pending.
 #![expect(
     dead_code,
-    reason = "Nous chat screen created in Phase 09 Wave 8, integration pending (#145)"
+    reason = "Nous chat screen created in Phase 09 Wave 8, integration pending (#737)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/screen_privacy.rs
+++ b/crates/thumos/src/screen_privacy.rs
@@ -26,7 +26,7 @@
     not(test),
     expect(
         dead_code,
-        reason = "Privacy dashboard created in Phase 08 Wave 7, kinit wiring pending (#145)"
+        reason = "Privacy dashboard created in Phase 08 Wave 7, kinit wiring pending (#737)"
     )
 )]
 

--- a/crates/thumos/src/screen_radio.rs
+++ b/crates/thumos/src/screen_radio.rs
@@ -22,7 +22,7 @@
     not(test),
     expect(
         dead_code,
-        reason = "Radio control screen created in Phase 07 Wave 6, kinit wiring pending (#145)"
+        reason = "Radio control screen created in Phase 07 Wave 6, kinit wiring pending (#737)"
     )
 )]
 

--- a/crates/thumos/src/screen_settings.rs
+++ b/crates/thumos/src/screen_settings.rs
@@ -15,7 +15,9 @@
 //! Subpages receive state snapshots to avoid holding references to
 //! kernel globals.
 
-// WHY: settings screens created in Phase 07 Wave 6, kinit wiring pending.
+// WHY: WifiSettingsScreen/BtSettingsScreen/AboutScreen created in Phase 07
+// Wave 6, kinit wiring pending; SettingsMenuScreen itself is already routed
+// via ui.rs's screen_kind -- only the three sub-screens remain unrouted.
 // cfg_attr(not(test), ...): the module's own tests now exercise its full
 // surface, so nothing is dead in the test build -- expecting dead_code there
 // makes the expectation unfulfilled. Production reachability is unchanged;
@@ -24,7 +26,7 @@
     not(test),
     expect(
         dead_code,
-        reason = "Settings screens created in Phase 07 Wave 6, kinit wiring pending (#145)"
+        reason = "WifiSettingsScreen/BtSettingsScreen/AboutScreen created in Phase 07 Wave 6, kinit wiring pending (#737); SettingsMenuScreen is wired"
     )
 )]
 

--- a/crates/thumos/src/screen_threat.rs
+++ b/crates/thumos/src/screen_threat.rs
@@ -25,10 +25,13 @@
 //! Accessible from `screen_search.rs` via function search "Threat Monitor"
 //! (`ScreenId::ThreatMonitor`), and from the status bar threat indicator.
 
-// WHY: threat monitor screen created in Phase 10 Wave 5, kinit wiring pending.
+// WHY: threat monitor screen created in Phase 10 Wave 5; alert aggregation
+// across the Phase 10 radio-intelligence subsystems and the #555
+// calibrated-score design (score-as-a-lens-over-the-log) are the remaining
+// kinit wiring dependency, tracked under #737.
 #![expect(
     dead_code,
-    reason = "Threat monitor screen created in Phase 10 Wave 5, kinit wiring pending"
+    reason = "Threat monitor screen implemented and tested; kinit wiring depends on #555's calibrated threat scores, tracked under #737"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/ui.rs
+++ b/crates/thumos/src/ui.rs
@@ -696,7 +696,7 @@ pub(crate) fn screen_kind(id: ScreenId) -> ScreenKind {
         ScreenId::Settings => ScreenKind::Settings,
         ScreenId::Calendar => ScreenKind::Calendar,
         ScreenId::FmRadio => ScreenKind::FmRadio,
-        // Compiled screens with no route into KernelState yet (#145 tracks
+        // Compiled screens with no route into KernelState yet (#737 tracks
         // wiring each in): Alarms/Timer/Stopwatch (screen_alarm.rs),
         // InCall (screen_call.rs), Contacts (screen_contacts.rs),
         // Nous (screen_nous.rs), Privacy (screen_privacy.rs),

--- a/docs/capability-inventory.toml
+++ b/docs/capability-inventory.toml
@@ -114,7 +114,8 @@ notes = "screen_calendar renders via the heorte witness; screen_fm is fed by fm-
 id = "screens-compiled-only"
 modules = ["screen_alarm", "screen_call", "screen_contacts", "screen_nous", "screen_privacy", "screen_radio", "screen_threat"]
 tier = "compiled-only"
-notes = "No route/input path reaches them today -- selecting their ScreenId renders the screen_unimplemented placeholder instead (#730). screen_alarm was previously (incorrectly) listed under screens-extended as 'routed but unwitnessed'; no route to it exists in kardia.rs at all, which is the drift #730 found and this entry corrects. Threat screen waits on #555's calibrated scores; alarm/nous/privacy/radio/call/contacts screens wait on their owning subsystems (#145)."
+notes = "No route/input path reaches them today -- selecting their ScreenId renders the screen_unimplemented placeholder instead (#730). screen_alarm was previously (incorrectly) listed under screens-extended as 'routed but unwitnessed'; no route to it exists in kardia.rs at all, which is the drift #730 found and this entry corrects. Threat screen waits on #555's calibrated scores; alarm/nous/privacy/radio/call/contacts screens wait on their owning subsystems reaching the kinit event loop (#737)."
+tracking_reason = "Implemented and unit-tested, not hardware-gated -- kinit route/input wiring tracked under #737 (#145 closed without a successor, which is what #737 corrects). screen_threat's alert aggregation additionally depends on #555's calibrated threat scores."
 
 [[capability]]
 id = "fm-radio"
@@ -128,6 +129,7 @@ id = "apps-compiled-only"
 modules = ["contacts", "t9", "briar", "meshtastic", "ekphrasis", "provision", "encryption", "nous"]
 tier = "compiled-only"
 notes = "No production call path from boot/loop. Owners: encryption #449/#446, nous #552, ekphrasis #553, provision USB OTG (Phase 8 deferral), briar/meshtastic Phase 9 stubs."
+tracking_reason = "Not hardware-gated -- encryption tracked under #449/#446, nous under #552, ekphrasis under #553. contacts and t9 have no open tracking issue for their kinit wiring; their #[expect(dead_code)] reasons still cite the closed #145, the same drift #737 corrects for the screens."
 
 [[capability]]
 id = "hardware-support"

--- a/scripts/check-wiring-inventory.sh
+++ b/scripts/check-wiring-inventory.sh
@@ -8,6 +8,9 @@ set -euo pipefail
 #       (the witness is claimed but nothing asserts it), or
 #   (c) a witness marker is absent from the QEMU boot log (default ./boot.log;
 #       pass --no-log to skip (c) when no boot has run yet)
+#   (d) a compiled-only capability has neither hardware_reason nor a
+#       tracking_reason naming a live issue (#737: a dead_code suppression
+#       that cites nothing checkable reads as vestigial to a cleanup sweep)
 # The inventory is the SSOT for capability reachability; README's capability
 # section and docs/KERNEL-WIRING-AUDIT.md's successor point at it.
 
@@ -73,7 +76,40 @@ if log_path:
             if w not in log:
                 fail(f"witness '{w}' (capability {cid}) did not fire in the boot log")
 
+
+# (d) every compiled-only capability names why it stays unwired: either a
+# hardware gate (hardware_reason -- physically blocked, no issue needed) or
+# a tracking_reason citing a live issue (implemented-but-unwired -- these
+# are different facts, per #737). Presence-only: confirming the cited issue
+# is still OPEN needs the GitHub API, which this offline gate refuses to
+# require. A closed-issue citation with no successor is exactly the failure
+# mode #737 exists to correct (#145 closed while nine screens kept citing
+# it) -- this check cannot see that, only that some live-looking reference
+# exists at all, which is the offline-checkable half of the problem.
+TRACKER_RE = re.compile(r'#\d+')
+compiled_only = [c for c in caps if c.get("tier") == "compiled-only"]
+for c in compiled_only:
+    hw = (c.get("hardware_reason") or "").strip()
+    tr = (c.get("tracking_reason") or "").strip()
+    if hw:
+        continue
+    if not tr:
+        fail(
+            f"capability '{c['id']}' is compiled-only but has neither hardware_reason nor "
+            "tracking_reason -- add hardware_reason if hardware-gated, or tracking_reason "
+            "citing a live issue (e.g. '#737') if implemented-but-unwired"
+        )
+    elif not TRACKER_RE.search(tr):
+        fail(
+            f"capability '{c['id']}' has a tracking_reason but it names no issue "
+            f"(expected a '#NNN' reference): '{tr}'"
+        )
+
 if rc == 0:
-    print(f"wiring inventory: {len(mods)} modules classified in {len(caps)} capabilities, {len(markers)} witness markers verified")
+    print(
+        f"wiring inventory: {len(mods)} modules classified in {len(caps)} capabilities, "
+        f"{len(markers)} witness markers verified, {len(compiled_only)} compiled-only "
+        "capabilities have a hardware or tracking reason"
+    )
 sys.exit(rc)
 PYEOF


### PR DESCRIPTION
Layers 1–3 of #737. Twelve screens are implemented, unit-tested, and unreachable, and the exemptions protecting them cited **closed** #145 — so a reader checking that claim found a finished issue and could reasonably conclude the code was vestigial.

## Layer 1 — repoint the citations

Nine screen files, plus `ui.rs`'s `screen_kind()` comment which carried the identical claim and was not in the original list.

Two judgement calls worth surfacing:

- **`screen_threat.rs` was worse than stale.** Its module-level `#[expect(dead_code)]` cited *"kinit wiring pending"* with **no issue number at all** — nothing to check. Its separate `#145` reference is a doc comment on `from_message_class` about the SMS path not being reached, which is the telephony gap, not screen reachability. Repointing that one at #737 would have misstated this issue's scope, so it was left.
- **`nous.rs` and `ekphrasis.rs` cite closed #145 while `capability-inventory.toml` already records their real trackers** — #552 and #553. The answer existed and was never applied to the source. Out of this PR's scope; recorded in #738.

## Layer 2 — `tracking_reason`

Mirrors the existing `hardware_reason` in shape and placement. The distinction is the point: *hardware-gated* and *written, tested, awaiting a data feed* are different facts, and a cleanup sweep should treat them differently.

Populated for **both** `compiled-only` tiers, not just screens — the guard's wording is generic, so leaving `apps-compiled-only` empty would have made this PR fail its own new check. Its value is honest about what is real: #449/#446, #552, #553 for the tracked modules, and an explicit admission that `contacts` and `t9` have **no tracker anywhere**.

## Layer 3 — the guard, proven to fire

`check-wiring-inventory.sh` now fails when a `compiled-only` entry has neither a hardware reason nor a tracking reference naming an issue.

Fault-injected twice against the live script rather than asserted:

```
field removed        -> INVENTORY DRIFT: capability 'screens-compiled-only' is compiled-only
                        but has neither hardware_reason nor tracking_reason ...
field with no #NNN   -> INVENTORY DRIFT: capability 'screens-compiled-only' has a
                        tracking_reason but it names no issue (expected a '#NNN' reference)
```

Both exit 1 and name the offending entry and what it lacks. Restored and reverified clean afterwards. A guard nobody has seen fail is an assertion, not a check.

**It deliberately does not verify issue *state*.** Whether an issue is closed cannot be determined offline, and this script runs inside the required `kernel` job — a guard reaching for the GitHub API there fails whenever the API does. It enforces presence, which is checkable offline.

## A correction to the brief

I told this lane the script ran `set -uo pipefail` and to check before adding `-e`. It already had `set -euo pipefail`, and `-e` is safe here for a reason worth recording: the multi-failure collection happens **inside** a single `python3` heredoc invocation, not across bash statements. `kernel-clippy.sh` omits `-e` because it runs sequential commands it needs to survive; this script runs one.

## Scope found, not fixed

`main.rs:17` carries a **crate-level** `#![expect(dead_code, reason = "compiled-but-unwired surface, tracked #145/#420")]` — and **both** issues are closed. 35 files carry 62 citations of #145, twenty in `emmc.rs` alone. Those sit under `kernel-wired`/`emulated-mock-proven` tiers, which this guard structurally cannot see. Filed as **#738**.

## Verification

CI [31531874210](https://github.com/forkwright/thumos/actions/runs/31531874210) green — `rustfmt`, `workspace clippy + tests`, and the full `kernel` job including the modified inventory-check step. `bash -n` and `shellcheck` clean.

Refs: #737, #738, #145
