### PR TITLE
feat(eidolon): add the on-screen keyboard and compose-field widgets

### DIFF
--- a/crates/eidolon/src/lib.rs
+++ b/crates/eidolon/src/lib.rs
@@ -14,7 +14,7 @@
 //! - [`font`]: 8×16 bitmap font with character and string rendering.
 //! - [`status_bar`]: top status strip (signal, time, battery).
 //! - [`widget`]: [`widget::Widget`] and [`widget::Focusable`] traits for UI components.
-//! - [`widgets`]: concrete widget implementations (list, menu, dialog, dialer).
+//! - [`widgets`]: concrete widget implementations (list, menu, dialog, dialer, keyboard, compose).
 
 extern crate alloc;
 
@@ -30,4 +30,7 @@ pub use font::{CHAR_HEIGHT, CHAR_WIDTH, draw_char, draw_str};
 pub use framebuffer::Framebuffer;
 pub use status_bar::StatusBar;
 pub use widget::{Focusable, Widget};
-pub use widgets::{Dialog, DialogButton, Menu, MenuItem, PhoneDialer, TextList, TextListConfig};
+pub use widgets::{
+    ComposeField, Dialog, DialogButton, Keyboard, KeyboardEvent, Menu, MenuItem, PhoneDialer,
+    TextList, TextListConfig,
+};

