### PR TITLE
fix(kernel): anchor the dead-code exemptions to a tracker that cannot rot

### DIFF
--- a/.kanon-lint-ignore
+++ b/.kanon-lint-ignore
@@ -1,9 +1,10 @@
-# release-please auto-generates CHANGELOG.md from conventional commits.
-# REPO-SETUP.md says to omit it, but release-please creates it automatically
-# and removing it would break the release workflow.
-RELEASES/changelog-present:CHANGELOG.md
-# DISCLAIMER.md is required by thumos's legal status (research/educational software).
-RELEASES/disclaimer-present:DISCLAIMER.md
+# CHANGELOG.md and DISCLAIMER.md are both present, so RELEASES/changelog-present
+# and RELEASES/disclaimer-present do not fire and no entry is needed. The
+# patterns that used to sit here matched nothing and kanon warned on them each
+# run. Kept as a note because the reasons are not obvious: release-please
+# generates CHANGELOG.md automatically even though REPO-SETUP.md says to omit
+# it, and DISCLAIMER.md is required by thumos's legal status as research and
+# educational software.
 
 # =============================================================================
 # Workspace library crates — public API for the out-of-workspace kernel binary
@@ -277,4 +278,8 @@ TESTING/no-tests:crates/metaxu-core/src/lib.rs
 # artifact that is present. Writing a second GLOSSARY.md to satisfy it would
 # create the drift the rule exists to prevent (one fact, one place).
 # Rule-side fix: kanon#3203.
-ARCHITECTURE/no-glossary:Cargo.toml
+#
+# No ignore pattern here on purpose: the rule reports against no path this
+# file can key on, so an entry matches nothing and kanon warns that it is
+# dead. The finding is Info severity and does not reach the gate; this
+# comment is the record.

--- a/crates/thumos/src/audio.rs
+++ b/crates/thumos/src/audio.rs
@@ -48,7 +48,7 @@
     not(test),
     expect(
         dead_code,
-        reason = "audio manager API exists; kinit wiring pending (tier in docs/capability-inventory.toml)"
+        reason = "audio manager API exists; kinit wiring pending (#753; tier in docs/capability-inventory.toml)"
     )
 )]
 

--- a/crates/thumos/src/audio_codec.rs
+++ b/crates/thumos/src/audio_codec.rs
@@ -38,7 +38,7 @@
 // WHY: audio codec API not yet wired to kinit (Wave 4 integration pending).
 #![expect(
     dead_code,
-    reason = "audio codec API exists; kinit wiring pending (tier in docs/capability-inventory.toml)"
+    reason = "audio codec API exists; kinit wiring pending (#753; tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;
@@ -70,7 +70,7 @@ const AFE_DL_GAIN: u16 = 0x2010;
 /// ADC digital gain register offset.
 #[expect(
     dead_code,
-    reason = "register constant reserved for future gain control (tier in docs/capability-inventory.toml)"
+    reason = "register constant reserved for future gain control (#753; tier in docs/capability-inventory.toml)"
 )]
 const AFE_UL_GAIN: u16 = 0x2014;
 

--- a/crates/thumos/src/audio_route.rs
+++ b/crates/thumos/src/audio_route.rs
@@ -28,7 +28,7 @@
 // WHY: route manager API not yet wired to kinit (Wave 4 integration pending).
 #![expect(
     dead_code,
-    reason = "audio route API exists; kinit wiring pending (tier in docs/capability-inventory.toml)"
+    reason = "audio route API exists; kinit wiring pending (#753; tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/avdtp.rs
+++ b/crates/thumos/src/avdtp.rs
@@ -23,7 +23,7 @@
 // WHY: A2DP profile not yet wired to audio session manager (Wave 8, kinit pending).
 #![expect(
     dead_code,
-    reason = "A2DP profile exists; audio manager wiring pending (tier in docs/capability-inventory.toml)"
+    reason = "A2DP profile exists; audio manager wiring pending (#753; tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/battery.rs
+++ b/crates/thumos/src/battery.rs
@@ -33,7 +33,7 @@
     not(test),
     expect(
         dead_code,
-        reason = "Battery monitor exists; kinit wiring pending (tier in docs/capability-inventory.toml)"
+        reason = "Battery monitor exists; kinit wiring pending (#753; tier in docs/capability-inventory.toml)"
     )
 )]
 

