### PR TITLE
ci(dependabot): watch all three cargo graphs and the action pins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,63 @@
+version: 2
+
+# WHY three cargo entries where the rest of the fleet has one: thumos carries
+# three independent dependency graphs, each with its own lockfile. The kernel
+# crate is excluded from the workspace so it can cross-compile bare-metal to
+# armv7a-none-eabi, and fuzz/ declares its own empty [workspace] because
+# cargo-fuzz requires nightly. A config watching only `/` leaves the other two
+# unwatched -- which is how fuzz/Cargo.lock drifted nine releases with two
+# path-dependencies missing entirely, invisible to cargo audit and cargo deny
+# the whole time (#768).
+
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      patch-updates:
+        update-types: [patch]
+      minor-updates:
+        update-types: [minor]
+    reviewers:
+      - forkwright
+
+  # Kernel crate: excluded from the workspace, own Cargo.lock.
+  - package-ecosystem: cargo
+    directory: /crates/thumos
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      patch-updates:
+        update-types: [patch]
+      minor-updates:
+        update-types: [minor]
+    reviewers:
+      - forkwright
+
+  # Fuzz targets: own [workspace], own Cargo.lock, nightly-only.
+  - package-ecosystem: cargo
+    directory: /fuzz
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      patch-updates:
+        update-types: [patch]
+      minor-updates:
+        update-types: [minor]
+    reviewers:
+      - forkwright
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        update-types: [minor, patch]


### PR DESCRIPTION
thumos had no dependabot config at all, so nothing watched any of its dependency graphs and nothing watched its GitHub Actions pins. No dependabot PR has ever been opened against this repo.

That is not a theoretical gap. All three lockfiles had drift-with-blind-audit-surface defects surface within one day, every one caught by hand: fuzz/Cargo.lock had drifted nine releases and was missing two path-dependencies entirely, so cargo audit and cargo deny never scanned whatever they pull in (#768); the root and kernel lockfiles were silently regenerable until --locked was added across CI (#757).

Copying the fleet template verbatim would have repeated the exact miss, because it watches the root directory only. thumos has three independent cargo graphs: the workspace root, the kernel crate excluded from the workspace so it can cross-compile bare-metal, and fuzz which declares its own workspace for nightly. Each has its own lockfile and each needs its own entry. The reason is stated in the file, since it is the non-obvious part.

The github-actions entry also closes the action-pin drift noted in #773: every thumos workflow pins actions/checkout at v6 while the shared reusable workflows it calls are on v7, so one pull request currently runs two majors of the same action. Dependabot now carries that forward rather than a human noticing.

Closes #773
