### PR TITLE
fix(ci): stop gate-attestation from cancelling its own push runs

### DIFF
--- a/.github/workflows/gate-attestation.yml
+++ b/.github/workflows/gate-attestation.yml
@@ -43,20 +43,12 @@ on:
   push:
     branches: [main]
 
-# WHY cancel-in-progress: true even on the push trigger: this workflow
-# verifies ref-tip state (fmt/check/clippy/nextest against a specific commit),
-# not a state mutation -- unlike release-please.yml (cancel-in-progress:
-# false), which creates/tags a release mid-run and would corrupt that if
-# interrupted. A gate-attestation run superseded by a newer push or a newer
-# commit on main has nothing worth finishing: the next PR always merges
-# against the LATEST main tip, so an in-flight attestation for a SHA that
-# is no longer any ref's tip has no consumer. Same group-key convention and
-# same trade-off as ci.yml/security.yml, which share this workflow's exact
-# pull_request+push trigger pair.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
+# NOTE: no concurrency block here by design. hybrid-gate.yml defines the group
+# itself (github.workflow-github.ref, which resolve to THIS caller's context in
+# a reusable call) and its own comment forbids callers from setting the same
+# key. A caller block whose group matches on push makes the run cancel itself:
+# it reports as a failure with zero jobs, and only on push, because on
+# pull_request the two groups differ. That took main's gate down silently.
 permissions:
   contents: read
 


### PR DESCRIPTION
## What broke

Every push to `main` since `ebd7567f` failed Gate Attestation — **14 consecutive runs over ~9 hours, none of which built main.** The runs report `failure` with **zero jobs**, which is a startup failure, not a build failure.

## Why

`ebd7567f` added a `concurrency` block to this caller. `hybrid-gate.yml` already defines one, and its own comment forbids exactly this:

> `Callers must NOT also set a concurrency group with this key, or the shared group self-cancels.`

Inside a reusable call, `github.workflow` and `github.ref` resolve to the **caller's** context. So the two groups are byte-identical on push:

| event | caller group | callee group | result |
|---|---|---|---|
| `push` to main | `Gate Attestation-refs/heads/main` | `Gate Attestation-refs/heads/main` | **identical → self-cancel** |
| `pull_request` | `Gate Attestation-<PR number>` | `Gate Attestation-refs/pull/N/merge` | differ → fine |

That asymmetry is why this was invisible: every PR run stayed green, and only main pushes died. `ci.yml` and `security.yml` carry the *same* group expression safely because their jobs run inline rather than delegating to a reusable workflow — which is what made the added block look precedented.

## Fix

Remove the caller's block; keep a note saying why there isn't one, so the next `YAML/missing-concurrency` finding doesn't reintroduce it.

## Two things worth acting on separately

**The lint rule can't see inherited config.** `YAML/missing-concurrency` fired on a workflow that *does* have concurrency — supplied by the reusable workflow it calls. Any workflow whose jobs are a `uses:` delegation will produce the same false positive fleet-wide. Filed against kanon.

**Nothing surfaced a 9-hour outage of the job that builds main.** Gate Attestation is not a required status check, so 14 straight failures produced no signal on any PR. The job exists precisely because a squash merge carries no trailer and *"without this nothing ever builds main"* — and for nine hours, nothing did. Worth deciding whether it should be required.

Refs: #718