--- a/crates/thumos/src/bluetooth.rs
+++ b/crates/thumos/src/bluetooth.rs
@@ -20,7 +20,7 @@
 // WHY: hardware driver API not yet wired to upper layers (kinit integration pending).
 #![expect(
     dead_code,
-    reason = "BT driver API wired in kinit but not yet called from userspace (tier in docs/capability-inventory.toml)"
+    reason = "BT driver API wired in kinit but not yet called from userspace (#753; tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/briar.rs
+++ b/crates/thumos/src/briar.rs
@@ -31,7 +31,7 @@
 // implementation pending.
 #![expect(
     dead_code,
-    reason = "Briar transport stub exists; BTP implementation pending (tier in docs/capability-inventory.toml)"
+    reason = "Briar transport stub exists; BTP implementation pending (#753; tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/clock.rs
+++ b/crates/thumos/src/clock.rs
@@ -24,7 +24,7 @@
 // syscalls still use the lower-level timer/time paths.
 #![expect(
     dead_code,
-    reason = "Clock trust manager is not wired into kernel time (tier in docs/capability-inventory.toml)"
+    reason = "Clock trust manager is not wired into kernel time (#753; tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/contacts.rs
+++ b/crates/thumos/src/contacts.rs
@@ -19,7 +19,7 @@
 // WHY: contacts module created in Phase 07 Wave 5, kinit wiring pending.
 #![expect(
     dead_code,
-    reason = "Contacts module exists; kinit wiring pending (tier in docs/capability-inventory.toml)"
+    reason = "Contacts module exists; kinit wiring pending (#753; tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/ekphrasis.rs
+++ b/crates/thumos/src/ekphrasis.rs
@@ -46,7 +46,7 @@
     not(test),
     expect(
         dead_code,
-        reason = "Ekphrasis exists; audio pipeline integration pending (tier in docs/capability-inventory.toml)"
+        reason = "Ekphrasis exists; audio pipeline integration pending (#753; tier in docs/capability-inventory.toml)"
     )
 )]
 

--- a/crates/thumos/src/emmc.rs
+++ b/crates/thumos/src/emmc.rs
@@ -94,15 +94,15 @@ const REG_SDC_RESP3: usize = 0x4C;
 const REG_SDC_BLK_NUM: usize = 0x50;
 
 /// Card status.
-#[expect(dead_code, reason = "reserved for future status readback")]
+#[expect(dead_code, reason = "reserved for future status readback (#753)")]
 const REG_SDC_CSTS: usize = 0x58;
 
 /// Data CRC status per DAT line.
-#[expect(dead_code, reason = "reserved for future CRC diagnostics")]
+#[expect(dead_code, reason = "reserved for future CRC diagnostics (#753)")]
 const REG_SDC_DCRC_STS: usize = 0x60;
 
 /// Advanced config 0.
-#[expect(dead_code, reason = "reserved for future tuning")]
+#[expect(dead_code, reason = "reserved for future tuning (#753)")]
 const REG_SDC_ADV_CFG0: usize = 0x64;
 
 /// eMMC config 0: boot mode, part access.
@@ -112,7 +112,7 @@ const REG_SDC_ADV_CFG0: usize = 0x64;
 // exactly there so it stays fulfilled in both configurations.
 #[cfg_attr(
     not(test),
-    expect(dead_code, reason = "reserved for boot mode configuration")
+    expect(dead_code, reason = "reserved for boot mode configuration (#753)")
 )]
 const REG_EMMC_CFG0: usize = 0x70;
 
@@ -120,7 +120,7 @@ const REG_EMMC_CFG0: usize = 0x70;
 // WHY cfg_attr(not(test)): see REG_EMMC_CFG0 above -- same reasoning.
 #[cfg_attr(
     not(test),
-    expect(dead_code, reason = "reserved for boot mode configuration")
+    expect(dead_code, reason = "reserved for boot mode configuration (#753)")
 )]
 const REG_EMMC_CFG1: usize = 0x74;
 
@@ -128,20 +128,23 @@ const REG_EMMC_CFG1: usize = 0x74;
 // WHY cfg_attr(not(test)): see REG_EMMC_CFG0 above -- same reasoning.
 #[cfg_attr(
     not(test),
