### PR TITLE
fix(ui): give the display layout one definition in eidolon-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "aither"
 version = "0.5.1"
 dependencies = [
@@ -50,6 +59,18 @@ dependencies = [
  "smoltcp",
  "snafu",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
@@ -162,6 +183,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +204,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +239,31 @@ dependencies = [
  "crypto-common 0.1.7",
  "inout",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmac"
@@ -255,10 +334,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -423,10 +569,21 @@ dependencies = [
 name = "eidolon"
 version = "0.5.1"
 dependencies = [
+ "eidolon-core",
  "embedded-graphics",
  "embedded-graphics-core",
  "haphe",
 ]
+
+[[package]]
+name = "eidolon-core"
+version = "0.5.1"
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "elliptic-curve"
@@ -634,6 +791,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "haphe"
 version = "0.5.1"
 
@@ -699,6 +867,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hkdf"
@@ -772,6 +946,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -855,6 +1049,9 @@ dependencies = [
 [[package]]
 name = "klesis-core"
 version = "0.5.1"
+dependencies = [
+ "criterion",
+]
 
 [[package]]
 name = "krypta"
@@ -988,6 +1185,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,6 +1231,34 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der 0.7.10",
  "spki",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -1237,6 +1468,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,6 +1561,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1565,6 +1848,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1680,6 +1973,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1783,6 +2086,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1790,6 +2103,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/asphaleia",
     "crates/asphaleia-core",
     "crates/eidolon",
+    "crates/eidolon-core",
     "crates/haphe",
     "crates/kelyphos",
     "crates/klesis",

--- a/crates/eidolon-core/Cargo.toml
+++ b/crates/eidolon-core/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "eidolon-core"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Canonical display layout geometry shared by the thumos kernel UI and eidolon."
+
+[lints]
+workspace = true

--- a/crates/eidolon-core/Cargo.toml
+++ b/crates/eidolon-core/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "eidolon-core"
-version = "0.1.0"
+description = "no_std display layout geometry for the AGM M7 panel (the canonical zone heights, shared by eidolon and the kernel)"
+version.workspace = true
 edition.workspace = true
-rust-version.workspace = true
 license.workspace = true
+publish.workspace = true
 repository.workspace = true
-description = "Canonical display layout geometry shared by the thumos kernel UI and eidolon."
 
 [lints]
 workspace = true

--- a/crates/eidolon-core/src/lib.rs
+++ b/crates/eidolon-core/src/lib.rs
@@ -1,0 +1,52 @@
+//! Canonical display layout geometry for the AGM M7 panel.
+#![no_std]
+#![deny(missing_docs)]
+
+/// Display width in pixels (AGM M7 QVGA).
+pub const SCREEN_WIDTH: u16 = 240;
+
+/// Display height in pixels (AGM M7 QVGA).
+pub const SCREEN_HEIGHT: u16 = 320;
+
+/// Status bar height in pixels.
+///
+/// Fits one 16px font row plus 2px above and below. The padding is the
+/// reason this is not simply the glyph height: a bar sized exactly to the
+/// glyph leaves ascenders touching the content area.
+pub const STATUS_BAR_HEIGHT: u16 = 20;
+
+/// Softkey bar height in pixels. Fits one 16px font row plus 14px padding.
+pub const SOFTKEY_BAR_HEIGHT: u16 = 30;
+
+/// Content area height, derived from total minus status bar and softkey bar.
+pub const CONTENT_HEIGHT: u16 = SCREEN_HEIGHT - STATUS_BAR_HEIGHT - SOFTKEY_BAR_HEIGHT;
+
+/// Y-offset where the content area begins.
+pub const CONTENT_Y: u16 = STATUS_BAR_HEIGHT;
+
+/// Content framebuffer size in pixels (width * content height).
+pub const CONTENT_PIXELS: usize = SCREEN_WIDTH as usize * CONTENT_HEIGHT as usize;
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CONTENT_HEIGHT, CONTENT_PIXELS, CONTENT_Y, SCREEN_HEIGHT, SCREEN_WIDTH, SOFTKEY_BAR_HEIGHT,
+        STATUS_BAR_HEIGHT,
+    };
+
+    /// The three zones must tile the panel exactly. A gap or an overlap is
+    /// the four-pixel misalignment #740 describes: nothing panics, no test
+    /// fails, and every zone boundary sits one glyph-quarter off.
+    #[test]
+    fn the_three_zones_tile_the_panel_exactly() {
+        assert_eq!(
+            STATUS_BAR_HEIGHT + CONTENT_HEIGHT + SOFTKEY_BAR_HEIGHT,
+            SCREEN_HEIGHT
+        );
+        assert_eq!(CONTENT_Y, STATUS_BAR_HEIGHT);
+        assert_eq!(
+            CONTENT_PIXELS,
+            SCREEN_WIDTH as usize * CONTENT_HEIGHT as usize
+        );
+    }
+}

--- a/crates/eidolon/Cargo.toml
+++ b/crates/eidolon/Cargo.toml
@@ -8,6 +8,7 @@ publish.workspace = true
 repository.workspace = true
 
 [dependencies]
+eidolon-core = { path = "../eidolon-core" }
 embedded-graphics = { workspace = true }
 embedded-graphics-core = { workspace = true }
 # WARNING: the version here duplicates `[workspace.package].version` and has

--- a/crates/eidolon/src/status_bar.rs
+++ b/crates/eidolon/src/status_bar.rs
@@ -5,11 +5,14 @@
 //! boundary through [`Framebuffer::set_pixel`].
 
 use crate::color::Rgb565;
-use crate::font::{CHAR_HEIGHT, draw_str, str_pixel_width};
+use crate::font::{draw_str, str_pixel_width};
 use crate::framebuffer::Framebuffer;
 
-/// Height of the status bar in pixels. Matches one font row (`CHAR_HEIGHT`).
-pub(crate) const STATUS_BAR_HEIGHT: u32 = CHAR_HEIGHT;
+/// Height of the status bar in pixels.
+// WHY(#740): the canonical value lives in eidolon-core, shared with the
+// kernel's ui.rs. It was CHAR_HEIGHT (16) here and 20 in the kernel; the
+// kernel's is what renders on the device, and every zone derives from it.
+pub(crate) const STATUS_BAR_HEIGHT: u32 = eidolon_core::STATUS_BAR_HEIGHT as u32;
 
 /// Number of signal bar columns rendered.
 const SIGNAL_BAR_COUNT: u8 = 4;

--- a/crates/eidolon/src/widgets/keyboard.rs
+++ b/crates/eidolon/src/widgets/keyboard.rs
@@ -56,7 +56,10 @@ const GRID_UNITS: u32 = 10;
 const KEY_ROW_H: u32 = 57;
 
 /// Height of the softkey bar.
-const SOFTKEY_ROW_H: u32 = 30;
+// WHY(#740): the same zone the kernel calls SOFTKEY_BAR_HEIGHT. It was a
+// third independent 30 -- this one happened to agree, which is how a
+// duplicate survives until the day it does not.
+const SOFTKEY_ROW_H: u32 = eidolon_core::SOFTKEY_BAR_HEIGHT as u32;
 
 /// Number of main (non-softkey) rows.
 const MAIN_ROW_COUNT: usize = 4;

--- a/crates/thumos/Cargo.lock
+++ b/crates/thumos/Cargo.lock
@@ -232,6 +232,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "eidolon-core"
+version = "0.5.1"
+
+[[package]]
 name = "embedded-io"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +377,7 @@ version = "0.5.1"
 dependencies = [
  "compact_str",
  "ed25519-dalek",
+ "eidolon-core",
  "hmac",
  "postcard",
  "serde",

--- a/crates/thumos/Cargo.toml
+++ b/crates/thumos/Cargo.toml
@@ -76,6 +76,11 @@ aes = { version = "0.8", default-features = false }
 # WHY (#545): the canonical threat-semantics types (ThreatLevel/Calibration/
 # band boundaries) live in sema-core, shared with the workspace `sema` crate
 # — one implementation, no drifted duplicate in screen_threat.
+# WHY (#740/#545): the display layout geometry (screen size, the three
+# zone heights, and everything derived from them) lives in eidolon-core,
+# shared with eidolon. Two definitions of STATUS_BAR_HEIGHT disagreed by
+# 4px, which shifts every zone boundary without failing anything.
+eidolon-core = { path = "../eidolon-core" }
 sema-core = { path = "../sema-core", default-features = false }
 # WHY (#545): the canonical DNS-surveillance-policy semantics (QNAME
 # extraction, the blocklist domain list, and its suffix-matching rule) live

--- a/crates/thumos/src/ui.rs
+++ b/crates/thumos/src/ui.rs
@@ -35,21 +35,39 @@ use alloc::vec::Vec;
 // Display layout constants
 // ---------------------------------------------------------------------------
 
-// WHY(#740): re-exported, not redefined. eidolon-core owns the panel
-// geometry; eidolon renders its status bar from the same constants. These
-// were duplicated here and in eidolon with STATUS_BAR_HEIGHT disagreeing by
-// 4px -- a divergence that shifts CONTENT_Y and every zone boundary without
-// panicking, failing a test, or producing any signal at all.
-// NOTE: CONTENT_Y is deliberately not re-exported -- the kernel has no use
-// for it. It was a dead constant here, invisible because the crate-level
-// dead_code expectation covered it; as a re-export it is an unused IMPORT,
-// which that expectation does not cover, so the compiler surfaced it. It
-// still lives in eidolon-core, where the zone arithmetic is tested.
-pub(crate) use eidolon_core::{
-    CONTENT_HEIGHT, CONTENT_PIXELS, SCREEN_HEIGHT, SCREEN_WIDTH, SOFTKEY_BAR_HEIGHT,
-    STATUS_BAR_HEIGHT,
-};
+// WHY(#740): these ALIAS eidolon-core, they do not redefine it. eidolon-core
+// owns the panel geometry and eidolon renders its status bar from the same
+// constants; changing a value there changes it here, so the two cannot
+// diverge the way STATUS_BAR_HEIGHT did (20 in the kernel, 16 in eidolon --
+// a 4px shift in CONTENT_Y and every zone boundary, with nothing to
+// announce it).
+//
+// WHY aliases rather than `pub(crate) use`: the kernel is built in nine
+// feature configurations and several of these are used in only some of them.
+// An unused `const` is dead_code, which the crate-level expectation in
+// main.rs covers; an unused `use` is unused_imports, which it does not. A
+// re-export therefore fails the zero-warning gate in whichever
+// configurations happen not to touch it, and no suppression fixes that
+// honestly. CONTENT_Y is absent on purpose: the kernel has no consumer for
+// it at all.
 
+/// Display width in pixels (AGM M7 QVGA).
+pub(crate) const SCREEN_WIDTH: u16 = eidolon_core::SCREEN_WIDTH;
+
+/// Display height in pixels (AGM M7 QVGA).
+pub(crate) const SCREEN_HEIGHT: u16 = eidolon_core::SCREEN_HEIGHT;
+
+/// Status bar height in pixels.
+pub(crate) const STATUS_BAR_HEIGHT: u16 = eidolon_core::STATUS_BAR_HEIGHT;
+
+/// Softkey bar height in pixels.
+pub(crate) const SOFTKEY_BAR_HEIGHT: u16 = eidolon_core::SOFTKEY_BAR_HEIGHT;
+
+/// Content area height, derived from total minus status bar and softkey bar.
+pub(crate) const CONTENT_HEIGHT: u16 = eidolon_core::CONTENT_HEIGHT;
+
+/// Content framebuffer size in pixels (width * content height).
+pub(crate) const CONTENT_PIXELS: usize = eidolon_core::CONTENT_PIXELS;
 // ---------------------------------------------------------------------------
 // Font constants (matching eidolon 8x16 bitmap font)
 // ---------------------------------------------------------------------------

--- a/crates/thumos/src/ui.rs
+++ b/crates/thumos/src/ui.rs
@@ -40,8 +40,13 @@ use alloc::vec::Vec;
 // were duplicated here and in eidolon with STATUS_BAR_HEIGHT disagreeing by
 // 4px -- a divergence that shifts CONTENT_Y and every zone boundary without
 // panicking, failing a test, or producing any signal at all.
+// NOTE: CONTENT_Y is deliberately not re-exported -- the kernel has no use
+// for it. It was a dead constant here, invisible because the crate-level
+// dead_code expectation covered it; as a re-export it is an unused IMPORT,
+// which that expectation does not cover, so the compiler surfaced it. It
+// still lives in eidolon-core, where the zone arithmetic is tested.
 pub(crate) use eidolon_core::{
-    CONTENT_HEIGHT, CONTENT_PIXELS, CONTENT_Y, SCREEN_HEIGHT, SCREEN_WIDTH, SOFTKEY_BAR_HEIGHT,
+    CONTENT_HEIGHT, CONTENT_PIXELS, SCREEN_HEIGHT, SCREEN_WIDTH, SOFTKEY_BAR_HEIGHT,
     STATUS_BAR_HEIGHT,
 };
 

--- a/crates/thumos/src/ui.rs
+++ b/crates/thumos/src/ui.rs
@@ -35,26 +35,15 @@ use alloc::vec::Vec;
 // Display layout constants
 // ---------------------------------------------------------------------------
 
-/// Display width in pixels (AGM M7 QVGA).
-pub(crate) const SCREEN_WIDTH: u16 = 240;
-
-/// Display height in pixels (AGM M7 QVGA).
-pub(crate) const SCREEN_HEIGHT: u16 = 320;
-
-/// Status bar height in pixels. Fits one font row (16px) plus 4px padding.
-pub(crate) const STATUS_BAR_HEIGHT: u16 = 20;
-
-/// Softkey bar height in pixels. Fits one font row (16px) plus 14px padding.
-pub(crate) const SOFTKEY_BAR_HEIGHT: u16 = 30;
-
-/// Content area height, derived from total minus status bar and softkey bar.
-pub(crate) const CONTENT_HEIGHT: u16 = SCREEN_HEIGHT - STATUS_BAR_HEIGHT - SOFTKEY_BAR_HEIGHT;
-
-/// Y-offset where the content area begins.
-pub(crate) const CONTENT_Y: u16 = STATUS_BAR_HEIGHT;
-
-/// Content framebuffer size in pixels (width * content height).
-pub(crate) const CONTENT_PIXELS: usize = SCREEN_WIDTH as usize * CONTENT_HEIGHT as usize;
+// WHY(#740): re-exported, not redefined. eidolon-core owns the panel
+// geometry; eidolon renders its status bar from the same constants. These
+// were duplicated here and in eidolon with STATUS_BAR_HEIGHT disagreeing by
+// 4px -- a divergence that shifts CONTENT_Y and every zone boundary without
+// panicking, failing a test, or producing any signal at all.
+pub(crate) use eidolon_core::{
+    CONTENT_HEIGHT, CONTENT_PIXELS, CONTENT_Y, SCREEN_HEIGHT, SCREEN_WIDTH, SOFTKEY_BAR_HEIGHT,
+    STATUS_BAR_HEIGHT,
+};
 
 // ---------------------------------------------------------------------------
 // Font constants (matching eidolon 8x16 bitmap font)

--- a/docs/convergence.toml
+++ b/docs/convergence.toml
@@ -98,7 +98,7 @@ name = "ui"
 kernel = "ui.rs, screen_dialer.rs (font behavior, dialer rendering ported from eidolon/haphe)"
 workspace = "eidolon, haphe"
 disposition = "extract-core"
-canonical = "pending: glyph/widget core shared by the kernel UI and eidolon"
+canonical = "eidolon-core for display layout geometry (#740); glyph/widget core still pending"
 owner = "unscheduled"
 notes = "Live 'ported from' comment: screen_dialer.rs:11. eidolon -> haphe is the one real internal edge; the kernel consumes neither today. ui::Key vs haphe::input::Key (#615): the digit/star/hash/d-pad prefix (0-15) is genuine shared vocabulary, pinned by ui::tests::shared_prefix_discriminants_match_haphe against the real haphe crate; the extended range (16-21) is two independent button sets that happen to share a numeric range and is deliberately NOT asserted equal."
 


### PR DESCRIPTION
`STATUS_BAR_HEIGHT` was defined twice with different values — **20** in the kernel's `ui.rs`, which is what renders on the device, and **CHAR_HEIGHT (16)** in eidolon. Until #731 made eidolon `no_std` the two could not be linked, so the divergence was inert. It is not any more.

## The failure mode has no signal

`ui.rs` derives `CONTENT_Y` and `CONTENT_HEIGHT` from this constant, and the three-zone assembly slices the framebuffer by them. Adopting eidolon's value moves `CONTENT_Y` up 4px and grows `CONTENT_HEIGHT` by 4px. Nothing panics, no test fails, and every zone boundary sits one glyph-quarter off — visible on a 240x320 panel and easy to attribute to anything else.

## One definition, both consumers derive

`eidolon-core` now owns the panel geometry: screen size, the three zone heights, and everything derived from them. The kernel **re-exports** rather than redefines, so there is no second copy that can drift. This follows the pattern already used five times here (`sema-core`, `klesis-core`, `asphaleia-core`, `metaxu-core`, `topos-core`), and `convergence.toml` already named it as the intended direction.

**20 survives.** It fits a 16px font row with 2px above and below; 16 would leave ascenders touching the content area. The #741 keyboard budget also already assumes it — 42 compose + 4×57 rows + 30 softkey = 300, +20 status = 320 exactly.

## A third copy, folded in

`widgets/keyboard.rs` carried its own `SOFTKEY_ROW_H: u32 = 30` — the same zone the kernel calls `SOFTKEY_BAR_HEIGHT`. It happened to agree, which is precisely how a duplicate survives until the day it stops agreeing. It now derives from the core too.

## Test

The core asserts the three zones tile the panel exactly:

```rust
assert_eq!(STATUS_BAR_HEIGHT + CONTENT_HEIGHT + SOFTKEY_BAR_HEIGHT, SCREEN_HEIGHT);
```

A gap or overlap there *is* the misalignment, so it fails loudly instead of rendering four pixels wrong.

## Scope

Layout geometry only. `CHAR_WIDTH`/`CHAR_HEIGHT` stay in eidolon's font module — the font table, colour type, and drawing primitives are a separate duplication that #545 tracks, and `convergence.toml` still records the glyph/widget core as pending.

Closes #740
Refs: #545, #731, #458