### PR TITLE
chore(repo): decide the four structural findings — runbook, benches, nextest config, glossary

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,42 @@
+# nextest configuration (TESTING/no-nextest-config, thumos#718).
+#
+# WHY these values, not a generic starter template: CI
+# (.github/workflows/ci.yml `workspace` job) invokes plain
+# `cargo nextest run --workspace --build-jobs 8 --test-threads 8` with no
+# `--profile` flag, so [profile.default] below is what both CI and any local
+# run actually use -- there is no separate CI-only profile in play.
+#
+# The workspace suite (crates/*, excluding crates/thumos which is excluded
+# from the workspace and runs its own i686 host-test script) is ~939 tests
+# across 19 crates, almost all synchronous unit tests over pure parsing/codec
+# logic. Two things actually take non-trivial wall-clock time:
+#   - crates/topos/src/nmea.rs: four `proptest!` properties (default 256
+#     cases each) over NMEA sentence parsing -- cheap per-case, but the
+#     slowest tests in the suite by design.
+#   - crates/klesis/src/transport.rs:485 `read_line_times_out_on_slow_trickle`
+#     drives a mock 5ms-per-byte trickle against a test-mode 50ms
+#     READ_LINE_TIMEOUT and asserts `elapsed < 2s` (transport.rs:517) --
+#     wall-clock by construction, self-bounding at ~2s in practice.
+# Neither approaches the job-level 30-minute ceiling (ci.yml:57,
+# .kanon-ci.toml "cargo nextest" timeout_secs = 1800); slow-timeout below is
+# calibrated against that real outlier, not a generic guess.
+[profile.default]
+# WHY 3: TESTING.md's own documented CI-default retry count (this profile
+# IS the CI-invoked one, per the note above). No test in this suite is
+# currently flaky or quarantined -- these retries exist as the standard's
+# diagnostic backstop, not because of a known flake.
+retries = 3
+# WHY 20s/4: ~30x the ~2s worst known outlier (the wall-clock trickle test
+# above), well under the 30-minute job ceiling, and tight enough that a
+# genuinely hung test (not a slow one) still reds well before the job
+# timeout kills the whole run without a named failure.
+slow-timeout = { period = "20s", terminate-after = 4 }
+failure-output = "immediate-final"
+
+[[profile.default.overrides]]
+# WHY: the one test in this suite that is deliberately wall-clock-timed
+# (crates/klesis/src/transport.rs:485-517) -- give it a per-test allowance
+# that reflects its own ~2s design bound plus scheduler-contention margin,
+# rather than inheriting the global slow-timeout meant for everything else.
+filter = "test(read_line_times_out_on_slow_trickle)"
+slow-timeout = { period = "10s", terminate-after = 2 }

--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -267,10 +267,14 @@ RUST/as-cast:crates/pteron/src/smp/pdu.rs
 TESTING/no-tests:crates/metaxu-core/src/lib.rs
 
 # =============================================================================
-# No standalone glossary — declined, not deferred
+# No standalone glossary — the glossary already exists
 # =============================================================================
 #
-# WHY(#718): thumos's domain vocabulary is defined at its point of use in the
-# code and in ARCHITECTURE.md. A separate GLOSSARY.md would be a second copy
-# of the same facts, and a second copy drifts (one fact, one place).
+# WHY(#718): _llm/glossary.toml IS this repo's domain glossary (47 lines,
+# [[terms]] with canonical flags). The rule searches docs/ and the repo root
+# for a filename containing "glossary"/"lexicon" and does not look in _llm/,
+# which is where the fleet keeps the LLM nav corpus -- so it reports a missing
+# artifact that is present. Writing a second GLOSSARY.md to satisfy it would
+# create the drift the rule exists to prevent (one fact, one place).
+# Rule-side fix: kanon#3203.
 ARCHITECTURE/no-glossary:Cargo.toml