-    expect(dead_code, reason = "reserved for boot status readback")
+    expect(dead_code, reason = "reserved for boot status readback (#753)")
 )]
 const REG_EMMC_STS: usize = 0x78;
 
 /// eMMC I/O control.
 // WHY cfg_attr(not(test)): see REG_EMMC_CFG0 above -- same reasoning.
-#[cfg_attr(not(test), expect(dead_code, reason = "reserved for eMMC I/O tuning"))]
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "reserved for eMMC I/O tuning (#753)")
+)]
 const REG_EMMC_IOCON: usize = 0x7C;
 
 /// DMA start address [35:32] (4 MSB).
 // WHY cfg_attr(not(test)): see REG_EMMC_CFG0 above -- same reasoning.
 #[cfg_attr(
     not(test),
-    expect(dead_code, reason = "MT6739 is 32-bit; high bits unused")
+    expect(dead_code, reason = "MT6739 is 32-bit; high bits unused (#753)")
 )]
 const REG_MSDC_DMA_SA_HIGH: usize = 0x8C;
 
@@ -152,7 +155,7 @@ const REG_MSDC_DMA_SA: usize = 0x90;
 // WHY cfg_attr(not(test)): see REG_EMMC_CFG0 above -- same reasoning.
 #[cfg_attr(
     not(test),
-    expect(dead_code, reason = "reserved for DMA progress monitoring")
+    expect(dead_code, reason = "reserved for DMA progress monitoring (#753)")
 )]
 const REG_MSDC_DMA_CA: usize = 0x94;
 
@@ -166,17 +169,20 @@ const REG_MSDC_DMA_CFG: usize = 0x9C;
 // WHY cfg_attr(not(test)): see REG_EMMC_CFG0 above -- same reasoning.
 #[cfg_attr(
     not(test),
-    expect(dead_code, reason = "length encoded in GPD/BD descriptors")
+    expect(dead_code, reason = "length encoded in GPD/BD descriptors (#753)")
 )]
 const REG_MSDC_DMA_LEN: usize = 0xA8;
 
 /// Patch register 0 (tuning overrides).
-#[expect(dead_code, reason = "reserved for auto-tuning")]
+#[expect(dead_code, reason = "reserved for auto-tuning (#753)")]
 const REG_MSDC_PATCH_BIT0: usize = 0xB0;
 
 /// Version register.
 // WHY cfg_attr(not(test)): see REG_EMMC_CFG0 above -- same reasoning.
-#[cfg_attr(not(test), expect(dead_code, reason = "reserved for version readback"))]
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "reserved for version readback (#753)")
+)]
 const REG_MSDC_VERSION: usize = 0x114;
 
 // NOTE: source `drivers/mmc/host/mediatek/ComboA/msdc_reg.h:75–221`
@@ -185,7 +191,7 @@ const REG_MSDC_VERSION: usize = 0x114;
 // WHY cfg_attr(not(test)): see REG_EMMC_CFG0 above -- same reasoning.
 #[cfg_attr(
     not(test),
-    expect(dead_code, reason = "reserved for encrypted storage layer")
+    expect(dead_code, reason = "reserved for encrypted storage layer (#753)")
 )]
 const REG_MSDC_AES_SEL: usize = 0x280;
 
@@ -206,7 +212,7 @@ const CFG_BUSWIDTH_1: u32 = 0b00 << 20;
 // WHY cfg_attr(not(test)): see REG_EMMC_CFG0 above -- same reasoning.
 #[cfg_attr(
     not(test),
-    expect(dead_code, reason = "eMMC uses 8-bit; kept for SD card support")
+    expect(dead_code, reason = "eMMC uses 8-bit; kept for SD card support (#753)")
 )]
 const CFG_BUSWIDTH_4: u32 = 0b01 << 20;
 
@@ -237,7 +243,7 @@ const CMD_RSPTYP_NONE: u32 = 0b00 << 7;
 const CMD_RSPTYP_R1: u32 = 0b01 << 7;
 
 /// Response type: R2 (136-bit).
-#[expect(dead_code, reason = "reserved for CID/CSD readback")]
+#[expect(dead_code, reason = "reserved for CID/CSD readback (#753)")]
 const CMD_RSPTYP_R2: u32 = 0b10 << 7;
 
 /// Response type: R3/R4 (48-bit, no CRC).
