### PR TITLE
fix(kernel): cite the wiring inventory instead of two closed issues

### DIFF
--- a/crates/thumos/src/audio.rs
+++ b/crates/thumos/src/audio.rs
@@ -48,7 +48,7 @@
     not(test),
     expect(
         dead_code,
-        reason = "audio manager API created in Phase 07 Wave 4, kinit wiring pending (#145)"
+        reason = "audio manager API exists; kinit wiring pending (tier in docs/capability-inventory.toml)"
     )
 )]
 

--- a/crates/thumos/src/audio_codec.rs
+++ b/crates/thumos/src/audio_codec.rs
@@ -38,7 +38,7 @@
 // WHY: audio codec API not yet wired to kinit (Wave 4 integration pending).
 #![expect(
     dead_code,
-    reason = "audio codec API created in Phase 07 Wave 4, kinit wiring pending (#145)"
+    reason = "audio codec API exists; kinit wiring pending (tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;
@@ -70,7 +70,7 @@ const AFE_DL_GAIN: u16 = 0x2010;
 /// ADC digital gain register offset.
 #[expect(
     dead_code,
-    reason = "register constant reserved for future gain control (#145)"
+    reason = "register constant reserved for future gain control (tier in docs/capability-inventory.toml)"
 )]
 const AFE_UL_GAIN: u16 = 0x2014;
 

--- a/crates/thumos/src/audio_route.rs
+++ b/crates/thumos/src/audio_route.rs
@@ -28,7 +28,7 @@
 // WHY: route manager API not yet wired to kinit (Wave 4 integration pending).
 #![expect(
     dead_code,
-    reason = "audio route API created in Phase 07 Wave 4, kinit wiring pending (#145)"
+    reason = "audio route API exists; kinit wiring pending (tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/avdtp.rs
+++ b/crates/thumos/src/avdtp.rs
@@ -23,7 +23,7 @@
 // WHY: A2DP profile not yet wired to audio session manager (Wave 8, kinit pending).
 #![expect(
     dead_code,
-    reason = "A2DP profile created in Phase 07 Wave 8, audio manager wiring pending (#145)"
+    reason = "A2DP profile exists; audio manager wiring pending (tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/battery.rs
+++ b/crates/thumos/src/battery.rs
@@ -33,7 +33,7 @@
     not(test),
     expect(
         dead_code,
-        reason = "Battery monitor created in Phase 07 Wave 5, kinit wiring pending (#145)"
+        reason = "Battery monitor exists; kinit wiring pending (tier in docs/capability-inventory.toml)"
     )
 )]
 

--- a/crates/thumos/src/bluetooth.rs
+++ b/crates/thumos/src/bluetooth.rs
@@ -20,7 +20,7 @@
 // WHY: hardware driver API not yet wired to upper layers (kinit integration pending).
 #![expect(
     dead_code,
-    reason = "BT driver API wired in kinit but not yet called from userspace (#145)"
+    reason = "BT driver API wired in kinit but not yet called from userspace (tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/briar.rs
+++ b/crates/thumos/src/briar.rs
@@ -31,7 +31,7 @@
 // implementation pending.
 #![expect(
     dead_code,
-    reason = "Briar transport stub created in Phase 09 Wave 7, BTP implementation pending (#145)"
+    reason = "Briar transport stub exists; BTP implementation pending (tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/clock.rs
+++ b/crates/thumos/src/clock.rs
@@ -24,7 +24,7 @@
 // syscalls still use the lower-level timer/time paths.
 #![expect(
     dead_code,
