### PR TITLE
ci: align action pins with the fleet, and make the auto-merge guard guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false # PROJECT: never expose the token to steps
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -134,7 +134,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
       security-events: write
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Initialize CodeQL
@@ -43,7 +43,7 @@ jobs:
       security-events: write
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Set up Rust toolchain

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -28,9 +28,16 @@ jobs:
           (steps.metadata.outputs.update-type == 'version-update:semver-minor' &&
            steps.metadata.outputs.dependency-type == 'direct:development')
         run: |
+          # WHY exit 1 and not 0: this step is a GUARD, and `exit 0` made it
+          # succeed. The two merge steps below gate only on
+          # `steps.metadata.outputs.update-type`, never on this step's outcome,
+          # and Actions skips a later step only when an earlier one FAILS. So
+          # the old code printed "skipping auto-merge" and then merged anyway.
+          # Branch protection still refused the merge, which is why nothing bad
+          # landed -- but the guard contributed no defence while claiming to.
           if ! gh pr checks "$PR_URL" --watch --interval 30 --required; then
-            echo "Required CI checks did not pass — skipping auto-merge"
-            exit 0
+            echo "Required CI checks did not pass; refusing auto-merge." >&2
+            exit 1
           fi
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -40,7 +40,7 @@ jobs:
           - fuzz_pdu
           - fuzz_wpa
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # nightly

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Validate PR title

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,7 +33,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v4
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           config-file: release-please-config.json
@@ -78,7 +78,7 @@ jobs:
       # path-safety entirely rather than sanitizing it.
       RELEASE_LABEL: ${{ needs.release-please.outputs.tag_name || format('dispatch-{0}', github.run_id) }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.ATTEST_REF }}
           persist-credentials: false
@@ -184,7 +184,7 @@ jobs:
           done
       - name: Attest source tarball provenance
         if: ${{ env.IS_RELEASE == 'true' }}
-        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v2
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: thumos-*.tar.gz
       # NOTE: two calls, not one glob -- sbom-path takes exactly one file,
@@ -193,13 +193,13 @@ jobs:
       # each need their own attestation call.
       - name: Attest workspace CycloneDX SBOM
         if: ${{ env.IS_RELEASE == 'true' }}
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v2
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
         with:
           subject-path: thumos-*.tar.gz
           sbom-path: sbom-workspace.cdx.json
       - name: Attest kernel CycloneDX SBOM
         if: ${{ env.IS_RELEASE == 'true' }}
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v2
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
         with:
           subject-path: thumos-*.tar.gz
           sbom-path: sbom-kernel.cdx.json

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false # PROJECT: security hardening — never expose token to steps
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -97,7 +97,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Install osv-scanner (pinned + checksum-verified)

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v10
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           stale-issue-message: >
             This issue has been inactive for 60 days. It will be closed in 14 days


### PR DESCRIPTION
ci: align action pins with the fleet, and make the auto-merge guard guard

Three things, smallest blast radius first.

**The auto-merge guard did not guard.** `dependabot-auto-merge.yml`'s "Wait for
CI checks to pass" step printed "skipping auto-merge" and then `exit 0`, which
makes the STEP SUCCEED. The two merge steps below it gate only on
`steps.metadata.outputs.update-type` — never on this step's outcome — and
Actions skips a later step only when an earlier one FAILS. So on a red required
check the workflow announced that it was skipping, and then ran
`gh pr merge --squash` anyway.

Nothing bad has landed, and the reason is worth stating precisely rather than
claiming a near-miss: branch protection (`strict`, `enforce_admins`, five
required contexts) refused the merge every time. The defect is that this guard
contributed no defence-in-depth while its own message asserted otherwise — a
check that reports a verdict it never enforced. `exit 1` now.

This is not a thumos-only bug. harmonia and the shared reusable in
forkwright/.github both carry the fix with a WHY comment naming this exact
failure mode; thumos's copy predates them. epistole and akroasis still have the
unfixed version, routed to their owners separately.

**actions/checkout was a major behind, everywhere.** 11 sites across 6
workflows on `de0fac2e` (v6.0.2) while every other sampled fleet repo pins
`3d3c42e5` (v7.0.1). Verified against the upstream tag ref directly rather than
copied from a report.

**Five version comments had rotted off current SHAs.** release-please-action
labelled `# v4` on the v5.0.0 commit, attest-build-provenance `# v2` on v4.2.2,
attest-sbom `# v2` on v4.1.0 (twice), actions/stale `# v10` on v11.0.0. The
pins themselves were already correct and match the fleet — only the labels
lied, which is worse than being behind: a reader checking currency by comment
concludes the repo is three majors stale when it is current.

Deliberately NOT in this change, each for a stated reason:

- The `dtolnay/rust-toolchain` to `actions-rust-lang/setup-rust-toolchain`
  migration. It is 7 sites across 4 files and changes each job's `with:` block
  shape, including the REQUIRED `kernel (i686 tests + armv7a build)` job's
  dual-target install (`targets:` is `target:` in the fleet action) and a real
  behaviour change in release-please.yml, where bare `stable` becomes the
  toolchain pinned in `rust-toolchain.toml`. That earns its own PR.
- `codeql.yml`'s `dtolnay` pin, which is deliberate: the shared reusable CodeQL
  workflow uses the identical action for the same reason — autobuild is a
  one-shot compile with no cache benefit.
- The `cargo install cargo-deny/cargo-audit --version ^0.20` install method,
  which contradicts kanon#2385's prebuilt-binary lesson. Bounded, evidenced,
  and independent — separate PR.
- osv-scanner's direct pinned download rather than the shared reusable, which
  `security.yml` already explains: the org Actions policy rejects cross-org
  reusable workflows and start-up-failed the whole Security workflow when tried.
  A stated reason, so it stays.
