### PR TITLE
feat(thumos): render the Ardent boot splash before kardia's first frame

### DIFF
--- a/crates/thumos/src/kinit.rs
+++ b/crates/thumos/src/kinit.rs
@@ -1886,9 +1886,9 @@ pub unsafe fn run() -> ! {
     // heap buffer -- so render_if_dirty actually runs and the UI surface is
     // CI-verifiable in emulation (the render path was dead under qemu before).
     #[cfg(feature = "qemu")]
-    let fb: Option<&'static mut [u16]> = Some(alloc::vec![0u16; FRAMEBUFFER_PIXELS].leak());
+    let mut fb: Option<&'static mut [u16]> = Some(alloc::vec![0u16; FRAMEBUFFER_PIXELS].leak());
     #[cfg(not(feature = "qemu"))]
-    let fb: Option<&'static mut [u16]> = if state.display_ok {
+    let mut fb: Option<&'static mut [u16]> = if state.display_ok {
         // SAFETY: display_ok is set only after display.init(FB_BASE) mapped
         // FB_BASE as a writable RGB565 framebuffer of FRAMEBUFFER_PIXELS pixels.
         Some(unsafe {
@@ -1897,6 +1897,51 @@ pub unsafe fn run() -> ! {
     } else {
         None
     };
+
+    // -----------------------------------------------------------------------
+    // Boot splash (#458)
+    // -----------------------------------------------------------------------
+    // WHY here, not Step 8 (display init): on device the panel is already
+    // live at Step 8 and painting the splash there would hold it on screen
+    // for the whole remaining boot -- but `fb` above is the one binding that
+    // exists identically on BOTH targets (Step 8's DDP/DSI writes are
+    // skipped entirely under qemu, which has no display model; `fb` is a
+    // synthetic heap buffer there instead). Painting here, once, right
+    // before this same buffer is handed to kardia, is the only insertion
+    // point that covers hardware and the CI-verifiable emulation with one
+    // code path, and it runs before kardia's OWN first frame -- the
+    // `render_if_dirty` call at the top of `kardia::service_loop` (#400) --
+    // so the splash is strictly the first thing painted, never a frame
+    // fighting the running UI for the buffer.
+    //
+    // WHY splash-only (never lock screen / status bar / running UI) and
+    // ASCII-through-the-existing-font (never a bitmap asset): see the WHY
+    // block above `ui::draw_splash` -- this is the mark's only call site,
+    // by design.
+    if let Some(fb) = fb.as_deref_mut() {
+        let splash_painted = ui::draw_splash(fb);
+        // Witness marker (#458), qemu-only like every other loop-entry
+        // witness in this boot path (scripts/witness/boot.sh has no
+        // observer on real hardware). WHY `splash_px=` and not
+        // `painted_px=`: the #400 witness extracts its pixel count with an
+        // UNANCHORED `grep -oE 'painted_px=[0-9]+' | head -1` -- a shared
+        // field name would make it silently pick up THIS line instead
+        // (this one lands earlier in the log than kardia's own frame
+        // render), passing while checking the wrong render entirely.
+        #[cfg(feature = "qemu")]
+        boot_log!(
+            serial,
+            "kardia: splash rendered splash_px={splash_painted}\r\n"
+        );
+        // WHY discarded here: real hardware has no CI witness to feed (see
+        // above); this keeps the binding used on both targets without a
+        // leading-underscore name (`_splash_painted` would trip
+        // clippy::used_underscore_binding the moment the qemu branch reads
+        // it, since pedantic is warn-level crate-wide).
+        #[cfg(not(feature = "qemu"))]
+        let _ = splash_painted;
+    }
+
     // #398: bring up the AT/call telephony stack on the modem transport. Under
     // qemu a seeded mock runs the real 10-step init + state machines; on device
     // the CCCI transport (init succeeds only once its wire protocol lands --

--- a/crates/thumos/src/ui.rs
+++ b/crates/thumos/src/ui.rs
@@ -314,6 +314,202 @@ pub(crate) fn draw_scaled_str_centered(
 }
 
 // ---------------------------------------------------------------------------
+// Boot splash (#458)
+// ---------------------------------------------------------------------------
+//
+// WHY splash-only, never lock screen / status bar / running UI: the Ardent
+// mark is a brand element, not a UI affordance -- every OTHER surface in
+// this module (status bar, softkeys, screens) is state the running kernel
+// re-draws every dirty tick, and none of them may grow a dependency on
+// branding. `draw_splash`/`draw_splash_mono` are called from exactly one
+// site (kinit, once, before kardia's first `render_if_dirty`) and nothing
+// else in this crate references [`SPLASH_ROWS`].
+//
+// WHY ASCII-through-the-existing-font, not a bitmap asset: this kernel is
+// bare-metal (`#![no_std]`, no filesystem-backed asset loader) and every
+// byte here ships in the kernel image. A bitmap would need its own decode
+// path, its own pipeline to regenerate from source art, and RGB565 pixel
+// bytes proportional to its resolution; the glyph shape below is a `&str`
+// array the linker folds into `.rodata`, drawn with the same `draw_str`
+// blitter every other kernel string already uses -- zero new kernel bytes
+// beyond the ~180-byte const array itself.
+
+/// Number of character columns the boot splash occupies.
+const SPLASH_COLS: u16 = 15;
+
+/// Number of character rows the boot splash occupies.
+const SPLASH_ROW_COUNT: u16 = 12;
+
+/// Character-cell column the splash's left edge starts at.
+///
+/// Deliberately short of true centering (`(SCREEN_WIDTH / CHAR_WIDTH -
+/// SPLASH_COLS) / 2` would be col 7.5, i.e. col 7 or 8) -- issue #458 fixes
+/// this at col 7 rather than deriving it, so the placement stays exactly
+/// the reviewed art's framing rather than drifting if the panel geometry
+/// ever changes.
+const SPLASH_ORIGIN_COL: u16 = 7;
+
+/// Character-cell row the splash's top edge starts at (see
+/// [`SPLASH_ORIGIN_COL`] -- same reasoning, fixed by #458, not derived).
+const SPLASH_ORIGIN_ROW: u16 = 3;
+
+/// Splash origin in pixels, derived from the character-cell origin and the
+/// canonical font-cell size -- never a raw pixel literal.
+const SPLASH_ORIGIN_X: u16 = SPLASH_ORIGIN_COL * CHAR_WIDTH;
+const SPLASH_ORIGIN_Y: u16 = SPLASH_ORIGIN_ROW * CHAR_HEIGHT;
+
+// The splash must fit inside the panel in character cells. SCREEN_WIDTH/
+// SCREEN_HEIGHT/CHAR_WIDTH/CHAR_HEIGHT are eidolon-core aliases (see the WHY
+// note at the top of this file); this check fails to COMPILE, not just to
+// lint, if the panel geometry ever shrinks under the fixed origin above.
+const _: () = assert!(
+    SPLASH_ORIGIN_COL + SPLASH_COLS <= SCREEN_WIDTH / CHAR_WIDTH,
+    "boot splash exceeds panel width in character cells"
+);
+const _: () = assert!(
+    SPLASH_ORIGIN_ROW + SPLASH_ROW_COUNT <= SCREEN_HEIGHT / CHAR_HEIGHT,
+    "boot splash exceeds panel height in character cells"
+);
+
+/// The Ardent mark, verbatim from issue #458 -- 15 columns x 12 rows,
+/// glyph set `{space, (, ), /, #, *}` (all in the font's 0x20-0x7E range).
+/// Rows are right-padded with spaces to [`SPLASH_COLS`] so every row draws
+/// the same pixel width regardless of its glyph content.
+///
+/// Two properties are load-bearing and must survive any future edit:
+/// - **The lean.** The tip (`*`, row 0) sits at column 12; the base (rows
+///   9-10) sits at column 4. Centering each row independently would erase
+///   this asymmetry and the mark would read as a campfire, not a flame.
+/// - **The inner curl.** The blank cells inside rows 5 and 6 (`(##( #)`,
+///   `(##)##)`) are negative space carving the mark's signature inner void
+///   -- not a misaligned typo to "fix". See
+///   `splash_inner_curl_rows_are_not_typos` below.
+const SPLASH_ROWS: [&str; SPLASH_ROW_COUNT as usize] = [
+    "            *  ",
+    "          /#)  ",
+    "         /##)  ",
+    "        /###)  ",
+    "       (####)  ",
+    "      (##( #)  ",
+    "      (##)##)  ",
+    "     (#####)   ",
+    "     (#####)   ",
+    "    (#####)    ",
+    "    (#####)    ",
+    "     (###)     ",
+];
+
+/// Tip colour (row 0) for the gradient enhancement: pale, warm white -- the
+/// thinnest, brightest part of a flame.
+const SPLASH_TIP_RGB: (u8, u8, u8) = (255, 224, 180);
+
+/// Base colour (last row) for the gradient enhancement: deep red -- the
+/// coolest, densest part of a flame. Deliberately darker than
+/// [`color::RED`] so the gradient reads as depth, not a flat hue swap.
+const SPLASH_BASE_RGB: (u8, u8, u8) = (139, 0, 0);
+
+/// Linear-interpolate one 8-bit colour channel from `a` (row 0) to `b` (the
+/// last row) at `row`. Integer math only -- this is kernel code with no
+/// FPU dependency assumed. `a`/`b` may fall either direction (the tip is
+/// brighter in every channel here, but nothing requires that), so the
+/// intermediate delta is computed in `i32` rather than `u8` to avoid an
+/// underflow panic on a descending channel.
+fn splash_lerp_channel(a: u8, b: u8, row: usize, last_row: usize) -> u8 {
+    let delta = i32::from(b) - i32::from(a);
+    // row <= last_row always (splash_row_color's only caller bounds it via
+    // SPLASH_ROWS' own length), so the result stays within [a, b] and fits
+    // back into u8 without truncation.
+    (i32::from(a) + (delta * row as i32) / last_row as i32) as u8
+}
+
+/// Heat-gradient colour for row `row` of [`SPLASH_ROWS`]: pale at the tip,
+/// deep red at the base. Enhancement over [`draw_splash_mono`]'s single
+/// colour -- per #458, "colour is not the carrier": the mark must read as
+/// a flame in mono first, and this only finishes it.
+fn splash_row_color(row: usize) -> u16 {
+    let last_row = (SPLASH_ROWS.len() - 1).max(1);
+    let (tip_r, tip_g, tip_b) = SPLASH_TIP_RGB;
+    let (base_r, base_g, base_b) = SPLASH_BASE_RGB;
+    color::from_rgb(
+        splash_lerp_channel(tip_r, base_r, row, last_row),
+        splash_lerp_channel(tip_g, base_g, row, last_row),
+        splash_lerp_channel(tip_b, base_b, row, last_row),
+    )
+}
+
+/// Count non-`bg` pixels inside the splash's own bounding box. Scoped to
+/// the box (not a whole-framebuffer scan) so the count is meaningful
+/// regardless of what the rest of `fb` holds -- on device `fb` is a live
+/// hardware framebuffer that may carry stale content outside the splash
+/// region.
+fn splash_painted_pixels(fb: &[u16], fb_width: u16, bg: u16) -> usize {
+    let w = usize::from(SPLASH_COLS) * usize::from(CHAR_WIDTH);
+    let h = usize::from(SPLASH_ROW_COUNT) * usize::from(CHAR_HEIGHT);
+    let mut count = 0;
+    for row in 0..h {
+        let py = usize::from(SPLASH_ORIGIN_Y) + row;
+        for col in 0..w {
+            let px = usize::from(SPLASH_ORIGIN_X) + col;
+            let idx = py * usize::from(fb_width) + px;
+            if fb.get(idx).is_some_and(|&v| v != bg) {
+                count += 1;
+            }
+        }
+    }
+    count
+}
+
+/// Draw every row of [`SPLASH_ROWS`], colouring row `i` with
+/// `color_for_row(i)`. Shared by [`draw_splash_mono`] and [`draw_splash`]
+/// so both draw the identical glyph geometry -- only the colour input
+/// differs.
+fn draw_splash_rows<F>(fb: &mut [u16], fb_width: u16, color_for_row: F, bg: u16)
+where
+    F: Fn(usize) -> u16,
+{
+    for (row, text) in SPLASH_ROWS.iter().copied().enumerate() {
+        let ry = SPLASH_ORIGIN_Y.saturating_add((row as u16).saturating_mul(CHAR_HEIGHT));
+        draw_str(
+            fb,
+            fb_width,
+            SPLASH_ORIGIN_X,
+            ry,
+            text,
+            color_for_row(row),
+            bg,
+        );
+    }
+}
+
+/// Render the boot splash in a single foreground colour.
+///
+/// This is the verified baseline (#458: "the shape must read in a single
+/// foreground colour... implement and verify the single-colour case
+/// first"). [`draw_splash`]'s gradient is built on the identical row/column
+/// geometry this function draws, so a shape regression is visible here
+/// first, independent of colour.
+///
+/// `fb` must be `SCREEN_WIDTH * SCREEN_HEIGHT` pixels (a full-panel
+/// framebuffer, matching [`SCREEN_WIDTH`] as `fb_width`). Returns the
+/// number of non-`bg` pixels painted, for the caller's boot witness.
+pub(crate) fn draw_splash_mono(fb: &mut [u16], fg: u16, bg: u16) -> usize {
+    draw_splash_rows(fb, SCREEN_WIDTH, |_row| fg, bg);
+    splash_painted_pixels(fb, SCREEN_WIDTH, bg)
+}
+
+/// Render the boot splash with the [`splash_row_color`] heat gradient: pale
+/// at the tip, deep red at the base. This is what kinit paints at boot
+/// (#458) -- the gradient is a finish over [`draw_splash_mono`]'s verified
+/// shape, not a different shape.
+///
+/// `fb` must be `SCREEN_WIDTH * SCREEN_HEIGHT` pixels. Returns the number
+/// of non-`bg` pixels painted, for the caller's boot witness.
+pub(crate) fn draw_splash(fb: &mut [u16]) -> usize {
+    draw_splash_rows(fb, SCREEN_WIDTH, splash_row_color, color::BLACK);
+    splash_painted_pixels(fb, SCREEN_WIDTH, color::BLACK)
+}
+
+// ---------------------------------------------------------------------------
 // Input event types (kernel-side, mirroring haphe::input::Key)
 // ---------------------------------------------------------------------------
 
@@ -1306,5 +1502,108 @@ mod tests {
         for (id, expect) in WIRED {
             assert_eq!(screen_kind(id), expect, "{id:?} classification drifted");
         }
+    }
+
+    #[test]
+    fn splash_rows_are_padded_to_15_columns() {
+        for (i, row) in SPLASH_ROWS.iter().enumerate() {
+            assert_eq!(
+                row.chars().count(),
+                usize::from(SPLASH_COLS),
+                "SPLASH_ROWS[{i}] must be padded to {SPLASH_COLS} columns"
+            );
+        }
+    }
+
+    #[test]
+    fn splash_lean_tip_near_col12_base_near_col4() {
+        // #458: "the tip sits near column 12 and the base near column 4 --
+        // that asymmetry is what makes it read as flame rather than
+        // campfire." Pin both ends of the lean directly against the art.
+        let leading_spaces = |row: &str| row.chars().take_while(|&c| c == ' ').count();
+        assert_eq!(
+            leading_spaces(SPLASH_ROWS[0]),
+            12,
+            "tip row (row 0) must start at column 12"
+        );
+        let base_col = SPLASH_ROWS
+            .iter()
+            .copied()
+            .map(leading_spaces)
+            .min()
+            .expect("SPLASH_ROWS is a non-empty const array");
+        assert_eq!(base_col, 4, "the widest (base) row must start at column 4");
+    }
+
+    #[test]
+    fn splash_inner_curl_rows_are_not_typos() {
+        // #458: "the blank cells inside rows 5-6 are negative space
+        // carving the mark's signature inner void. Do not 'fix' them as
+        // typos." Pin the exact glyph content so a future edit that
+        // "aligns" these rows fails here instead of silently flattening
+        // the mark.
+        assert_eq!(
+            SPLASH_ROWS[5].trim_end(),
+            "      (##( #)",
+            "row 5 must keep its inner blank cell (the curl's void)"
+        );
+        assert_eq!(
+            SPLASH_ROWS[6].trim_end(),
+            "      (##)##)",
+            "row 6 must keep its inner closing paren (the curl's void)"
+        );
+    }
+
+    #[test]
+    fn draw_splash_mono_paints_nonzero_pixels() {
+        let mut fb = alloc::vec![0u16; SCREEN_WIDTH as usize * SCREEN_HEIGHT as usize];
+        let painted = draw_splash_mono(&mut fb, color::RED, color::BLACK);
+        assert!(painted > 0, "mono splash must paint visible pixels");
+        assert!(
+            fb.iter().any(|&px| px == color::RED),
+            "mono splash must use the single requested foreground colour"
+        );
+    }
+
+    #[test]
+    fn draw_splash_gradient_paints_same_shape_as_mono() {
+        // #458: "colour is not the carrier" -- the gradient enhancement
+        // must not change WHICH pixels are foreground, only what colour
+        // they are. A shape regression in either function shows up as a
+        // painted-pixel-count mismatch here.
+        let mut fb_mono = alloc::vec![0u16; SCREEN_WIDTH as usize * SCREEN_HEIGHT as usize];
+        let mono_count = draw_splash_mono(&mut fb_mono, color::RED, color::BLACK);
+
+        let mut fb_gradient = alloc::vec![0u16; SCREEN_WIDTH as usize * SCREEN_HEIGHT as usize];
+        let gradient_count = draw_splash(&mut fb_gradient);
+
+        assert_eq!(
+            mono_count, gradient_count,
+            "gradient and mono splash must paint the identical pixel count"
+        );
+        assert!(
+            gradient_count > 0,
+            "gradient splash must paint visible pixels"
+        );
+    }
+
+    #[test]
+    fn draw_splash_stays_out_of_status_and_softkey_zones() {
+        // #458: splash-only -- never the status bar or softkey bar. The
+        // fixed origin (col 7, row 3) must land entirely inside the
+        // content zone; this pins that as a running invariant rather than
+        // leaving it to the compile-time panel-fit check alone (which only
+        // proves the splash fits ON the panel, not that it avoids the
+        // status/softkey bands within it).
+        let top = SPLASH_ORIGIN_Y;
+        let bottom = SPLASH_ORIGIN_Y + SPLASH_ROW_COUNT * CHAR_HEIGHT;
+        assert!(
+            top >= STATUS_BAR_HEIGHT,
+            "splash must start below the status bar"
+        );
+        assert!(
+            bottom <= STATUS_BAR_HEIGHT + CONTENT_HEIGHT,
+            "splash must end above the softkey bar"
+        );
     }
 }

--- a/crates/thumos/src/ui.rs
+++ b/crates/thumos/src/ui.rs
@@ -414,20 +414,30 @@ const SPLASH_BASE_RGB: (u8, u8, u8) = (139, 0, 0);
 /// brighter in every channel here, but nothing requires that), so the
 /// intermediate delta is computed in `i32` rather than `u8` to avoid an
 /// underflow panic on a descending channel.
-fn splash_lerp_channel(a: u8, b: u8, row: usize, last_row: usize) -> u8 {
+fn splash_lerp_channel(a: u8, b: u8, row: u16, last_row: u16) -> u8 {
     let delta = i32::from(b) - i32::from(a);
-    // row <= last_row always (splash_row_color's only caller bounds it via
-    // SPLASH_ROWS' own length), so the result stays within [a, b] and fits
-    // back into u8 without truncation.
-    (i32::from(a) + (delta * row as i32) / last_row as i32) as u8
+    let scaled = i32::from(a) + (delta * i32::from(row)) / i32::from(last_row);
+    // INVARIANT: row <= last_row, so `scaled` stays within [min(a,b), max(a,b)]
+    // -- both u8, so the conversion cannot fail. The else arm is a fail-closed
+    // floor rather than a panic: the kernel denies unwrap/expect on production
+    // paths (#663), and a splash pixel is never worth aborting a boot for.
+    let Ok(channel) = u8::try_from(scaled) else {
+        return b;
+    };
+    channel
 }
 
 /// Heat-gradient colour for row `row` of [`SPLASH_ROWS`]: pale at the tip,
 /// deep red at the base. Enhancement over [`draw_splash_mono`]'s single
 /// colour -- per #458, "colour is not the carrier": the mark must read as
 /// a flame in mono first, and this only finishes it.
-fn splash_row_color(row: usize) -> u16 {
-    let last_row = (SPLASH_ROWS.len() - 1).max(1);
+fn splash_row_color(row: u16) -> u16 {
+    // WHY u16 throughout: SPLASH_ROWS is a dozen rows, so every index fits
+    // losslessly and `i32::from` replaces a `usize as i32` cast that
+    // clippy::cast_possible_wrap denies under the zero-warning gate (#663).
+    let last_row = u16::try_from(SPLASH_ROWS.len().saturating_sub(1))
+        .unwrap_or(1)
+        .max(1);
     let (tip_r, tip_g, tip_b) = SPLASH_TIP_RGB;
     let (base_r, base_g, base_b) = SPLASH_BASE_RGB;
     color::from_rgb(
@@ -465,10 +475,18 @@ fn splash_painted_pixels(fb: &[u16], fb_width: u16, bg: u16) -> usize {
 /// differs.
 fn draw_splash_rows<F>(fb: &mut [u16], fb_width: u16, color_for_row: F, bg: u16)
 where
-    F: Fn(usize) -> u16,
+    F: Fn(u16) -> u16,
 {
-    for (row, text) in SPLASH_ROWS.iter().copied().enumerate() {
-        let ry = SPLASH_ORIGIN_Y.saturating_add((row as u16).saturating_mul(CHAR_HEIGHT));
+    // WHY u16 rather than the enumerate index: the whole splash path is u16 so
+    // it needs no numeric casts, which clippy::cast_possible_wrap and
+    // cast_possible_truncation both deny under the zero-warning gate (#663).
+    // SPLASH_ROWS is a dozen rows, so the conversion cannot fail; breaking is a
+    // fail-closed floor rather than a panic on a decorative surface.
+    for (idx, text) in SPLASH_ROWS.iter().copied().enumerate() {
+        let Ok(row) = u16::try_from(idx) else {
+            break;
+        };
+        let ry = SPLASH_ORIGIN_Y.saturating_add(row.saturating_mul(CHAR_HEIGHT));
         draw_str(
             fb,
             fb_width,

--- a/crates/thumos/src/ui.rs
+++ b/crates/thumos/src/ui.rs
@@ -1560,7 +1560,7 @@ mod tests {
         let painted = draw_splash_mono(&mut fb, color::RED, color::BLACK);
         assert!(painted > 0, "mono splash must paint visible pixels");
         assert!(
-            fb.iter().any(|&px| px == color::RED),
+            fb.contains(&color::RED),
             "mono splash must use the single requested foreground colour"
         );
     }

--- a/docs/capability-inventory.toml
+++ b/docs/capability-inventory.toml
@@ -48,8 +48,8 @@ notes = "NullCodec in emulation; MT6357 codec + BT HCI are hardware-gated."
 id = "ui"
 modules = ["ui", "status_bar", "screen_home"]
 tier = "emulated-mock-proven"
-witness = ["kardia: frame rendered painted_px=", "kardia: nav Home -> Search", "kardia: nav Search -> Home", "kardia: statusbar net=Lte"]
-notes = "Render + input dispatch + navigation through the real screen path (#400)."
+witness = ["kardia: splash rendered splash_px=", "kardia: frame rendered painted_px=", "kardia: nav Home -> Search", "kardia: nav Search -> Home", "kardia: statusbar net=Lte"]
+notes = "Render + input dispatch + navigation through the real screen path (#400). Boot splash (#458) paints once from kinit before kardia's first frame; the mark's only call site -- never the lock screen, status bar, or a running Screen impl."
 
 [[capability]]
 id = "heorte"

--- a/docs/target-test-ledger.toml
+++ b/docs/target-test-ledger.toml
@@ -692,7 +692,7 @@ mechanism = "host"
 
 [[module]]
 name = "ui"
-tests = 24
+tests = 30
 mechanism = "both"
 witness = "boot.sh"
 

--- a/scripts/witness/boot.sh
+++ b/scripts/witness/boot.sh
@@ -32,6 +32,14 @@ grep -q 'shell: hello from userspace' boot.log || { echo 'FAIL #526: /shell did 
 grep -q '2 userspace ELF processes running' boot.log || { echo 'FAIL #526: kinit did not report both userspace processes running'; exit 1; }
 ic=$(grep -c 'init: hello from userspace' boot.log || true); test "$ic" -eq 1 || { echo "FAIL #526: 'init: hello' x$ic (want 1) -- per-process image-frame clobber regressed (#502)"; exit 1; }
 sc=$(grep -c 'shell: hello from userspace' boot.log || true); test "$sc" -eq 1 || { echo "FAIL #526: 'shell: hello' x$sc (want 1) -- per-process image-frame clobber regressed (#502)"; exit 1; }
+# #458 boot splash: kinit paints the Ardent mark once into the same fb
+# kardia is about to hand off to (before kardia's own #400 first-frame
+# render below), proving the splash draw path produces real pixels rather
+# than merely not panicking. `splash_px=` (not `painted_px=`) so this line
+# cannot collide with the #400 check's unanchored painted_px extraction
+# below -- this marker lands earlier in the log than kardia's own render.
+grep -q 'kardia: splash rendered splash_px=' boot.log || { echo 'FAIL #458: boot splash never rendered (splash draw path dead)'; exit 1; }
+spx=$(grep -oE 'splash_px=[0-9]+' boot.log | head -1 | grep -oE '[0-9]+' || true); test "${spx:-0}" -gt 0 || { echo "FAIL #458: boot splash rendered BLANK (splash_px=${spx:-0})"; exit 1; }
 # #400 render foundation through the real screen-dispatch path.
 grep -q 'kardia: frame rendered painted_px=' boot.log || { echo 'FAIL #400: service loop never rendered a frame (render path dead)'; exit 1; }
 px=$(grep -oE 'painted_px=[0-9]+' boot.log | head -1 | grep -oE '[0-9]+' || true); test "${px:-0}" -gt 0 || { echo "FAIL #400: rendered frame is BLANK (painted_px=${px:-0}) -- screen draw produced nothing"; exit 1; }


### PR DESCRIPTION
Closes #458

## What

Renders the Ardent flame mark at the boot splash, per #458's decided design: 15x12 ASCII art (glyph set `{space, (, ), /, #, *}`) drawn through the existing 8x16 kernel font -- no bitmap asset, no new asset pipeline, no kernel bytes beyond a small const array.

## Where it's wired

`crates/thumos/src/kinit.rs`, right after the `fb` binding is resolved (the point where kinit hands the framebuffer to `kardia::service_loop`) and before that handoff. This is the one point in the boot path where a real, pixel-writable framebuffer exists identically on both targets:

- On device, Step 8 (display init) brings up the real GC9306 panel, but that write is entirely skipped under qemu (no DDP/DSI model on `-machine virt`).
- Under qemu, `fb` is a synthetic heap buffer allocated at this same later point instead.

Painting here, once, means the splash is strictly the first thing painted -- before kardia's own first frame (`render_if_dirty` at the top of `service_loop`, #400) -- with one code path covering both hardware and the CI-verifiable emulation, and no delay/displacement of any existing boot step or witness.

## Reuse, not new drawing code

`crates/thumos/src/ui.rs` gets a new "Boot splash (#458)" section built entirely on the existing `draw_str` blitter and the eidolon-core-aliased layout constants (`SCREEN_WIDTH`/`SCREEN_HEIGHT`/`CHAR_WIDTH`/`CHAR_HEIGHT`) -- no new glyph-blitting code, no raw pixel literals for placement (a compile-time assertion fails the build if the fixed origin (col 7, row 3) ever stops fitting the panel).

- `draw_splash_mono` -- single foreground colour, the verified baseline ("colour is not the carrier").
- `draw_splash` -- a pale-tip-to-deep-red heat gradient over the *identical* row geometry, built with the existing `color::from_rgb`. A test (`draw_splash_gradient_paints_same_shape_as_mono`) pins that both paint the same pixel count, so a shape regression in either function fails regardless of which is wired into boot.

Six new unit tests also pin the two properties the design explicitly calls out as load-bearing: the lean (tip at column 12, base at column 4) and the inner-curl negative space in rows 5-6 (asserted against the exact glyph text, not just "some pixels somewhere").

## CI wiring

- New witness marker `kardia: splash rendered splash_px=N`, registered under the `ui` capability in `docs/capability-inventory.toml` and asserted in `scripts/witness/boot.sh`. Verified locally with `scripts/check-wiring-inventory.sh --no-log` (23 witness markers now checked, up from 22).
- Named `splash_px=` rather than `painted_px=` deliberately -- the existing #400 witness extracts its pixel count with an *unanchored* `grep -oE 'painted_px=[0-9]+' | head -1`, and my marker lands earlier in the log than kardia's own frame-render marker, so a shared field name would make that check silently verify the wrong render.
- `docs/target-test-ledger.toml`'s `ui` row updated 24 -> 30 tests for the six additions.

## Not touched

Lock screen, status bar, and every running `Screen` impl -- `draw_splash`/`draw_splash_mono` have exactly one call site (kinit, once), matching the decision that the mark never reaches those surfaces.

## Verification

`cargo fmt --check` clean. Did not run `cargo build`/`test`/`clippy` locally per fleet policy (metis has 8 shared cores) -- pushing for CI, including the QEMU boot witness.