### PR TITLE
feat(lint): enable deny(missing_docs) across the five -core crates

### DIFF
--- a/crates/asphaleia-core/src/lib.rs
+++ b/crates/asphaleia-core/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![deny(missing_docs)]
 //! asphaleia-core: the canonical packet-parse and DNS-surveillance-policy
 //! semantics (#545).
 //!

--- a/crates/klesis-core/src/lib.rs
+++ b/crates/klesis-core/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![deny(missing_docs)]
 //! klesis-core: the canonical GSM-7, SMS-PDU, and AT-response semantics
 //! (#545, #662, #685).
 //!

--- a/crates/metaxu-core/src/lib.rs
+++ b/crates/metaxu-core/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![deny(missing_docs)]
 //! `no_std` + alloc core for the Aletheia/Thumos wire protocol (#544/#545).
 //!
 //! Extracted from `metaxu` so the bare-metal kernel and the `metaxu`
@@ -16,8 +17,27 @@
 
 extern crate alloc;
 
+/// The versioned wire envelope (magic, schema, major/minor, kind,
+/// correlation ID, declared length) that every Aletheia-facing frame
+/// travels inside — validated before any payload allocation or decode.
 pub mod envelope;
+
+/// The encode/decode error type for this crate's wire functions --
+/// deliberately narrower than `metaxu`'s own `Error<E>`, which wraps this
+/// type at the crate boundary rather than re-deriving it.
 pub mod error;
+
+/// Cryptographically verified, expiring capability grants: an Aletheia
+/// runtime's signed, time-bounded authorization for one device to request
+/// specific capabilities, plus the response-authentication key they derive.
 pub mod grants;
+
+/// Wire protocol types for the Aletheia/Thumos bridge: typed task
+/// requests, capability grants, and responses, encoded inside the
+/// versioned [`envelope`].
 pub mod protocol;
+
+/// The authenticated session layer: one mutually authenticated
+/// Thumos-to-Aletheia round trip, built on a verified
+/// [`grants::SignedGrant`] over the versioned [`envelope`].
 pub mod session;

--- a/crates/metaxu-core/src/lib.rs
+++ b/crates/metaxu-core/src/lib.rs
@@ -17,27 +17,33 @@
 
 extern crate alloc;
 
-/// The versioned wire envelope (magic, schema, major/minor, kind,
-/// correlation ID, declared length) that every Aletheia-facing frame
-/// travels inside — validated before any payload allocation or decode.
+/// The versioned wire envelope every Aletheia-facing frame travels inside.
+///
+/// Magic, schema, major/minor, kind, correlation ID, and declared length --
+/// validated before any payload allocation or decode.
 pub mod envelope;
 
-/// The encode/decode error type for this crate's wire functions --
-/// deliberately narrower than `metaxu`'s own `Error<E>`, which wraps this
+/// The encode/decode error type for this crate's wire functions.
+///
+/// Deliberately narrower than `metaxu`'s own `Error<E>`, which wraps this
 /// type at the crate boundary rather than re-deriving it.
 pub mod error;
 
-/// Cryptographically verified, expiring capability grants: an Aletheia
-/// runtime's signed, time-bounded authorization for one device to request
-/// specific capabilities, plus the response-authentication key they derive.
+/// Cryptographically verified, expiring capability grants.
+///
+/// An Aletheia runtime's signed, time-bounded authorization for one device
+/// to request specific capabilities, plus the response-authentication key
+/// they derive.
 pub mod grants;
 
-/// Wire protocol types for the Aletheia/Thumos bridge: typed task
-/// requests, capability grants, and responses, encoded inside the
-/// versioned [`envelope`].
+/// Wire protocol types for the Aletheia/Thumos bridge.
+///
+/// Typed task requests, capability grants, and responses, encoded inside
+/// the versioned [`envelope`].
 pub mod protocol;
 
-/// The authenticated session layer: one mutually authenticated
-/// Thumos-to-Aletheia round trip, built on a verified
+/// The authenticated session layer between Thumos and Aletheia.
+///
+/// One mutually authenticated round trip, built on a verified
 /// [`grants::SignedGrant`] over the versioned [`envelope`].
 pub mod session;

--- a/crates/sema-core/src/lib.rs
+++ b/crates/sema-core/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![deny(missing_docs)]
 //! sema-core: the canonical threat-semantics types (#545).
 //!
 //! This crate is the single home of [`ThreatLevel`], [`Calibration`], and

--- a/crates/topos-core/src/lib.rs
+++ b/crates/topos-core/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![deny(missing_docs)]
 //! topos-core: the canonical NMEA 0183 checksum, coordinate, and fix-quality
 //! semantics (#545).
 //!


### PR DESCRIPTION
## Finding

`ARCHITECTURE/no-deny-missing-docs` flags all five `-core` crates (high severity) under #756: each
is the single shared public API consumed by both the kernel (`crates/thumos`, cross-compiled
bare-metal, excluded from the cargo workspace) and a workspace crate. Nothing enforced that every
public item on that one shared boundary was documented.

## What changed

Added `#![deny(missing_docs)]` to `sema-core`, `klesis-core`, `asphaleia-core`, `topos-core`, and
`metaxu-core`, following `eidolon-core`'s established idiom (the one crate that already carried it).

The finding was narrower than expected: every public item in all five crates already carried a
substantive doc comment (types, fields, enum variants, `# Errors`/`# Panics` sections, and the
WHY-this-exists rationale behind each `-core` split) — evidently written as part of the #545
convergence work. The only actual gap was **metaxu-core's five `pub mod` declarations**
(`envelope`, `error`, `grants`, `protocol`, `session`), which had no doc comment at all; those are
documented in this PR. Everywhere else, this PR is the one-line attribute per crate, gate-verified
by `cargo doc`/`cargo check` denying the lint if anything is ever left undocumented going forward.

Nearly every public item earns its visibility as part of the crate's role as the canonical shared
definition — verified by grepping every borderline "primitive utility" export (`hex_encode`,
`hex_decode`, `gsm7_udh_septets`, `is_valid_dial_byte`, `rssi_to_dbm`, `dbm_to_bars`,
`pack_bcd_digits`, `parse_udh_ports`, ...) against both consuming crates (the workspace crate and
`crates/thumos`); each has real external callers on at least one side. One exception:

**`metaxu_core::grants::hkdf_sha256` is `pub` but has no external caller anywhere in the repo** —
its only call site is internal, from `SignedGrant::response_key` two lines above it in the same
file. Its sibling `response_mac` in the same file is correctly `pub(crate)`; `hkdf_sha256` looks
like the one inconsistency in an otherwise deliberately-scoped module. Left unchanged here
(visibility on a crypto primitive is a different kind of change than adding docs, and this PR's
sole purpose is the doc gate) — flagging rather than narrowing it unasked.

## Commits

One per crate (independently revertible):
- `sema-core`
- `klesis-core`
- `asphaleia-core`
- `topos-core`
- `metaxu-core` (plus the five module docs, then a follow-up fixing a clippy
  `too_long_first_doc_paragraph` failure those docs caused)

## Notes

- All five crates are `no_std` + alloc; no `# Examples` doc-tests were added (matching the existing
  repo idiom for this crate class, and avoiding a `std`-assuming doctest in a `no_std` crate).
- `docs/target-test-ledger.toml` is untouched — these crates aren't kernel modules tracked there,
  and no test count changed (doc comments only, no new `#[test]`s or doctests).
- `cargo fmt -p` run on all five crates; no reformatting was needed.

Refs: #756

