### PR TITLE
fix(ci): pin parity was blind to the dotted-header dependency form

### DIFF
--- a/scripts/check-pin-parity.sh
+++ b/scripts/check-pin-parity.sh
@@ -38,13 +38,34 @@ import pathlib
 root = pathlib.Path(sys.argv[1])
 
 def parse_deps(text, section_names):
-    """Map dependency name -> literal version string, for one manifest."""
+    """Map dependency name -> literal version string, for one manifest.
+
+    WHY three forms and not two: TOML lets a dependency be declared as a bare
+    string (`name = "1"`), an inline table (`name = { version = "1", ... }`),
+    OR as its own dotted-header table (`[workspace.dependencies.name]` with
+    `version = "1"` beneath). A parser keyed on an exact section name sees only
+    the first two and silently drops every dep declared the third way -- which
+    is the same shape as the defect this whole check exists to catch, one level
+    up: a scanner that misses a valid spelling and reports green. aletheia
+    declares `regex` and `serde` this way today, so the form is in live fleet
+    use, not hypothetical.
+    """
     out = {}
     section = None
+    dotted = None          # dep name when inside [<section>.<name>]
     for raw in text.splitlines():
         line = raw.strip()
         if line.startswith("[") and line.endswith("]"):
             section = line[1:-1]
+            dotted = None
+            for base in section_names:
+                if section.startswith(base + "."):
+                    dotted = section[len(base) + 1:].strip('"')
+            continue
+        if dotted is not None:
+            vm = re.match(r'^version\s*=\s*"([^"]+)"', line)
+            if vm:
+                out[dotted] = vm.group(1)
             continue
         if section not in section_names:
             continue


### PR DESCRIPTION
fix(ci): pin parity was blind to the dotted-header dependency form

TOML lets a dependency be declared three ways: a bare string
(`name = "1"`), an inline table (`name = { version = "1", ... }`), or its own
dotted-header table (`[workspace.dependencies.name]` with `version` beneath).
The parser keyed on an exact section name, so it saw the first two and
silently dropped every dep declared the third way.

That is the same defect this check exists to catch, one level up: a scanner
that misses a valid spelling and reports green. It is also the second time
today the same shape has bitten — the convergence ratchet's detector missed
every phrasing other than one literal string, and the first pin sweep in this
repo used a regex matching only the bare-string form and declared the tree
clean while a stale `compact_str` pin sat in `metaxu-core`.

The form is in live fleet use, not hypothetical: aletheia's workspace declares
`regex` and `serde` this way. thumos does not today, which is exactly why this
was worth fixing now rather than after someone adds one and the check quietly
stops covering it.

Verified in both directions. On the real tree: 17 pins against 22 workspace
declarations, passing. With a `[workspace.dependencies.probecrate]` header
added and a disagreeing literal pin in `metaxu-core`, the declaration count
rises to 23 — the dotted entry is now seen — and the drift is caught by name.
Before this change the count stayed at 22 and the pin was invisible.
