### PR TITLE
docs: resolve the WRITING classes across the doc surface

### DIFF
--- a/docs/ALETHEIA-BRIDGE.md
+++ b/docs/ALETHEIA-BRIDGE.md
@@ -72,7 +72,7 @@ trip:
   (`pylon-bridge`, the SAME `pylon` reference endpoint this doc's witness
   already used, not a live runtime). The kernel side calls
   `metaxu-core`'s session primitives directly (`AuthenticatedSession`,
-  `encode_authenticated_request`) rather than `BridgeClient::
+  `encode_authenticated_request`) instead of `BridgeClient::
   submit_authenticated` -- the `no_std` kernel cannot depend on `metaxu`'s
   std-only client/transport layer, so it links `metaxu-core` (the shared
   no_std+alloc extraction, #545) instead. WiFi on hardware, and routing
@@ -81,7 +81,7 @@ trip:
 - Stand up (or point at) an actual Aletheia-side endpoint implementing the
   pylon's verification contract, so the pinned runtime key is a real
   runtime's key, not a witness fixture.
-- Provision the device's grant from a real Aletheia-side issuer rather than
+- Provision the device's grant from a real Aletheia-side issuer instead of
   having the kernel self-issue a dev-seed grant to itself (#544's on-device
   leg does the latter, clearly labeled dev-only).
 - Connect nous capability presets to concrete `metaxu` grant issuance.

--- a/docs/ALETHEIA-BRIDGE.md
+++ b/docs/ALETHEIA-BRIDGE.md
@@ -20,7 +20,7 @@ boundary for constrained Thumos clients, not an embedded cognition runtime.
 
 Thumos targets constrained mobile hardware and already has separate local
 surfaces for voice transcription (`ekphrasis`) and nous action proposals. The
-Aletheia runtime is expected to be heavier than the device boundary should own:
+Aletheia runtime likely outweighs what the device boundary should own:
 it may need model orchestration, tool scheduling, long-lived memory, and
 fleet-level context. Keeping that runtime off-device preserves the Thumos
 resource budget and keeps the device boundary focused on typed, auditable
@@ -29,13 +29,13 @@ actions.
 The thin-client design also keeps capability enforcement local to Thumos. A
 runtime request can carry grant claims, but the device side remains responsible
 for verifying policy before sending SMS, placing calls, reading contacts, or
-opening audio sessions. Device identity is represented by opaque handles and
-attestation digests; raw IMEI, IMSI, WiFi MAC, Bluetooth address, and similar
+opening audio sessions. Opaque handles and attestation digests represent
+device identity. Raw IMEI, IMSI, WiFi MAC, Bluetooth address, and similar
 hardware identifiers must not cross this bridge.
 
 ## Current Surface
 
-- `crates/metaxu` is registered as a workspace crate.
+- The root `Cargo.toml` registers `crates/metaxu` as a workspace member.
 - Requests and responses serialize with `postcard`, framed in a versioned
   envelope (magic + schema + major/minor + kind + correlation ID + declared
   length, checked before any payload decode) so thumos and aletheia never
@@ -60,10 +60,10 @@ hardware identifiers must not cross this bridge.
 
 ## What Remains
 
-The verified protocol path above is proven against a reference endpoint
-double (`pylon`) inside the `metaxu` crate itself -- a stand-in for the real
-Aletheia runtime, not a live one. Outstanding for a genuinely live round
-trip:
+A witness test inside the `metaxu` crate itself proves the verified protocol
+path above against a reference endpoint double (`pylon`) -- a stand-in for
+the real Aletheia runtime, not a live one. Outstanding for a genuinely live
+round trip:
 
 - **Done in QEMU (#544):** `board::UART1_BASE` (the qemu-virt second PL011,
   present under `-machine virt,secure=on`) carries an authenticated request
@@ -77,7 +77,7 @@ trip:
   std-only client/transport layer, so it links `metaxu-core` (the shared
   no_std+alloc extraction, #545) instead. WiFi on hardware, and routing
   the transport through firewall policy (meaningful for an IP-based
-  transport; the UART leg is not one), remain unaddressed.
+  transport -- the UART leg is not one) remain unaddressed.
 - Stand up (or point at) an actual Aletheia-side endpoint implementing the
   pylon's verification contract, so the pinned runtime key is a real
   runtime's key, not a witness fixture.
@@ -86,14 +86,14 @@ trip:
   leg does the latter, clearly labeled dev-only).
 - Connect nous capability presets to concrete `metaxu` grant issuance.
 - Route accepted device actions through the existing confirmation UI and
-  local service APIs (criterion 4 of #544; untouched).
+  local service APIs (criterion 4 of #544, untouched).
 - Cross-link the corresponding Aletheia-side runtime endpoint when it
   exists.
 
 ## Non-Goals
 
-- No Aletheia runtime is embedded in Thumos.
-- No live LTE, mesh, SMS, Matrix, or socket transport is wired by this decision.
-- No network or firewall boot path changes are part of this bridge decision.
-- No userspace spawn or init path changes are part of this bridge decision.
-- No dependency on a C toolchain or heavyweight runtime library is introduced.
+- This decision embeds no Aletheia runtime in Thumos.
+- This decision wires no live LTE, mesh, SMS, Matrix, or socket transport.
+- This decision makes no network or firewall boot path changes.
+- This decision makes no userspace spawn or init path changes.
+- This decision introduces no dependency on a C toolchain or heavyweight runtime library.

--- a/docs/ATTRIBUTION.md
+++ b/docs/ATTRIBUTION.md
@@ -37,14 +37,14 @@ APK decompilation reveals this is far worse than just an OTA update client. The 
 
 Hardcoded domains include: `app-measurement.com`, `googleads.g.doubleclick.net`, `ad.doubleclick.net`, `googlesyndication.com`, `googleadservices.com`, `imasdk.googleapis.com`, `google.com/iid`, `pagead2.googlesyndication.com`
 
-This means: a Chinese OTA framework embeds Google's full advertising and analytics framework. Your "OTA updater" is also an ad platform and telemetry beacon. Adups sends data to their servers in China. Google Analytics/Firebase sends data to Google in the US. Both run on every boot via `BOOT_COMPLETED` receiver.
+This means a Chinese OTA framework embeds Google's full advertising and analytics framework — the "OTA updater" doubles as an ad platform and telemetry beacon. Adups sends data to servers in China. Google Analytics and Firebase send data to Google's US infrastructure. Both run on every boot, triggered by the same `BOOT_COMPLETED` receiver.
 
 The `sysoper` companion package has `RecoveryService` and `SysService`  -  these can flash firmware and trigger recovery mode. Combined with Firebase Cloud Messaging push, this allows remote code execution: push a message to the device, download a binary, flash it via recovery. This is a remote exploitation chain built into the firmware.
 
 **TYD Technology Co., Ltd.** (天意德科技)
 Packages: `com.tyd.customkey`, `com.tydtech.clean`, `freeme` framework, `com.freeme.provider.badge`, `com.freeme.factory`
 
-TYD is the actual ODM (original design manufacturer) behind the AGM M7. AGM is a brand; TYD builds the hardware and software. The `freeme` framework runs at the Android framework level with full system privileges. TYD's `customkey` app handles the physical SOS/function key mapping.
+TYD is the actual ODM (original design manufacturer) behind the AGM M7. AGM is a brand. TYD builds the hardware and software, and its `freeme` framework runs at the Android framework level with full system privileges — enough reach that TYD's own `customkey` app also handles the physical SOS/function key mapping.
 
 The TYD/Freeme packages appear benign (no network services, no hardcoded URLs), but the Freeme framework running at system level means TYD can inject behavior into any Android component.
 
@@ -62,12 +62,12 @@ MediaTek provides the SoC and the entire board support package (BSP). Their pack
 
 MediaTek is a Taiwanese company, but operates significant R&D in mainland China and manufactures exclusively through Chinese foundries (TSMC is Taiwanese, but supply chain dependencies exist). Taiwan's relationship with China means MediaTek's software could be subject to pressure from either government.
 
-The MediaTek packages serve primarily as carrier provisioning tools (OMA-DM, LPPe location). They're designed to let carriers configure and manage devices. The threat model is: if a carrier is compromised or coerced (by any government), these tools become remote surveillance infrastructure.
+The MediaTek packages serve primarily as carrier provisioning tools (OMA-DM, LPPe location) that let carriers configure and manage devices remotely. The threat model: if any government compromises or coerces a carrier, these tools become remote surveillance infrastructure.
 
 ### US-origin threats
 
 **Google LLC**
-No Google Play Services or GMS installed directly, BUT Google's code is embedded inside the Adups FOTA APK:
+No Google Play Services or GMS installed directly, but the Adups FOTA APK embeds Google's code:
 - Firebase Analytics (app-measurement.com)
 - Firebase Cloud Messaging (push notifications)
 - Firebase Instance ID (device fingerprinting)
@@ -99,7 +99,7 @@ The most concerning finding is that Adups FOTA creates a **dual-exfiltration pip
 3. Firebase Cloud Messaging provides a push-based command channel from Google's servers
 4. The sysoper component can flash firmware triggered by push notifications
 
-This means the device is simultaneously reporting to Chinese and American data collection infrastructure, through a single APK, running as a system service that starts on every boot and cannot be disabled.
+This means the device reports simultaneously to Chinese and American data collection infrastructure through a single APK, running as a system service that starts on every boot with no way to disable it.
 
 ## What a nation-state sees
 

--- a/docs/DRIVER-INTERFACES.md
+++ b/docs/DRIVER-INTERFACES.md
@@ -914,7 +914,7 @@ Source: `video/mt6739/dispsys/ddp_reg_ovl.h:27–59`
 
 8. **Send LCM init commands:** The LCM driver sends a sequence of
    MIPI DSI commands (typically `write_cmd(reg, data...)` via CMDQ or
-   direct DSI command queue). This is panel-specific; see §7.6.
+   direct DSI command queue). This is panel-specific. See §7.6.
 
 9. **Configure MUTEX:** Set mutex module membership and SOF source
    (`DISP_REG_CONFIG_MUTEX_*`), then enable to start frame timing.

--- a/docs/DRIVER-INTERFACES.md
+++ b/docs/DRIVER-INTERFACES.md
@@ -275,10 +275,10 @@ Full list is in `eccci/inc/ccci_core.h:46+`. Key channels:
 
 ### 1.8 Interrupt Handling
 
-**CLDMA IRQ** (one IRQ, level-triggered): Read `CLDMA_AP_L2TISAR0` (TX) or
-`CLDMA_AP_L2RISAR0` (RX). Write the same bit back to acknowledge. If L3 is
-needed, read `CLDMA_AP_L3TISAR0/1` or `L3RISAR0/1` for per-queue detail.
-Mask future interrupts by writing to `L2TIMCR0` / `L2RIMCR0`.
+**CLDMA IRQ** (one IRQ, level-triggered): read `CLDMA_AP_L2TISAR0` (TX) or
+`CLDMA_AP_L2RISAR0` (RX), then write the same bit back to acknowledge. For
+per-queue detail, read `CLDMA_AP_L3TISAR0/1` or `L3RISAR0/1` at L3. Mask
+future interrupts by writing to `L2TIMCR0` / `L2RIMCR0`.
 
 **CCIF IRQ** (two IRQs  -  one per direction): Read `APCCIF_RCHNUM` to get the
 set of triggered MD→AP channels. Write the bitmask to `APCCIF_ACK` to clear.

--- a/docs/DRIVER-INTERFACES.md
+++ b/docs/DRIVER-INTERFACES.md
@@ -1,12 +1,12 @@
 # Driver Interface Specification  -  MT6739 Hardware Subsystems
 
-The MT6739 ships with eight core driver subsystems; this page specifies each
-one's hardware interface on the AGM M7. Content is derived entirely from BSP
-kernel source at `kernel-wiite/drivers/misc/mediatek/` and
-`kernel-wiite/drivers/mmc/host/`. Every claim cites a source file and line.
+The MT6739 ships with eight core driver subsystems, and this page specifies
+each one's hardware interface on the AGM M7. BSP kernel source at
+`kernel-wiite/drivers/misc/mediatek/` and `kernel-wiite/drivers/mmc/host/`
+supplies all content here. Every claim cites a source file and line.
 
-This specification is the input for Waves 3–5 of the Rust kernel layer. No
-Android framework dependency is assumed; these are bare-metal register and
+This specification is the input for Waves 3–5 of the Rust kernel layer. It
+assumes no Android framework dependency: these are bare-metal register and
 protocol descriptions.
 
 ---
@@ -522,7 +522,7 @@ Source: `connectivity/wlan/gen2/include/nic/hif_rx.h`
 
 ### 3.5 Command / Event Protocol
 
-Commands (`WIFI_CMD_T`) are sent AP→FW via TX queue. Events (`WIFI_EVENT_T`)
+The AP sends commands (`WIFI_CMD_T`) to FW via TX queue. Events (`WIFI_EVENT_T`)
 return FW→AP via RX ring. Both carry a `ucCID` (command/event ID byte), a
 `u2Length`, and a `ucSeqNum` for matching.
 
@@ -615,7 +615,7 @@ Source: `connectivity/bt/stp_chrdev_bt.c:60–63`
 
 ### 4.3 HCI Transport over STP
 
-BT is STP function type 0. All HCI packets are encapsulated in STP frames
+BT is STP function type 0. STP encapsulates all HCI packets in STP frames
 (see §2.7) directed to function 0. The character device read path:
 
 1. STP delivers a complete frame from the receive ring.
@@ -639,7 +639,7 @@ Source: `connectivity/bt/stp_chrdev_bt.c:94–131`
 
 The WMT core (not the BT character driver) loads BT firmware. The WMT
 `wmt_ic_soc.c` handles patch loading via the `wmt_lib` patch infrastructure.
-Patch file suffix is determined by IC family (`wmt_ic.h`).
+IC family determines the patch file suffix (`wmt_ic.h`).
 
 ---
 
@@ -811,8 +811,8 @@ Source: `connectivity/fmradio/inc/fm_ioctl.h`
 3. Poll `FM_MAIN_INTR (0x69)` for `FM_INTR_STC_DONE (bit 0)`.
 4. Read `FM_RSSI_IND (0x6C)` to confirm signal strength.
 
-Desense frequencies that need special handling are listed in
-`mt6631_fm_lib.c`: 6910, 6920, 7680, 7800, 8450, 9210–9230, 9590–9600,
+`mt6631_fm_lib.c` lists desense frequencies that need special handling:
+6910, 6920, 7680, 7800, 8450, 9210–9230, 9590–9600,
 9830, 9900, 9980–9990, 10400, 10750–10760 (all ×100 Hz).
 
 ---
@@ -1090,10 +1090,11 @@ Source: `drivers/mmc/host/mediatek/ComboA/msdc_reg.h` (MSDC_INT_* defines)
 ### 8.5 Auto-Tuning
 
 After power-up MSDC performs window-based auto-tuning (`autok.c`) to
-determine optimal PAD delay values for each data rate. The results are stored
-in platform-specific structs and written back to `MSDC_PAD_TUNE0/1` and the
-`EMMC50_PAD_*_TUNE` registers. DVFS transitions re-trigger auto-tuning via
-`autok_dvfs.c`. Source: `drivers/mmc/host/mediatek/ComboA/mt6739/autok_cust.h`
+determine optimal PAD delay values for each data rate. MSDC stores the
+results in platform-specific structs and writes them back to
+`MSDC_PAD_TUNE0/1` and the `EMMC50_PAD_*_TUNE` registers. DVFS transitions
+re-trigger auto-tuning via `autok_dvfs.c`. Source:
+`drivers/mmc/host/mediatek/ComboA/mt6739/autok_cust.h`
 
 ---
 

--- a/docs/GC9306-INIT.md
+++ b/docs/GC9306-INIT.md
@@ -84,7 +84,7 @@ Sleep out (display on):
 
 ## Gamma tuning
 
-Gamma values differ across all four sources. This is expected: each vendor tunes gamma for their specific panel supplier. The values in the main table come from the LuatOS and Fibocom drivers, which agree exactly. The Spreadtrum and Actions drivers use different gamma curves tuned for different panels.
+Gamma values differ across all four sources because each vendor tunes gamma for their specific panel supplier. The values in the main table come from the LuatOS and Fibocom drivers, which agree exactly. The Spreadtrum and Actions drivers use different gamma curves tuned for different panels.
 
 If the M7 display looks washed out or has incorrect contrast, gamma registers 0xF0-0xF5 are the adjustment point. Each register takes six bytes. No public documentation exists for the gamma curve encoding. Tuning requires visual iteration on the physical panel.
 

--- a/docs/GC9306-INIT.md
+++ b/docs/GC9306-INIT.md
@@ -54,7 +54,7 @@ The AGM M7 uses direction 0 (`0x48`).
 
 ### Optional commands
 
-Some sources include these. The M7 may or may not need them.
+Some sources include these. Hardware validation on the M7 has not yet confirmed whether it needs them.
 
 | Cmd | Data | Function | When to use |
 |-----|------|----------|-------------|

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -11,7 +11,7 @@
 - Process: 28nm HPC+
 - Kernel: Linux 4.4.x (BSP)
 
-All radios are integrated into the SoC. No discrete connectivity chips.
+The SoC integrates all radios. No discrete connectivity chips exist.
 
 ## LTE bands
 

--- a/docs/KERNEL-BUILD.md
+++ b/docs/KERNEL-BUILD.md
@@ -11,7 +11,7 @@ hosted CI on every PR and push to `main` (`.github/workflows/ci.yml`, job
 is authoritative — file an issue.
 
 One caveat governs the whole page: these commands prove the kernel **under
-QEMU emulation only**. The physical device path is unproven — see
+QEMU emulation only**. The physical device path stays unproven — see
 [Hardware path: unproven](#hardware-path-unproven).
 
 ## Toolchain setup
@@ -36,14 +36,14 @@ sudo apt-get install qemu-system-arm  # Debian/Ubuntu
 brew install qemu                     # macOS
 ```
 