-    reason = "Clock trust manager is not wired into kernel time (#145)"
+    reason = "Clock trust manager is not wired into kernel time (tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;
@@ -363,7 +363,7 @@ pub(crate) fn parse_ntp_response(packet: &[u8]) -> Option<u64> {
 #[must_use]
 pub(crate) fn calculate_ntp_offset(local_send_secs: u64, server_transmit_epoch: u64) -> i64 {
     // INVARIANT: unlike the other u64 -> i64 sites in this module, this
-    // function has no wired-in caller yet (#145 -- the clock trust manager
+    // function has no wired-in caller yet (the clock trust manager
     // is not wired into kernel time) to bound `local_send_secs` by
     // construction, and `server_transmit_epoch` is meant to carry a value
     // parsed from a network-supplied NTP packet (see `parse_ntp_response`).

--- a/crates/thumos/src/contacts.rs
+++ b/crates/thumos/src/contacts.rs
@@ -19,7 +19,7 @@
 // WHY: contacts module created in Phase 07 Wave 5, kinit wiring pending.
 #![expect(
     dead_code,
-    reason = "Contacts module created in Phase 07 Wave 5, kinit wiring pending (#145)"
+    reason = "Contacts module exists; kinit wiring pending (tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/ekphrasis.rs
+++ b/crates/thumos/src/ekphrasis.rs
@@ -46,7 +46,7 @@
     not(test),
     expect(
         dead_code,
-        reason = "Ekphrasis created in Phase 09 Wave 6, audio pipeline integration pending (#145)"
+        reason = "Ekphrasis exists; audio pipeline integration pending (tier in docs/capability-inventory.toml)"
     )
 )]
 

--- a/crates/thumos/src/emmc.rs
+++ b/crates/thumos/src/emmc.rs
@@ -94,15 +94,15 @@ const REG_SDC_RESP3: usize = 0x4C;
 const REG_SDC_BLK_NUM: usize = 0x50;
 
 /// Card status.
-#[expect(dead_code, reason = "reserved for future status readback (#145)")]
+#[expect(dead_code, reason = "reserved for future status readback")]
 const REG_SDC_CSTS: usize = 0x58;
 
 /// Data CRC status per DAT line.
-#[expect(dead_code, reason = "reserved for future CRC diagnostics (#145)")]
+#[expect(dead_code, reason = "reserved for future CRC diagnostics")]
 const REG_SDC_DCRC_STS: usize = 0x60;
 
 /// Advanced config 0.
-#[expect(dead_code, reason = "reserved for future tuning (#145)")]
+#[expect(dead_code, reason = "reserved for future tuning")]
 const REG_SDC_ADV_CFG0: usize = 0x64;
 
 /// eMMC config 0: boot mode, part access.
@@ -112,7 +112,7 @@ const REG_SDC_ADV_CFG0: usize = 0x64;
 // exactly there so it stays fulfilled in both configurations.
 #[cfg_attr(
     not(test),
-    expect(dead_code, reason = "reserved for boot mode configuration (#145)")
+    expect(dead_code, reason = "reserved for boot mode configuration")
 )]
 const REG_EMMC_CFG0: usize = 0x70;
 
@@ -120,7 +120,7 @@ const REG_EMMC_CFG0: usize = 0x70;
 // WHY cfg_attr(not(test)): see REG_EMMC_CFG0 above -- same reasoning.
 #[cfg_attr(
     not(test),
-    expect(dead_code, reason = "reserved for boot mode configuration (#145)")
+    expect(dead_code, reason = "reserved for boot mode configuration")
 )]
 const REG_EMMC_CFG1: usize = 0x74;
 
@@ -128,23 +128,20 @@ const REG_EMMC_CFG1: usize = 0x74;
 // WHY cfg_attr(not(test)): see REG_EMMC_CFG0 above -- same reasoning.
 #[cfg_attr(
     not(test),
-    expect(dead_code, reason = "reserved for boot status readback (#145)")
+    expect(dead_code, reason = "reserved for boot status readback")
 )]
 const REG_EMMC_STS: usize = 0x78;
 
 /// eMMC I/O control.
 // WHY cfg_attr(not(test)): see REG_EMMC_CFG0 above -- same reasoning.