@@ -250,7 +256,7 @@ const CMD_DTYPE_READ: u32 = 0b01 << 11;
 const CMD_DTYPE_WRITE: u32 = 0b10 << 11;
 
 /// Block length shift for `SDC_CMD` (bits [31:16] in some configs).
-#[expect(dead_code, reason = "block length SET via SDC_CFG on MT6739")]
+#[expect(dead_code, reason = "block length SET via SDC_CFG on MT6739 (#753)")]
 const CMD_BLK_LEN_SHIFT: u32 = 16;
 
 // ---------------------------------------------------------------------------
@@ -264,7 +270,7 @@ const DMA_CTRL_START: u32 = 1 << 0;
 const DMA_CTRL_STOP: u32 = 1 << 1;
 
 /// DMA mode: basic (single buffer).
-#[expect(dead_code, reason = "descriptor mode used for scatter-gather")]
+#[expect(dead_code, reason = "descriptor mode used for scatter-gather (#753)")]
 const DMA_CTRL_MODE_BASIC: u32 = 0b00 << 8;
 
 /// DMA mode: descriptor (GPD/BD chain).
@@ -407,7 +413,7 @@ const CMD0_GO_IDLE: u32 = 0;
 const CMD1_SEND_OP_COND: u32 = 1;
 
 /// CMD2: `ALL_SEND_CID`  -  request card identification.
-#[expect(dead_code, reason = "reserved for CID readback")]
+#[expect(dead_code, reason = "reserved for CID readback (#753)")]
 const CMD2_ALL_SEND_CID: u32 = 2;
 
 /// CMD3: `SET_RELATIVE_ADDR`  -  assign relative card address.
@@ -417,11 +423,11 @@ const CMD3_SET_RELATIVE_ADDR: u32 = 3;
 const CMD7_SELECT_CARD: u32 = 7;
 
 /// CMD8: `SEND_EXT_CSD`  -  read extended CSD register.
-#[expect(dead_code, reason = "reserved for EXT_CSD readback")]
+#[expect(dead_code, reason = "reserved for EXT_CSD readback (#753)")]
 const CMD8_SEND_EXT_CSD: u32 = 8;
 
 /// CMD13: `SEND_STATUS`  -  read card status register.
-#[expect(dead_code, reason = "reserved for status polling")]
+#[expect(dead_code, reason = "reserved for status polling (#753)")]
 const CMD13_SEND_STATUS: u32 = 13;
 
 /// CMD16: `SET_BLOCKLEN`  -  SET block length to 512 bytes.

--- a/crates/thumos/src/gps.rs
+++ b/crates/thumos/src/gps.rs
@@ -36,7 +36,7 @@
 // WHY: hardware driver API not yet wired to upper layers (kinit integration pending).
 #![expect(
     dead_code,
-    reason = "GPS driver API wired in kinit but not yet called from userspace (tier in docs/capability-inventory.toml)"
+    reason = "GPS driver API wired in kinit but not yet called from userspace (#753; tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/harmostes.rs
+++ b/crates/thumos/src/harmostes.rs
@@ -33,7 +33,7 @@
 // WHY: Matrix client created in Phase 09 Wave 2, full integration pending in Wave 5.
 #![expect(
     dead_code,
-    reason = "Matrix client exists; unified inbox integration pending (tier in docs/capability-inventory.toml)"
+    reason = "Matrix client exists; unified inbox integration pending (#753; tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/http_client.rs
+++ b/crates/thumos/src/http_client.rs
@@ -35,7 +35,7 @@
     not(test),
     expect(
         dead_code,
-        reason = "HTTP client exists; harmostes integration pending (tier in docs/capability-inventory.toml)"
+        reason = "HTTP client exists; harmostes integration pending (#753; tier in docs/capability-inventory.toml)"
     )
 )]
 

--- a/crates/thumos/src/json_mini.rs
+++ b/crates/thumos/src/json_mini.rs
@@ -22,10 +22,10 @@
 //!   `\t`, `\uXXXX` (BMP only, no surrogate pair handling)
 //! - Maximum nesting depth of 32 to prevent stack overflow
 
-// WHY: JSON primitives exists; harmostes integration pending (tier in docs/capability-inventory.toml).
+// WHY: JSON primitives exists; harmostes integration pending (#753; tier in docs/capability-inventory.toml).
 #![expect(
     dead_code,
