### PR TITLE
chore(deps): bump the remaining four crates and enforce literal pin parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,17 @@ jobs:
         # own "fastest check first" rule rather than waiting behind the
         # kernel job's ~20-minute build+QEMU-witness chain for nothing.
         run: scripts/check-doc-inventory.sh
+      - name: Literal pin parity
+        # WHY: crates/metaxu-core and crates/thumos cannot inherit every
+        # dependency -- the first needs `default-features = false` (which
+        # cargo refuses as a member override), the second is excluded from
+        # the workspace entirely -- so both restate versions the workspace
+        # also declares. metaxu-core's header asserts those match; it has
+        # been false twice (ed25519-dalek 2 vs 3, compact_str 0.8 vs 0.10),
+        # and two majors of one crate are two distinct types across a
+        # boundary these crates exchange values over. Source-level and
+        # cheap, so it rides in the fastest job like the check above.
+        run: scripts/check-pin-parity.sh
 
   workspace:
     # WHY: clippy (deny warnings) + the workspace test suite for the 13

--- a/.kanon-ci.toml
+++ b/.kanon-ci.toml
@@ -33,6 +33,7 @@ stages = [
     "kernel qemu witnesses",
     "wiring inventory",
     "doc inventory",
+    "pin parity",
     "kernel lockfile versions",
     "fuzz lockfile versions",
     "target test ledger",
@@ -136,6 +137,16 @@ timeout_secs = 300
 [stages."doc inventory"]
 cmd = "scripts/check-doc-inventory.sh"
 timeout_secs = 300
+
+# WHY: metaxu-core and the excluded kernel crate cannot inherit every
+# dependency, so both restate versions the workspace also declares.
+# metaxu-core's header asserts they match exactly; that was false twice in one
+# day (ed25519-dalek 2 against a workspace on 3, compact_str 0.8 against 0.10)
+# and two majors of one crate are two distinct types across a boundary these
+# crates exchange values over. Source-level, cheap.
+[stages."pin parity"]
+cmd = "scripts/check-pin-parity.sh"
+timeout_secs = 120
 
 # WHY (#688): crates/thumos is excluded from the workspace and carries its own
 # lockfile. release-please updates it through an explicit selector that once

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,6 +287,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79fcda08c33bb58b97008b2cdada6622500e949e060f5913361763121abd2416"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "serde",
+ "static_assertions",
+ "zmij",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.8.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
 dependencies = [
  "hash32 0.3.1",
  "stable_deref_trait",
@@ -1054,7 +1068,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 name = "metaxu"
 version = "0.7.1"
 dependencies = [
- "compact_str",
+ "compact_str 0.10.0",
  "ed25519-dalek",
  "hmac",
  "metaxu-core",
@@ -1069,7 +1083,7 @@ dependencies = [
 name = "metaxu-core"
 version = "0.7.1"
 dependencies = [
- "compact_str",
+ "compact_str 0.8.1",
  "ed25519-dalek",
  "hmac",
  "postcard",
@@ -1606,31 +1620,31 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smoltcp"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad095989c1533c1c266d9b1e8d70a1329dd3723c3edac6d03bbd67e7bf6f4bb"
+checksum = "5f73d40463bba65efc9adc6370b56df76d563cc46e2482bba58351b4afb7535e"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",
  "cfg-if",
- "heapless 0.8.0",
+ "heapless 0.9.3",
  "managed",
 ]
 
 [[package]]
 name = "snafu"
-version = "0.8.9"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+checksum = "e45cb604038abb7b926b679887b3226d8d0f23874b66623625a0454be425a4b7"
 dependencies = [
  "snafu-derive",
 ]
 
 [[package]]
 name = "snafu-derive"
-version = "0.8.9"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+checksum = "287f59010008f0d7cf5e3b03196d666c1acc46c8d3e9cf34c28a1a7157601e72"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1812,9 +1826,9 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ulid"
-version = "1.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+checksum = "947dde63b6d514cc5e044edad4e0ca7261afd1099d16c83d942cb2b2f348689c"
 dependencies = [
  "web-time",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,21 +273,6 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
-dependencies = [
- "castaway",
- "cfg-if",
- "itoa",
- "rustversion",
- "ryu",
- "serde",
- "static_assertions",
-]
-
-[[package]]
-name = "compact_str"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79fcda08c33bb58b97008b2cdada6622500e949e060f5913361763121abd2416"
@@ -1068,7 +1053,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 name = "metaxu"
 version = "0.7.1"
 dependencies = [
- "compact_str 0.10.0",
+ "compact_str",
  "ed25519-dalek",
  "hmac",
  "metaxu-core",
@@ -1083,7 +1068,7 @@ dependencies = [
 name = "metaxu-core"
 version = "0.7.1"
 dependencies = [
- "compact_str 0.8.1",
+ "compact_str",
  "ed25519-dalek",
  "hmac",
  "postcard",
@@ -1457,12 +1442,6 @@ dependencies = [
  "tempfile",
  "wait-timeout",
 ]
-
-[[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ sha2 = "0.11"
 x25519-dalek = { version = "3", features = ["static_secrets", "zeroize"] }
 
 # Networking
-smoltcp = { version = "0.12", default-features = false, features = [
+smoltcp = { version = "0.13", default-features = false, features = [
     "medium-ethernet",
     "proto-ipv4",
     "proto-ipv6",
@@ -111,17 +111,17 @@ serde = { version = "1", features = ["derive"] }
 postcard = { version = "1", features = ["alloc"] }
 
 # Errors
-snafu = "0.8"
+snafu = "0.9"
 
 # Logging
 log = "0.4"
 
 # Time
 jiff = "0.2"
-ulid = { version = "1", default-features = false }
+ulid = { version = "3", default-features = false }
 
 # Strings
-compact_str = "0.8"
+compact_str = "0.10"
 
 # Async (for userspace daemons)
 tokio = { version = "1", features = [

--- a/crates/metaxu-core/Cargo.toml
+++ b/crates/metaxu-core/Cargo.toml
@@ -18,7 +18,7 @@ repository.workspace = true
 # declaration already sets `default-features = false` (metaxu's own
 # no-override need, pre-dating this crate).
 [dependencies]
-compact_str = { version = "0.8", default-features = false, features = [
+compact_str = { version = "0.10", default-features = false, features = [
     "serde",
 ] }
 ed25519-dalek = { version = "3", default-features = false, features = [

--- a/crates/thumos/Cargo.lock
+++ b/crates/thumos/Cargo.lock
@@ -110,21 +110,6 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
-dependencies = [
- "castaway",
- "cfg-if",
- "itoa",
- "rustversion",
- "ryu",
- "serde",
- "static_assertions",
-]
-
-[[package]]
-name = "compact_str"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79fcda08c33bb58b97008b2cdada6622500e949e060f5913361763121abd2416"
@@ -414,7 +399,7 @@ checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 name = "metaxu-core"
 version = "0.7.1"
 dependencies = [
- "compact_str 0.8.2",
+ "compact_str",
  "ed25519-dalek",
  "hmac",
  "postcard",
@@ -513,12 +498,6 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
-
-[[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sema-core"
@@ -680,7 +659,7 @@ dependencies = [
  "aes",
  "asphaleia-core",
  "cbc",
- "compact_str 0.10.0",
+ "compact_str",
  "ed25519-dalek",
  "eidolon-core",
  "haphe",

--- a/crates/thumos/Cargo.lock
+++ b/crates/thumos/Cargo.lock
@@ -124,6 +124,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79fcda08c33bb58b97008b2cdada6622500e949e060f5913361763121abd2416"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "serde",
+ "static_assertions",
+ "zmij",
+]
+
+[[package]]
 name = "cpubits"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.8.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
 dependencies = [
  "hash32",
  "stable_deref_trait",
@@ -400,7 +414,7 @@ checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 name = "metaxu-core"
 version = "0.7.1"
 dependencies = [
- "compact_str",
+ "compact_str 0.8.2",
  "ed25519-dalek",
  "hmac",
  "postcard",
@@ -587,9 +601,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smoltcp"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad095989c1533c1c266d9b1e8d70a1329dd3723c3edac6d03bbd67e7bf6f4bb"
+checksum = "5f73d40463bba65efc9adc6370b56df76d563cc46e2482bba58351b4afb7535e"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -666,7 +680,7 @@ dependencies = [
  "aes",
  "asphaleia-core",
  "cbc",
- "compact_str",
+ "compact_str 0.10.0",
  "ed25519-dalek",
  "eidolon-core",
  "haphe",
@@ -700,9 +714,9 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ulid"
-version = "1.2.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+checksum = "947dde63b6d514cc5e044edad4e0ca7261afd1099d16c83d942cb2b2f348689c"
 dependencies = [
  "web-time",
 ]
@@ -796,3 +810,9 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/crates/thumos/Cargo.toml
+++ b/crates/thumos/Cargo.toml
@@ -123,10 +123,10 @@ metaxu-core = { path = "../metaxu-core", default-features = false }
 # dependency's types without declaring the dependency itself. Versions
 # match metaxu-core's workspace pins (compact_str "0.8", ulid "1"
 # default-features=false).
-compact_str = { version = "0.8", default-features = false, features = [
+compact_str = { version = "0.10", default-features = false, features = [
     "serde",
 ] }
-ulid = { version = "1", default-features = false }
+ulid = { version = "3", default-features = false }
 ed25519-dalek = { version = "3", default-features = false, features = [
     "digest",
     "serde",
@@ -143,7 +143,7 @@ serde = { version = "1", default-features = false, features = [
     "derive",
     "alloc",
 ] }
-smoltcp = { version = "0.12", default-features = false, features = [
+smoltcp = { version = "0.13", default-features = false, features = [
     "medium-ethernet",
     "proto-ipv4",
     "socket-tcp",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -182,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.8.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
 dependencies = [
  "hash32",
  "stable_deref_trait",
@@ -370,9 +370,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "smoltcp"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad095989c1533c1c266d9b1e8d70a1329dd3723c3edac6d03bbd67e7bf6f4bb"
+checksum = "5f73d40463bba65efc9adc6370b56df76d563cc46e2482bba58351b4afb7535e"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",
@@ -383,18 +383,18 @@ dependencies = [
 
 [[package]]
 name = "snafu"
-version = "0.8.9"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+checksum = "e45cb604038abb7b926b679887b3226d8d0f23874b66623625a0454be425a4b7"
 dependencies = [
  "snafu-derive",
 ]
 
 [[package]]
 name = "snafu-derive"
-version = "0.8.9"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+checksum = "287f59010008f0d7cf5e3b03196d666c1acc46c8d3e9cf34c28a1a7157601e72"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/scripts/check-pin-parity.sh
+++ b/scripts/check-pin-parity.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check-pin-parity.sh — a crate that pins a dependency LITERALLY must pin the
+# same version the workspace declares for it.
+#
+# WHY this exists: two crates cannot use `{ workspace = true }` for everything.
+# `crates/metaxu-core` needs `default-features = false` on several deps and
+# cargo refuses a member override of the workspace's `default-features`, so it
+# spells six dependencies out by hand. `crates/thumos` is excluded from the
+# workspace entirely (it cross-compiles bare-metal), so inheritance is not
+# available to it at all. Both therefore restate versions the workspace also
+# declares, and metaxu-core's own header asserts the invariant this script
+# enforces: "Versions match the workspace pins exactly."
+#
+# WHY it is a check rather than a comment: that sentence was already written
+# and was already false, twice in one day. When the RustCrypto wave moved the
+# workspace to ed25519-dalek 3, metaxu-core stayed on 2; when the following
+# wave moved compact_str to 0.10, metaxu-core stayed on 0.8. Neither is a
+# harmless lag — metaxu and metaxu-core exchange `SignedGrant`, `SigningKey`
+# and `CompactString` values, and two majors of the same crate are two
+# distinct types that do not typecheck across that boundary. Both were caught
+# by noticing duplicate majors in the lockfile, which is luck rather than
+# process: a dependency bump that happens not to be exchanged across a crate
+# boundary would drift silently and indefinitely.
+#
+# A grep is not sufficient and was the first thing that failed here: a pattern
+# matching `name = "1.2"` misses `name = { version = "1.2", ... }`, which is
+# the form every one of these pins actually uses.
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+python3 - "$repo_root" <<'PY'
+import re
+import sys
+import pathlib
+
+root = pathlib.Path(sys.argv[1])
+
+def parse_deps(text, section_names):
+    """Map dependency name -> literal version string, for one manifest."""
+    out = {}
+    section = None
+    for raw in text.splitlines():
+        line = raw.strip()
+        if line.startswith("[") and line.endswith("]"):
+            section = line[1:-1]
+            continue
+        if section not in section_names:
+            continue
+        m = re.match(r'^([A-Za-z0-9_-]+)\s*=\s*(.*)$', line)
+        if not m:
+            continue
+        name, rhs = m.group(1), m.group(2)
+        if "workspace" in rhs and "true" in rhs:
+            continue
+        vm = re.search(r'version\s*=\s*"([^"]+)"', rhs)
+        if not vm:
+            vm = re.match(r'^"([^"]+)"', rhs)
+        if vm:
+            out[name] = vm.group(1)
+    return out
+
+ws_text = (root / "Cargo.toml").read_text(encoding="utf-8")
+workspace = parse_deps(ws_text, {"workspace.dependencies"})
+if not workspace:
+    sys.exit("check-pin-parity: no [workspace.dependencies] found — refusing to pass vacuously")
+
+manifests = sorted(root.glob("crates/*/Cargo.toml"))
+drift = []
+checked = 0
+
+for man in manifests:
+    text = man.read_text(encoding="utf-8")
+    local = parse_deps(text, {"dependencies", "dev-dependencies", "build-dependencies"})
+    rel = man.relative_to(root)
+    for name, ver in sorted(local.items()):
+        if name not in workspace:
+            continue          # crate-only dependency; nothing to agree with
+        checked += 1
+        if ver != workspace[name]:
+            drift.append(f"  {rel}: {name} = \"{ver}\"  but workspace declares \"{workspace[name]}\"")
+
+print(f"== pin parity: {checked} literal pin(s) checked against {len(workspace)} workspace declarations ==")
+
+if checked == 0:
+    sys.exit("check-pin-parity: zero pins compared — the parser matched nothing, which is a defect in this script rather than a clean tree")
+
+if drift:
+    print("PIN DRIFT: a crate pins a version the workspace does not declare.")
+    print("These are the same type to a reader and different types to the compiler.")
+    print()
+    for d in drift:
+        print(d)
+    sys.exit(1)
+
+print("all literal pins agree with the workspace")
+PY


### PR DESCRIPTION
- **chore(deps): bump the four remaining independent crates**
- **chore(deps): bump compact_str, smoltcp, ulid and snafu across all graphs**
- **feat(ci): enforce that a literal dependency pin matches the workspace**