-#[cfg_attr(
-    not(test),
-    expect(dead_code, reason = "reserved for eMMC I/O tuning (#145)")
-)]
+#[cfg_attr(not(test), expect(dead_code, reason = "reserved for eMMC I/O tuning"))]
 const REG_EMMC_IOCON: usize = 0x7C;
 
 /// DMA start address [35:32] (4 MSB).
 // WHY cfg_attr(not(test)): see REG_EMMC_CFG0 above -- same reasoning.
 #[cfg_attr(
     not(test),
-    expect(dead_code, reason = "MT6739 is 32-bit; high bits unused (#145)")
+    expect(dead_code, reason = "MT6739 is 32-bit; high bits unused")
 )]
 const REG_MSDC_DMA_SA_HIGH: usize = 0x8C;
 
@@ -155,7 +152,7 @@ const REG_MSDC_DMA_SA: usize = 0x90;
 // WHY cfg_attr(not(test)): see REG_EMMC_CFG0 above -- same reasoning.
 #[cfg_attr(
     not(test),
-    expect(dead_code, reason = "reserved for DMA progress monitoring (#145)")
+    expect(dead_code, reason = "reserved for DMA progress monitoring")
 )]
 const REG_MSDC_DMA_CA: usize = 0x94;
 
@@ -169,20 +166,17 @@ const REG_MSDC_DMA_CFG: usize = 0x9C;
 // WHY cfg_attr(not(test)): see REG_EMMC_CFG0 above -- same reasoning.
 #[cfg_attr(
     not(test),
-    expect(dead_code, reason = "length encoded in GPD/BD descriptors (#145)")
+    expect(dead_code, reason = "length encoded in GPD/BD descriptors")
 )]
 const REG_MSDC_DMA_LEN: usize = 0xA8;
 
 /// Patch register 0 (tuning overrides).
-#[expect(dead_code, reason = "reserved for auto-tuning (#145)")]
+#[expect(dead_code, reason = "reserved for auto-tuning")]
 const REG_MSDC_PATCH_BIT0: usize = 0xB0;
 
 /// Version register.
 // WHY cfg_attr(not(test)): see REG_EMMC_CFG0 above -- same reasoning.
-#[cfg_attr(
-    not(test),
-    expect(dead_code, reason = "reserved for version readback (#145)")
-)]
+#[cfg_attr(not(test), expect(dead_code, reason = "reserved for version readback"))]
 const REG_MSDC_VERSION: usize = 0x114;
 
 // NOTE: source `drivers/mmc/host/mediatek/ComboA/msdc_reg.h:75–221`
@@ -191,7 +185,7 @@ const REG_MSDC_VERSION: usize = 0x114;
 // WHY cfg_attr(not(test)): see REG_EMMC_CFG0 above -- same reasoning.
 #[cfg_attr(
     not(test),
-    expect(dead_code, reason = "reserved for encrypted storage layer (#145)")
+    expect(dead_code, reason = "reserved for encrypted storage layer")
 )]
 const REG_MSDC_AES_SEL: usize = 0x280;
 
@@ -212,7 +206,7 @@ const CFG_BUSWIDTH_1: u32 = 0b00 << 20;
 // WHY cfg_attr(not(test)): see REG_EMMC_CFG0 above -- same reasoning.
 #[cfg_attr(
     not(test),
-    expect(dead_code, reason = "eMMC uses 8-bit; kept for SD card support (#145)")
+    expect(dead_code, reason = "eMMC uses 8-bit; kept for SD card support")
 )]
 const CFG_BUSWIDTH_4: u32 = 0b01 << 20;
 
@@ -243,7 +237,7 @@ const CMD_RSPTYP_NONE: u32 = 0b00 << 7;
 const CMD_RSPTYP_R1: u32 = 0b01 << 7;
 
 /// Response type: R2 (136-bit).
-#[expect(dead_code, reason = "reserved for CID/CSD readback (#145)")]
+#[expect(dead_code, reason = "reserved for CID/CSD readback")]
 const CMD_RSPTYP_R2: u32 = 0b10 << 7;
 
 /// Response type: R3/R4 (48-bit, no CRC).