--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -265,3 +265,12 @@ RUST/as-cast:crates/pteron/src/smp/pdu.rs
 # metaxu-core's lib.rs is module declarations and re-exports; its submodules
 # carry 19 tests (envelope.rs 10, grants.rs 6, protocol.rs 3).
 TESTING/no-tests:crates/metaxu-core/src/lib.rs
+
+# =============================================================================
+# No standalone glossary — declined, not deferred
+# =============================================================================
+#
+# WHY(#718): thumos's domain vocabulary is defined at its point of use in the
+# code and in ARCHITECTURE.md. A separate GLOSSARY.md would be a second copy
+# of the same facts, and a second copy drifts (one fact, one place).
+ARCHITECTURE/no-glossary:Cargo.toml

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,187 @@
+# RUNBOOK
+
+Operational procedures for thumos. Every command below is a real repository
+mechanism — a script under `scripts/`, a step from `.github/workflows/ci.yml`,
+or the local gate (`kanon gate`, `.kanon-ci.toml`) that mirrors it. If a
+command here ever drifts from CI, CI is authoritative (same rule as
+`docs/KERNEL-BUILD.md`) — file an issue rather than trusting this page.
+
+thumos is not a deployed service: there is no running instance to page for,
+no database, and no user traffic. "Operational" here means the kernel's own
+QEMU-proven lifecycle — build, boot-witness, and diagnose a failure — plus
+the boot-signing material the build depends on. Sections below follow
+`OPERATIONS.md`'s runbook shape; sections that do not apply to a bare-metal
+kernel project say so rather than being silently dropped.
+
+## Architecture
+
+Full architecture, the crate roster, and current phase status live in
+`ARCHITECTURE.md` and `README.md` — this section only orients where to run
+things, not what they are (a second description here would drift from
+those). Two directories matter operationally:
+
+- `crates/thumos/` — the kernel binary. Deliberately excluded from the
+  Cargo workspace (bare-metal target), so its build, its host tests, and
+  its lint pass each need their own invocation — see Start/stop and
+  Common issues.
+- The 19 workspace library crates under `crates/` (`klesis`, `klesis-core`,
+  `aither`, `pteron`, ... — full list in `Cargo.toml`'s `members`) — a
+  normal `cargo`-buildable workspace, one host toolchain, one test runner.
+
+## Start/stop (build and boot)
+
+From a clean checkout, one-time toolchain setup:
+
+```bash
+rustup target add armv7a-none-eabi i686-unknown-linux-gnu
+cargo install cargo-nextest --locked --version ^0.9
+sudo dnf install qemu-system-arm gcc-multilib   # Fedora: gcc-multilib -> glibc-devel.i686
+# Debian/Ubuntu: sudo apt-get install qemu-system-arm gcc-multilib
+```
+
+Workspace crates (host):
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+cargo nextest run --workspace --build-jobs 8 --test-threads 8
+cargo test --doc --workspace   # nextest does not run doctests
+```
+
+Kernel crate (bare-metal, excluded from the workspace — run its commands
+from `crates/thumos/`, since `.cargo/config.toml` is discovered from the
+invocation directory, not from `--manifest-path`):
+
+```bash
+scripts/kernel-build.sh          # release cross-compile, armv7a-none-eabi, -D warnings gate
+scripts/kernel-host-tests.sh     # i686 host unit tests (u32-faithful syscall ABI)
+scripts/kernel-clippy.sh         # i686 clippy, zero-warning gate
+```
+
+"Stop" has no separate meaning here — there is no long-running process to
+signal. A QEMU boot run (below) is bounded by its own timeout and exits on
+its own.
+
+## Health check (the QEMU boot witness)
+
+The kernel's only proof of correctness beyond unit tests is booting under
+QEMU and asserting on its own log output. Run the full witness matrix in
+canonical order (same scripts CI runs step-by-step):
+
+```bash
+scripts/witness-run-all.sh
+```
+
+Or the boot witness alone:
+
+```bash
+cd crates/thumos
+cargo build --release --target armv7a-none-eabi --features qemu
+THUMOS_QEMU_TIMEOUT=60 ../../scripts/qemu-runner.sh target/armv7a-none-eabi/release/thumos | tee boot.log
+```
+
+Minimum "is it alive" check — the same three lines CI asserts first:
+
+```bash
+grep 'THUMOS v0.1.0' boot.log                     # boot banner
+grep 'THUMOS-QEMU: boot-complete' boot.log        # kinit reached boot-complete
+grep 'THUMOS-QEMU: service-loop ticks=' boot.log  # PID 0 serviced real ticks
+```
+
+`scripts/witness/boot.sh` asserts far more than that (fail-closed degraded
+boot, measured userspace, `/init` + `/shell` per-process isolation, render,
+input, clock, telephony/audio/SIM/BT/firewall state machines, and the PL0
+isolation probes) — read it directly for the full assertion list rather
+than trusting a paraphrase here.
+
+## Common issues
+
+| Symptom | Likely cause | Resolution |
+|---|---|---|
+| `qemu-runner.sh` exits 127 | `qemu-system-arm` not installed | Install it (command printed by the runner itself); see toolchain setup above |
+| `qemu-runner.sh` exits 124 | Guest hung past `THUMOS_QEMU_TIMEOUT` (default 60s) | Not a bare timeout — every real failure path exits with a named code first (0/1/2/3/4/5); 124 alone means the guest never reached any exit path. Attach GDB (below) rather than guessing |
+| `qemu-runner.sh` exits 5 | Service-loop stall — the tick source (#461 class) is not advancing | Check `boot.log` for `kardia: timer elapsed_ms=advancing`; a missing line points at a CNTFRQ/CNTPCT regression |
+| `qemu-runner.sh` exits 1 | Kernel panic or non-zero guest exit | Read `boot.log` in full (the runner always prints it) for the panic message before the exit |
+| `scripts/kernel-build.sh` fails on a new warning | The `-D warnings` gate in `crates/thumos/.cargo/config.toml` is always on (#431) | Fix the warning. Never pass `RUSTFLAGS` through the environment when building the kernel — it clobbers the config's rustflags and silently drops this gate |
+| `scripts/kernel-host-tests.sh` fails to link | 32-bit crt objects missing | `gcc-multilib` (Debian/Ubuntu) or `glibc-devel.i686` (Fedora) — the script's own probe step names the fix |
+| A PL0 isolation probe (`witness/boot.sh`'s probe loop) fails | The kernel did not fault, kill, and reap the offending process, or a sibling process died with it | Read the specific `FAIL isolation[...]` message — it names which of fault/kill/reap/survive broke |
+
+For anything not covered above: every failure path in the witness scripts
+prints a named `FAIL: ...` message (never a bare non-zero exit) — that
+message is the starting point, not the exit code alone.
+
+## Credential rotation
+
+No user-facing or service credential exists here; the nearest analog is
+the boot-image signing key. `crates/thumos/build.rs` embeds one Ed25519
+public key (the boot trust anchor) into every image. The committed dev
+keypair (`crates/thumos/keys/dev/`) is deliberately public — anyone can
+build and sign a dev image — and no production key is ever committed
+(`keys/.gitignore` blocks it). Rotating to a production key means building
+with `--features production` and `THUMOS_BOOT_KEY_PUB=<file>` naming a key
+provisioned by offline signing infrastructure; the build refuses to
+proceed without it, refuses the dev key, and refuses RFC 8032's published
+test-vector keys (their private halves are public, so they cannot
+establish trust). Full detail: `docs/KERNEL-BUILD.md` § Signing and
+attestation boundary.
+
+## Database inspection
+
+Not applicable. thumos has no external database. The kernel's own
+persistent storage (log-structured filesystem, encrypted userdata volume)
+is in-kernel state on the target device, not an operable service
+component, and is unreachable from this runbook until the hardware path
+below is proven.
+
+## Backup/restore
+
+Not applicable in the OPERATIONS.md sense (no deployed data store to back
+up). The closest analog — recovering a broken build or a bad commit — is
+ordinary git: `git bisect` against `main`, or re-run the exact CI job
+(`kernel`, `workspace`, or `fmt` in `.github/workflows/ci.yml`) locally via
+its scripted steps above.
+
+## Performance debugging
+
+- **Kernel boot/runtime.** The QEMU witness logs are the only signal
+  available pre-hardware; there is no profiler attached to the emulated
+  target today. Use the GDB workflow below to inspect state at a specific
+  point rather than guessing from log timing.
+- **Workspace library code (host).** `benches/` holds Criterion
+  benchmarks for the codec paths every SMS PDU runs through
+  (`klesis-core`'s GSM-7 and BCD-address encode/decode) — run with
+  `cargo bench -p klesis-core`. `cargo clippy --workspace --all-targets`
+  already compiles these on every PR, so a benchmark that stops compiling
+  is caught immediately even though the timing run itself is not part of
+  CI (benchmark timing on shared CI runners is noise, not signal — see
+  `TESTING.md` § Benchmarks).
+
+GDB attach (kernel, under QEMU):
+
+```bash
+THUMOS_QEMU_GDB=1 scripts/qemu-runner.sh target/armv7a-none-eabi/release/thumos &
+scripts/gdb-thumos.sh target/armv7a-none-eabi/release/thumos
+```
+
+Drops into a live GDB session with symbols loaded, breakpointed at
+`kinit::run`, against the same boot path the witnesses use — no kernel
+code changes required. Details and port override: `scripts/README.md`.
+
+## Escalation
+
+No on-call rotation exists for a public open-source kernel project.
+Escalation is a GitHub issue on `forkwright/thumos`, same as the standard
+"if a command here drifts, file an issue" convention this repo already
+follows (`docs/KERNEL-BUILD.md`). For a red required CI check, the job's
+own log is authoritative over any local reproduction.
+
+## Hardware bring-up status
+
+Everything above proves the kernel **under QEMU `-machine virt` only**.
+The Rust kernel has never booted on the physical AGM M7 / MT6739, and the
+repository produces no flashable device package today — no Android boot
+image, no scatter-file integration. There is nothing to flash, and no
+hardware brick-recovery procedure exists because nothing has been flashed
+to a device from this repository. Do not treat any command on this page as
+proven beyond the emulator. Full detail, including what the `qemu` feature
+deliberately does not model: `docs/KERNEL-BUILD.md` § Hardware path:
+unproven.

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -116,7 +116,7 @@ the boot-image signing key. `crates/thumos/build.rs` embeds one Ed25519
 public key (the boot trust anchor) into every image. The committed dev
 keypair (`crates/thumos/keys/dev/`) is deliberately public — anyone can
 build and sign a dev image — and no production key is ever committed
-(`keys/.gitignore` blocks it). Rotating to a production key means building
+(`crates/thumos/keys/.gitignore` blocks it). Rotating to a production key means building
 with `--features production` and `THUMOS_BOOT_KEY_PUB=<file>` naming a key
 provisioned by offline signing infrastructure; the build refuses to
 proceed without it, refuses the dev key, and refuses RFC 8032's published

--- a/benches/klesis_core_pdu_codec.rs
+++ b/benches/klesis_core_pdu_codec.rs
@@ -1,0 +1,93 @@
+//! Criterion benchmarks for `klesis-core`'s GSM-7 and BCD-address codecs
+//! (TESTING/no-benchmarks, thumos#718).
+//!
+//! WHY these two paths: every inbound and outbound SMS on the device runs
+//! through both. `encode`/`decode` walk `char_to_septet`, which does a
+//! *linear scan* over the extension table and then the 128-entry base
+//! GSM-7 table for every character (`crates/klesis-core/src/lib.rs`) — an
+//! O(n * 128) cost paid per message, not per byte. `decode_bcd_address`
+//! runs on every sender/recipient address in every PDU. Both are called
+//! from `klesis::pdu::decode_deliver` (the workspace telephony daemon) and,
+//! once #126 lands, from the kernel's own `sms.rs` — the path actually
+//! reached on the device.
+//!
+//! Registered on `klesis-core` via `[[bench]]` in its `Cargo.toml` with an
+//! explicit `path` into this directory (TESTING/no-benchmarks expects a
+//! workspace-root `benches/` sibling to the root `Cargo.toml`; Cargo itself
+//! has no opinion on where a `[[bench]]` target's source file lives).
+
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use klesis_core::{decode, decode_bcd_address, encode, encode_bcd_address};
+
+/// 3GPP TS 23.038 single-segment SMS cap: 160 septets.
+const SMS_BODY_MAX_CHARS: usize = 160;
+
+/// Unwrap a benchmark input built from a known-good, hand-verified literal.
+///
+/// Centralizes the one `.expect()` this file needs so a codec regression
+/// still panics loudly (a benchmark that silently timed an error path
+/// would be worse than no benchmark at all) without scattering
+/// `#[expect(clippy::expect_used)]` across every call site.
+#[inline]
+#[expect(
+    clippy::expect_used,
+    reason = "benchmark inputs are known-good by construction; a failure here is a real codec regression"
+)]
+fn must<T, E: core::fmt::Debug>(result: Result<T, E>) -> T {
+    result.expect("benchmark input must be valid by construction")
+}
+
+/// A representative single-segment SMS body: ordinary prose, not repeated
+/// bytes, so the septet-table scan sees the same character mix real traffic
+/// does.
+fn representative_sms_body() -> String {
+    let phrase = "The kernel booted, the service loop ticked, and the modem \
+        reported LTE registration with nonzero signal bars and a ready SIM. ";
+    phrase.chars().cycle().take(SMS_BODY_MAX_CHARS).collect()
+}
+
+fn bench_gsm7_codec(c: &mut Criterion) {
+    let text = representative_sms_body();
+    let packed = must(encode(&text));
+    let num_septets = SMS_BODY_MAX_CHARS;
+
+    let mut group = c.benchmark_group("gsm7_codec");
+    group.bench_function("encode_160_char_sms", |b| {
+        b.iter(|| must(encode(black_box(&text))));
+    });
+    group.bench_function("decode_160_septet_sms", |b| {
+        b.iter(|| must(decode(black_box(&packed), black_box(num_septets))));
+    });
+    group.finish();
+}
+
+fn bench_bcd_address_codec(c: &mut Criterion) {
+    // WHY this input: a 15-digit E.164 international MSISDN is the common
+    // case for both the originating- and destination-address fields of a
+    // real PDU.
+    let msisdn = "+447700900123456";
+    let (type_of_address, packed) = must(encode_bcd_address(msisdn));
+    let len_digits = must(u8::try_from(msisdn.len() - 1));
+
+    let mut group = c.benchmark_group("bcd_address_codec");
+    group.bench_function("encode_15_digit_msisdn", |b| {
+        b.iter(|| must(encode_bcd_address(black_box(msisdn))));
+    });
+    group.bench_function("decode_15_digit_msisdn", |b| {
+        let type_of_address = black_box(type_of_address);
+        let packed = black_box(&packed);
+        b.iter(|| {
+            must(decode_bcd_address(
+                black_box(len_digits),
+                type_of_address,
+                packed,
+            ))
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_gsm7_codec, bench_bcd_address_codec);
+criterion_main!(benches);

--- a/crates/klesis-core/Cargo.toml
+++ b/crates/klesis-core/Cargo.toml
@@ -7,6 +7,18 @@ license.workspace = true
 publish.workspace = true
 repository.workspace = true
 
+# WHY the explicit path (#718): TESTING/no-benchmarks expects a
+# workspace-root `benches/` directory as a sibling of the root Cargo.toml,
+# not a per-crate one — this target's source lives there while still
+# compiling as part of this package.
+[[bench]]
+name = "klesis_core_pdu_codec"
+harness = false
+path = "../../benches/klesis_core_pdu_codec.rs"
+
+[dev-dependencies]
+criterion = "0.5"
+
 [lints]
 workspace = true
 


### PR DESCRIPTION
The four structural findings from #718 — `OPERATIONS/no-runbook`, `TESTING/no-benchmarks`, `TESTING/no-nextest-config`, `ARCHITECTURE/no-glossary`. #718 asks for these to be *decided*, not burned down; three are yes, one turns out to be a false positive.

## RUNBOOK.md

Derived from `scripts/` and `.github/workflows/ci.yml`, not invented. Every path and command in it was checked against the tree — `kernel-build.sh`, `kernel-clippy.sh` (i686, as the script itself explains: the kernel crate has no host target), `kernel-host-tests.sh`, `qemu-runner.sh`, `witness/boot.sh`, `witness-run-all.sh`, `gdb-thumos.sh` all exist and are labelled with what they actually do. A runbook containing a command that does not work is worse than no runbook, because someone runs it during an incident.

## benches/klesis_core_pdu_codec.rs

GSM-7 encode/decode and BCD-address encode/decode — the SMS PDU codec primitives every inbound and outbound message passes through (`klesis::pdu::decode_deliver` today, kernel `sms.rs` once #126 lands). `char_to_septet` linear-scans a 128-entry table per character, so there is a real cost to measure.

Source sits at root `benches/` (where the rule looks) and is wired into `klesis-core` via an explicit `[[bench]] path`, so it compiles as a real target rather than sitting unbuilt. **CI already builds it** — `cargo clippy --workspace --all-targets -- -D warnings` covers benches via `--all-targets`, unmodified. There is no `cargo bench --no-run` link step; adding one needs `ci.yml`, which another lane owned, so it is flagged rather than improvised.

## .config/nextest.toml

Not a template. `retries = 3` matches `TESTING.md`'s documented CI default, and CI invokes `cargo nextest run --workspace` with no `--profile`, so `[profile.default]` is what actually runs. `slow-timeout` is sized off the one real wall-clock test in the suite (`klesis::transport::read_line_times_out_on_slow_trickle`, self-bounding at ~2s) rather than guessed.

## The glossary is not a decline — the rule is looking in the wrong place

`_llm/glossary.toml` **already exists**: 47 lines, `[[terms]]` with canonical flags, a real domain glossary. `ARCHITECTURE/no-glossary` searches `docs/` and the repo root only, so it reports a missing artifact that is present.

That matters more than the finding does. An agent resolving it writes `docs/GLOSSARY.md`, and the repo then has **two** glossaries defining the same terms — the exact drift the rule exists to prevent. The `.kanon-lint-ignore` entry records it as a wrong-location false positive with that reasoning, not as "we decided not to." Rule-side fix filed as kanon#3203.

## One thing left open, deliberately

`OPERATIONS/no-runbook` fires **per `Cargo.toml`** — all 22 manifests here (root + 18 members + fuzz), not just the root. Unlike the other three rules it never checks `is_separate_workspace_crate`. This PR resolves the root instance, which is what #718's framing asks for ("each a yes/no about *this repo*"). The 21 per-crate instances are a rule-granularity gap and were not suppressed.

Confirmed no effect on the gate either way: `kanon lint . --summary` at real gate settings reports **224 violations before and after** — these are Info severity and invisible to the default gate.

Refs: #718, kanon#3203
