### PR TITLE
fix(ci): resolve every kernel/workspace dependency graph with --locked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,12 @@ jobs:
   workspace:
     # WHY: clippy (deny warnings) + the workspace test suite for the 13
     # library crates. Concurrency pinned to 8 per CI.md § kanon-ci caps.
+    #
+    # WHY --locked (#757): without it, a dependency-resolving step silently
+    # regenerates Cargo.lock when a manifest and the committed lock disagree
+    # -- the lock never fails, and whatever drifted in is never scanned by
+    # cargo-audit/cargo-deny. --locked (not --frozen, which also forbids
+    # network) turns that drift into a build failure instead.
     name: workspace clippy + tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -83,15 +89,15 @@ jobs:
         with:
           key: workspace
       - name: clippy
-        run: cargo clippy --workspace --all-targets --jobs 8 -- -D warnings
+        run: cargo clippy --workspace --all-targets --locked --jobs 8 -- -D warnings
       - name: Install cargo-nextest
         run: cargo install cargo-nextest --locked --version ^0.9
       - name: nextest
-        run: cargo nextest run --workspace --build-jobs 8 --test-threads 8
+        run: cargo nextest run --workspace --locked --build-jobs 8 --test-threads 8
       - name: doctests
         # WHY: cargo nextest does not run doctests; this covers them (and is
         # the workspace's `cargo test` gate step).
-        run: cargo test --doc --workspace --jobs 8
+        run: cargo test --doc --workspace --locked --jobs 8
 
   kernel:
     # WHY: the bare-metal kernel is excluded from the workspace, so its host

--- a/.github/workflows/gate-attestation.yml
+++ b/.github/workflows/gate-attestation.yml
@@ -11,7 +11,9 @@
 # trailer and a green full-gate-build attest the identical stages, per the
 # reusable workflow's own contract. --jobs 8 / --build-jobs 8 --test-threads 8
 # match .kanon-ci.toml's concurrency cap (OOM guard on the local gate box;
-# harmless headroom on the hosted runner).
+# harmless headroom on the hosted runner). --locked (#757) must stay in sync
+# with .kanon-ci.toml too -- it is what makes a Cargo.lock inconsistent with
+# its manifests fail here instead of being silently regenerated.
 #
 # NOTE: the excluded bare-metal kernel crate (crates/thumos, `exclude`d from
 # [workspace]) is covered by neither this gate NOR .kanon-ci.toml's fmt/
@@ -57,9 +59,9 @@ jobs:
     uses: forkwright/.github/.github/workflows/hybrid-gate.yml@main
     with:
       fmt_cmd: "cargo fmt --all -- --check"
-      check_cmd: "cargo check --workspace --all-targets --jobs 8"
-      clippy_cmd: "cargo clippy --workspace --all-targets --jobs 8 -- -D warnings"
-      nextest_cmd: "cargo nextest run --workspace --build-jobs 8 --test-threads 8"
+      check_cmd: "cargo check --workspace --all-targets --locked --jobs 8"
+      clippy_cmd: "cargo clippy --workspace --all-targets --locked --jobs 8 -- -D warnings"
+      nextest_cmd: "cargo nextest run --workspace --locked --build-jobs 8 --test-threads 8"
       doctest_cmd: ""
       system_packages: ""
       needs_fleet_repo_token: false