@@ -256,7 +250,7 @@ const CMD_DTYPE_READ: u32 = 0b01 << 11;
 const CMD_DTYPE_WRITE: u32 = 0b10 << 11;
 
 /// Block length shift for `SDC_CMD` (bits [31:16] in some configs).
-#[expect(dead_code, reason = "block length SET via SDC_CFG on MT6739 (#145)")]
+#[expect(dead_code, reason = "block length SET via SDC_CFG on MT6739")]
 const CMD_BLK_LEN_SHIFT: u32 = 16;
 
 // ---------------------------------------------------------------------------
@@ -270,7 +264,7 @@ const DMA_CTRL_START: u32 = 1 << 0;
 const DMA_CTRL_STOP: u32 = 1 << 1;
 
 /// DMA mode: basic (single buffer).
-#[expect(dead_code, reason = "descriptor mode used for scatter-gather (#145)")]
+#[expect(dead_code, reason = "descriptor mode used for scatter-gather")]
 const DMA_CTRL_MODE_BASIC: u32 = 0b00 << 8;
 
 /// DMA mode: descriptor (GPD/BD chain).
@@ -413,7 +407,7 @@ const CMD0_GO_IDLE: u32 = 0;
 const CMD1_SEND_OP_COND: u32 = 1;
 
 /// CMD2: `ALL_SEND_CID`  -  request card identification.
-#[expect(dead_code, reason = "reserved for CID readback (#145)")]
+#[expect(dead_code, reason = "reserved for CID readback")]
 const CMD2_ALL_SEND_CID: u32 = 2;
 
 /// CMD3: `SET_RELATIVE_ADDR`  -  assign relative card address.
@@ -423,11 +417,11 @@ const CMD3_SET_RELATIVE_ADDR: u32 = 3;
 const CMD7_SELECT_CARD: u32 = 7;
 
 /// CMD8: `SEND_EXT_CSD`  -  read extended CSD register.
-#[expect(dead_code, reason = "reserved for EXT_CSD readback (#145)")]
+#[expect(dead_code, reason = "reserved for EXT_CSD readback")]
 const CMD8_SEND_EXT_CSD: u32 = 8;
 
 /// CMD13: `SEND_STATUS`  -  read card status register.
-#[expect(dead_code, reason = "reserved for status polling (#145)")]
+#[expect(dead_code, reason = "reserved for status polling")]
 const CMD13_SEND_STATUS: u32 = 13;
 
 /// CMD16: `SET_BLOCKLEN`  -  SET block length to 512 bytes.

--- a/crates/thumos/src/gps.rs
+++ b/crates/thumos/src/gps.rs
@@ -36,7 +36,7 @@
 // WHY: hardware driver API not yet wired to upper layers (kinit integration pending).
 #![expect(
     dead_code,
-    reason = "GPS driver API wired in kinit but not yet called from userspace (#145)"
+    reason = "GPS driver API wired in kinit but not yet called from userspace (tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/harmostes.rs
+++ b/crates/thumos/src/harmostes.rs
@@ -33,7 +33,7 @@
 // WHY: Matrix client created in Phase 09 Wave 2, full integration pending in Wave 5.
 #![expect(
     dead_code,
-    reason = "Matrix client created in Phase 09 Wave 2, unified inbox integration pending (#145)"
+    reason = "Matrix client exists; unified inbox integration pending (tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/http_client.rs
+++ b/crates/thumos/src/http_client.rs
@@ -35,7 +35,7 @@
     not(test),
     expect(
         dead_code,
-        reason = "HTTP client created in Phase 09 Wave 1, harmostes integration pending (#145)"
+        reason = "HTTP client exists; harmostes integration pending (tier in docs/capability-inventory.toml)"
     )
 )]
 

