### PR TITLE
ci(gate): bump the shared hybrid-gate pin to pick up the docs_only output

### DIFF
--- a/.github/workflows/gate-attestation.yml
+++ b/.github/workflows/gate-attestation.yml
@@ -67,7 +67,7 @@ permissions:
 
 jobs:
   gate:
-    uses: forkwright/.github/.github/workflows/hybrid-gate.yml@54f1af7c711546304409593695e1258a91004453 # main
+    uses: forkwright/.github/.github/workflows/hybrid-gate.yml@230c932fd8a44f96ef0e81a93f4d83d5c674e84a # main
     with:
       fmt_cmd: "cargo fmt --all -- --check"
       check_cmd: "cargo check --workspace --all-targets --locked --jobs 8"


### PR DESCRIPTION
ci(gate): bump the shared hybrid-gate pin to pick up the docs_only output

forkwright/.github#35 exposes `docs_only` as a `workflow_call` output, built
in response to thumos#775 after I declined to reimplement the path
classification locally. Adopters pin by SHA, so each repo needs its own bump.

Purely additive on this side: no caller behaviour changes, and nothing here
consumes the output yet. Bumping first so the capability is available and the
pin does not drift further — it was already a release behind.

Consuming it is a separate change and a larger one, deliberately not folded in
here. thumos's expensive job (`kernel (i686 tests + armv7a build)`) lives in
`ci.yml` while the hybrid-gate call lives in `gate-attestation.yml`, and a job
cannot `needs:` across workflow files. Making the required check read
`docs_only` therefore means restructuring where that job lives — and it is a
REQUIRED context, so getting it wrong leaves the check never reporting and
strands every PR. That earns its own PR and its own verification.

Two constraints from the output's own description, recorded here so the
consuming change does not have to rediscover them: the value is EMPTY, not
`false`, when check-trailer reaches no verdict, so only the literal `'true'`
may be acted on; and the guard must gate the expensive STEPS rather than the
job, because a required check that can pass vacuously is worse than a slow one.