--- a/.kanon-ci.toml
+++ b/.kanon-ci.toml
@@ -49,8 +49,13 @@ stages = [
 cmd = "cargo fmt --all -- --check"
 timeout_secs = 300
 
+# WHY --locked (#757): without it, a dependency-resolving stage silently
+# regenerates Cargo.lock when a manifest and the committed lock disagree --
+# the drift never fails, and whatever it pulled in is never scanned by
+# cargo-audit/cargo-deny. --locked (not --frozen, which also forbids network)
+# turns that drift into a stage failure instead.
 [stages."cargo check"]
-cmd = "cargo check --workspace --all-targets --jobs 8"
+cmd = "cargo check --workspace --all-targets --locked --jobs 8"
 timeout_secs = 900
 
 # WHY (#546): the canonical build is scripts/kernel-build.sh — crates/thumos/
@@ -141,11 +146,11 @@ cmd = "scripts/check-kernel-lockfile-versions.sh"
 timeout_secs = 60
 
 [stages."cargo clippy"]
-cmd = "cargo clippy --workspace --all-targets --jobs 8 -- -D warnings"
+cmd = "cargo clippy --workspace --all-targets --locked --jobs 8 -- -D warnings"
 timeout_secs = 900
 
 [stages."cargo nextest"]
-cmd = "cargo nextest run --workspace --build-jobs 8 --test-threads 8"
+cmd = "cargo nextest run --workspace --locked --build-jobs 8 --test-threads 8"
 timeout_secs = 1800
 
 [stages."kanon lint"]

--- a/crates/thumos/Cargo.lock
+++ b/crates/thumos/Cargo.lock
@@ -255,21 +255,21 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -377,7 +377,6 @@ version = "0.6.2"
 dependencies = [
  "compact_str",
  "ed25519-dalek",
- "eidolon-core",
  "hmac",
  "postcard",
  "serde",
@@ -634,6 +633,7 @@ dependencies = [
  "cbc",
  "compact_str",
  "ed25519-dalek",
+ "eidolon-core",
  "haphe",
  "hkdf",
  "hmac",

--- a/crates/thumos/Cargo.toml
+++ b/crates/thumos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "thumos"
 description = "Thumos kernel: bare-metal Rust OS for the MT6739"
-version = "0.1.0"
+version = "0.6.2"
 edition = "2024"
 license = "AGPL-3.0-only"
 repository = "https://github.com/forkwright/thumos"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -81,6 +81,11 @@
           "type": "toml",
           "path": "crates/thumos/Cargo.lock",
           "jsonpath": "$.package[?(!@.source && @.name != 'thumos')].version"
+        },
+        {
+          "type": "toml",
+          "path": "crates/thumos/Cargo.toml",
+          "jsonpath": "$.package.version"
         }
       ]
     }

--- a/scripts/check-kernel-lockfile-versions.sh
+++ b/scripts/check-kernel-lockfile-versions.sh
@@ -17,8 +17,9 @@ set -euo pipefail
 # An enumeration of things that grow goes stale silently. This check is what
 # makes the staleness loud.
 #
-# WHY `thumos` is exempt: its 0.1.0 in crates/thumos/Cargo.toml is its own
-# version, deliberately not workspace-inherited, so it must NOT track releases.
+# `thumos` is checked like every other first-party crate here (#757):
+# crates/thumos/Cargo.toml's version is now in release-please's rewrite set
+# alongside the lock, so it tracks the workspace version too.
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
@@ -50,8 +51,6 @@ for block in lock.split("[[package]]")[1:]:
     if not name or not ver:
         continue
     if re.search(r"^source\s*=", block, re.M):
-        continue
-    if name.group(1) == "thumos":
         continue
     checked += 1
     if ver.group(1) != want:

--- a/scripts/check-target-test-ledger.sh
+++ b/scripts/check-target-test-ledger.sh
@@ -27,6 +27,10 @@ set -euo pipefail
 # here is a cache hit, not a fresh compile — this stage's placement in the
 # pipeline is load-bearing, not incidental. Invoked standalone with no prior
 # build, this script builds first like any other nextest call.
+#
+# WHY --locked (#757): crates/thumos keeps its own lockfile; without --locked
+# a manifest/lock disagreement here is silently resolved and rewritten
+# instead of failing the build.
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 LEDGER="$REPO_ROOT/docs/target-test-ledger.toml"
@@ -48,13 +52,13 @@ trap 'rm -f "$LIST_DEFAULT" "$LIST_DEBUG" "$LIST_DEFAULT.err" "$LIST_DEBUG.err"'
 # default features, then --features debug-console (the only feature that
 # gates in extra host-testable modules -- console). Their union is the
 # runnable set this ledger is checked against.