--- a/crates/thumos/src/json_mini.rs
+++ b/crates/thumos/src/json_mini.rs
@@ -22,10 +22,10 @@
 //!   `\t`, `\uXXXX` (BMP only, no surrogate pair handling)
 //! - Maximum nesting depth of 32 to prevent stack overflow
 
-// WHY: JSON primitives created in Phase 09 Wave 1, harmostes integration pending (#145).
+// WHY: JSON primitives exists; harmostes integration pending (tier in docs/capability-inventory.toml).
 #![expect(
     dead_code,
-    reason = "JSON primitives created in Phase 09 Wave 1, harmostes integration pending (#145)"
+    reason = "JSON primitives exists; harmostes integration pending (tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/kardia.rs
+++ b/crates/thumos/src/kardia.rs
@@ -14,7 +14,7 @@
 //! userspace, `process::switch_to`'s taken branch runs, the process faults, the
 //! kernel kills + reaps it, and control round-robins back to this loop (which
 //! then services ticks to the cap). That is the two-process preempt-and-return
-//! soak TODO(#420) asked for, now permanent in CI.
+//! soak, permanent in CI.
 //!
 //! WHY WFI (not WFE) for the phone idle (#461): WFE has no configured event
 //! source (no SEV/SEVONPEND) and parks forever under qemu-virt; WFI wakes on

--- a/crates/thumos/src/main.rs
+++ b/crates/thumos/src/main.rs
@@ -8,13 +8,23 @@
 #![cfg_attr(not(test), no_main)]
 // WHY (#431): the kernel carries a large compiled-and-tested surface that is
 // not yet boot-wired (radio/messaging/UI subsystems built ahead of the boot
-// path). That is a deliberate, tracked state (#145 wiring audit, #420
-// boot-wiring), not cruft, so dead_code is expected crate-wide rather than
-// annotated at ~715 sites. WHY expect not allow: the wiring waves progressively
-// consume the surface, and once it is fully wired this expectation goes
+// path). That is a deliberate, RECORDED state, not cruft: every module's
+// reachability tier lives in docs/capability-inventory.toml, and
+// scripts/check-wiring-inventory.sh fails the gate on a compiled-only entry
+// with no stated reason. That inventory is the tracker -- a machine-checked
+// file, not an issue -- so this exemption cites it rather than a ticket that
+// can close while the surface it described still exists.
+// WHY crate-wide rather than ~715 per-item annotations: deadness here is
+// per-feature-configuration (an item live under `qemu` is dead under
+// `production`), so a per-item #[expect] is unfulfilled in some of the nine
+// configurations the gate lints and cannot be written correctly.
+// WHY expect not allow: as wiring consumes the surface this expectation goes
 // unfulfilled and prompts its own removal. All OTHER warning classes stay live
 // under the -D warnings gate.
-#![expect(dead_code, reason = "compiled-but-unwired surface, tracked #145/#420")]
+#![expect(
+    dead_code,
+    reason = "compiled-but-unwired surface; per-module tiers in docs/capability-inventory.toml, enforced by scripts/check-wiring-inventory.sh"
+)]
 // WHY: unwrap_used/expect_used are denied crate-wide (Cargo.toml) to keep
 // panics out of shipping kernel paths, where a panic is a crash. In a test,
 // an unwrap()/expect() panic IS the assertion -- the failure signal the test

--- a/crates/thumos/src/matrix_crypto.rs
+++ b/crates/thumos/src/matrix_crypto.rs
@@ -36,10 +36,10 @@
 // that path via a `to_device.events` block. This module stays unreachable
 // from `kernel_main` regardless -- `MatrixClient` itself is not yet
 // constructed anywhere outside tests, a separate, broader integration
-// (#145) this issue does not close.
+// this issue does not close.
 #![expect(
     dead_code,
