### PR TITLE
fix(thumos): resolve SHELL/* lint classes (set-euo-pipefail, strict-mode, missing-local)

### DIFF
--- a/scripts/kernel-clippy.sh
+++ b/scripts/kernel-clippy.sh
@@ -118,7 +118,9 @@ production_key() {
     fi
     printf '%s' "$PRODUCTION_KEY_DIR/ci-boot.pub"
 }
-cleanup() { [ -n "$PRODUCTION_KEY_DIR" ] && rm -rf "$PRODUCTION_KEY_DIR"; }
+cleanup() {
+    [ -n "$PRODUCTION_KEY_DIR" ] && rm -rf "$PRODUCTION_KEY_DIR"
+}
 trap cleanup EXIT
 
 # WHY dynamic column width, not the original hand-picked padding (#704):

--- a/scripts/kernel-clippy.sh
+++ b/scripts/kernel-clippy.sh
@@ -110,14 +110,25 @@ done
 # proves a real key is accepted with, generated lazily (only if a
 # `production` pass is actually in the list above) and scoped to this run.
 PRODUCTION_KEY_DIR=""
-production_key() {
+# WHY a plain function, not one invoked via $(...): a command substitution
+# runs in a subshell, so an assignment to PRODUCTION_KEY_DIR made only
+# inside `$(production_key)` never reaches this shell -- the variable
+# stays "" here regardless of whether the key was generated. Under `set
+# -e` that silently starves cleanup()'s EXIT trap: its `[ -n
+# "$PRODUCTION_KEY_DIR" ]` reads false, the trap's last command is that
+# failing test, and a failing trap's exit status becomes the WHOLE
+# script's exit status -- turning a fully green run into a reported
+# failure with no FAIL message anywhere (found live in CI: every one of
+# the 9 feature passes compiled clean, then the script still exited 1).
+# Call ensure_production_key as a bare statement so the assignment lands
+# in this shell, then read PRODUCTION_KEY_DIR directly.
+ensure_production_key() {
     if [[ -z "$PRODUCTION_KEY_DIR" ]]; then
         PRODUCTION_KEY_DIR=$(mktemp -d)
         openssl genpkey -algorithm ed25519 -out "$PRODUCTION_KEY_DIR/ci-boot.pem" 2>/dev/null
         openssl pkey -in "$PRODUCTION_KEY_DIR/ci-boot.pem" -pubout -outform DER \
             | tail -c 32 | od -An -tx1 | tr -d ' \n' > "$PRODUCTION_KEY_DIR/ci-boot.pub"
     fi
-    printf '%s' "$PRODUCTION_KEY_DIR/ci-boot.pub"
 }
 cleanup() {
     [ -n "$PRODUCTION_KEY_DIR" ] && rm -rf "$PRODUCTION_KEY_DIR"
@@ -148,7 +159,8 @@ for i in "${!PASS_TAGS[@]}"; do
     # feature's result together).
     rc=0
     if [[ "$tag" = "production" ]]; then
-        out=$(cd "$KERNEL_DIR" && THUMOS_BOOT_KEY_PUB="$(production_key)" cargo clippy --bin thumos --tests \
+        ensure_production_key
+        out=$(cd "$KERNEL_DIR" && THUMOS_BOOT_KEY_PUB="$PRODUCTION_KEY_DIR/ci-boot.pub" cargo clippy --bin thumos --tests \
             --features "$features" --target i686-unknown-linux-gnu -- -D warnings 2>&1) || rc=$?
     elif [ -n "$features" ]; then
         out=$(cd "$KERNEL_DIR" && cargo clippy --bin thumos --tests \

--- a/scripts/kernel-clippy.sh
+++ b/scripts/kernel-clippy.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # kernel-clippy.sh — kernel crate clippy gate (#663, #704). The kernel crate is
 # excluded from the workspace, so every --workspace clippy invocation in the
 # repo silently skips it. Shared by ci.yml and .kanon-ci.toml so the
 # admission gate and the PR gate execute the identical check.
-set -euo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 KERNEL_DIR="${THUMOS_KERNEL_DIR:-$REPO_ROOT/crates/thumos}"

--- a/scripts/kernel-clippy.sh
+++ b/scripts/kernel-clippy.sh
@@ -3,7 +3,7 @@
 # excluded from the workspace, so every --workspace clippy invocation in the
 # repo silently skips it. Shared by ci.yml and .kanon-ci.toml so the
 # admission gate and the PR gate execute the identical check.
-set -uo pipefail
+set -euo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 KERNEL_DIR="${THUMOS_KERNEL_DIR:-$REPO_ROOT/crates/thumos}"
@@ -139,17 +139,23 @@ for i in "${!PASS_TAGS[@]}"; do
     label=$(printf '[%s]' "$tag")
     label=$(printf '%-*s' "$((tagwidth + 3))" "$label")
 
+    # WHY the explicit `|| rc=$?`, not a trailing `rc=$?` after the fi: under
+    # `set -e`, an unguarded `out=$(...)` failing inside an if/elif/else BODY
+    # (not its condition) aborts the whole script at the first red feature
+    # pass -- before the remaining passes run and before the aggregate
+    # failures[] report below ever prints (#704's whole point is seeing every
+    # feature's result together).
+    rc=0
     if [[ "$tag" = "production" ]]; then
         out=$(cd "$KERNEL_DIR" && THUMOS_BOOT_KEY_PUB="$(production_key)" cargo clippy --bin thumos --tests \
-            --features "$features" --target i686-unknown-linux-gnu -- -D warnings 2>&1)
+            --features "$features" --target i686-unknown-linux-gnu -- -D warnings 2>&1) || rc=$?
     elif [ -n "$features" ]; then
         out=$(cd "$KERNEL_DIR" && cargo clippy --bin thumos --tests \
-            --features "$features" --target i686-unknown-linux-gnu -- -D warnings 2>&1)
+            --features "$features" --target i686-unknown-linux-gnu -- -D warnings 2>&1) || rc=$?
     else
         out=$(cd "$KERNEL_DIR" && cargo clippy --bin thumos --tests \
-            --target i686-unknown-linux-gnu -- -D warnings 2>&1)
+            --target i686-unknown-linux-gnu -- -D warnings 2>&1) || rc=$?
     fi
-    rc=$?
     printf '%s\n' "$out" | sed "s/^/${label}/"
     RCS+=("$rc")
 done

--- a/scripts/kernel-host-tests.sh
+++ b/scripts/kernel-host-tests.sh
@@ -3,7 +3,7 @@
 # is excluded from the workspace, so its host unit tests (i686, u32-faithful
 # ABI) run against the 32-bit target. Shared by ci.yml and .kanon-ci.toml so
 # the admission gate and the PR gate execute the identical suite.
-set -uo pipefail
+set -euo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 KERNEL_DIR="${THUMOS_KERNEL_DIR:-$REPO_ROOT/crates/thumos}"
@@ -45,10 +45,11 @@ grep -q 'console::tests' <<<"$out" || {
     echo "FAIL #459: --features debug-console pass ran zero console::tests — the tests are dead again" >&2
     exit 1
 }
-# WHY (#616): no `set -e` here, so a red pass does not abort the script — and
-# without this check the script's exit code was the grep's, letting a failing
-# test pass ship rc=0 to CI. Both passes run to completion either way (a red
-# main pass must not hide the debug-console witness output).
+# WHY (#616): pass1/pass2 are captured via `|| pass=$?`, not left to fall out
+# the bottom — without that, the script's own exit code was the grep's,
+# letting a failing test pass ship rc=0 to CI. The explicit capture is also
+# what keeps both passes running to completion under `set -e` (a red main
+# pass must not hide the debug-console witness output).
 if [[ "$pass1" -ne 0 ]] || [[ "$pass2" -ne 0 ]]; then
     echo "FAIL: kernel host tests failed (main pass rc=$pass1, debug-console pass rc=$pass2)" >&2
     exit 1

--- a/scripts/kernel-host-tests.sh
+++ b/scripts/kernel-host-tests.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # kernel-host-tests.sh — kernel i686 host test suite (#546). The kernel crate
 # is excluded from the workspace, so its host unit tests (i686, u32-faithful
 # ABI) run against the 32-bit target. Shared by ci.yml and .kanon-ci.toml so
 # the admission gate and the PR gate execute the identical suite.
-set -euo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 KERNEL_DIR="${THUMOS_KERNEL_DIR:-$REPO_ROOT/crates/thumos}"

--- a/scripts/witness/boot.sh
+++ b/scripts/witness/boot.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # witness/boot.sh — kernel QEMU boot + service-loop witness (#546), extracted
 # verbatim from the ci.yml kernel job. The `qemu` feature retargets peripherals
 # to the virt board; the REAL kinit boots, hands off to kardia (PID 0), and
@@ -6,7 +8,6 @@
 # a named assertion from the original inline block — same markers, same counts.
 # Runner exit codes: 0=loop ran; 5=service-loop stalled (#461 tick-source
 # class); 1=panic; 2/3/4=aborts; 124=hang (runner timeout).
-set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
 witness_deps

--- a/scripts/witness/boot.sh
+++ b/scripts/witness/boot.sh
@@ -6,7 +6,7 @@
 # a named assertion from the original inline block — same markers, same counts.
 # Runner exit codes: 0=loop ran; 5=service-loop stalled (#461 tick-source
 # class); 1=panic; 2/3/4=aborts; 124=hang (runner timeout).
-set -uo pipefail
+set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
 witness_deps
@@ -29,17 +29,17 @@ grep -q 'init: hello from userspace' boot.log || { echo 'FAIL: userspace /init d
 grep -q '/shell spawned PL0' boot.log || { echo 'FAIL #526: /shell did not spawn (absent from ramfs or spawn regressed)'; exit 1; }
 grep -q 'shell: hello from userspace' boot.log || { echo 'FAIL #526: /shell did not run + syscall from its own frame'; exit 1; }
 grep -q '2 userspace ELF processes running' boot.log || { echo 'FAIL #526: kinit did not report both userspace processes running'; exit 1; }
-ic=$(grep -c 'init: hello from userspace' boot.log); test "$ic" -eq 1 || { echo "FAIL #526: 'init: hello' x$ic (want 1) -- per-process image-frame clobber regressed (#502)"; exit 1; }
-sc=$(grep -c 'shell: hello from userspace' boot.log); test "$sc" -eq 1 || { echo "FAIL #526: 'shell: hello' x$sc (want 1) -- per-process image-frame clobber regressed (#502)"; exit 1; }
+ic=$(grep -c 'init: hello from userspace' boot.log || true); test "$ic" -eq 1 || { echo "FAIL #526: 'init: hello' x$ic (want 1) -- per-process image-frame clobber regressed (#502)"; exit 1; }
+sc=$(grep -c 'shell: hello from userspace' boot.log || true); test "$sc" -eq 1 || { echo "FAIL #526: 'shell: hello' x$sc (want 1) -- per-process image-frame clobber regressed (#502)"; exit 1; }
 # #400 render foundation through the real screen-dispatch path.
 grep -q 'kardia: frame rendered painted_px=' boot.log || { echo 'FAIL #400: service loop never rendered a frame (render path dead)'; exit 1; }
-px=$(grep -oE 'painted_px=[0-9]+' boot.log | head -1 | grep -oE '[0-9]+'); test "${px:-0}" -gt 0 || { echo "FAIL #400: rendered frame is BLANK (painted_px=${px:-0}) -- screen draw produced nothing"; exit 1; }
+px=$(grep -oE 'painted_px=[0-9]+' boot.log | head -1 | grep -oE '[0-9]+' || true); test "${px:-0}" -gt 0 || { echo "FAIL #400: rendered frame is BLANK (painted_px=${px:-0}) -- screen draw produced nothing"; exit 1; }
 # #400 input + navigation round trip.
 grep -q 'kardia: nav Home -> Search' boot.log || { echo 'FAIL #400: synthetic input did not navigate Home->Search (input dispatch / on_key broken)'; exit 1; }
 grep -q 'kardia: nav Search -> Home' boot.log || { echo 'FAIL #400: back-navigation did not return to Home (screen stack broken)'; exit 1; }
 # #402 clock trust hierarchy wired + seeded + driving the display.
 grep -q 'kardia: clock src=manual' boot.log || { echo 'FAIL #402: ClockManager not wired/seeded (no manual source)'; exit 1; }
-wall=$(grep -oE 'clock src=manual wall=[0-9]+' boot.log | head -1 | grep -oE '[0-9]+$'); test "${wall:-0}" -gt 1700000000 || { echo "FAIL #402: wall clock is not a real epoch (wall=${wall:-0}) -- ClockManager not driving time"; exit 1; }
+wall=$(grep -oE 'clock src=manual wall=[0-9]+' boot.log | head -1 | grep -oE '[0-9]+$' || true); test "${wall:-0}" -gt 1700000000 || { echo "FAIL #402: wall clock is not a real epoch (wall=${wall:-0}) -- ClockManager not driving time"; exit 1; }
 # #461 clock health witness: elapsed_ms must advance under virt (measured
 # root cause 2026-08-04); a counter/frequency regression reds here instead
 # of silently hanging the wait loops that consume elapsed_ms.
@@ -48,7 +48,7 @@ grep -q 'kardia: timer elapsed_ms=advancing' boot.log || { echo 'FAIL #461: elap
 # ClockManager time into set_realtime_offset; the emitted offset must be a
 # real ~2025+ epoch (an unwired offset would stay at its small default).
 grep -qE 'kardia: realtime offset=[0-9]+' boot.log || { echo 'FAIL #506: kardia never emitted its realtime offset (set_realtime_offset not wired)'; exit 1; }
-off=$(grep -oE 'kardia: realtime offset=[0-9]+' boot.log | head -1 | grep -oE '[0-9]+$'); test "${off:-0}" -gt 1700000000 || { echo "FAIL #506: realtime offset is not the ClockManager epoch (offset=${off:-0})"; exit 1; }
+off=$(grep -oE 'kardia: realtime offset=[0-9]+' boot.log | head -1 | grep -oE '[0-9]+$' || true); test "${off:-0}" -gt 1700000000 || { echo "FAIL #506: realtime offset is not the ClockManager epoch (offset=${off:-0})"; exit 1; }
 # #398 telephony: seeded mock transport, LIVE stack, Registered.
 grep -q 'kardia: modem ready state=Registered' boot.log || { echo 'FAIL #398: Telephony did not initialize to Registered (AT state machine / mock wiring broken)'; exit 1; }
 # #399 audio session manager + mic audit.
@@ -93,7 +93,7 @@ for probe in kread:data-abort kwrite:data-abort kexec:prefetch-abort cp15:undefi
     grep -q '/init spawned PL0' "probe-$variant.log" || { echo "FAIL isolation[$variant]: /init did not spawn PL0 (cannot test isolation)"; exit 1; }
     grep -q "PROBE: $variant" "probe-$variant.log" || { echo "FAIL isolation[$variant]: the wrong probe variant was built (no 'PROBE: $variant' marker -- a cfg mixup)"; exit 1; }
     grep -Eq "USERFAULT: pid=[0-9]+ kind=$kind .*killed" "probe-$variant.log" || { echo "FAIL isolation[$variant]: no USERFAULT $kind kill marker -- PL0 op did not fault (ISOLATION BROKEN) or the kill path broke"; exit 1; }
-    ufc=$(grep -c 'USERFAULT:' "probe-$variant.log")
+    ufc=$(grep -c 'USERFAULT:' "probe-$variant.log" || true)
     test "$ufc" -eq 1 || { echo "FAIL isolation[$variant]: expected exactly 1 USERFAULT, got $ufc (a re-fault loop or double kill)"; exit 1; }
     grep -q 'kardia: reaped .* fault-killed' "probe-$variant.log" || { echo "FAIL isolation[$variant]: fault-killed process was not reaped (PCB-slot leak -- table exhausts at MAX_PROCS)"; exit 1; }
     ! grep -q 'init: hello from userspace' "probe-$variant.log" || { echo "FAIL isolation[$variant]: /init reached the write -- the PL0 op did NOT fault (ISOLATION BROKEN)"; exit 1; }

--- a/scripts/witness/brk.sh
+++ b/scripts/witness/brk.sh
@@ -5,7 +5,7 @@
 # overlay a section, so brk growth failed on every real boot while host tests
 # (absent-entry fixture) stayed green. This witness is the only real-table
 # proof for heap growth: grow two pages, canary R/W at PL0, shrink back.
-set -uo pipefail
+set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
 witness_deps

--- a/scripts/witness/brk.sh
+++ b/scripts/witness/brk.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # witness/brk.sh — QEMU brk heap growth on a real page table (#533), verbatim
 # from ci.yml. sys_brk growth maps into the heap window (mb 0x100), covered by
 # a 1 MB identity SECTION on every real process L1 — and map_page refuses to
 # overlay a section, so brk growth failed on every real boot while host tests
 # (absent-entry fixture) stayed green. This witness is the only real-table
 # proof for heap growth: grow two pages, canary R/W at PL0, shrink back.
-set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
 witness_deps

--- a/scripts/witness/crashloop.sh
+++ b/scripts/witness/crashloop.sh
@@ -5,7 +5,7 @@
 # restart x3, give up — the counts are the assertion. #526 reconciliation: a
 # CLEAN exit (/shell) must NEVER be restarted; /init is deliberately
 # unsupervised and must be unaffected.
-set -uo pipefail
+set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
 witness_deps
@@ -16,17 +16,17 @@ echo "=== crashloop: runner rc=$crc (want 0) ==="
 test "$crc" -eq 0 || { echo "FAIL #492: kernel did not survive the crash loop (rc=$crc; 124=hang 2/3=abort)"; exit 1; }
 ! grep -q 'crasher: NOT killed' crashloop.log || { echo 'FAIL #492: /crasher read kernel memory WITHOUT faulting (ISOLATION BROKEN)'; exit 1; }
 ! grep -q 'supervisor FAILED to restart' crashloop.log || { echo 'FAIL #492: a relaunch failed (ramfs re-plan / load_confined under the kernel L1 broke)'; exit 1; }
-starts=$(grep -c 'crasher: start' crashloop.log)
+starts=$(grep -c 'crasher: start' crashloop.log || true)
 test "$starts" -eq 4 || { echo "FAIL #492: /crasher ran $starts times (want 4 = initial + 3 restarts) -- the restart policy or the relaunched image is wrong"; exit 1; }
-restarts=$(grep -c 'kardia: supervisor restarted /crasher' crashloop.log)
+restarts=$(grep -c 'kardia: supervisor restarted /crasher' crashloop.log || true)
 test "$restarts" -eq 3 || { echo "FAIL #492: $restarts restarts (want 3 = MAX_RESTARTS)"; exit 1; }
-audited=$(grep -c 'kardia: fault audited pid=' crashloop.log)
+audited=$(grep -c 'kardia: fault audited pid=' crashloop.log || true)
 test "$audited" -eq 4 || { echo "FAIL #492: $audited faults audited (want 4) -- every report must reach the audit trail"; exit 1; }
 grep -q 'kardia: supervisor giving up on /crasher after 3 restarts' crashloop.log || { echo 'FAIL #492: the crash loop was never rate-limited (no give-up)'; exit 1; }
-faults=$(grep -c 'USERFAULT:.*kind=data-abort.*killed' crashloop.log)
+faults=$(grep -c 'USERFAULT:.*kind=data-abort.*killed' crashloop.log || true)
 test "$faults" -eq 4 || { echo "FAIL #492: $faults data-abort kills (want 4) -- a 5th means give-up did not stop the loop"; exit 1; }
 ! grep -q 'supervisor restarted /shell' crashloop.log || { echo 'FAIL #492: /shell exited CLEANLY and was restarted -- the supervisor is keying on Dead state, not on fault reports'; exit 1; }
-shells=$(grep -c 'shell: hello from userspace' crashloop.log)
+shells=$(grep -c 'shell: hello from userspace' crashloop.log || true)
 test "$shells" -eq 1 || { echo "FAIL #492: /shell ran $shells times (want 1) -- a clean exit must not be relaunched"; exit 1; }
 grep -q 'init: hello from userspace' crashloop.log || { echo 'FAIL #492: /init did not run (unsupervised, must be unaffected)'; exit 1; }
 grep -q 'kardia: reaped' crashloop.log || { echo 'FAIL #492: the reaper stopped reclaiming slots (the supervisor must not replace it)'; exit 1; }

--- a/scripts/witness/crashloop.sh
+++ b/scripts/witness/crashloop.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # witness/crashloop.sh — QEMU PID-0 fault supervisor + crash-loop rate limit
 # (#492), verbatim from ci.yml. The crashloop-probe feature makes kinit spawn
 # + supervise /crasher, a program that data-aborts on EVERY launch: launch,
 # restart x3, give up — the counts are the assertion. #526 reconciliation: a
 # CLEAN exit (/shell) must NEVER be restarted; /init is deliberately
 # unsupervised and must be unaffected.
-set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
 witness_deps

--- a/scripts/witness/exec.sh
+++ b/scripts/witness/exec.sh
@@ -4,7 +4,7 @@
 # the NEW image's _start runs (remap + ACTIVE_FRAME install), its privileged
 # cp15 read UNDEF-faults at PL0 (unprivileged proof), the OLD image is gone,
 # and the kernel survives.
-set -uo pipefail
+set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
 witness_deps

--- a/scripts/witness/exec.sh
+++ b/scripts/witness/exec.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # witness/exec.sh — QEMU exec correctness + PL0 (#489), verbatim from ci.yml.
 # PL0 execve must REPLACE the caller's image with a new one that runs at PL0:
 # the NEW image's _start runs (remap + ACTIVE_FRAME install), its privileged
 # cp15 read UNDEF-faults at PL0 (unprivileged proof), the OLD image is gone,
 # and the kernel survives.
-set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
 witness_deps

--- a/scripts/witness/fork.sh
+++ b/scripts/witness/fork.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # witness/fork.sh — QEMU fork correctness + isolation (#478), verbatim from
 # ci.yml. A PL0 fork must give the child its OWN deep-copied memory: distinct
 # parent/child markers prove the r0 split; the child mutates canaries the
 # parent then verifies untouched; child exit + waitpid proves exit_cleanup
 # freed the CHILD's frames, not the parent's.
-set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
 witness_deps

--- a/scripts/witness/fork.sh
+++ b/scripts/witness/fork.sh
@@ -4,7 +4,7 @@
 # parent/child markers prove the r0 split; the child mutates canaries the
 # parent then verifies untouched; child exit + waitpid proves exit_cleanup
 # freed the CHILD's frames, not the parent's.
-set -uo pipefail
+set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
 witness_deps

--- a/scripts/witness/forkexec.sh
+++ b/scripts/witness/forkexec.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # witness/forkexec.sh — QEMU fork+exec composes, per-process images (#502),
 # verbatim from ci.yml. /init forks; the CHILD execs /init2 (its OWN image,
 # not a re-run of /init — the fork bomb is dead); the exec marker appears
 # EXACTLY ONCE; the parent's own image frame is never touched.
-set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
 witness_deps

--- a/scripts/witness/forkexec.sh
+++ b/scripts/witness/forkexec.sh
@@ -3,7 +3,7 @@
 # verbatim from ci.yml. /init forks; the CHILD execs /init2 (its OWN image,
 # not a re-run of /init — the fork bomb is dead); the exec marker appears
 # EXACTLY ONCE; the parent's own image frame is never touched.
-set -uo pipefail
+set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
 witness_deps
@@ -17,7 +17,7 @@ grep -q 'forkexec: parent waiting' forkexec.log || { echo 'FAIL forkexec: no par
 ! grep -q 'forkexec: fork FAILED' forkexec.log || { echo 'FAIL forkexec: fork returned an error'; exit 1; }
 ! grep -q 'forkexec: child exec FAILED' forkexec.log || { echo 'FAIL forkexec: the child execve returned an error (per-process image load broken)'; exit 1; }
 grep -q 'init2: reached via exec' forkexec.log || { echo 'FAIL forkexec: the child never ran /init2 -- exec did not load the new per-process image'; exit 1; }
-xc=$(grep -c 'forkexec: child exec-ing /init2' forkexec.log)
+xc=$(grep -c 'forkexec: child exec-ing /init2' forkexec.log || true)
 test "$xc" -eq 1 || { echo "FAIL forkexec: the exec marker appeared $xc times (want 1) -- a FORK BOMB re-ran /init instead of /init2 (#502 regressed)"; exit 1; }
 grep -q 'forkexec: parent integrity ok' forkexec.log || { echo 'FAIL forkexec: parent .data was corrupted by the child exec (per-process image isolation broken)'; exit 1; }
 ! grep -q 'forkexec: parent integrity BROKEN' forkexec.log || { echo 'FAIL forkexec: explicit parent-integrity break'; exit 1; }

--- a/scripts/witness/guard.sh
+++ b/scripts/witness/guard.sh
@@ -5,7 +5,7 @@
 # child HAS its own copy — the fix); 0x07 = TRANSLATION fault (the page was
 # DROPPED from the deep-copy — the #496 bug regressed). The parent reaps
 # (SIGSEGV=139) and mprotects NONE->READ.
-set -uo pipefail
+set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
 witness_deps
@@ -20,7 +20,7 @@ grep -q 'init: guard mapped' guard.log || { echo 'FAIL #496: mmap(PROT_NONE) was
 ! grep -q 'init: guard NOT enforced' guard.log || { echo 'FAIL #496: the child READ the PROT_NONE guard without faulting -- PL0 access was not denied (SECURITY)'; exit 1; }
 grep -Eq 'USERFAULT: pid=[0-9]+ kind=data-abort addr=0x20000000 status=0x0000000f killed' guard.log || { echo 'FAIL #496: no PERMISSION data-abort at the guard VA -- the forked child did not get its own PROT_NONE page'; exit 1; }
 ! grep -q 'USERFAULT.*addr=0x20000000 status=0x00000007' guard.log || { echo 'FAIL #496: TRANSLATION fault at the guard VA -- fork DROPPED the PROT_NONE page from the deep-copy (the #496 bug regressed)'; exit 1; }
-gufc=$(grep -c 'USERFAULT:' guard.log)
+gufc=$(grep -c 'USERFAULT:' guard.log || true)
 test "$gufc" -eq 1 || { echo "FAIL #496: expected exactly 1 USERFAULT, got $gufc"; exit 1; }
 grep -q 'init: guard child killed status=139' guard.log || { echo 'FAIL #496: the guard-faulting child did not exit SIGSEGV(139) / was not reaped by the parent'; exit 1; }
 grep -q 'init: guard readable after mprotect' guard.log || { echo 'FAIL #496: mprotect(PROT_NONE -> PROT_READ) failed, or the guard frame did not survive'; exit 1; }

--- a/scripts/witness/guard.sh
+++ b/scripts/witness/guard.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # witness/guard.sh — QEMU PROT_NONE guard pages survive fork (#496), verbatim
 # from ci.yml. /init mmaps a PROT_NONE guard, forks, and the CHILD reads it.
 # The load-bearing assertion is the DFSR status: 0x0f = PERMISSION fault (the
 # child HAS its own copy — the fix); 0x07 = TRANSLATION fault (the page was
 # DROPPED from the deep-copy — the #496 bug regressed). The parent reaps
 # (SIGSEGV=139) and mprotects NONE->READ.
-set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
 witness_deps

--- a/scripts/witness/kfault.sh
+++ b/scripts/witness/kfault.sh
@@ -4,7 +4,7 @@
 # boot-complete must take the KERNEL branch: qemu exit 4, no service-loop
 # resume. If fault handling ever wrongly "recovers" a kernel fault, the boot
 # continues to ticks=/exit 0 and this reds.
-set -uo pipefail
+set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
 witness_deps

--- a/scripts/witness/kfault.sh
+++ b/scripts/witness/kfault.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # witness/kfault.sh — kernel-fault halts witness (#546), verbatim from ci.yml.
 # The other half of the safety property: a deliberate PL1 `udf` after
 # boot-complete must take the KERNEL branch: qemu exit 4, no service-loop
 # resume. If fault handling ever wrongly "recovers" a kernel fault, the boot
 # continues to ticks=/exit 0 and this reds.
-set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
 witness_deps

--- a/scripts/witness/lib.sh
+++ b/scripts/witness/lib.sh
@@ -10,8 +10,17 @@
 #   THUMOS_QEMU_TIMEOUT — runner timeout seconds (default: 60)
 #   THUMOS_INIT_VARIANT — init-harness variant for probe scripts
 # Exit codes: 0 pass; non-zero fail with a named assertion (never a bare timeout).
+#
+# WARNING: under `set -e`, `x=$(grep -c pat log)` or a piped
+# `x=$(grep -oE pat log | head -1 | grep -oE '[0-9]+')` aborts the WHOLE
+# script at the assignment when the pattern has zero matches (grep's/the
+# pipe's nonzero status is the assignment's own status) — before the
+# caller's own `test "$x" -eq N || { echo FAIL...; exit 1; }` ever runs,
+# losing the named assertion. Callers that read a count/value this way
+# before testing it guard the assignment with `|| true` so the intended
+# custom FAIL message still fires.
 
-set -uo pipefail
+set -euo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 KERNEL_DIR="${THUMOS_KERNEL_DIR:-$REPO_ROOT/crates/thumos}"

--- a/scripts/witness/lib.sh
+++ b/scripts/witness/lib.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # witness/lib.sh — shared helpers for the kernel QEMU witness scripts (#546).
 # Source, don't execute. Every witness script preserves the exact assertions of
 # the ci.yml kernel job it was extracted from; edit assertions in ONE place

--- a/scripts/witness/metaxu-negative.sh
+++ b/scripts/witness/metaxu-negative.sh
@@ -26,7 +26,7 @@
 # so the kernel never touches UART1 regardless of feature -- pylon-bridge
 # runs unmodified and its silence (no "PYLON: frame received" line) is the
 # proof nothing crossed the wire.
-set -uo pipefail
+set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
 witness_deps

--- a/scripts/witness/metaxu-negative.sh
+++ b/scripts/witness/metaxu-negative.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # witness/metaxu-negative.sh — the #544 negative-case coverage metaxu.sh
 # does not exercise: metaxu.sh proves the happy path only, which passes
 # against a bridge that accepts anything. Three distinct outcomes, one

--- a/scripts/witness/metaxu.sh
+++ b/scripts/witness/metaxu.sh
@@ -10,7 +10,7 @@
 # chardev connects OUT to that port as a client (THUMOS_QEMU_METAXU_PORT,
 # read by scripts/qemu-runner.sh), so the guest never races an unbound
 # host socket.
-set -uo pipefail
+set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
 REPO_ROOT=$(git rev-parse --show-toplevel)

--- a/scripts/witness/metaxu.sh
+++ b/scripts/witness/metaxu.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # witness/metaxu.sh — the #544 on-device round trip: a real Thumos
 # userspace process (/metaxu_probe) drives an authenticated metaxu-core
 # request over the second PL011 to a real host `pylon-bridge` process (the

--- a/scripts/witness/signal.sh
+++ b/scripts/witness/signal.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # witness/signal.sh — userspace signal delivery end-to-end (#446), verbatim
 # from ci.yml. /init installs SIGUSR1/SIGUSR2 handlers, raises BOTH against
 # itself, then yields. The kernel must rewrite the IRQ trap frame into the
@@ -7,7 +9,6 @@
 # marker must appear AFTER USR1's -- its pending bit surviving USR1's
 # delivery is the exact-clear contract (the old clear-any-pending could wipe
 # the wrong signal).
-set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
 witness_deps

--- a/scripts/witness/signal.sh
+++ b/scripts/witness/signal.sh
@@ -7,7 +7,7 @@
 # marker must appear AFTER USR1's -- its pending bit surviving USR1's
 # delivery is the exact-clear contract (the old clear-any-pending could wipe
 # the wrong signal).
-set -uo pipefail
+set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
 witness_deps

--- a/scripts/witness/sleep.sh
+++ b/scripts/witness/sleep.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # witness/sleep.sh — userspace sleep really yields (#477), verbatim from ci.yml.
 # A userspace nanosleep/Sleep must YIELD (switch away, resume after the
 # interval), not busy-wait. The old busy-wait ran IRQ-masked in the SVC trap,
 # so ticks() froze and the WHOLE kernel hung. The sleep /init variant sleeps
 # 30ms between "sleeping" and "woke": a real yield lets the service loop run
 # meanwhile and /init resume; a busy-wait hangs the kernel -> runner timeout.
-set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
 witness_deps

--- a/scripts/witness/sleep.sh
+++ b/scripts/witness/sleep.sh
@@ -5,7 +5,7 @@
 # so ticks() froze and the WHOLE kernel hung. The sleep /init variant sleeps
 # 30ms between "sleeping" and "woke": a real yield lets the service loop run
 # meanwhile and /init resume; a busy-wait hangs the kernel -> runner timeout.
-set -uo pipefail
+set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
 witness_deps

--- a/scripts/witness/trust-anchor.sh
+++ b/scripts/witness/trust-anchor.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # witness/trust-anchor.sh — trust-anchor build guard (#233), verbatim from
 # ci.yml. A production image must FAIL to build without a provisioned key,
 # must REFUSE the committed (deliberately public) dev key, and must BUILD
 # with a real key — proven here with an ephemeral one. Dev/qemu/host builds
 # keep building keylessly.
-set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
 cd "$KERNEL_DIR"

--- a/scripts/witness/trust-anchor.sh
+++ b/scripts/witness/trust-anchor.sh
@@ -4,7 +4,7 @@
 # must REFUSE the committed (deliberately public) dev key, and must BUILD
 # with a real key — proven here with an ephemeral one. Dev/qemu/host builds
 # keep building keylessly.
-set -uo pipefail
+set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
 cd "$KERNEL_DIR"


### PR DESCRIPTION
Resolves the three SHELL/* lint classes from #756: `set-euo-pipefail`, `strict-mode`, `missing-local`. Scope held to `scripts/` only, per issue instructions — no `crates/`, `docs/`, or `.github/workflows/` touched.

## Measured before/after (`kanon lint . --summary`, CLI, matches CI)

| Rule | Before | After |
|---|---|---|
| `SHELL/set-euo-pipefail` | 16 | 0 |
| `SHELL/strict-mode` | 16 | 0 |
| `SHELL/missing-local` | 10 | 0 |
| Total repo violations | 178 | 136 |

`SHELL/unpinned-action` (1, in `.github/workflows/`) is a different rule, out of scope, untouched.

## Three commits, one per rule class

1. **`SHELL/missing-local`** — `kernel-clippy.sh`'s single-line `cleanup() { ...; }` left kanon lint's brace-depth scope tracker permanently "in function" (it never re-scans a function-opening line's own remainder for a same-line close), misflagging every top-level assignment for the rest of the file as needing `local` — which is invalid outside a function and would itself break the script. All 10 findings in the repo were this one false positive. Reformatted the function to multi-line; filed the scanner bug upstream as **forkwright/kanon#3223** with a minimal repro and exact `file:line` citation (`crates/basanos/src/rules/shell.rs:341-348`).
2. **`SHELL/set-euo-pipefail`** — flips `set -uo pipefail` → `set -euo pipefail` in all 16 files, plus the guards that keeps that safe (see below).
3. **`SHELL/strict-mode`** — pure reposition of the pragma to line 2 (right after the shebang, before the header comment), matching the convention already used by `qemu-runner.sh`/`witness-run-all.sh`. This rule counts the literal first 5 lines (unlike its sibling, which allows the first 10 *non-comment* lines), so every script's multi-line header comment pushed it past the window. The rule-pair mismatch itself is already tracked upstream as **forkwright/kanon#2827** (open) — not re-filed.

## Where -e changes behavior, and how each was handled

`set -e` changes behavior, so every script was read for what it does before flipping the flag — per-script reasoning is in the second commit message, summarized here:

- **`witness/{boot,crashloop,forkexec,guard}.sh`** (13 sites): several `x=$(grep -c ...)` / piped `x=$(grep -oE ... | head -1 | grep -oE ...)` assignments read a count/value *before* testing it with a named `FAIL #NNN: ...` message. Verified empirically that under `-e` (+ the pre-existing `pipefail`), an assignment from a zero-match grep aborts the *whole script* at that line — before the intended `test "$x" -eq N || { FAIL...; }` ever runs, replacing a named assertion with a bare abort. Guarded each with `|| true` so the existing test-and-message still fires; same outcome, same diagnostics, verified against direct `set -e` repros before applying.
- **`kernel-clippy.sh`**: the per-feature-pass loop assigned `out=$(...)` inside an `if/elif/else` *body* (not its condition) with a trailing bare `rc=$?`. Verified that under `-e` this specific pattern — assignment failure inside a compound-command body — is NOT exempt (unlike assignment failure on the left of `&&`/`||`, which is exempt and was left alone elsewhere). It would have aborted the script at the *first* red clippy pass, before the remaining feature passes ran and before the aggregate `failures[]` report ever printed — silently defeating the multi-pass visibility #704 built this script for. Restructured to `rc=0` + explicit `|| rc=$?` per branch, matching the pattern `kernel-host-tests.sh` already used correctly.
- **`kernel-host-tests.sh`**: `pass1`/`pass2` were already captured via `|| pass=$?`, so nothing needed to change under `-e` — verified that pattern is `-e`-safe regardless of errexit state. Corrected the accompanying `#616` comment, which had claimed "no `set -e` here" as the reason both test passes run to completion; the explicit capture is what actually guarantees that, independent of whether `-e` is on.
- **`witness/trust-anchor.sh`**: no explicit rc-handling existed for the final `cargo check --features production` build (the actual point of the script) or the `openssl` keygen chain feeding it — without `-e`, a failure there fell through silently to the trailing `"trust-anchor witness: PASS"` echo. Adding `-e` here is a genuine bug fix, not just a lint pragma.
- **Every other flagged script** (`brk`, `exec`, `fork`, `kfault`, `lib`, `metaxu`, `metaxu-negative`, `signal`, `sleep`): no unguarded command exists outside a `||`/`if` context. `-e` added with **no behavior change** — verified line-by-line, no guards needed.

`lib.sh` (sourced, not executed, by every witness script) documents the `|| true` guard pattern once in its contract comment, since several callers needed it and it's better explained in one place than repeated per-file.

## Verification

- `bash -n` on every touched file: clean.
- `shellcheck` on every touched file: identical findings to `origin/main` (SC1091/SC2209/SC2034, all pre-existing) — nothing new introduced.
- `scripts/check-witness-extraction.sh`: passes (no assertion-marker drift into `ci.yml`/`.kanon-ci.toml`).
- `kanon lint . --summary`: counts above.

Refs: #756

## Update: one CI-caught bug in the second commit, fixed in a fourth

The first CI run on this PR failed `kernel (i686 tests + armv7a build)` at the `kernel-clippy.sh` step, after all 9 feature passes compiled clean with zero clippy warnings and no `FAIL:` message printed anywhere.

Root cause: `production_key()` set `PRODUCTION_KEY_DIR` from inside its own body, but every call site invoked it as `THUMOS_BOOT_KEY_PUB="$(production_key)"` — a command substitution, which runs in a subshell. The assignment never reached the script's own shell, so `PRODUCTION_KEY_DIR` stayed `""` there regardless of whether the `production` pass ran. That bug pre-dates this PR (it silently leaked the generated key directory on every run, since `cleanup()`'s `[ -n "$PRODUCTION_KEY_DIR" ]` always read false and never cleaned it up), but was harmless under the old `set -uo pipefail` because a trap's own exit status doesn't normally affect the script's exit code. Under `set -e` it does: a failing command as the *last* thing an EXIT trap runs becomes the whole script's exit status — silently turning a fully green run into a reported failure.

Verified the mechanism in isolation (`bash -e` repros, both directions) and the fix end-to-end by running the real script against a mocked `cargo`/`rustup`/`openssl` PATH — exit 0 after the fix. Fixed in the fourth commit; pushed and re-running CI now.
