### PR TITLE
fix(witness): keep the ephemeral boot key out of a predictable shared path

### DIFF
--- a/scripts/witness/trust-anchor.sh
+++ b/scripts/witness/trust-anchor.sh
@@ -9,14 +9,26 @@ set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
 cd "$KERNEL_DIR"
-if cargo check --release --target armv7a-none-eabi --features production 2>keyless-err.log; then
+
+# WHY every artifact this script writes goes in one private temp dir: the step
+# below generates an ed25519 PRIVATE key, and it used a fixed shared-temp path.
+# That path is world-predictable -- any process on the box can read the key, and
+# one that pre-creates a symlink there redirects the write somewhere of its
+# choosing. `mktemp -d` gives an unpredictable 0700 directory instead, and the
+# EXIT trap removes it even when a check below fails and exits early. The two
+# build logs move here for a duller reason: they were written into the kernel
+# directory, are not gitignored, and left the tree dirty after every local run.
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+if cargo check --release --target armv7a-none-eabi --features production 2>"$work/keyless-err.log"; then
     echo 'FAIL: production build succeeded without THUMOS_BOOT_KEY_PUB'; exit 1
 fi
-grep -q 'THUMOS_BOOT_KEY_PUB' keyless-err.log || { echo 'FAIL: keyless production error lacks provisioning message'; cat keyless-err.log; exit 1; }
-if THUMOS_BOOT_KEY_PUB=keys/dev/boot-dev.pub cargo check --release --target armv7a-none-eabi --features production 2>devkey-err.log; then
+grep -q 'THUMOS_BOOT_KEY_PUB' "$work/keyless-err.log" || { echo 'FAIL: keyless production error lacks provisioning message'; cat "$work/keyless-err.log"; exit 1; }
+if THUMOS_BOOT_KEY_PUB=keys/dev/boot-dev.pub cargo check --release --target armv7a-none-eabi --features production 2>"$work/devkey-err.log"; then
     echo 'FAIL: production build accepted the dev key'; exit 1
 fi
-openssl genpkey -algorithm ed25519 -out /tmp/ci-boot.pem
-openssl pkey -in /tmp/ci-boot.pem -pubout -outform DER | tail -c 32 | od -An -tx1 | tr -d ' \n' > /tmp/ci-boot.pub
-THUMOS_BOOT_KEY_PUB=/tmp/ci-boot.pub cargo check --release --target armv7a-none-eabi --features production
+openssl genpkey -algorithm ed25519 -out "$work/ci-boot.pem"
+openssl pkey -in "$work/ci-boot.pem" -pubout -outform DER | tail -c 32 | od -An -tx1 | tr -d ' \n' > "$work/ci-boot.pub"
+THUMOS_BOOT_KEY_PUB="$work/ci-boot.pub" cargo check --release --target armv7a-none-eabi --features production
 echo "trust-anchor witness: PASS"


### PR DESCRIPTION
`scripts/witness/trust-anchor.sh` generates an **ed25519 private key** to prove a production image builds with a real trust anchor. It wrote that key to a fixed path in the shared temp directory.

## Why that is wrong

```bash
openssl genpkey -algorithm ed25519 -out /tmp/ci-boot.pem
```

- **World-predictable path.** Any process on the box can read the key while the script runs.
- **Symlink-attackable write.** A process that pre-creates a symlink at that path redirects where the private key lands.
- **Never removed.** The key persisted after the script exited, including on failure paths.

This script runs on CI runners *and* locally on a workstation whose temp directory is shared with several concurrent agent sessions. The key is ephemeral and only proves a build guard, so the blast radius is bounded — but a repo built around measured boot should not be the one writing a boot trust anchor to a guessable path.

Found by `SECURITY/hardcoded-tmp` (3 findings, all this file) during a lint triage under #756.

## The fix

Everything the script writes goes into a `mktemp -d` directory — unpredictable name, mode 0700 — removed by an `EXIT` trap so it is cleaned even when an earlier check fails and exits.

The two build logs (`keyless-err.log`, `devkey-err.log`) move there too, for a duller reason: they were written into the kernel directory, are **not gitignored**, and left the working tree dirty after every local run. On a shared clone that dirt is not cosmetic — it blocks operations that legitimately refuse to run against a modified tree.

## Note on the comment

The WHY comment deliberately describes the old path as "a fixed shared-temp path" rather than quoting it. basanos matches rule patterns against comment text — a lint triage this week found `RUST/unwrap` and `RUST/expect` firing on those words inside a comment in `build.rs` — so quoting the literal path would have kept the finding alive in a comment explaining its removal.

Refs: #756