-    reason = "MatrixClient (and therefore MatrixCrypto) is not yet constructed from kernel_main; unreachable pending Phase-09 unified-inbox integration (#145)"
+    reason = "MatrixClient (and therefore MatrixCrypto) is not yet constructed from kernel_main; unreachable pending Phase-09 unified-inbox integration (tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/meshtastic.rs
+++ b/crates/thumos/src/meshtastic.rs
@@ -34,7 +34,7 @@
 // protocol implementation via akroasis kerykeion pending.
 #![expect(
     dead_code,
-    reason = "Meshtastic transport stub created in Phase 09 Wave 7, serial protocol pending (#145)"
+    reason = "Meshtastic transport stub exists; serial protocol pending (tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/mic_audit.rs
+++ b/crates/thumos/src/mic_audit.rs
@@ -39,7 +39,7 @@
     not(test),
     expect(
         dead_code,
-        reason = "Mic audit log created in Phase 07 Wave 8, audio manager wiring pending (#145)"
+        reason = "Mic audit log exists; audio manager wiring pending (tier in docs/capability-inventory.toml)"
     )
 )]
 

--- a/crates/thumos/src/nous.rs
+++ b/crates/thumos/src/nous.rs
@@ -47,7 +47,7 @@
 // WHY: nous created in Phase 09 Wave 8, full Matrix room wiring pending.
 #![expect(
     dead_code,
-    reason = "Nous created in Phase 09 Wave 8, Matrix room wiring pending (#145)"
+    reason = "Nous exists; Matrix room wiring pending (tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/sbc.rs
+++ b/crates/thumos/src/sbc.rs
@@ -28,7 +28,7 @@
     not(test),
     expect(
         dead_code,
-        reason = "A2DP profile created in Phase 07 Wave 8, audio manager wiring pending (#145)"
+        reason = "A2DP profile exists; audio manager wiring pending (tier in docs/capability-inventory.toml)"
     )
 )]
 