-    reason = "JSON primitives exists; harmostes integration pending (tier in docs/capability-inventory.toml)"
+    reason = "JSON primitives exists; harmostes integration pending (#753; tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/main.rs
+++ b/crates/thumos/src/main.rs
@@ -23,7 +23,7 @@
 // under the -D warnings gate.
 #![expect(
     dead_code,
-    reason = "compiled-but-unwired surface; per-module tiers in docs/capability-inventory.toml, enforced by scripts/check-wiring-inventory.sh"
+    reason = "compiled-but-unwired surface (#753); per-module tiers in docs/capability-inventory.toml, enforced by scripts/check-wiring-inventory.sh"
 )]
 // WHY: unwrap_used/expect_used are denied crate-wide (Cargo.toml) to keep
 // panics out of shipping kernel paths, where a panic is a crash. In a test,

--- a/crates/thumos/src/matrix_crypto.rs
+++ b/crates/thumos/src/matrix_crypto.rs
@@ -39,7 +39,7 @@
 // this issue does not close.
 #![expect(
     dead_code,
-    reason = "MatrixClient (and therefore MatrixCrypto) is not yet constructed from kernel_main; unreachable pending Phase-09 unified-inbox integration (tier in docs/capability-inventory.toml)"
+    reason = "MatrixClient (and therefore MatrixCrypto) is not yet constructed from kernel_main; unreachable pending Phase-09 unified-inbox integration (#753; tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/meshtastic.rs
+++ b/crates/thumos/src/meshtastic.rs
@@ -34,7 +34,7 @@
 // protocol implementation via akroasis kerykeion pending.
 #![expect(
     dead_code,
-    reason = "Meshtastic transport stub exists; serial protocol pending (tier in docs/capability-inventory.toml)"
+    reason = "Meshtastic transport stub exists; serial protocol pending (#753; tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/mic_audit.rs
+++ b/crates/thumos/src/mic_audit.rs
@@ -39,7 +39,7 @@
     not(test),
     expect(
         dead_code,
-        reason = "Mic audit log exists; audio manager wiring pending (tier in docs/capability-inventory.toml)"
+        reason = "Mic audit log exists; audio manager wiring pending (#753; tier in docs/capability-inventory.toml)"
     )
 )]
 

--- a/crates/thumos/src/nous.rs
+++ b/crates/thumos/src/nous.rs
@@ -47,7 +47,7 @@
 // WHY: nous created in Phase 09 Wave 8, full Matrix room wiring pending.
 #![expect(
     dead_code,
-    reason = "Nous exists; Matrix room wiring pending (tier in docs/capability-inventory.toml)"
+    reason = "Nous exists; Matrix room wiring pending (#753; tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/sbc.rs
+++ b/crates/thumos/src/sbc.rs
@@ -28,7 +28,7 @@
     not(test),
     expect(
         dead_code,
-        reason = "A2DP profile exists; audio manager wiring pending (tier in docs/capability-inventory.toml)"
+        reason = "A2DP profile exists; audio manager wiring pending (#753; tier in docs/capability-inventory.toml)"
     )
 )]
 

--- a/crates/thumos/src/screen_threat.rs
+++ b/crates/thumos/src/screen_threat.rs
@@ -57,7 +57,7 @@
     not(test),
     expect(
         dead_code,
-        reason = "sema (crates/sema) is not a thumos dependency, so ImsiCatcher/BleTracker/DeauthAttack/CcciAnomaly/GeofenceBreach/ModemAnomaly have no producer; FirewallMode::Restricted/Blocked have no switch anywhere in the kernel"
+        reason = "(#753) sema (crates/sema) is not a thumos dependency, so ImsiCatcher/BleTracker/DeauthAttack/CcciAnomaly/GeofenceBreach/ModemAnomaly have no producer; FirewallMode::Restricted/Blocked have no switch anywhere in the kernel"
     )
 )]
 

--- a/crates/thumos/src/sms.rs
+++ b/crates/thumos/src/sms.rs
@@ -36,7 +36,7 @@
     not(test),
     expect(
         dead_code,
-        reason = "SMS API exists; kinit wiring pending (tier in docs/capability-inventory.toml)"
+        reason = "SMS API exists; kinit wiring pending (#753; tier in docs/capability-inventory.toml)"
     )
 )]
 