--- a/crates/eidolon/src/widgets/compose.rs
+++ b/crates/eidolon/src/widgets/compose.rs
@@ -1,0 +1,562 @@
+//! Compose text-buffer widget.
+//!
+//! [`ComposeField`] is the growable multi-character body with a cursor that
+//! nothing else in eidolon manages -- [`crate::widgets::PhoneDialer`] only
+//! ever holds a fixed-purpose digit string. It owns insert/backspace/cursor
+//! movement and renders a scrolling preview that keeps the cursor visible
+//! when the buffer outgrows the strip.
+//!
+//! WHY 42px tall (#458): the full-screen keyboard layout budgets
+//! status(20) + preview(42) + 4 key rows(57 each=228) + softkey(30) = 320,
+//! the panel's exact height. 42 divides evenly by 2 lines (21px each),
+//! itself taller than the 16px glyph it centers -- a deliberate touch
+//! target for the tap-to-place-cursor affordance below.
+//!
+//! ## Dual input
+//!
+//! - Touch: tapping inside the preview places the cursor at the tapped
+//!   character position. This is the case the operator named for touch as a
+//!   modal accelerator over the keypad -- jumping the cursor to an arbitrary
+//!   point in already-typed text has no comfortable keypad equivalent
+//!   (repeated Left/Right presses), so touch clearly beats it here.
+//! - Keypad: [`Key::Left`]/[`Key::Right`] step the cursor one character at a
+//!   time, clamped at the buffer's ends -- the same reach as touch, just
+//!   slower, since every touch affordance still needs a keypad path.
+//!
+//! Character insertion and backspace are NOT driven through [`Key`] events:
+//! the physical keypad has no letter keys ([`haphe::input::Key`] is digits,
+//! `*`/`#`, and d-pad/action buttons only), so the only sources of
+//! characters are the [`crate::widgets::Keyboard`] widget's [`take_event`]
+//! and T9 (kernel-side, out of scope here). Whatever assembles the compose
+//! screen calls [`ComposeField::insert_char`] / [`ComposeField::backspace`]
+//! with the drained events; this widget does not know or care where a
+//! character came from.
+//!
+//! ## Coverage cost
+//!
+//! [`insert_char`] silently drops any character outside [`crate::font`]'s
+//! `0x20`-`0x7E` range: no accented characters, no emoji, no box-drawing
+//! glyphs can enter the buffer, because nothing on this panel can render
+//! them.
+//!
+//! [`take_event`]: crate::widgets::Keyboard::take_event
+//! [`insert_char`]: ComposeField::insert_char
+
+use alloc::string::String;
+
+use haphe::input::{Key, TouchPoint};
+
+use crate::color::Rgb565;
+use crate::font::{CHAR_HEIGHT, CHAR_WIDTH, draw_char};
+use crate::framebuffer::Framebuffer;
+use crate::widget::{Focusable, Widget};
+
+/// Total pixel height of the preview strip.
+const PREVIEW_HEIGHT: u32 = 42;
+
+/// Number of text lines shown in the preview.
+const PREVIEW_LINES: u32 = 2;
+
+/// Pixel height of each line's touch/render band (evenly divides `PREVIEW_HEIGHT`).
+const LINE_BAND_H: u32 = PREVIEW_HEIGHT / PREVIEW_LINES;
+
+/// Pixel width of the caret indicator.
+const CARET_WIDTH: u32 = 2;
+
+/// Lowest character this widget will insert (matches [`crate::font`]'s range).
+const FONT_MIN: char = ' ';
+
+/// Highest character this widget will insert (matches [`crate::font`]'s range).
+const FONT_MAX: char = '~';
+
+/// Byte offset of the `char_idx`-th character in `s`, or `s.len()` if
+/// `char_idx` is at or past the end.
+fn byte_index(s: &str, char_idx: usize) -> usize {
+    s.char_indices().nth(char_idx).map_or(s.len(), |(i, _)| i)
+}
+
+/// First visible character index for a buffer of `total` characters,
+/// a cursor at `cursor`, and a window of `capacity` characters.
+///
+/// Positions before `capacity` always show from the start (`0`). Once
+/// `total` exceeds `capacity`, the window is pinned to keep `cursor` inside
+/// `[start, start + capacity]`, preferring the buffer's tail.
+const fn window_start(cursor: usize, total: usize, capacity: usize) -> usize {
+    if capacity == 0 {
+        return 0;
+    }
+    let max_start = total.saturating_sub(capacity);
+    let by_cursor = cursor.saturating_sub(capacity);
+    if by_cursor < max_start {
+        by_cursor
+    } else {
+        max_start
+    }
+}
+
+/// Compose text buffer with cursor and a 2-line scrolling preview.
+///
+/// Call [`ComposeField::insert_char`] / [`ComposeField::backspace`] to
+/// mutate the buffer (see the module docs for why these are plain methods
+/// rather than [`Key`]-driven); [`Focusable::on_key`] only moves the cursor.
+#[derive(Debug)]
+pub struct ComposeField {
+    buffer: String,
+    /// Cursor position, in characters (not bytes).
+    cursor: usize,
+    width: u32,
+    focused: bool,
+}
+
+impl ComposeField {
+    /// Create an empty compose field with the given pixel width (240 on the real panel).
+    #[must_use]
+    pub(crate) const fn new(width: u32) -> Self {
+        Self {
+            buffer: String::new(),
+            cursor: 0,
+            width,
+            focused: false,
+        }
+    }
+
+    /// The composed text so far.
+    #[must_use]
+    pub(crate) fn buffer(&self) -> &str {
+        &self.buffer
+    }
+
+    /// Cursor position, in characters from the start of the buffer.
+    #[must_use]
+    pub(crate) const fn cursor(&self) -> usize {
+        self.cursor
+    }
+
+    /// Insert `ch` at the cursor and advance the cursor past it.
+    ///
+    /// Silently ignored if `ch` falls outside the font's renderable range
+    /// (see the module docs).
+    pub(crate) fn insert_char(&mut self, ch: char) {
+        if !(FONT_MIN..=FONT_MAX).contains(&ch) {
+            return;
+        }
+        let idx = byte_index(&self.buffer, self.cursor);
+        self.buffer.insert(idx, ch);
+        self.cursor += 1;
+    }
+
+    /// Delete the character before the cursor. No-op at the start of the buffer.
+    pub(crate) fn backspace(&mut self) {
+        if self.cursor == 0 {
+            return;
+        }
+        let start = byte_index(&self.buffer, self.cursor - 1);
+        self.buffer.remove(start);
+        self.cursor -= 1;
+    }
+
+    /// Move the cursor left one character, clamping at the start.
+    fn cursor_left(&mut self) {
+        self.cursor = self.cursor.saturating_sub(1);
+    }
+
+    /// Move the cursor right one character, clamping at the end.
+    fn cursor_right(&mut self) {
+        let len = self.buffer.chars().count();
+        if self.cursor < len {
+            self.cursor += 1;
+        }
+    }
+
+    /// Characters shown per line.
+    fn cols_per_line(&self) -> usize {
+        usize::try_from(self.width / CHAR_WIDTH).unwrap_or(0)
+    }
+
+    /// Total characters visible in the preview window.
+    fn capacity(&self) -> usize {
+        self.cols_per_line()
+            .saturating_mul(usize::try_from(PREVIEW_LINES).unwrap_or(2))
+    }
+}
+
+impl Widget for ComposeField {
+    fn draw(&self, fb: &mut Framebuffer, x: u32, y: u32) {
+        fb.fill_rect(x, y, self.width, PREVIEW_HEIGHT, Rgb565::BLACK);
+
+        let cols = self.cols_per_line();
+        if cols == 0 {
+            return;
+        }
+        let capacity = self.capacity();
+        let total = self.buffer.chars().count();
+        let start = window_start(self.cursor, total, capacity);
+        let end = (start + capacity).min(total);
+        let start_byte = byte_index(&self.buffer, start);
+        let end_byte = byte_index(&self.buffer, end);
+        let visible = self.buffer.get(start_byte..end_byte).unwrap_or("");
+
+        let lines_usize = usize::try_from(PREVIEW_LINES).unwrap_or(2);
+        for (i, ch) in visible.chars().enumerate() {
+            let line = i / cols;
+            if line >= lines_usize {
+                break;
+            }
+            let col = i % cols;
+            let glyph_x = x + u32::try_from(col).unwrap_or(0) * CHAR_WIDTH;
+            let glyph_y = y
+                + u32::try_from(line).unwrap_or(0) * LINE_BAND_H
+                + (LINE_BAND_H.saturating_sub(CHAR_HEIGHT)) / 2;
+            draw_char(fb, glyph_x, glyph_y, ch, Rgb565::WHITE, Rgb565::BLACK);
+        }
+
+        if self.focused {
+            let rel = self
+                .cursor
+                .saturating_sub(start)
+                .min(capacity.saturating_sub(1));
+            let line = rel / cols;
+            let col = rel % cols;
+            let caret_x = x + u32::try_from(col).unwrap_or(0) * CHAR_WIDTH;
+            let caret_y = y
+                + u32::try_from(line).unwrap_or(0) * LINE_BAND_H
+                + (LINE_BAND_H.saturating_sub(CHAR_HEIGHT)) / 2;
+            fb.fill_rect(caret_x, caret_y, CARET_WIDTH, CHAR_HEIGHT, Rgb565::YELLOW);
+        }
+    }
+
+    fn width(&self) -> u32 {
+        self.width
+    }
+
+    fn height(&self) -> u32 {
+        PREVIEW_HEIGHT
+    }
+}
+
+impl Focusable for ComposeField {
+    fn on_key(&mut self, key: Key) -> bool {
+        match key {
+            Key::Left => {
+                self.cursor_left();
+                true
+            }
+            Key::Right => {
+                self.cursor_right();
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn on_touch(&mut self, point: TouchPoint) -> bool {
+        let x = u32::from(point.x);
+        let y = u32::from(point.y);
+        if x >= self.width || y >= PREVIEW_HEIGHT {
+            return false;
+        }
+        let cols = self.cols_per_line();
+        if cols == 0 {
+            return false;
+        }
+        let line = usize::try_from(y / LINE_BAND_H).unwrap_or(0);
+        let col = usize::try_from(x / CHAR_WIDTH)
+            .unwrap_or(0)
+            .min(cols.saturating_sub(1));
+        let total = self.buffer.chars().count();
+        let capacity = self.capacity();
+        let start = window_start(self.cursor, total, capacity);
+        let idx_in_window = line.saturating_mul(cols) + col;
+        self.cursor = (start + idx_in_window).min(total);
+        true
+    }
+
+    fn is_focused(&self) -> bool {
+        self.focused
+    }
+
+    fn set_focused(&mut self, focused: bool) {
+        self.focused = focused;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sizing_is_correct() {
+        let c = ComposeField::new(240);
+        assert_eq!(c.width(), 240, "width must match constructor arg");
+        assert_eq!(
+            c.height(),
+            42,
+            "height must be the fixed 42px preview budget"
+        );
+    }
+
+    #[test]
+    fn new_is_empty() {
+        let c = ComposeField::new(240);
+        assert_eq!(c.buffer(), "", "new field must start with an empty buffer");
+        assert_eq!(c.cursor(), 0, "new field must start with cursor at 0");
+    }
+
+    #[test]
+    fn insert_char_appends_in_order() {
+        let mut c = ComposeField::new(240);
+        c.insert_char('h');
+        c.insert_char('i');
+        assert_eq!(c.buffer(), "hi", "characters must insert in press order");
+        assert_eq!(c.cursor(), 2, "cursor must advance past each insert");
+    }
+
+    #[test]
+    fn insert_char_rejects_out_of_font_range() {
+        let mut c = ComposeField::new(240);
+        c.insert_char('e');
+        c.insert_char('\u{E9}'); // outside 0x20-0x7E
+        c.insert_char('\n'); // below 0x20
+        c.insert_char('\u{7F}'); // one past 0x7E
+        assert_eq!(
+            c.buffer(),
+            "e",
+            "characters outside the font's ASCII range must be silently dropped"
+        );
+    }
+
+    #[test]
+    fn insert_char_accepts_font_boundary_chars() {
+        let mut c = ComposeField::new(240);
+        c.insert_char(' '); // 0x20, lowest renderable
+        c.insert_char('~'); // 0x7E, highest renderable
+        assert_eq!(
+            c.buffer(),
+            " ~",
+            "the font's own min/max characters must be accepted"
+        );
+    }
+
+    #[test]
+    fn backspace_removes_preceding_char() {
+        let mut c = ComposeField::new(240);
+        c.insert_char('a');
+        c.insert_char('b');
+        c.backspace();
+        assert_eq!(
+            c.buffer(),
+            "a",
+            "backspace must remove the char before the cursor"
+        );
+        assert_eq!(c.cursor(), 1, "cursor must retreat with the removed char");
+    }
+
+    #[test]
+    fn backspace_on_empty_is_noop() {
+        let mut c = ComposeField::new(240);
+        c.backspace();
+        assert_eq!(
+            c.buffer(),
+            "",
+            "backspace on empty buffer must not panic or error"
+        );
+        assert_eq!(c.cursor(), 0);
+    }
+
+    #[test]
+    fn cursor_left_right_clamp_at_bounds() {
+        let mut c = ComposeField::new(240);
+        c.insert_char('a');
+        c.insert_char('b');
+        assert!(c.on_key(Key::Left), "Left must be consumed");
+        assert_eq!(c.cursor(), 1);
+        c.on_key(Key::Left);
+        c.on_key(Key::Left); // already at 0, must clamp
+        assert_eq!(c.cursor(), 0, "cursor must clamp at 0, not go negative");
+        c.on_key(Key::Right);
+        c.on_key(Key::Right);
+        c.on_key(Key::Right); // already at len, must clamp
+        assert_eq!(c.cursor(), 2, "cursor must clamp at buffer length");
+    }
+
+    #[test]
+    fn insert_at_mid_cursor_position() {
+        let mut c = ComposeField::new(240);
+        c.insert_char('a');
+        c.insert_char('c');
+        c.on_key(Key::Left); // cursor between 'a' and 'c'
+        c.insert_char('b');
+        assert_eq!(
+            c.buffer(),
+            "abc",
+            "insert must land at the cursor, not always append"
+        );
+        assert_eq!(c.cursor(), 2);
+    }
+
+    #[test]
+    fn backspace_at_mid_cursor_position() {
+        let mut c = ComposeField::new(240);
+        c.insert_char('a');
+        c.insert_char('b');
+        c.insert_char('c');
+        c.on_key(Key::Left); // cursor between 'b' and 'c'
+        c.backspace();
+        assert_eq!(
+            c.buffer(),
+            "ac",
+            "backspace must remove the char before the cursor, not the last char"
+        );
+        assert_eq!(c.cursor(), 1);
+    }
+
+    #[test]
+    fn unrelated_key_not_consumed() {
+        let mut c = ComposeField::new(240);
+        assert!(
+            !c.on_key(Key::Select),
+            "Select has no meaning on the compose field"
+        );
+    }
+
+    // --- window_start boundary math ---
+
+    #[test]
+    fn window_start_shows_from_zero_when_buffer_fits() {
+        assert_eq!(window_start(0, 0, 60), 0);
+        assert_eq!(
+            window_start(10, 20, 60),
+            0,
+            "total under capacity must show from 0"
+        );
+    }
+
+    #[test]
+    fn window_start_pins_to_tail_when_cursor_at_end() {
+        assert_eq!(
+            window_start(60, 60, 60),
+            0,
+            "exactly-full window with cursor at the end must still start at 0"
+        );
+        assert_eq!(
+            window_start(100, 100, 60),
+            40,
+            "cursor at the very end of an overflowing buffer must pin the tail"
+        );
+    }
+
+    #[test]
+    fn window_start_scrolls_minimally_past_capacity() {
+        assert_eq!(
+            window_start(70, 100, 60),
+            10,
+            "cursor just past the first page must shift the window by exactly the overrun"
+        );
+    }
+
+    #[test]
+    fn window_start_early_cursor_shows_from_start_even_in_long_buffer() {
+        assert_eq!(
+            window_start(50, 200, 60),
+            0,
+            "a cursor still within the first page must not scroll early"
+        );
+    }
+
+    // --- overflow rendering ---
+
+    #[test]
+    fn draw_does_not_panic_with_overflowing_buffer() {
+        let mut c = ComposeField::new(240);
+        for _ in 0..100 {
+            c.insert_char('x');
+        }
+        c.set_focused(true);
+        let mut fb = Framebuffer::new(240, 42);
+        fb.clear(Rgb565::WHITE);
+        c.draw(&mut fb, 0, 0);
+        assert!(
+            fb.as_bytes().iter().any(|&b| b != 0xFF),
+            "overflowing buffer must still render visible pixels"
+        );
+    }
+
+    #[test]
+    fn draw_does_not_panic_when_empty() {
+        let c = ComposeField::new(240);
+        let mut fb = Framebuffer::new(240, 42);
+        fb.clear(Rgb565::WHITE);
+        c.draw(&mut fb, 0, 0);
+        // Background fill alone must produce non-background pixels (black fill on white bg).
+        assert!(
+            fb.as_bytes().iter().any(|&b| b != 0xFF),
+            "an empty field must still paint its background"
+        );
+    }
+
+    // --- touch cursor placement ---
+
+    #[test]
+    fn touch_places_cursor_at_column_edges_on_line_zero() {
+        let mut c = ComposeField::new(240);
+        for _ in 0..40 {
+            c.insert_char('x');
+        }
+        c.on_touch(TouchPoint::new(0, 0, 100, 0));
+        assert_eq!(
+            c.cursor(),
+            0,
+            "tapping the first cell must place the cursor at 0"
+        );
+        c.on_touch(TouchPoint::new(7, 0, 100, 0));
+        assert_eq!(c.cursor(), 0, "x=7 is still inside column 0 (8px wide)");
+        c.on_touch(TouchPoint::new(8, 0, 100, 0));
+        assert_eq!(c.cursor(), 1, "x=8 is the first pixel of column 1");
+    }
+
+    #[test]
+    fn touch_places_cursor_on_line_boundary() {
+        let mut c = ComposeField::new(240);
+        for _ in 0..40 {
+            c.insert_char('x');
+        }
+        c.on_touch(TouchPoint::new(0, 20, 100, 0));
+        assert_eq!(
+            c.cursor(),
+            0,
+            "y=20 is the last pixel of line 0 (21px band)"
+        );
+        c.on_touch(TouchPoint::new(0, 21, 100, 0));
+        assert_eq!(
+            c.cursor(),
+            30,
+            "y=21 is the first pixel of line 1, which starts at window index 30 (cols_per_line)"
+        );
+    }
+
+    #[test]
+    fn touch_out_of_bounds_not_consumed() {
+        let mut c = ComposeField::new(240);
+        assert!(
+            !c.on_touch(TouchPoint::new(240, 0, 100, 0)),
+            "x == width is off-widget and must not be consumed"
+        );
+        assert!(
+            !c.on_touch(TouchPoint::new(0, 42, 100, 0)),
+            "y == height is off-widget and must not be consumed"
+        );
+    }
+
+    #[test]
+    fn focus_set_and_cleared() {
+        let mut c = ComposeField::new(240);
+        assert!(!c.is_focused(), "field must start unfocused");
+        c.set_focused(true);
+        assert!(c.is_focused(), "must be focused after set_focused(true)");
+        c.set_focused(false);
+        assert!(
+            !c.is_focused(),
+            "must be unfocused after set_focused(false)"
+        );
+    }
+}

--- a/crates/eidolon/src/widgets/compose.rs
+++ b/crates/eidolon/src/widgets/compose.rs
@@ -156,7 +156,7 @@ impl ComposeField {
     }
 
     /// Move the cursor left one character, clamping at the start.
-    fn cursor_left(&mut self) {
+    const fn cursor_left(&mut self) {
         self.cursor = self.cursor.saturating_sub(1);
     }
 

--- a/crates/eidolon/src/widgets/keyboard.rs
+++ b/crates/eidolon/src/widgets/keyboard.rs
@@ -714,11 +714,12 @@ mod tests {
     fn space_row_collapses_and_recenters_from_its_own_width() {
         let mut k = Keyboard::new(240);
         k.set_focused(true);
-        // From row 2 col 9 (period), Down into row 3: the single full-width
-        // key absorbs every incoming column.
+        // Row 0 col 9 -> row 1 col 9 -> row 2 col 9 (period) -> row 3: the
+        // single full-width key absorbs every incoming column.
         for _ in 0..9 {
             k.on_key(Key::Right);
         }
+        k.on_key(Key::Down);
         k.on_key(Key::Down);
         k.on_key(Key::Down);
         k.on_key(Key::Select);

--- a/crates/eidolon/src/widgets/keyboard.rs
+++ b/crates/eidolon/src/widgets/keyboard.rs
@@ -1,0 +1,924 @@
+//! On-screen QWERTY keyboard widget.
+//!
+//! [`Keyboard`] renders a touch QWERTY grid over a fixed-pitch 10-unit column
+//! system (24px per unit at the 240px panel width) so hit-testing and keypad
+//! navigation share the same geometry. Layout (#458), top to bottom:
+//!
+//! - Row 0: `q w e r t y u i o p` (10 letters, 1 unit each)
+//! - Row 1: `a s d f g h j k l` (9 letters) + `DEL` (1 unit)
+//! - Row 2: `Shift` (1 unit) + `z x c v b n m` (7 letters) + `,` + `.`
+//! - Row 3: a single `SPACE` key spanning the full width
+//! - Softkey bar: `T9` (switch to multi-tap fallback) + `DONE` (5 units each)
+//!
+//! WHY these row heights (#458): the full-screen layout budgets
+//! status(20) + compose-preview(42) + 4x`KEY_ROW_H`(57) + softkey(30) = 320,
+//! the panel's exact height. 57px is 97% of the 59px comfortable finger
+//! target derived for this panel (2.4in/240x320 -> 166.7 PPI -> 9mm contact);
+//! the 30px softkey row and the 24px unit width both undershoot that target
+//! deliberately -- width is the permanent constraint on this panel, and the
+//! softkey bar carries secondary, infrequent actions.
+//!
+//! ## Dual input
+//!
+//! Every key is reachable both ways:
+//! - Touch: tapping a key's rect presses it directly.
+//! - Keypad: [`Key::Up`]/[`Key::Down`]/[`Key::Left`]/[`Key::Right`] move a
+//!   highlighted-key cursor; [`Key::Select`] presses whatever is
+//!   highlighted. Vertical movement preserves horizontal pixel position by
+//!   re-resolving the nearest key under the previous key's center in the
+//!   target row, so moving between rows of different key counts (e.g. the
+//!   10-key letter rows and the single full-width `SPACE` row) lands
+//!   somewhere sensible rather than on a fixed column index.
+//!
+//! `Shift` is a sticky toggle (not one-shot): no widget in this crate has a
+//! time source, so "revert after one letter" is not implementable without
+//! one. Pressing `Shift` again reverts it.
+//!
+//! ## Coverage cost
+//!
+//! [`crate::font`] only covers ASCII `0x20`-`0x7E`. This grid exposes `,`
+//! and `.` directly and nothing else beyond letters/space/backspace --
+//! apostrophe and other ASCII punctuation are reachable through neither
+//! touch nor the keypad cursor on this grid. `T9` is one softkey away as
+//! the accuracy/coverage fallback.
+
+use haphe::input::{Key, TouchPoint};
+
+use crate::color::Rgb565;
+use crate::font::{CHAR_HEIGHT, draw_str, str_pixel_width};
+use crate::framebuffer::Framebuffer;
+use crate::widget::{Focusable, Widget};
+
+/// Grid columns per full-width row (10 QWERTY keys at 24px each on a 240px panel).
+const GRID_UNITS: u32 = 10;
+
+/// Height of each of the four main key rows.
+const KEY_ROW_H: u32 = 57;
+
+/// Height of the softkey bar.
+const SOFTKEY_ROW_H: u32 = 30;
+
+/// Number of main (non-softkey) rows.
+const MAIN_ROW_COUNT: usize = 4;
+
+/// Total number of rows, including the softkey bar.
+const NUM_ROWS: usize = MAIN_ROW_COUNT + 1;
+
+/// Total pixel height of the widget: four 57px rows plus the 30px softkey bar.
+const KEYBOARD_HEIGHT: u32 = KEY_ROW_H * MAIN_ROW_COUNT as u32 + SOFTKEY_ROW_H;
+
+/// Background color for an unhighlighted key (matches [`crate::widgets::PhoneDialer`]'s keypad).
+const KEY_BG: Rgb565 = Rgb565::from_rgb(30, 30, 60);
+
+/// What a key does when pressed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KeyAction {
+    /// Lowercase letter; display and emission respect `shift_active`.
+    Letter(char),
+    /// Fixed punctuation; unaffected by shift.
+    Symbol(char),
+    /// Inserts a literal space.
+    Space,
+    /// Deletes the character before the cursor in the compose buffer.
+    Backspace,
+    /// Toggles `shift_active`.
+    Shift,
+    /// Requests a switch to T9 multi-tap input (the accuracy fallback).
+    SwitchToT9,
+    /// Requests the keyboard be dismissed / composition committed.
+    Done,
+}
+
+/// One key's action, grid width, and (for non-letter keys) fixed label.
+#[derive(Debug, Clone, Copy)]
+struct KeyDef {
+    action: KeyAction,
+    /// Width in grid units (24px each at the 240px panel width).
+    units: u32,
+    /// Fixed label for non-letter/symbol keys; `None` means the display
+    /// character is derived from `action` at draw time (case-sensitive to shift).
+    label: Option<&'static str>,
+}
+
+impl KeyDef {
+    /// A single-unit lowercase letter key.
+    const fn letter(ch: char) -> Self {
+        Self {
+            action: KeyAction::Letter(ch),
+            units: 1,
+            label: None,
+        }
+    }
+
+    /// A single-unit fixed-symbol key, unaffected by shift.
+    const fn symbol(ch: char) -> Self {
+        Self {
+            action: KeyAction::Symbol(ch),
+            units: 1,
+            label: None,
+        }
+    }
+
+    /// A key with a fixed multi-character label spanning `units` grid columns.
+    const fn special(action: KeyAction, units: u32, label: &'static str) -> Self {
+        Self {
+            action,
+            units,
+            label: Some(label),
+        }
+    }
+}
+
+/// Row 0: `q w e r t y u i o p`.
+const ROW0: [KeyDef; 10] = [
+    KeyDef::letter('q'),
+    KeyDef::letter('w'),
+    KeyDef::letter('e'),
+    KeyDef::letter('r'),
+    KeyDef::letter('t'),
+    KeyDef::letter('y'),
+    KeyDef::letter('u'),
+    KeyDef::letter('i'),
+    KeyDef::letter('o'),
+    KeyDef::letter('p'),
+];
+
+/// Row 1: `a s d f g h j k l` + backspace.
+const ROW1: [KeyDef; 10] = [
+    KeyDef::letter('a'),
+    KeyDef::letter('s'),
+    KeyDef::letter('d'),
+    KeyDef::letter('f'),
+    KeyDef::letter('g'),
+    KeyDef::letter('h'),
+    KeyDef::letter('j'),
+    KeyDef::letter('k'),
+    KeyDef::letter('l'),
+    KeyDef::special(KeyAction::Backspace, 1, "DEL"),
+];
+
+/// Row 2: shift + `z x c v b n m` + `,` + `.`.
+const ROW2: [KeyDef; 10] = [
+    KeyDef::special(KeyAction::Shift, 1, "^"),
+    KeyDef::letter('z'),
+    KeyDef::letter('x'),
+    KeyDef::letter('c'),
+    KeyDef::letter('v'),
+    KeyDef::letter('b'),
+    KeyDef::letter('n'),
+    KeyDef::letter('m'),
+    KeyDef::symbol(','),
+    KeyDef::symbol('.'),
+];
+
+/// Row 3: a single full-width space bar.
+const ROW3: [KeyDef; 1] = [KeyDef::special(KeyAction::Space, GRID_UNITS, "SPACE")];
+
+/// Softkey bar: T9 fallback + Done.
+const SOFTKEY_ROW: [KeyDef; 2] = [
+    KeyDef::special(KeyAction::SwitchToT9, 5, "T9"),
+    KeyDef::special(KeyAction::Done, 5, "DONE"),
+];
+
+/// All rows, top to bottom, including the softkey bar as the final row.
+const ROWS: [&[KeyDef]; NUM_ROWS] = [&ROW0, &ROW1, &ROW2, &ROW3, &SOFTKEY_ROW];
+
+/// Pixel width of one grid unit at the given widget width.
+const fn unit_width(width: u32) -> u32 {
+    width / GRID_UNITS
+}
+
+/// X offset of `col` within `row`, in pixels, relative to the row's start.
+fn key_x_start(row: &[KeyDef], uw: u32, col: usize) -> u32 {
+    let units: u32 = row.iter().take(col).map(|k| k.units).sum();
+    units * uw
+}
+
+/// Pixel width of `col` within `row`; zero if `col` is out of range.
+fn key_width_px(row: &[KeyDef], uw: u32, col: usize) -> u32 {
+    row.get(col).map_or(0, |k| k.units * uw)
+}
+
+/// Which key in `row` contains pixel offset `x` (relative to the row's start).
+///
+/// Clamps to the last key if `x` falls past the row's end.
+fn key_at_x(row: &[KeyDef], uw: u32, x: u32) -> usize {
+    let mut start = 0u32;
+    for (i, k) in row.iter().enumerate() {
+        let end = start + k.units * uw;
+        if x < end {
+            return i;
+        }
+        start = end;
+    }
+    row.len().saturating_sub(1)
+}
+
+/// Y offset of `row` from the widget's top.
+const fn row_y(row: usize) -> u32 {
+    if row >= MAIN_ROW_COUNT {
+        KEY_ROW_H * MAIN_ROW_COUNT as u32
+    } else {
+        KEY_ROW_H * row as u32
+    }
+}
+
+/// Pixel height of `row` (the softkey bar is shorter than the main rows).
+const fn row_height(row: usize) -> u32 {
+    if row >= MAIN_ROW_COUNT {
+        SOFTKEY_ROW_H
+    } else {
+        KEY_ROW_H
+    }
+}
+
+/// Which row a Y offset (relative to the widget's top) falls in.
+///
+/// Clamps to the last row (the softkey bar) for `y` past the grid's bottom.
+fn row_at_y(y: u32) -> usize {
+    let mut start = 0u32;
+    for row in 0..NUM_ROWS {
+        let end = start + row_height(row);
+        if y < end {
+            return row;
+        }
+        start = end;
+    }
+    NUM_ROWS.saturating_sub(1)
+}
+
+/// Rectangle of a single key on the panel, in absolute framebuffer pixels.
+#[derive(Debug, Clone, Copy)]
+struct Rect {
+    x: u32,
+    y: u32,
+    w: u32,
+    h: u32,
+}
+
+/// Result of pressing a key: what the caller (the compose screen, not built
+/// here) should do to the text buffer or input mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum KeyboardEvent {
+    /// Insert this character (already case-resolved against shift) into the
+    /// compose buffer.
+    Char(char),
+    /// Delete the character before the cursor.
+    Backspace,
+    /// Switch input to T9 multi-tap -- the accuracy fallback one softkey away.
+    SwitchToT9,
+    /// Composition is finished (send/save/close is the caller's call).
+    Done,
+}
+
+/// On-screen QWERTY keyboard: a fixed-pitch touch grid with a keypad-cursor
+/// equivalent for every key. See the module docs for the row layout and the
+/// dual-input mapping.
+///
+/// Call [`Keyboard::take_event`] after each input cycle to drain a pending
+/// key press.
+#[derive(Debug)]
+pub struct Keyboard {
+    cursor_row: usize,
+    cursor_col: usize,
+    shift_active: bool,
+    pending: Option<KeyboardEvent>,
+    focused: bool,
+    width: u32,
+}
+
+impl Keyboard {
+    /// Create a keyboard with the given pixel width (240 on the real panel).
+    #[must_use]
+    pub(crate) const fn new(width: u32) -> Self {
+        Self {
+            cursor_row: 0,
+            cursor_col: 0,
+            shift_active: false,
+            pending: None,
+            focused: false,
+            width,
+        }
+    }
+
+    /// Return and clear the pending key event, if any.
+    pub(crate) const fn take_event(&mut self) -> Option<KeyboardEvent> {
+        self.pending.take()
+    }
+
+    /// Whether shift is currently toggled on (affects letter case).
+    #[must_use]
+    pub(crate) const fn is_shift_active(&self) -> bool {
+        self.shift_active
+    }
+
+    /// Move the highlighted-key cursor up a row, preserving horizontal position.
+    fn move_up(&mut self) {
+        if self.cursor_row == 0 {
+            return;
+        }
+        self.move_row(self.cursor_row - 1);
+    }
+
+    /// Move the highlighted-key cursor down a row, preserving horizontal position.
+    fn move_down(&mut self) {
+        if self.cursor_row + 1 >= NUM_ROWS {
+            return;
+        }
+        self.move_row(self.cursor_row + 1);
+    }
+
+    /// Re-target the cursor at `new_row`, resolving the column nearest the
+    /// current key's horizontal center.
+    fn move_row(&mut self, new_row: usize) {
+        let uw = unit_width(self.width);
+        let Some(cur_row) = ROWS.get(self.cursor_row) else {
+            return;
+        };
+        let center = key_x_start(cur_row, uw, self.cursor_col)
+            + key_width_px(cur_row, uw, self.cursor_col) / 2;
+        let Some(target_row) = ROWS.get(new_row) else {
+            return;
+        };
+        self.cursor_row = new_row;
+        self.cursor_col = key_at_x(target_row, uw, center);
+    }
+
+    /// Move the highlighted-key cursor left within the current row, clamping at 0.
+    fn move_left(&mut self) {
+        if self.cursor_col > 0 {
+            self.cursor_col -= 1;
+        }
+    }
+
+    /// Move the highlighted-key cursor right within the current row, clamping at the end.
+    fn move_right(&mut self) {
+        let Some(row) = ROWS.get(self.cursor_row) else {
+            return;
+        };
+        if self.cursor_col + 1 < row.len() {
+            self.cursor_col += 1;
+        }
+    }
+
+    /// Press whatever key is currently highlighted.
+    fn activate(&mut self) {
+        let Some(row) = ROWS.get(self.cursor_row) else {
+            return;
+        };
+        let Some(key) = row.get(self.cursor_col) else {
+            return;
+        };
+        match key.action {
+            KeyAction::Letter(ch) => {
+                let out = if self.shift_active {
+                    ch.to_ascii_uppercase()
+                } else {
+                    ch
+                };
+                self.pending = Some(KeyboardEvent::Char(out));
+            }
+            KeyAction::Symbol(ch) => self.pending = Some(KeyboardEvent::Char(ch)),
+            KeyAction::Space => self.pending = Some(KeyboardEvent::Char(' ')),
+            KeyAction::Backspace => self.pending = Some(KeyboardEvent::Backspace),
+            KeyAction::Shift => self.shift_active = !self.shift_active,
+            KeyAction::SwitchToT9 => self.pending = Some(KeyboardEvent::SwitchToT9),
+            KeyAction::Done => self.pending = Some(KeyboardEvent::Done),
+        }
+    }
+
+    /// Background/foreground color for a cell: cursor highlight takes
+    /// priority over the shift-active indicator, which takes priority over
+    /// the default key color.
+    fn cell_colors(&self, row: usize, col: usize, action: KeyAction) -> (Rgb565, Rgb565) {
+        if self.focused && row == self.cursor_row && col == self.cursor_col {
+            (Rgb565::BLUE, Rgb565::WHITE)
+        } else if action == KeyAction::Shift && self.shift_active {
+            (Rgb565::CYAN, Rgb565::BLACK)
+        } else {
+            (KEY_BG, Rgb565::WHITE)
+        }
+    }
+
+    /// Draw a single key's label, centered in `rect`.
+    fn draw_label(&self, fb: &mut Framebuffer, rect: Rect, key: &KeyDef, fg: Rgb565, bg: Rgb565) {
+        match key.action {
+            KeyAction::Letter(ch) => {
+                let disp = if self.shift_active {
+                    ch.to_ascii_uppercase()
+                } else {
+                    ch
+                };
+                let mut buf = [0u8; 4];
+                let s = disp.encode_utf8(&mut buf);
+                Self::draw_centered(fb, rect, s, fg, bg);
+            }
+            KeyAction::Symbol(ch) => {
+                let mut buf = [0u8; 4];
+                let s = ch.encode_utf8(&mut buf);
+                Self::draw_centered(fb, rect, s, fg, bg);
+            }
+            _ => {
+                Self::draw_centered(fb, rect, key.label.unwrap_or(""), fg, bg);
+            }
+        }
+    }
+
+    /// Draw `s` horizontally and vertically centered within `rect`.
+    fn draw_centered(fb: &mut Framebuffer, rect: Rect, s: &str, fg: Rgb565, bg: Rgb565) {
+        let text_w = str_pixel_width(s);
+        let lx = rect.x + rect.w.saturating_sub(text_w) / 2;
+        let ly = rect.y + rect.h.saturating_sub(CHAR_HEIGHT) / 2;
+        draw_str(fb, lx, ly, s, fg, bg);
+    }
+}
+
+impl Widget for Keyboard {
+    fn draw(&self, fb: &mut Framebuffer, x: u32, y: u32) {
+        let uw = unit_width(self.width);
+        for (row_idx, row) in ROWS.iter().enumerate() {
+            let ry = row_y(row_idx);
+            let rh = row_height(row_idx);
+            for (col_idx, key) in row.iter().enumerate() {
+                let kx = key_x_start(row, uw, col_idx);
+                let kw = key.units * uw;
+                let rect = Rect {
+                    x: x + kx,
+                    y: y + ry,
+                    w: kw,
+                    h: rh,
+                };
+                let (bg, fg) = self.cell_colors(row_idx, col_idx, key.action);
+                fb.fill_rect(
+                    rect.x,
+                    rect.y,
+                    rect.w.saturating_sub(1),
+                    rect.h.saturating_sub(1),
+                    bg,
+                );
+                self.draw_label(fb, rect, key, fg, bg);
+            }
+        }
+    }
+
+    fn width(&self) -> u32 {
+        self.width
+    }
+
+    fn height(&self) -> u32 {
+        KEYBOARD_HEIGHT
+    }
+}
+
+impl Focusable for Keyboard {
+    fn on_key(&mut self, key: Key) -> bool {
+        match key {
+            Key::Up => {
+                self.move_up();
+                true
+            }
+            Key::Down => {
+                self.move_down();
+                true
+            }
+            Key::Left => {
+                self.move_left();
+                true
+            }
+            Key::Right => {
+                self.move_right();
+                true
+            }
+            Key::Select => {
+                self.activate();
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn on_touch(&mut self, point: TouchPoint) -> bool {
+        let x = u32::from(point.x);
+        let y = u32::from(point.y);
+        if x >= self.width || y >= KEYBOARD_HEIGHT {
+            return false;
+        }
+        let row_idx = row_at_y(y);
+        let Some(row) = ROWS.get(row_idx) else {
+            return false;
+        };
+        let uw = unit_width(self.width);
+        self.cursor_row = row_idx;
+        self.cursor_col = key_at_x(row, uw, x);
+        self.activate();
+        true
+    }
+
+    fn is_focused(&self) -> bool {
+        self.focused
+    }
+
+    fn set_focused(&mut self, focused: bool) {
+        self.focused = focused;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sizing_is_correct() {
+        let k = Keyboard::new(240);
+        assert_eq!(k.width(), 240, "width must match constructor arg");
+        assert_eq!(
+            k.height(),
+            258,
+            "height must be 4*57 (main rows) + 30 (softkey bar)"
+        );
+    }
+
+    #[test]
+    fn keypad_reaches_every_key_in_row0() {
+        let mut k = Keyboard::new(240);
+        k.set_focused(true);
+        let expected = "qwertyuiop";
+        for (i, ch) in expected.chars().enumerate() {
+            k.on_key(Key::Select);
+            assert_eq!(
+                k.take_event(),
+                Some(KeyboardEvent::Char(ch)),
+                "column {i} of row 0 must press '{ch}'"
+            );
+            k.on_key(Key::Right);
+        }
+    }
+
+    #[test]
+    fn keypad_reaches_backspace_at_end_of_row1() {
+        let mut k = Keyboard::new(240);
+        k.set_focused(true);
+        k.on_key(Key::Down); // row 1, col 0 ('a')
+        for _ in 0..9 {
+            k.on_key(Key::Right);
+        }
+        k.on_key(Key::Select);
+        assert_eq!(
+            k.take_event(),
+            Some(KeyboardEvent::Backspace),
+            "row 1's 10th key must be backspace"
+        );
+    }
+
+    #[test]
+    fn keypad_reaches_shift_comma_period_in_row2() {
+        let mut k = Keyboard::new(240);
+        k.set_focused(true);
+        k.on_key(Key::Down);
+        k.on_key(Key::Down); // row 2, col 0 (shift)
+        k.on_key(Key::Select);
+        assert!(k.is_shift_active(), "row 2 col 0 must be shift, toggled on");
+        for _ in 0..8 {
+            k.on_key(Key::Right);
+        }
+        k.on_key(Key::Select);
+        assert_eq!(
+            k.take_event(),
+            Some(KeyboardEvent::Char(',')),
+            "row 2 col 8 must be comma"
+        );
+        k.on_key(Key::Right);
+        k.on_key(Key::Select);
+        assert_eq!(
+            k.take_event(),
+            Some(KeyboardEvent::Char('.')),
+            "row 2 col 9 must be period"
+        );
+    }
+
+    #[test]
+    fn shift_uppercases_letters_until_toggled_off() {
+        let mut k = Keyboard::new(240);
+        k.set_focused(true);
+        k.on_key(Key::Down);
+        k.on_key(Key::Down);
+        k.on_key(Key::Select); // toggle shift on
+        k.on_key(Key::Left); // no-op, already at col 0
+        k.on_key(Key::Right); // col 1: 'z'
+        k.on_key(Key::Select);
+        assert_eq!(
+            k.take_event(),
+            Some(KeyboardEvent::Char('Z')),
+            "letter pressed while shift is active must be uppercase"
+        );
+        // Toggle shift back off.
+        k.on_key(Key::Left);
+        k.on_key(Key::Select);
+        assert!(!k.is_shift_active(), "second shift press must toggle off");
+        k.on_key(Key::Right);
+        k.on_key(Key::Select);
+        assert_eq!(
+            k.take_event(),
+            Some(KeyboardEvent::Char('z')),
+            "letter pressed after shift toggles off must be lowercase"
+        );
+    }
+
+    #[test]
+    fn shift_does_not_affect_symbols() {
+        let mut k = Keyboard::new(240);
+        k.set_focused(true);
+        k.on_key(Key::Down);
+        k.on_key(Key::Down);
+        k.on_key(Key::Select); // shift on
+        for _ in 0..8 {
+            k.on_key(Key::Right);
+        }
+        k.on_key(Key::Select);
+        assert_eq!(
+            k.take_event(),
+            Some(KeyboardEvent::Char(',')),
+            "comma must be unaffected by an active shift"
+        );
+    }
+
+    #[test]
+    fn keypad_reaches_space_in_row3() {
+        let mut k = Keyboard::new(240);
+        k.set_focused(true);
+        for _ in 0..3 {
+            k.on_key(Key::Down);
+        }
+        k.on_key(Key::Select);
+        assert_eq!(
+            k.take_event(),
+            Some(KeyboardEvent::Char(' ')),
+            "row 3 must be a single full-width space key"
+        );
+    }
+
+    #[test]
+    fn keypad_reaches_softkeys() {
+        let mut k = Keyboard::new(240);
+        k.set_focused(true);
+        for _ in 0..4 {
+            k.on_key(Key::Down);
+        }
+        // Descending from column 0 each row preserves a center of x=12,
+        // which lands in row 3's single space key, whose own center (x=120)
+        // sits exactly on the T9/Done boundary; the half-open interval
+        // convention resolves a boundary to the right-hand key (Done).
+        k.on_key(Key::Select);
+        assert_eq!(
+            k.take_event(),
+            Some(KeyboardEvent::Done),
+            "center x=120 resolves to Done, the boundary's right-hand key"
+        );
+        k.on_key(Key::Left);
+        k.on_key(Key::Select);
+        assert_eq!(
+            k.take_event(),
+            Some(KeyboardEvent::SwitchToT9),
+            "softkey col 0 must be T9"
+        );
+    }
+
+    #[test]
+    fn vertical_navigation_preserves_horizontal_position_across_uniform_rows() {
+        let mut k = Keyboard::new(240);
+        k.set_focused(true);
+        // Row 0 col 9 ('p') is centered at x=228 (216..240).
+        for _ in 0..9 {
+            k.on_key(Key::Right);
+        }
+        // Row 1 is also 10 uniform 1-unit keys: same center falls in col 9 (backspace).
+        k.on_key(Key::Down);
+        k.on_key(Key::Select);
+        assert_eq!(
+            k.take_event(),
+            Some(KeyboardEvent::Backspace),
+            "preserved column 9 in row 1 must be backspace"
+        );
+        // Row 2 is likewise 10 uniform 1-unit keys: same center falls in col 9 (period).
+        k.on_key(Key::Down);
+        k.on_key(Key::Select);
+        assert_eq!(
+            k.take_event(),
+            Some(KeyboardEvent::Char('.')),
+            "preserved column 9 in row 2 must be period"
+        );
+    }
+
+    #[test]
+    fn space_row_collapses_and_recenters_from_its_own_width() {
+        let mut k = Keyboard::new(240);
+        k.set_focused(true);
+        // From row 2 col 9 (period), Down into row 3: the single full-width
+        // key absorbs every incoming column.
+        for _ in 0..9 {
+            k.on_key(Key::Right);
+        }
+        k.on_key(Key::Down);
+        k.on_key(Key::Down);
+        k.on_key(Key::Select);
+        assert_eq!(
+            k.take_event(),
+            Some(KeyboardEvent::Char(' ')),
+            "any column landing in row 3 must hit its one full-width key"
+        );
+        // Leaving that single wide key, the preserved "position" is its OWN
+        // center (x=120, the panel's midpoint) rather than wherever the
+        // cursor entered from -- there is no other position to remember once
+        // a row collapses to one key. x=120 falls in row 2's column 5 ('b').
+        k.on_key(Key::Up);
+        k.on_key(Key::Select);
+        assert_eq!(
+            k.take_event(),
+            Some(KeyboardEvent::Char('b')),
+            "leaving the space key must re-resolve from its own center, not the prior column"
+        );
+    }
+
+    #[test]
+    fn left_right_clamp_at_row_bounds() {
+        let mut k = Keyboard::new(240);
+        k.set_focused(true);
+        k.on_key(Key::Left);
+        k.on_key(Key::Select);
+        assert_eq!(
+            k.take_event(),
+            Some(KeyboardEvent::Char('q')),
+            "Left at column 0 must clamp, not wrap"
+        );
+        for _ in 0..20 {
+            k.on_key(Key::Right);
+        }
+        k.on_key(Key::Select);
+        assert_eq!(
+            k.take_event(),
+            Some(KeyboardEvent::Char('p')),
+            "Right past the last column must clamp at the last key"
+        );
+    }
+
+    #[test]
+    fn up_down_clamp_at_grid_bounds() {
+        let mut k = Keyboard::new(240);
+        k.set_focused(true);
+        k.on_key(Key::Up); // already at row 0
+        k.on_key(Key::Select);
+        assert_eq!(
+            k.take_event(),
+            Some(KeyboardEvent::Char('q')),
+            "Up at row 0 must clamp, not wrap"
+        );
+        for _ in 0..10 {
+            k.on_key(Key::Down);
+        }
+        k.on_key(Key::Select);
+        assert_eq!(
+            k.take_event(),
+            Some(KeyboardEvent::Done),
+            "Down past the last row must clamp at the softkey row, not wrap or panic"
+        );
+    }
+
+    #[test]
+    fn touch_hits_row0_column_edges() {
+        let mut k = Keyboard::new(240);
+        k.on_touch(TouchPoint::new(0, 0, 100, 0));
+        assert_eq!(k.take_event(), Some(KeyboardEvent::Char('q')));
+        k.on_touch(TouchPoint::new(23, 0, 100, 0));
+        assert_eq!(
+            k.take_event(),
+            Some(KeyboardEvent::Char('q')),
+            "x=23 is the last pixel of column 0 (24px wide)"
+        );
+        k.on_touch(TouchPoint::new(24, 0, 100, 0));
+        assert_eq!(
+            k.take_event(),
+            Some(KeyboardEvent::Char('w')),
+            "x=24 is the first pixel of column 1"
+        );
+        k.on_touch(TouchPoint::new(239, 0, 100, 0));
+        assert_eq!(
+            k.take_event(),
+            Some(KeyboardEvent::Char('p')),
+            "x=239 is the last pixel on the panel, still column 9"
+        );
+    }
+
+    #[test]
+    fn touch_hits_row_boundaries() {
+        let mut k = Keyboard::new(240);
+        k.on_touch(TouchPoint::new(0, 56, 100, 0));
+        assert_eq!(
+            k.take_event(),
+            Some(KeyboardEvent::Char('q')),
+            "y=56 is the last pixel of row 0 (57px tall)"
+        );
+        k.on_touch(TouchPoint::new(0, 57, 100, 0));
+        assert_eq!(
+            k.take_event(),
+            Some(KeyboardEvent::Char('a')),
+            "y=57 is the first pixel of row 1"
+        );
+        k.on_touch(TouchPoint::new(0, 227, 100, 0));
+        assert_eq!(
+            k.take_event(),
+            Some(KeyboardEvent::Char(' ')),
+            "y=227 is the last pixel of row 3 (the space row)"
+        );
+        k.on_touch(TouchPoint::new(0, 228, 100, 0));
+        assert_eq!(
+            k.take_event(),
+            Some(KeyboardEvent::SwitchToT9),
+            "y=228 is the first pixel of the softkey row"
+        );
+    }
+
+    #[test]
+    fn touch_hits_softkey_boundary() {
+        let mut k = Keyboard::new(240);
+        k.on_touch(TouchPoint::new(119, 228, 100, 0));
+        assert_eq!(
+            k.take_event(),
+            Some(KeyboardEvent::SwitchToT9),
+            "x=119 is the last pixel of the T9 softkey (0..120)"
+        );
+        k.on_touch(TouchPoint::new(120, 228, 100, 0));
+        assert_eq!(
+            k.take_event(),
+            Some(KeyboardEvent::Done),
+            "x=120 is the first pixel of the Done softkey"
+        );
+        k.on_touch(TouchPoint::new(239, 257, 100, 0));
+        assert_eq!(
+            k.take_event(),
+            Some(KeyboardEvent::Done),
+            "the panel's last pixel must still hit Done"
+        );
+    }
+
+    #[test]
+    fn touch_out_of_bounds_not_consumed() {
+        let mut k = Keyboard::new(240);
+        assert!(
+            !k.on_touch(TouchPoint::new(240, 0, 100, 0)),
+            "x == width is off-widget and must not be consumed"
+        );
+        assert!(
+            !k.on_touch(TouchPoint::new(0, 258, 100, 0)),
+            "y == height is off-widget and must not be consumed"
+        );
+        assert!(
+            k.take_event().is_none(),
+            "an unconsumed touch must not queue an event"
+        );
+    }
+
+    #[test]
+    fn take_event_drains_pending() {
+        let mut k = Keyboard::new(240);
+        k.on_touch(TouchPoint::new(0, 0, 100, 0));
+        let first = k.take_event();
+        let second = k.take_event();
+        assert!(first.is_some(), "first take_event must return the press");
+        assert!(second.is_none(), "second take_event must be None");
+    }
+
+    #[test]
+    fn unrelated_key_not_consumed() {
+        let mut k = Keyboard::new(240);
+        assert!(
+            !k.on_key(Key::Call),
+            "Call has no meaning on the keyboard grid and must not be consumed"
+        );
+    }
+
+    #[test]
+    fn focus_set_and_cleared() {
+        let mut k = Keyboard::new(240);
+        assert!(!k.is_focused(), "keyboard must start unfocused");
+        k.set_focused(true);
+        assert!(k.is_focused(), "must be focused after set_focused(true)");
+        k.set_focused(false);
+        assert!(
+            !k.is_focused(),
+            "must be unfocused after set_focused(false)"
+        );
+    }
+
+    #[test]
+    fn draw_does_not_panic() {
+        let k = Keyboard::new(240);
+        let mut fb = Framebuffer::new(240, 320);
+        fb.clear(Rgb565::WHITE);
+        k.draw(&mut fb, 0, 62); // below a 20px status + 42px preview
+        assert!(
+            fb.as_bytes().iter().any(|&b| b != 0xFF),
+            "keyboard must write at least one pixel"
+        );
+    }
+}

--- a/crates/eidolon/src/widgets/keyboard.rs
+++ b/crates/eidolon/src/widgets/keyboard.rs
@@ -346,7 +346,7 @@ impl Keyboard {
     }
 
     /// Move the highlighted-key cursor left within the current row, clamping at 0.
-    fn move_left(&mut self) {
+    const fn move_left(&mut self) {
         if self.cursor_col > 0 {
             self.cursor_col -= 1;
         }

--- a/crates/eidolon/src/widgets/mod.rs
+++ b/crates/eidolon/src/widgets/mod.rs
@@ -3,12 +3,16 @@
 //! All widgets implement [`crate::widget::Widget`] for rendering and
 //! optionally [`crate::widget::Focusable`] for input handling.
 
+pub mod compose;
 pub mod dialer;
 pub mod dialog;
+pub mod keyboard;
 pub mod list;
 pub mod menu;
 
+pub use compose::ComposeField;
 pub use dialer::PhoneDialer;
 pub use dialog::{Dialog, DialogButton};
+pub use keyboard::{Keyboard, KeyboardEvent};
 pub use list::{TextList, TextListConfig};
 pub use menu::{ACTION_NONE, Menu, MenuItem};


### PR DESCRIPTION
First build on the eidolon `no_std` port (#731): an on-screen keyboard and a compose-text widget, in `crates/eidolon` only. No kernel integration — that is separate, later work.

## The interaction model this is built for

Keypad, button combinations, and T9 are **primary**. T9 is retained, not replaced. Touch is a **modal accelerator** for the case where it clearly wins — composing a message — and the keyboard claims the full screen while active rather than competing for space as a persistent surface.

That framing is what makes the layout viable: modality buys height, which is why rows land at a usable size even though width is permanently constrained.

## Layout, in real pixels

| zone | height |
|---|---|
| `ComposeField` | 42px — two 21px lines, 30 cols x 8px |
| `Keyboard` main rows | 4 x 57px = 228px |
| softkey bar | 30px |
| **widgets total** | **300px** |
| status strip (not owned here) | 20px |
| | **320px exact** |

Grid is 10 units x 24px = 240px, uniform across rows. Rows: `qwertyuiop` / `asdfghjkl` + `DEL` / `Shift` + `zxcvbnm` + `,` `.` / full-width `SPACE` / softkeys `T9` and `DONE`.

Row height is 57px against the **59px comfortable finger target derived for this panel** — 2.4in diagonal at 240x320 gives 166.7 PPI and 0.1524 mm/px, so the ~9mm physical basis behind Apple's 44pt and Material's 48dp lands at 59px here. Copying "44px" from modern guidance would have given 6.7mm and undershot badly. Columns at 24px are 41% of comfortable; that is the permanent width constraint, not a layout choice.

## Every touch affordance has a keypad equivalent

Because the keypad is primary, a user who never touches the screen must still be able to compose a full message. Tapping a key's rect and D-pad-plus-Select go through the same mechanism.

The non-obvious part is **cross-row cursor movement**, and it is tested: moving vertically re-resolves the nearest key under the *previous* key's horizontal centre, so traversing rows of different key counts — 10 uniform keys, then a single full-width `SPACE`, then 2 softkeys — still lands sensibly. Leaving `SPACE` re-centres from its own width (x=120) rather than from wherever the cursor entered it.

Tap-to-position in the compose field is the one genuine touch-beats-keypad case; its keypad equivalent is `Left`/`Right` stepping.

## Deliberate simplifications, stated

- **Shift is a sticky toggle, not one-shot.** No widget in this crate has a time source, so "revert after one letter" is not implementable here. Documented rather than silently approximated.
- **No predictive text.** Real small keyboards close the 24px-column gap with statistical disambiguation; `t9.rs` is a fixed multi-tap table with no language model, and building one is separate substantial scope. T9 one softkey away is the accuracy fallback — which is exactly why the touch keyboard does not need to be maximally accurate, only fast for someone who knows QWERTY.
- **ASCII `0x20`-`0x7E` only**, so no accented characters or box-drawing glyphs can ever be composed; `insert_char` drops anything outside that range. **The grid exposes only `,` and `.` as punctuation — apostrophe is currently reachable through neither touch nor keypad.** A symbols layer was deferred to keep v1 in scope. See below.

## Overflow

`ComposeField` tracks a char cursor over a `String`. The two-line preview computes a pure `window_start(cursor, total, capacity)` — shows from 0 while the buffer fits, pins to the tail once it overflows, always keeps the cursor visible. Boundary cases verified directly: exactly-full buffer, cursor mid-buffer, cursor at tail.

## Tests

41 total — 20 in `keyboard.rs`, 21 in `compose.rs`. Pixel-edge hit-testing at column, row, and softkey boundaries plus off-widget taps; full keypad traversal of every row including edge clamping; the cross-row centre-preservation maths; shift toggling and its non-effect on symbols; insert/backspace/cursor at buffer start, middle, and end; `window_start` boundaries.

## What CI caught that hand-tracing did not

One test had an off-by-one in the number of `Down` presses to reach a row — surfaced only by the real `nextest` run, not by tracing the grid arithmetic by hand. Fixed in a follow-up commit. `clippy::missing_const_for_fn` (nursery, denied) also fired on two trivial helpers. Both fixes are separate commits.

## A divergence this surfaced

`eidolon/src/status_bar.rs:12` defines `STATUS_BAR_HEIGHT = CHAR_HEIGHT` (16px); `thumos/src/ui.rs:45` defines it as 20px. The layout above reserves 20, matching the kernel. These widgets do not own that zone so it is not reconciled here — filed as **#740**, since linking eidolon now shifts every zone below it by 4px.

Refs: #458, #731, #740