--- a/crates/thumos/src/screen_threat.rs
+++ b/crates/thumos/src/screen_threat.rs
@@ -215,7 +215,7 @@ impl ThreatAlertType {
     /// its icon, and its tests described an event that could never occur.
     /// This is the seam that lets a decode result reach the screen. The
     /// remaining step is the kinit event loop, which does not yet reach the
-    /// SMS path at all (#145).
+    /// SMS path at all.
     #[must_use]
     pub(crate) const fn from_message_class(class: klesis_core::MessageClass) -> Option<Self> {
         match class {

--- a/crates/thumos/src/sms.rs
+++ b/crates/thumos/src/sms.rs
@@ -36,7 +36,7 @@
     not(test),
     expect(
         dead_code,
-        reason = "SMS API created in Phase 07 Wave 3, kinit wiring pending (#145)"
+        reason = "SMS API exists; kinit wiring pending (tier in docs/capability-inventory.toml)"
     )
 )]
 
@@ -795,7 +795,8 @@ mod tests {
         // WHY (#662): ThreatAlertType::SilentSms existed with an icon, a
         // Display impl, and tests -- and no producer anywhere in the
         // kernel. This is the seam that gives a decode result somewhere to
-        // go. Wiring it into the live event loop is #145.
+        // go. Wiring it into the live event loop is tracked by this module's
+        // tier in docs/capability-inventory.toml.
         use crate::screen_threat::ThreatAlertType;
         assert_eq!(
             ThreatAlertType::from_message_class(MessageClass::Silent { pid: 0x40 }),

--- a/crates/thumos/src/t9.rs
+++ b/crates/thumos/src/t9.rs
@@ -28,10 +28,10 @@
 //! key sequence, all words whose letter-to-key mapping matches the pressed
 //! keys as a prefix are returned as candidates.
 
-// WHY: T9 input created in Phase 07 Wave 5, kinit wiring pending (#145).
+// WHY: T9 input exists; kinit wiring pending (tier in docs/capability-inventory.toml).
 #![expect(
     dead_code,
-    reason = "T9 input created in Phase 07 Wave 5, kinit wiring pending (#145)"
+    reason = "T9 input exists; kinit wiring pending (tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/telephony.rs
+++ b/crates/thumos/src/telephony.rs
@@ -29,7 +29,7 @@
 // WHY: hardware driver API not yet wired to upper layers (Wave 3 integration).
 #![expect(
     dead_code,
-    reason = "Telephony driver API not yet wired to kinit (Wave 3) (#145)"
+    reason = "Telephony driver API not yet wired to kinit (tier in docs/capability-inventory.toml)"
 )]
 
 // Re-export parser functions so external callers can still use crate::telephony::*.

--- a/crates/thumos/src/ui.rs
+++ b/crates/thumos/src/ui.rs
@@ -25,7 +25,7 @@
 // dispatch through UiManager are still pending.
 #![expect(
     dead_code,
-    reason = "UI framework has only initial home-frame kinit wiring (#145)"
+    reason = "UI framework has only initial home-frame kinit wiring (tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/wifi.rs
+++ b/crates/thumos/src/wifi.rs
@@ -26,7 +26,7 @@
 // frame TX/RX, scan, and association are implemented on the target.
 #![expect(
     dead_code,
-    reason = "WiFi hardware data path not yet implemented on target (#145)"
+    reason = "WiFi hardware data path not yet implemented on target (tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;


### PR DESCRIPTION
The crate-level exemption at `main.rs` claimed `tracked #145/#420`. **Both issues are closed**, so the justification asserted tracking that no longer existed. 58 further sites carried the same citation.

## The tracker is a file, not a ticket

`docs/capability-inventory.toml` records every module's reachability tier (`compiled-only` / `kernel-wired` / `emulated-mock-proven` / `hardware-proven`), and `scripts/check-wiring-inventory.sh` fails the gate on a compiled-only entry with no stated reason. That is a machine-checked artifact — it cannot close while the surface it describes still exists, which is exactly how #145 and #420 became false.

Every reason that claimed tracking now cites the inventory.

## Three classes, handled differently

**`emmc.rs` register constants (21 sites)** used `#145` as a generic not-used-yet tag. `reason = "reserved for future CRC diagnostics (#145)"` — the reason already stands on its own, and the issue number added nothing but a false claim. Tag dropped, not repointed.

**Module-level exemptions** kept their wiring-pending statement, lost the `created in Phase 09 Wave 8,` narration (living surfaces are timeless; git owns history), and point at the inventory:

```
- reason = "Nous created in Phase 09 Wave 8, Matrix room wiring pending (#145)"
+ reason = "Nous exists; Matrix room wiring pending (tier in docs/capability-inventory.toml)"
```

**WHY comments citing `#420`** to explain *why code is shaped a given way* are historical context, not tracking claims, and are left alone — with one exception: `kardia.rs` carried a structured `TODO(#420)` tag describing work that is already done and permanent in CI. A TODO tag pointing at a closed issue reads as live work to both a human and a linter.

## Why the exemption stays crate-wide

The obvious reading of #738 is "replace the blanket with per-item exemptions." **That cannot be written correctly here, and it was tried first.**

The kernel is linted in **nine feature configurations**, and deadness is per-configuration: an item live under `qemu` is dead under `production`. A per-item `#[expect(dead_code)]` is *unfulfilled* wherever the item is live, and `#[expect]` errors when unfulfilled. Applying ~800 per-item attributes produced **332 unfulfilled-expectation errors across 47 files** on the armv7a build alone, and 3589 lines of insertion — every one carrying the same boilerplate reason string, which is a blanket exemption wearing per-item clothing. It carried no more information than the single line it replaced.

That reasoning is now written where the exemption is, so the next reader doesn't retry it. The original comment already said "rather than annotated at ~715 sites"; it just didn't say *why* that was impossible rather than merely tedious.

`#[expect]` is also retained over `#[allow]` deliberately: as wiring consumes the surface, the expectation eventually goes unfulfilled and forces its own removal. An `#[allow]` would sit there forever.

Closes #738