--- a/crates/thumos/src/t9.rs
+++ b/crates/thumos/src/t9.rs
@@ -28,10 +28,10 @@
 //! key sequence, all words whose letter-to-key mapping matches the pressed
 //! keys as a prefix are returned as candidates.
 
-// WHY: T9 input exists; kinit wiring pending (tier in docs/capability-inventory.toml).
+// WHY: T9 input exists; kinit wiring pending (#753; tier in docs/capability-inventory.toml).
 #![expect(
     dead_code,
-    reason = "T9 input exists; kinit wiring pending (tier in docs/capability-inventory.toml)"
+    reason = "T9 input exists; kinit wiring pending (#753; tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/telephony.rs
+++ b/crates/thumos/src/telephony.rs
@@ -29,7 +29,7 @@
 // WHY: hardware driver API not yet wired to upper layers (Wave 3 integration).
 #![expect(
     dead_code,
-    reason = "Telephony driver API not yet wired to kinit (tier in docs/capability-inventory.toml)"
+    reason = "Telephony driver API not yet wired to kinit (#753; tier in docs/capability-inventory.toml)"
 )]
 
 // Re-export parser functions so external callers can still use crate::telephony::*.

--- a/crates/thumos/src/ui.rs
+++ b/crates/thumos/src/ui.rs
@@ -25,7 +25,7 @@
 // dispatch through UiManager are still pending.
 #![expect(
     dead_code,
-    reason = "UI framework has only initial home-frame kinit wiring (tier in docs/capability-inventory.toml)"
+    reason = "UI framework has only initial home-frame kinit wiring (#753; tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;

--- a/crates/thumos/src/wifi.rs
+++ b/crates/thumos/src/wifi.rs
@@ -26,7 +26,7 @@
 // frame TX/RX, scan, and association are implemented on the target.
 #![expect(
     dead_code,
-    reason = "WiFi hardware data path not yet implemented on target (tier in docs/capability-inventory.toml)"
+    reason = "WiFi hardware data path not yet implemented on target (#753; tier in docs/capability-inventory.toml)"
 )]
 
 extern crate alloc;


### PR DESCRIPTION
#738 removed the closed `#145`/`#420` citations from the kernel's dead-code exemptions. That left 45 reasons with no `#NNN`, and `WORKFLOW/unwired-dead-code-untracked` requires one — **45 findings at high severity**, self-inflicted by that fix.

## Both halves of the conflict were real

The citations *were* false: both issues were closed while the surface they described still existed. And the rule *does* want a traceable reference.

What makes this worth more than a one-line fix is that **the rule cannot tell the difference**. From its own description:

> Flags Rust dead_code allow or expect attributes whose reason does not carry a tracking issue … **does not verify the issue is open or topically related.**

So the stale `#145` satisfied it for months. The rule enforces the *form* of tracking while being blind to whether the tracking is real — which is exactly the defect #738 was filed about. Filed against kanon separately.

## An anchor that cannot rot

**#753** tracks the *existence* of the unwired surface rather than the work of wiring it. Closing it is only a true statement once the surface is gone — which is also precisely when these exemptions should be removed. That is the property `#145` lacked: it was a work item, so it closed on its own terms while the thing it justified carried on.

The detail is not duplicated into the issue. `docs/capability-inventory.toml` stays the machine-checked record of every module's tier, enforced by `scripts/check-wiring-inventory.sh`. #753 exists so the exemptions have a live number to name, and it says so.

Result: `WORKFLOW/unwired-dead-code-untracked` **45 → 0**.

## Three dead ignore entries, removed

Each matched no file, and kanon warned about each on every run:

| entry | why it was dead |
|---|---|
| `ARCHITECTURE/no-glossary:Cargo.toml` | keyed a path the rule never reports against |
| `RELEASES/changelog-present:CHANGELOG.md` | the rule stops firing once the file exists, and it does |
| `RELEASES/disclaimer-present:DISCLAIMER.md` | same |

Their reasons are kept as comments — release-please generates `CHANGELOG.md` even though `REPO-SETUP.md` says to omit it, and `DISCLAIMER.md` is required by thumos's status as research and educational software. Those are worth knowing; the dead patterns were not.

Dead ignore entries remaining: **0**. Repo total: **221 → 176**.

Refs: #753, #738, #718