-if ! (cd "$KERNEL_DIR" && cargo nextest list --bin thumos --target i686-unknown-linux-gnu \
+if ! (cd "$KERNEL_DIR" && cargo nextest list --bin thumos --target i686-unknown-linux-gnu --locked \
         --build-jobs "${THUMOS_BUILD_JOBS:-8}" --message-format json) >"$LIST_DEFAULT" 2>"$LIST_DEFAULT.err"; then
     cat "$LIST_DEFAULT.err" >&2
     echo "LEDGER DRIFT: cargo nextest list (default features) failed -- cannot derive runnable test counts" >&2
     exit 1
 fi
-if ! (cd "$KERNEL_DIR" && cargo nextest list --bin thumos --target i686-unknown-linux-gnu \
+if ! (cd "$KERNEL_DIR" && cargo nextest list --bin thumos --target i686-unknown-linux-gnu --locked \
         --features debug-console --build-jobs "${THUMOS_BUILD_JOBS:-8}" --message-format json) >"$LIST_DEBUG" 2>"$LIST_DEBUG.err"; then
     cat "$LIST_DEBUG.err" >&2
     echo "LEDGER DRIFT: cargo nextest list (--features debug-console) failed -- cannot derive runnable test counts" >&2

--- a/scripts/kernel-build.sh
+++ b/scripts/kernel-build.sh
@@ -7,6 +7,10 @@ set -euo pipefail
 # release build from the kernel directory. NEVER pass RUSTFLAGS through the
 # environment — env rustflags CLOBBER the config's and silently drop the
 # zero-warning gate (the live drift this script exists to kill).
+#
+# WHY --locked (#757): crates/thumos keeps its own lockfile; without --locked
+# a manifest/lock disagreement here is silently resolved and rewritten
+# instead of failing the build.
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 KERNEL_DIR="${THUMOS_KERNEL_DIR:-$REPO_ROOT/crates/thumos}"
@@ -18,4 +22,4 @@ rustup target list --installed 2>/dev/null | grep -q '^armv7a-none-eabi$' || {
 # WHY the cd: cargo discovers .cargo/config.toml from the INVOCATION cwd, not
 # from --manifest-path's directory. Building from anywhere but the kernel dir
 # silently drops the armv7a target, the link script, and the -D warnings gate.
-(cd "$KERNEL_DIR" && env -u RUSTFLAGS cargo build --release --jobs "${THUMOS_BUILD_JOBS:-8}")
+(cd "$KERNEL_DIR" && env -u RUSTFLAGS cargo build --release --locked --jobs "${THUMOS_BUILD_JOBS:-8}")

--- a/scripts/kernel-clippy.sh
+++ b/scripts/kernel-clippy.sh
@@ -5,6 +5,10 @@ set -euo pipefail
 # excluded from the workspace, so every --workspace clippy invocation in the
 # repo silently skips it. Shared by ci.yml and .kanon-ci.toml so the
 # admission gate and the PR gate execute the identical check.
+#
+# WHY --locked (#757): crates/thumos keeps its own lockfile; without --locked
+# a manifest/lock disagreement here is silently resolved and rewritten
+# instead of failing the build.
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 KERNEL_DIR="${THUMOS_KERNEL_DIR:-$REPO_ROOT/crates/thumos}"
@@ -160,13 +164,13 @@ for i in "${!PASS_TAGS[@]}"; do
     rc=0
     if [[ "$tag" = "production" ]]; then
         ensure_production_key
-        out=$(cd "$KERNEL_DIR" && THUMOS_BOOT_KEY_PUB="$PRODUCTION_KEY_DIR/ci-boot.pub" cargo clippy --bin thumos --tests \
+        out=$(cd "$KERNEL_DIR" && THUMOS_BOOT_KEY_PUB="$PRODUCTION_KEY_DIR/ci-boot.pub" cargo clippy --bin thumos --tests --locked \
             --features "$features" --target i686-unknown-linux-gnu -- -D warnings 2>&1) || rc=$?
     elif [ -n "$features" ]; then
-        out=$(cd "$KERNEL_DIR" && cargo clippy --bin thumos --tests \
+        out=$(cd "$KERNEL_DIR" && cargo clippy --bin thumos --tests --locked \
             --features "$features" --target i686-unknown-linux-gnu -- -D warnings 2>&1) || rc=$?
     else
-        out=$(cd "$KERNEL_DIR" && cargo clippy --bin thumos --tests \
+        out=$(cd "$KERNEL_DIR" && cargo clippy --bin thumos --tests --locked \
             --target i686-unknown-linux-gnu -- -D warnings 2>&1) || rc=$?
     fi
     printf '%s\n' "$out" | sed "s/^/${label}/"

--- a/scripts/kernel-host-tests.sh
+++ b/scripts/kernel-host-tests.sh
@@ -5,6 +5,10 @@ set -euo pipefail
 # is excluded from the workspace, so its host unit tests (i686, u32-faithful
 # ABI) run against the 32-bit target. Shared by ci.yml and .kanon-ci.toml so
 # the admission gate and the PR gate execute the identical suite.
+#
+# WHY --locked (#757): crates/thumos keeps its own lockfile; without --locked
+# a manifest/lock disagreement here is silently resolved and rewritten
+# instead of failing the build.
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 KERNEL_DIR="${THUMOS_KERNEL_DIR:-$REPO_ROOT/crates/thumos}"
@@ -28,7 +32,7 @@ rm -rf "$probe_dir"
 command -v cargo-nextest >/dev/null || { echo "FAIL: cargo-nextest not installed" >&2; exit 1; }
 
 pass1=0
-(cd "$KERNEL_DIR" && cargo nextest run --bin thumos --target i686-unknown-linux-gnu \
+(cd "$KERNEL_DIR" && cargo nextest run --bin thumos --target i686-unknown-linux-gnu --locked \
     --build-jobs "${THUMOS_BUILD_JOBS:-8}" --test-threads "${THUMOS_TEST_THREADS:-8}") || pass1=$?
 
 # WHY (#459): the debug console is now host-testable (heap/page/process stub
@@ -36,7 +40,7 @@ pass1=0
 # second pass runs them — and asserts they actually execute, since this class
 # of bug is "tests never ran" (the gate left them dead source for weeks).
 pass2=0
-out=$(cd "$KERNEL_DIR" && cargo nextest run --bin thumos --target i686-unknown-linux-gnu \
+out=$(cd "$KERNEL_DIR" && cargo nextest run --bin thumos --target i686-unknown-linux-gnu --locked \
     --features debug-console --build-jobs "${THUMOS_BUILD_JOBS:-8}" --test-threads "${THUMOS_TEST_THREADS:-8}" 2>&1) || pass2=$?
 printf '%s\n' "$out"
 # WHY a herestring, not a pipe: under `set -o pipefail`, `printf | grep -q`

--- a/scripts/witness/lib.sh
+++ b/scripts/witness/lib.sh
@@ -43,9 +43,12 @@ witness_deps() {
 }
 
 # build_kernel <feature-flags> — release cross-compile for the qemu board.
+# WHY --locked (#757): crates/thumos keeps its own lockfile; without --locked
+# a manifest/lock disagreement here is silently resolved and rewritten
+# instead of failing the build.
 build_kernel() {
     local features="${1:-qemu}"
-    (cd "$KERNEL_DIR" && cargo build --release --target armv7a-none-eabi --features "$features" --jobs "${THUMOS_BUILD_JOBS:-8}") \
+    (cd "$KERNEL_DIR" && cargo build --release --target armv7a-none-eabi --locked --features "$features" --jobs "${THUMOS_BUILD_JOBS:-8}") \
         || { echo "FAIL: kernel build failed (features=$features)"; exit 1; }
 }
 
@@ -66,8 +69,12 @@ run_qemu() {
 # host socket. Extra args pass through to the pylon-bridge binary (e.g.
 # --tamper-mac, #544 negative-case witness). Sets PYLON_LOG, PYLON_PID,
 # PYLON_PORT for the caller.
+#
+# WHY --locked (#757): this resolves against the root workspace lockfile;
+# without --locked a manifest/lock disagreement is silently resolved and
+# rewritten instead of failing the build.
 start_pylon_bridge() {
-    (cd "$REPO_ROOT" && cargo build --release --features metaxu/pylon-bin --bin pylon-bridge \
+    (cd "$REPO_ROOT" && cargo build --release --locked --features metaxu/pylon-bin --bin pylon-bridge \
         --jobs "${THUMOS_BUILD_JOBS:-8}") \
         || { echo "FAIL: pylon-bridge build failed"; exit 1; }
     local bin="$REPO_ROOT/target/release/pylon-bridge"

--- a/scripts/witness/trust-anchor.sh
+++ b/scripts/witness/trust-anchor.sh
@@ -6,6 +6,10 @@ set -euo pipefail
 # must REFUSE the committed (deliberately public) dev key, and must BUILD
 # with a real key — proven here with an ephemeral one. Dev/qemu/host builds
 # keep building keylessly.
+#
+# WHY --locked (#757): crates/thumos keeps its own lockfile; without --locked
+# a manifest/lock disagreement here is silently resolved and rewritten
+# instead of failing the build.
 source "$(dirname "$0")/lib.sh"
 
 cd "$KERNEL_DIR"
@@ -21,14 +25,14 @@ cd "$KERNEL_DIR"
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 
-if cargo check --release --target armv7a-none-eabi --features production 2>"$work/keyless-err.log"; then
+if cargo check --release --target armv7a-none-eabi --locked --features production 2>"$work/keyless-err.log"; then
     echo 'FAIL: production build succeeded without THUMOS_BOOT_KEY_PUB'; exit 1
 fi
 grep -q 'THUMOS_BOOT_KEY_PUB' "$work/keyless-err.log" || { echo 'FAIL: keyless production error lacks provisioning message'; cat "$work/keyless-err.log"; exit 1; }
-if THUMOS_BOOT_KEY_PUB=keys/dev/boot-dev.pub cargo check --release --target armv7a-none-eabi --features production 2>"$work/devkey-err.log"; then
+if THUMOS_BOOT_KEY_PUB=keys/dev/boot-dev.pub cargo check --release --target armv7a-none-eabi --locked --features production 2>"$work/devkey-err.log"; then
     echo 'FAIL: production build accepted the dev key'; exit 1
 fi
 openssl genpkey -algorithm ed25519 -out "$work/ci-boot.pem"
 openssl pkey -in "$work/ci-boot.pem" -pubout -outform DER | tail -c 32 | od -An -tx1 | tr -d ' \n' > "$work/ci-boot.pub"
-THUMOS_BOOT_KEY_PUB="$work/ci-boot.pub" cargo check --release --target armv7a-none-eabi --features production
+THUMOS_BOOT_KEY_PUB="$work/ci-boot.pub" cargo check --release --target armv7a-none-eabi --locked --features production
 echo "trust-anchor witness: PASS"


### PR DESCRIPTION
Closes #757

## Problem

Nothing in CI resolved dependencies with `--locked`, so a `Cargo.lock` inconsistent with its manifests was silently regenerated during the build and never scanned. #748's criterion benchmark merged green with its entire dependency tree (20+ crates) absent from `Cargo.lock` for a day, invisible to `cargo audit`/`cargo deny`.

## What this does

1. **Syncs `crates/thumos/Cargo.toml`'s version with its lock and covers it in release-please's rewrite set.** The kernel manifest declared `version = "0.1.0"` while `crates/thumos/Cargo.lock` recorded the live release version (release-please rewrites the lock through `extra-files` but never touched the manifest) — `--locked` fails by construction against that asymmetry. Added a `crates/thumos/Cargo.toml` entry to `release-please-config.json`'s `extra-files` (same `toml` + jsonpath pattern already used for the lock) and set the manifest to `0.6.2` to match the lock as it stood.

2. **Adds `--locked` to every dependency-resolving cargo invocation**, in all three places they're declared so no entry point is left uncovered:
   - `.github/workflows/ci.yml` (workspace clippy/nextest/doctests)
   - `.kanon-ci.toml` (the local kanon gate's cargo check/clippy/nextest stages)
   - `.github/workflows/gate-attestation.yml`, which mirrors `.kanon-ci.toml`'s command strings verbatim by its own header comment — an unlisted third entry point that would have made this a half-fix if missed
   - `scripts/kernel-build.sh`, `scripts/kernel-host-tests.sh`, `scripts/kernel-clippy.sh`, `scripts/witness/trust-anchor.sh`, `scripts/witness/lib.sh` (`build_kernel` + `start_pylon_bridge`), `scripts/check-target-test-ledger.sh` — every cargo invocation resolving against `crates/thumos/Cargo.lock` or the root lock via those scripts

   `--locked`, not `--frozen`: `--frozen` also forbids network access, which would break fetching a genuinely new dependency.

3. **Drops `check-kernel-lockfile-versions.sh`'s exemption for `thumos`.** Its premise — "thumos's version is deliberately not workspace-inherited" — is exactly what commit 1 changes; `thumos` is now checked like every other first-party crate in the kernel lock.

## Lockfile consistency, verified before adding the flag

Both lockfiles were checked for consistency with `cargo metadata --locked` (the lightest command that exercises the identical resolver-level lock-consistency check `--locked` triggers in `build`/`check`/`clippy`/`nextest`, without compiling anything — used throughout instead of a real build per this repo's local core-budget constraint):

- **Root `Cargo.lock`**: already consistent, no changes needed.
- **`crates/thumos/Cargo.lock`**: inconsistent, as expected from the version asymmetry. Fixing the manifest version was not sufficient on its own — a conservative `cargo generate-lockfile` (not `cargo update`; 7 lines changed out of ~2500) surfaced a **second, unrelated drift**: the lock had `eidolon-core` misattributed to `metaxu-core`'s dependency list instead of `thumos`'s own, even though `crates/metaxu-core/Cargo.toml` never declared it and `crates/thumos/Cargo.toml` has always declared it directly. Both are now correct; `cargo metadata --locked` passes clean from `crates/thumos/`.

## Proof the flag actually bites

On uncommitted, unpushed changes (reverted immediately after, working tree confirmed clean):

- **Root**: added `[dependencies]\nbstr = "1"` to `crates/eidolon-core/Cargo.toml` (zero-dependency crate) without touching `Cargo.lock`. `cargo metadata --locked` from the repo root failed: `error: cannot update the lock file .../Cargo.lock because --locked was passed to prevent this`. Reverted; passes clean again.
- **Kernel**: added `bstr = "1"` to `crates/haphe/Cargo.toml` (a direct `thumos` path-dependency, empty `[dependencies]` block) without touching `crates/thumos/Cargo.lock`. `cargo metadata --locked` from `crates/thumos/` failed identically. Reverted; passes clean again.

I did **not** run `cargo build`/`check`/`clippy`/`nextest` locally themselves — this repo's local dev box has 8 cores shared with an interactive session, and those subcommands are excluded from local use here. `cargo metadata --locked` triggers the same resolver-level lock-consistency check those subcommands share (it's the same code path, just without compilation), so the failure mode proven above is the same failure mode CI's `--locked` additions will hit on real drift. CI is what runs the actual `build`/`check`/`clippy`/`nextest` invocations end to end.

## Found along the way (not fixed here)

`fuzz/Cargo.lock` is also currently drifted — its three first-party path-dependency entries (`aither`, `asphaleia`, `klesis`) are pinned at `0.1.16` against a `0.6.2` workspace, and two real path-dependencies (`asphaleia-core`, `klesis-core`) are missing from the lock entirely, unscanned by `cargo audit`/`cargo deny` as a result. `release-please-config.json`'s `fuzz/Cargo.lock` selectors still use the pre-#650 enumerated-name pattern (one entry per crate name) that was already proven to miss new path-deps for the kernel lock — but even the three existing entries appear to have never fired across nine releases, which isn't explained by that alone. Scoped out of this PR because it needs an actual regeneration + a real build to verify (not `cargo metadata`), which I can't safely do without running a full build locally. Filed as #768.

## Contradicts / clarifies the issue text

The issue's release-please-config.json snippet implies `crates/thumos/Cargo.lock`'s existing `@.name != 'thumos'` filter successfully excludes `thumos`'s own entry from being rewritten. Checked the actual release history (`git show <release-commit> -- crates/thumos/Cargo.lock`): the `thumos` package's version entry in the lock has in fact been bumped by release-please on every release (0.5.0 → 0.5.1 → 0.6.0 → 0.6.1 → 0.6.2), same as every other first-party crate, despite the `!= 'thumos'` clause. That filter has not been functioning as an exclusion in practice; I left it in place rather than removing it, since it's inert either way and removing it wasn't part of the requested fix.