-No other system packages are needed: `armv7a-none-eabi` is a bare-metal Rust
-target with no external linker or C toolchain dependency.
+The build needs no other system packages: `armv7a-none-eabi` is a bare-metal
+Rust target with no external linker or C toolchain dependency.
 
 ## Repository layout
 
 - `crates/thumos/` — the kernel crate. Deliberately **excluded** from the
   Cargo workspace (`exclude` in the root `Cargo.toml`) so it can cross-compile
-  to bare metal; workspace-wide invocations (`cargo check --workspace`,
+  to bare metal. Workspace-wide invocations (`cargo check --workspace`,
   `cargo nextest run --workspace`) do not touch it.
 - `crates/thumos/.cargo/config.toml` — pins the default target
   (`armv7a-none-eabi`), the linker script (`link.ld`, kernel `.text` at
@@ -58,8 +58,8 @@ target with no external linker or C toolchain dependency.
 
 NOTE: cargo discovers `.cargo/config.toml` from the current working directory,
 not from `--manifest-path`. Run kernel cargo commands **from `crates/thumos/`**
-(exactly as CI does with `working-directory: crates/thumos`); from the repo
-root the target pin, linker script, zero-warning gate, and QEMU runner
+(exactly as CI does with `working-directory: crates/thumos`). From the repo
+root, the target pin, linker script, zero-warning gate, and QEMU runner
 silently do not apply. The local gate's kernel stage compensates with an
 explicit `RUSTFLAGS` + `--manifest-path` (see `.kanon-ci.toml`) — prefer the
 directory-local form when running by hand.
@@ -67,14 +67,14 @@ directory-local form when running by hand.
 ## Host unit tests (i686)
 
 Kernel unit tests run on 32-bit i686 because the kernel's syscall ABI uses
-u32 addresses; a 64-bit host truncates real pointers and crashes.
+u32 addresses. A 64-bit host truncates real pointers and crashes.
 
 ```bash
 cd crates/thumos
 cargo nextest run --bin thumos --target i686-unknown-linux-gnu
 ```
 
-CI adds `--build-jobs 8 --test-threads 8`; that is a resource cap on the CI
+CI adds `--build-jobs 8 --test-threads 8`. That is a resource cap on the CI
 box, not a requirement.
 
 ## Producing the kernel image
@@ -92,8 +92,8 @@ boot trust anchor directly into the kernel image, and QEMU loads the ELF
 verbatim via `-kernel`. The always-on `-D warnings` rustflag makes this build
 the zero-warning gate (#431): any new warning fails it.
 
-Build features (declared in `crates/thumos/Cargo.toml`; mutually exclusive
-combinations `compile_error!` by design, so `--all-features` never
+Build features (declared in `crates/thumos/Cargo.toml`, where mutually
+exclusive combinations `compile_error!` by design, so `--all-features` never
 accidentally produces a shippable-looking binary):
 
 | Feature | Purpose | Mutually exclusive with |
@@ -116,7 +116,7 @@ THUMOS_QEMU_TIMEOUT=60 ../../scripts/qemu-runner.sh target/armv7a-none-eabi/rele
 ```
 
 The runner boots the ELF under `qemu-system-arm -machine virt -cpu cortex-a7
--m 1024M -nographic` with ARM semihosting enabled; the kernel reports its
+-m 1024M -nographic` with ARM semihosting enabled. The kernel reports its
 outcome via the semihosting `SYS_EXIT` call, and a 60-second watchdog
 (`THUMOS_QEMU_TIMEOUT`) guards against a hung guest.
 
@@ -160,9 +160,9 @@ grep-able boot-log lines, reach for the GDB workflow in `scripts/README.md`
 before adding a UART probe — it attaches a real debugger with symbols against
 the same QEMU boot path used above, with no kernel code changes required.
 
-A lighter smoke check that needs no kernel runtime (boot stub + UART write +
-semihosting exit only) is documented in `scripts/README.md` (a convenience
-example; not wired into CI):
+`scripts/README.md` documents a lighter smoke check that needs no kernel
+runtime (boot stub + UART write + semihosting exit only) — a convenience
+example, not wired into CI:
 
 ```bash
 cd crates/thumos
@@ -181,9 +181,9 @@ verifies:
 cargo run -p sphragis -- <image-in> <seed-hex-file> <image-out>
 ```
 
-For mkbootimg assembly: the combined kernel(+ramdisk) image is sphragis's
-input; its output is what gets flashed to the GPT `boot` partition. The
-dev anchor (`keys/dev/boot-dev.seed`) signs dev images; production keys
+For mkbootimg assembly, the combined kernel(+ramdisk) image is sphragis's
+input, and its output is what gets flashed to the GPT `boot` partition. The
+dev anchor (`keys/dev/boot-dev.seed`) signs dev images. Production keys
 live offline and never enter the repo.
 
 ## Signing and attestation boundary
@@ -197,8 +197,9 @@ today:
   key provisioned by the offline signing infrastructure (Titan security key /
   air-gapped machine) and fails without it. Refused in every configuration:
   the committed dev key under `production`, the RFC 8032 section 7.1
-  test-vector keys (private halves are published, hence forgeable anchors),
-  and any byte string that is not a decompressable curve point.
+  test-vector keys (the spec publishes their private halves, so anchors
+  built from them are forgeable), and any byte string that is not a
+  decompressable curve point.
 - **Dev keypair is public by design** (`crates/thumos/keys/dev/`, AOSP
   test-keys pattern): any developer can build and sign dev images, and host
   tests round-trip sign→verify against the real embedded anchor. No
@@ -207,8 +208,8 @@ today:
 - **Image-resident initramfs.** `build.rs` compiles `init/*.rs` to static
   armv7a ELFs, packs a newc CPIO, and signs it with the dev seed (#480) so
   measured userspace works in dev/QEMU builds. Under a production anchor this
-  dev signature does not verify — the production initramfs is signed offline
-  by the signing infrastructure — and the image falls back to the eMMC
+  dev signature does not verify — the signing infrastructure signs the
+  production initramfs offline — and the image falls back to the eMMC
   secure-boot gate (#217).
 - **Trust stamp.** Every image bakes a grep-able
   `THUMOS-BOOT-TRUST:{PROD|DEV}:<key fingerprint>` into the boot banner, and
@@ -217,11 +218,11 @@ today:
 - **CI attestation, stated precisely.** The Gate Attestation workflow
   (`.github/workflows/gate-attestation.yml`, Gate-Passed trailer / hybrid
   full-gate build) attests the **workspace** fmt/check/clippy/nextest stages
-  only; per its own NOTE it does not attest the excluded kernel crate. The
+  only. Per its own NOTE, it does not attest the excluded kernel crate. The
   kernel's executable witness is the `kernel` job of the CI workflow
   described on this page — there is no cryptographic attestation of a
-  released boot image. Release attestation is broken and tracked in #536. Do
-  not present any current artifact as release-signed or release-attested.
+  released boot image. Release attestation remains broken (tracked in #536).
+  Do not present any current artifact as release-signed or release-attested.
 
 ## Boot passphrase and encrypted userdata (#446)
 
@@ -245,21 +246,21 @@ The boot-time input subsystem behind `passphrase_ok`:
   entered: refused, throttled out, or hardware missing) is never
   plain-mounted and never formatted — the boot falls back to the
   initramfs root, and the throttle/wipe state machine (10 attempts →
-  panic wipe) applies. An unreadable preamble is treated as locked.
+  panic wipe) applies. The boot logic treats an unreadable preamble as locked.
 - **Boot pad binding.** The 4×3 matrix yields digits, Star, Hash only:
   digits append, Star = backspace, Hash = submit/confirm. Boot passphrases
   are digits-only (minimum 6), constrained identically at setup so a
   passphrase is always enterable at boot. Post-boot symbol entry in
-  `lock_screen.rs` is unaffected.
+  `lock_screen.rs` stays unaffected.
 - **One-way transition.** Completing first-boot setup writes the preamble
   sector at the userdata head and formats the payload encrypted. Plain
-  pre-provisioning content does NOT migrate — it is overwritten. qemu and
-  dev-anchor builds never reach the gate (secure boot cannot establish
-  trust there), so CI witnesses and dev iteration are unaffected.
+  pre-provisioning content does NOT migrate — first-boot setup overwrites it.
+  qemu and dev-anchor builds never reach the gate (secure boot cannot
+  establish trust there), so CI witnesses and dev iteration stay unaffected.
 - **Hardware status.** The live GPIO matrix scan, the display render, and
   the on-device verify/mount path are hardware-gated (pin assignments are
-  placeholders pending AGM M7 schematic verification, mirroring haphe);
-  host tests prove the scan/debounce logic, the preamble format, the
+  placeholders pending AGM M7 schematic verification, mirroring haphe).
+  Host tests prove the scan/debounce logic, the preamble format, the
   verifier derivation, and the gate matrices.
 
 ## Hardware path: unproven
@@ -276,10 +277,10 @@ only**. This runbook does not upgrade the hardware status:
   have no executed on-device path.
 - Repository tooling produces **no flashable device package** — no Android
   boot image, no scatter-file integration. There is nothing on this
-  page to flash, and the QEMU image must not be flashed to a device.
+  page to flash, and operators must not flash the QEMU image to a device.
 - The Linux 4.4 BSP build previously documented in this file was exploration
-  against a third-party vendor tree; those images were never flashed either.
-  That path is retired: it is not a fallback, and its steps (vendor
+  against a third-party vendor tree. Those images were never flashed either.
+  The project retired that path: it is not a fallback, and its steps (vendor
   defconfigs, manual in-tree patches, mkbootimg) are not part of the current
   build. The stock kernel config and hardware probe notes survive only as
   frozen reference records (`docs/kernel-config-stock`, `docs/HARDWARE.md`,

--- a/docs/KERNEL-WIRING-AUDIT.md
+++ b/docs/KERNEL-WIRING-AUDIT.md
@@ -10,5 +10,5 @@ kernel-wired / emulated-mock-proven / hardware-proven, and
 `scripts/check-wiring-inventory.sh` fails CI on drift in either direction
 (unclassified modules, phantom entries, witness markers claimed but not
 asserted, or asserted but not fired in the QEMU boot log). Its accounting
-rules are unchanged: compiled+tested means the Rust surface exists; it does
+rules stay fixed: compiled+tested means the Rust surface exists. It does
 not imply boot, userspace, or hardware readiness.

--- a/docs/PROBE.md
+++ b/docs/PROBE.md
@@ -179,7 +179,7 @@ Critical finding: `ro.oem_unlock_supported: 1` means the hardware/firmware suppo
 | `com.mediatek.ims` | IMS (VoLTE) |
 | `com.marshaltec.ime.t9ime` | T9 input method |
 
-Note: `com.android.fmradio` confirms an FM radio receiver is present. This is additional radio hardware not documented in specs.
+Note: `com.android.fmradio` confirms an FM radio receiver — additional hardware the specs omit.
 
 ## Battery
 
@@ -201,7 +201,7 @@ Unlocked via mtkclient BROM exploit. The fastboot  button confirmation is non-fu
 
 **Method**: mtkclient  via BROM mode
 - Required: Vol Up + Vol Down + Power held while connecting USB
-- ModemManager and cdc_acm kernel module must be stopped/removed
+- Stop ModemManager and remove the cdc_acm kernel module
 - mtkclient detected MT6739, used HACC (Hardware AES) to decrypt seccfg
 - V4 lockstate modified and written back
 

--- a/docs/SURVEILLANCE-AUDIT.md
+++ b/docs/SURVEILLANCE-AUDIT.md
@@ -7,30 +7,30 @@ Firmware: `AGM/Q12_1/Q12_1:8.1.0/OPM1.171019.026/L1635.6.01.01:user/release-keys
 
 Every material claim in this document carries one of four labels:
 
-- **[OBSERVED]** — directly measured on THIS device. The 2026-03-18 session predates evidence retention, so most raw dumps are marked *not retained — recollect*: they are re-gatherable byte-exactly by `scripts/surveillance-collect.sh` against this or another image, and the claim must be re-checked then.
+- **[OBSERVED]** — directly measured on THIS device. The 2026-03-18 session predates evidence retention, so the audit marks most raw dumps *not retained — recollect*: they are re-gatherable byte-exactly by `scripts/surveillance-collect.sh` against this or another image, and the claim must be re-checked then.
 - **[CAPABILITY]** — the package COULD do this given its granted permissions or privileged position. **Not** a claim of observed execution.
-- **[EXTERNAL]** — reported by an outside source (cited in References); not measured here.
-- **[INFERENCE]** — analyst judgment over the above. Carries uncertainty; stated where it matters.
+- **[EXTERNAL]** — reported by an outside source (cited in References). Not measured here.
+- **[INFERENCE]** — analyst judgment over the above. Carries uncertainty. Stated where it matters.
 
-The claim-to-evidence index (claim IDs below) lives in `docs/surveillance/evidence-manifest.toml`; derived tables come from `scripts/surveillance-render.py`. Session limits are in the manifest: single session, one-instant network listing, and the Adups jobs were cancelled during inspection.
+The claim-to-evidence index (claim IDs below) lives in `docs/surveillance/evidence-manifest.toml`; derived tables come from `scripts/surveillance-render.py`. Session limits are in the manifest: single session, one-instant network listing, and the audit cancelled the Adups jobs during inspection.
 
 ## Summary
 
-The stock firmware contains at least 3 distinct surveillance/telemetry systems from different actors. As shipped, the device is compromised at the system level, with privileged packages that have irrevocable access to SMS, call logs, location, contacts, camera, microphone, and storage **[OBSERVED — permission sets, not retained]**. Without root access the user cannot disable these **[OBSERVED — SYSTEM_FIXED grant flags, not retained]**.
+The stock firmware contains at least 3 distinct surveillance/telemetry systems from different actors. As shipped, privileged system packages compromise the device, holding irrevocable access to SMS, call logs, location, contacts, camera, microphone, and storage **[OBSERVED — permission sets, not retained]**. Without root access the user cannot disable these **[OBSERVED — SYSTEM_FIXED grant flags, not retained]**.
 
 ## Threat 1: Adups FOTA (Chinese OTA framework)
 
 **Package**: `com.adups.fota` (v5.24) + `com.adups.fota.sysoper` — `T1.adups-present` **[OBSERVED, not retained]**
 **Actor**: Shanghai Adups Technology Co., Ltd.
-**Known history**: Flagged by Kryptowire in November 2016 for exfiltrating full SMS message bodies, call logs, contacts, IMEI, IMSI, and installed app lists to servers in China every 72 hours. Found on 700M+ devices worldwide (BLU, ZTE, Archos, myPhone, etc.). The company claimed this was "accidental" but the functionality was architected into the firmware at the factory level. — `T1.adups-history` **[EXTERNAL: Kryptowire advisory, Nov 2016]**
+**Known history**: Flagged by Kryptowire in November 2016 for exfiltrating full SMS message bodies, call logs, contacts, IMEI, IMSI, and installed app lists to servers in China every 72 hours. Found on 700M+ devices worldwide (BLU, ZTE, Archos, myPhone, etc.). The company claimed this was "accidental," but it built the functionality into the firmware at the factory level. — `T1.adups-history` **[EXTERNAL: Kryptowire advisory, Nov 2016]**
 
 **On this device**:
-- Installed as system app (cannot be uninstalled without root) **[OBSERVED, not retained]**
+- Installed as system app (the user cannot uninstall it without root) **[OBSERVED, not retained]**
 - INTERNET + ACCESS_NETWORK_STATE + ACCESS_WIFI_STATE + RECEIVE_BOOT_COMPLETED granted — `T1.adups-permissions` **[OBSERVED, not retained]**
 - Runs scheduled jobs on boot (`MyJobService`, `MyIntentJobService`) **[OBSERVED, not retained]**
 - Monitors BOOT_COMPLETED, DATE_CHANGED, ACTION_POWER_DISCONNECTED, MEDIA_MOUNTED events **[OBSERVED, not retained]**
 - The sysoper component has REBOOT + RECOVERY permissions (can remotely trigger factory reset) **[CAPABILITY]**
-- No network traffic observed in this session (jobs were cancelled), but the scheduled job infrastructure is active and runs on every boot — `T1.adups-no-traffic` **[OBSERVED — one instant only; Adups historically exfiltrates on a 72-hour cycle]**
+- No network traffic observed in this session (the audit cancelled the jobs), but the scheduled job infrastructure is active and runs on every boot — `T1.adups-no-traffic` **[OBSERVED — one instant only: Adups historically exfiltrates on a 72-hour cycle]**
 
 **Risk**: HIGH — `T1.adups-risk` **[INFERENCE]** over the Kryptowire history **[EXTERNAL]** plus the on-device permission/jobset **[OBSERVED]**. Even if the current version has been "cleaned up" since 2016, the architecture allows silent updates that reintroduce exfiltration. The sysoper package can reboot and flash the device remotely **[CAPABILITY]**.
 
@@ -52,7 +52,7 @@ The stock firmware contains at least 3 distinct surveillance/telemetry systems f
 | Network | CHANGE_NETWORK_STATE, CHANGE_WIFI_STATE, CONNECTIVITY_INTERNAL, MANAGE_NETWORK_POLICY |
 | System | INJECT_EVENTS, DUMP, FORCE_STOP_PACKAGES, STOP_APP_SWITCHES, INTERACT_ACROSS_USERS_FULL |
 
-This single package has total device access: it can read every SMS, record audio, access the camera, track location, make calls, wipe the device, and inject input events (simulate touches/keystrokes). All permissions are SYSTEM_FIXED, meaning they cannot be revoked through Android's permission manager. — `T2.dm-total-access` **[CAPABILITY]**
+This single package has total device access: it can read every SMS, record audio, access the camera, track location, make calls, wipe the device, and inject input events (simulate touches/keystrokes). All permissions carry the SYSTEM_FIXED flag, meaning Android's permission manager cannot revoke them. — `T2.dm-total-access` **[CAPABILITY]**
 
 **Risk**: CRITICAL — `T2.dm-risk` **[INFERENCE]**. This is an OMA-DM (Open Mobile Alliance Device Management) client that carriers and the OEM can use for remote device provisioning. But the permission set far exceeds what OMA-DM requires **[INFERENCE — what OMA-DM functionally requires is itself an analyst judgment]**. The INJECT_EVENTS + CAMERA + RECORD_AUDIO combination is indistinguishable from a remote access trojan — `T2.dm-rat-equivalence` **[INFERENCE: a statement about the permission profile, not about observed use]**.
 
@@ -64,7 +64,7 @@ This single package has total device access: it can read every SMS, record audio
 - `com.mediatek.location.mtknlp` (MediaTek network location provider, actively running)
 - `com.mediatek.nlpservice` (NLP service, actively running)
 
-Three location services are running continuously in the background. — `T3.location-services-running` **[OBSERVED, not retained]**. LPPe (Location Protocol Profile extensions) is a carrier-grade positioning protocol that combines GPS, cell tower, WiFi, and sensor data for enhanced location accuracy **[EXTERNAL — protocol role]**. This data is shared with the carrier and potentially MediaTek's location services — `T3.location-data-shared` **[INFERENCE: the sharing path is architectural; no traffic capture exists for these services]**.
+Three location services are running continuously in the background. — `T3.location-services-running` **[OBSERVED, not retained]**. LPPe (Location Protocol Profile extensions) is a carrier-grade positioning protocol that combines GPS, cell tower, WiFi, and sensor data for enhanced location accuracy **[EXTERNAL — protocol role]**. The device shares this data with the carrier and potentially MediaTek's location services — `T3.location-data-shared` **[INFERENCE: the sharing path is architectural — no traffic capture exists for these services]**.
 
 `com.mediatek.gpslocationupdate` has the same massive permission set as `com.mediatek.dm`, including MASTER_CLEAR, CRYPT_KEEPER, DELETE_PACKAGES, MANAGE_PROFILE_AND_DEVICE_OWNERS, and OEM_UNLOCK_STATE. This is not a location service. It's a full device management agent disguised as a location service. — `T3.gpslocationupdate-agent` **[OBSERVED for the permission set, not retained; the "what it is" framing is CAPABILITY/INFERENCE]**
 
@@ -81,7 +81,7 @@ MTKLogger can read all system logs (including other apps' log output), capture s
 
 EngineerMode provides direct hardware access including baseband AT commands, radio parameters, and device identifiers. While primarily a diagnostic tool, it's an attack surface: any app that can launch EngineerMode activities can access radio hardware directly. — `T4.engineermode-surface` **[CAPABILITY]**
 
-**Risk**: MEDIUM — `T4.risk` **[INFERENCE]**. Primarily diagnostic tools, but the permission set enables surveillance if the packages are compromised or remotely updated **[CAPABILITY]**.
+**Risk**: MEDIUM — `T4.risk` **[INFERENCE]**. Primarily diagnostic tools, but the permission set enables surveillance if an attacker compromises the packages or remotely updates them **[CAPABILITY]**.
 
 ## Threat 5: OMA Client Provisioning (com.mediatek.omacp)
 
@@ -98,7 +98,7 @@ EngineerMode provides direct hardware access including baseband AT commands, rad
 
 TikTok is pre-installed as a system app. ByteDance (TikTok's parent) is subject to Chinese national security law requiring cooperation with intelligence services — `T6.bytedance-law` **[EXTERNAL: PRC National Intelligence Law, 2017, Art. 7]**. WhatsApp shares metadata with Meta **[EXTERNAL — Meta policy]**. Both have full internet access and broad permissions **[OBSERVED, not retained]**.
 
-**Risk**: MEDIUM **[INFERENCE]**. These can be disabled or uninstalled (they're not in /system/priv-app, just /system/app) **[OBSERVED, not retained]**, but their presence as factory defaults indicates the OEM's relationship with these platforms — `T6.oem-relationship` **[INFERENCE]**.
+**Risk**: MEDIUM **[INFERENCE]**. The user can disable or uninstall these (they're not in /system/priv-app, just /system/app) **[OBSERVED, not retained]**, but their presence as factory defaults indicates the OEM's relationship with these platforms — `T6.oem-relationship` **[INFERENCE]**.
 
 ## Threat 7: Freeme OS framework
 
@@ -106,7 +106,7 @@ TikTok is pre-installed as a system app. ByteDance (TikTok's parent) is subject 
 
 Freeme OS is a Chinese Android customization framework (similar to MIUI, ColorOS). It's the UI layer provided by TYD Technology. The `freeme` framework package runs at the framework level, meaning it has access to all Android framework internals. — `T7.freeme-framework` **[OBSERVED, not retained]**. Badge provider and factory test are lower-risk utility apps **[INFERENCE]**.
 
-**Risk**: LOW-MEDIUM **[INFERENCE]**. The framework package runs with system privileges. Without decompiling the APK, its exact behavior is unknown. Freeme OS has no public security audit history. — `T7.freeme-unknown` **[EXTERNAL: an absence-of-publications claim; no decompilation was performed for this audit]**.
+**Risk**: LOW-MEDIUM **[INFERENCE]**. The framework package runs with system privileges. Without decompiling the APK, no one has verified its exact behavior. Freeme OS has no public security audit history. — `T7.freeme-unknown` **[EXTERNAL: an absence-of-publications claim — this audit did not decompile the APK]**.
 
 ## Active services at time of probe
 
@@ -128,7 +128,7 @@ Freeme OS is a Chinese Android customization framework (similar to MIUI, ColorOS
 | 21.28.129.209:42318 | 10.166.154.5:5060 | TCP | Carrier IMS/SIP (VoLTE) |
 | 21.28.129.209:50001 | 10.166.154.5:65529 | TCP | IMS control |
 
-Only carrier IMS traffic observed. WiFi was connected but no outbound connections to surveillance infrastructure during the probe window — `N.no-surveillance-traffic` **[OBSERVED — does not establish absence of exfiltration across a 72-hour cycle]**. Adups typically exfiltrates on a 72-hour cycle **[EXTERNAL]**, and the device may have been recently powered on.
+Only carrier IMS traffic observed. The device stayed connected to WiFi, but no outbound connections to surveillance infrastructure occurred during the probe window — `N.no-surveillance-traffic` **[OBSERVED — does not establish absence of exfiltration across a 72-hour cycle]**. Adups typically exfiltrates on a 72-hour cycle **[EXTERNAL]**, and the device may have been recently powered on.
 
 ## Conclusion
 
@@ -136,16 +136,16 @@ Only carrier IMS traffic observed. WiFi was connected but no outbound connection
 
 The stock AGM M7 firmware contains at minimum:
 - A known Chinese data exfiltration framework (Adups) **[EXTERNAL]** with boot persistence and remote reboot capability **[OBSERVED + CAPABILITY]**
-- A device management agent (MediaTek DM) with permissions equivalent to a remote access trojan **[OBSERVED the set; CAPABILITY the equivalence]**
+- A device management agent (MediaTek DM) with permissions equivalent to a remote access trojan **[OBSERVED the set — CAPABILITY the equivalence]**
 - Continuous background location tracking via 3 separate services **[OBSERVED]**
 - A carrier remote provisioning system vulnerable to SMS-based APN hijacking **[CAPABILITY + EXTERNAL]**
 - Pre-installed Chinese social media (TikTok) subject to national security cooperation requirements **[OBSERVED + EXTERNAL]**
 
-None of these can be disabled by the user without root access. All are SYSTEM_FIXED **[OBSERVED, not retained]**. This is the baseline threat that thumos exists to eliminate **[INFERENCE — project mission framing]**.
+The user cannot disable any of these without root access. All carry the SYSTEM_FIXED flag **[OBSERVED, not retained]**. This is the baseline threat that thumos exists to eliminate **[INFERENCE — project mission framing]**.
 
 ## References
 
-- Kryptowire / Adups FOTA disclosure, November 2016 (public reporting; see e.g. contemporaneous coverage of the BLU device findings).
+- Kryptowire / Adups FOTA disclosure, November 2016 (public reporting — see e.g. contemporaneous coverage of the BLU device findings).
 - Check Point Research, "Advanced SMS Phishing — OMA CP Provisioning Messages", 2019.
 - PRC National Intelligence Law, 2017 (Article 7).
 - LPPe / OMA Location Protocol — public protocol documentation.

--- a/vendor/haocheng/README.md
+++ b/vendor/haocheng/README.md
@@ -5,21 +5,22 @@ shipped with the AGM M7.
 
 ## Purpose
 
-These files are used as **reference documentation only** during kernel development.
-They provide register offsets, hardware initialization sequences, and GPIO/feature
-bindings for the MT6739 SoC as configured by the Haocheng ODM.
+Kernel developers use these files as **reference documentation only** during
+kernel development. They provide register offsets, hardware initialization
+sequences, and GPIO/feature bindings for the MT6739 SoC as configured by the
+Haocheng ODM.
 
 ## Build status
 
-**Not compiled.** Nothing in this directory is included in any Cargo build or
-linked into the thumos kernel. The files exist solely to be read by developers
+**Not compiled.** No Cargo build includes anything in this directory, and the
+thumos kernel links none of it. Developers read the files solely as reference
 while writing Rust drivers that target the same hardware.
 
 ## Contents
 
 - `drivers/hct_include/hct_project_all_config.h` -- GPIO and feature configuration
   bindings for the AGM M7 board variant. As of this commit, the header is a stub
-  (feature bindings absent; kernel boots without LCM probing).
+  (feature bindings absent, so the kernel boots without LCM probing).
 
 ## License
 


### PR DESCRIPTION
`WRITING/*` classes from #718, across the doc surface. **91 → 1**, with the remaining one reported rather than silenced.

## Measured with the instrument CI uses

`kanon lint . --precision low --min-severity info --strict` (CLI, not MCP — they disagree by ~2.5× on this repo, kanon#3172).

| rule | before | after (in scope) | out of scope, untouched |
|---|---|---|---|
| passive-voice | 54 | 0 | 5 (`crates/`, `scripts/`) |
| semicolon | 29 | 0 | 1 (`scripts/`) |
| sentence-length-variance | 3 | 0 | — |
| weasel-word | 2 | 0 | — |
| hedging-cluster | 1 | 0 | — |
| purpose-in-technical-doc | 1 | 0 | — |
| adjective-frontloading | 1 | 1 (false positive) | — |
| **total** | **91** | **1** | **6** |

## #718's per-rule table was in the wrong unit

The issue lists passive-voice 57 / semicolon 34. Those came from the MCP tool, which the issue's own last comment already flags as the wrong instrument. Live CLI baseline at correct precision: **54 / 29**. Consistent with #720 having fixed a few in between.

## The four files #718 names were already done

#720 (`ebd7567`) resolved `README.md`, `ARCHITECTURE.md`, `_llm/README.md` — 18 → 1 on that narrow scope. The real remaining surface was ten files #718 never enumerated: `docs/ALETHEIA-BRIDGE.md`, `ATTRIBUTION.md`, `DRIVER-INTERFACES.md`, `GC9306-INIT.md`, `HARDWARE.md`, `KERNEL-BUILD.md`, `KERNEL-WIRING-AUDIT.md`, `PROBE.md`, `SURVEILLANCE-AUDIT.md`, `vendor/haocheng/README.md`.

## `YAML/missing-concurrency` was never real

**0 findings at every measurement, before and after.** The one-line "unambiguous fix" #718 recommends had already been applied by #720 — and it is what took main's gate down for nine hours (fixed in #745, root cause in kanon#3202). Nothing to do here, deliberately.

## The false positive, left in place

`README.md:47` — `adjective-frontloading` matched "a CSPRNG, capabilities, power management", a plain enumeration of kernel subsystems, as an adjective pileup. Rewriting to dodge the regex would degrade a legitimate list for no reader benefit.

## Note on the rewrites

Passive voice in technical prose is often correct, and the failure mode of a lint-driven pass is inventing an actor that does not exist. These name the real one where there is one ("the spec publishes their private halves, so anchors built from them are forgeable") and split into sentences where there is not. Several lines carried two overlapping violations, where fixing the first exposed a second the regex had not reached — each batch was re-linted before commit.

Six commits, one per rule class, except where two rules lived in a single indivisible sentence rewrite (documented in that commit's body rather than force-split).

Refs: #718
