### PR TITLE
fix(ui): clip x in set_pixel, matching eidolon's framebuffer

### DIFF
--- a/crates/thumos/src/ui.rs
+++ b/crates/thumos/src/ui.rs
@@ -1281,8 +1281,7 @@ mod tests {
         let mut fb = [0u16; 4 * 2];
         draw_str(&mut fb, 4, 4, 0, " ", color::BLACK, color::WHITE);
         assert_eq!(
-            fb,
-            [0u16; 8],
+            fb, [0u16; 8],
             "a glyph drawn entirely past fb_width must write nothing -- \
              row 1 must not pick up row 0's overflow"
         );

--- a/crates/thumos/src/ui.rs
+++ b/crates/thumos/src/ui.rs
@@ -326,8 +326,19 @@ pub(crate) mod color {
 
 /// Set a single pixel in a flat `u16` framebuffer.
 ///
-/// Out-of-bounds coordinates are silently ignored.
+/// Out-of-bounds coordinates are silently ignored. `x` is clipped against
+/// `fb_width` explicitly below -- without that check, `x >= fb_width` still
+/// yields a flat index that is valid for every row but the last, so the
+/// pixel would alias into the start of the row below instead of being
+/// dropped (#760). `y` needs no equivalent check here: this function takes
+/// no `fb_height`, so an out-of-range `y` is caught the same way it always
+/// was, by the flat index exceeding `fb.len()`. Matches
+/// `eidolon::framebuffer::Framebuffer::set_pixel`, the other side of the
+/// #545 duplication.
 pub(crate) fn set_pixel(fb: &mut [u16], fb_width: u16, x: u16, y: u16, color: u16) {
+    if x >= fb_width {
+        return;
+    }
     let idx = y as usize * fb_width as usize + x as usize;
     if let Some(px) = fb.get_mut(idx) {
         *px = color;
@@ -384,7 +395,9 @@ pub(crate) fn draw_char(fb: &mut [u16], fb_width: u16, x: u16, y: u16, ch: char,
 /// Render a string starting at pixel position `(x, y)`.
 ///
 /// Characters are placed left-to-right with no wrapping. Out-of-bounds
-/// pixels are clipped by [`set_pixel`].
+/// pixels are clipped by [`set_pixel`], which checks `x` against `fb_width`
+/// explicitly (#760) -- a glyph that runs past the right edge is cut off
+/// there, not bled into the row below.
 pub(crate) fn draw_str(fb: &mut [u16], fb_width: u16, x: u16, y: u16, s: &str, fg: u16, bg: u16) {
     for (i, ch) in s.chars().enumerate() {
         let cx = x.saturating_add((i as u16).saturating_mul(CHAR_WIDTH));
@@ -1249,6 +1262,38 @@ mod tests {
         // Fill that extends past bounds must not panic.
         fill_rect(&mut fb, 10, 10, 5, 5, 100, 100, color::WHITE);
         assert_eq!(fb.len(), 100, "framebuffer size must not change");
+    }
+
+    #[test]
+    fn draw_str_clips_x_instead_of_bleeding_into_next_row() {
+        // Regression for #760: set_pixel computed a flat index from
+        // (x, y) and only bounds-checked the result against fb.len(),
+        // so x >= fb_width landed on a VALID index in the following
+        // row for every row but the last, instead of being dropped.
+        //
+        // 4-wide, 2-row framebuffer. A one-character string drawn at
+        // x == fb_width starts fully past the right edge: every
+        // column the glyph would touch (x + 0..8) is out of bounds.
+        // Space is used because its glyph is all-zero bits, so every
+        // pixel in its 8x16 box resolves to `bg` (WHITE) rather than
+        // `fg` -- an unclipped write is unambiguously visible against
+        // an untouched (0x0000) buffer.
+        let mut fb = [0u16; 4 * 2];
+        draw_str(&mut fb, 4, 4, 0, " ", color::BLACK, color::WHITE);
+        assert_eq!(
+            fb,
+            [0u16; 8],
+            "a glyph drawn entirely past fb_width must write nothing -- \
+             row 1 must not pick up row 0's overflow"
+        );
+
+        // An in-bounds glyph still renders normally in the same framebuffer.
+        draw_str(&mut fb, 4, 0, 0, " ", color::BLACK, color::WHITE);
+        assert_eq!(
+            fb[0],
+            color::WHITE,
+            "an in-bounds glyph must still write its pixels"
+        );
     }
 
     #[test]

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -692,7 +692,7 @@ mechanism = "host"
 
 [[module]]
 name = "ui"
-tests = 23
+tests = 24
 mechanism = "both"
 witness = "boot.sh"
 


### PR DESCRIPTION
## Finding

`set_pixel` computed `idx = y * fb_width + x` and only bounds-checked the
resulting flat index. For any row but the last, `x >= fb_width` still lands
on a *valid* index in the row below, so it was aliased, not clipped. Normal
text rendering reaches it: `draw_char` passes `x.saturating_add(col)`
unclamped into `set_pixel`.

`crates/eidolon/src/framebuffer.rs`'s `Framebuffer::set_pixel` -- the other
side of the #545 duplication -- already checks `x >= self.width` before
computing the index. The two copies of "the same" primitive disagreed in
behaviour, not merely in existence.

## Fix

Added the same `x >= fb_width` check to `set_pixel`, matching eidolon's
version. `y` needed no equivalent change: `set_pixel` takes no `fb_height`,
so an out-of-range `y` was, and still is, caught by the flat index
exceeding `fb.len()`.

Corrected both doc comments that promised clipping the code didn't
perform: `set_pixel`'s own ("Out-of-bounds coordinates are silently
ignored") and `draw_str`'s ("Out-of-bounds pixels are clipped by
`set_pixel`") -- both are now accurate, and `set_pixel`'s spells out why
`x` needs an explicit check while `y` doesn't.

## Test

`set_pixel` had zero test coverage (it appears four times in the file,
none in the test module) -- the only clipping test, `fill_rect_clips_to_bounds`,
covers `fill_rect`, which pre-clamps its loop bounds and never reaches
`set_pixel`'s bug. Added `draw_str_clips_x_instead_of_bleeding_into_next_row`
right beside it, in the same style.

I cannot run `cargo test` on this box (metis policy -- compile work runs on
CI). I traced it by hand instead of claiming a local run:

- 4-wide, 2-row framebuffer (`[0u16; 8]`).
- Draw a one-character string (space -- its glyph is all-zero bits, so
  every pixel resolves to `bg` rather than `fg`, making an unclipped write
  unambiguous against an untouched `0x0000` buffer) at `x == fb_width`, i.e.
  fully past the right edge for every column the glyph would touch
  (`x + 0..8`).
- Before the fix: for the glyph's first pixel row (`py = 0`), columns
  `col = 0..3` give `px = 4..7`, and `idx = py*4 + px = 4..7` -- in bounds,
  landing in row 1's four slots, all set to `0xFFFF`. Columns `col = 4..7`
  give `idx = 8..11`, past `fb.len() = 8`, dropped by `get_mut` regardless.
  So the buggy code leaves row 1 entirely `0xFFFF`.
- After the fix: `x >= fb_width` (`4 >= 4`) is true for every column before
  `idx` is ever computed, so nothing is written and the buffer stays all
  zero.

That's why the test fails before this change and passes after. A second
assertion in the same test draws an in-bounds glyph in the same buffer and
checks it still writes normally.

## Ledger

`docs/target-test-ledger.toml`'s `ui` row: `tests = 23` -> `24` for the new
test (`scripts/check-target-test-ledger.sh` derives the count from
`cargo nextest list` and fails on drift).

Closes #760