### PR TITLE
ci: adopt the fleet's Rust setup and prebuilt audit tools, and build the kernel in one place

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,18 @@ jobs:
         with:
           target: i686-unknown-linux-gnu, armv7a-none-eabi
           cache: false
+          # WHY rustflags is emptied HERE and nowhere else (#546): this action
+          # exports RUSTFLAGS="-D warnings" by default, and an env RUSTFLAGS
+          # REPLACES the rustflags in crates/thumos/.cargo/config.toml rather
+          # than merging with them — dropping `-C link-arg=-Tlink.ld` and the
+          # -D warnings gate (#431) the config owns. Every step in this job runs
+          # cargo against the kernel crate, whose flags are config-owned; the
+          # other jobs build the root workspace, which declares no config
+          # rustflags, so there `-D warnings` is the only source and is wanted.
+          # Empty means UNSET, not set-to-empty: the action skips the export
+          # entirely, and cargo treats a set-but-empty RUSTFLAGS as an override
+          # to nothing, which would clobber just the same.
+          rustflags: ""
       - uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
         with:
           key: kernel
@@ -195,6 +207,13 @@ jobs:
         # only being caught (if at all) by the weekly fuzz.yml run against an
         # ephemeral runner that never commits the drift back.
         run: scripts/check-external-lockfile-versions.sh fuzz/Cargo.lock
+      - name: Kernel build entrypoint check (#546)
+        # WHY it runs BEFORE the build: it is a source-level grep that names the
+        # CAUSE of the failure the next steps would otherwise report as
+        # undefined linker symbols. A kernel build that inherits an env
+        # RUSTFLAGS loses the link script and the warning gate together, and
+        # only the link loss is loud.
+        run: scripts/check-kernel-build-entrypoint.sh
       - name: Kernel cross-compile (armv7a) + zero-warning gate (#431)
         # WHY (#431): the zero-warning gate lives in crates/thumos/.cargo/
         # config.toml's rustflags; scripts/kernel-build.sh builds through it

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false # PROJECT: never expose the token to steps
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
-          toolchain: "1.94"
           components: rustfmt
+          cache: false
       - run: cargo fmt --all --check
       # WHY: the kernel crate is excluded from the workspace, so --all misses it.
       - run: cargo fmt --manifest-path crates/thumos/Cargo.toml --check
@@ -102,10 +102,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
-          toolchain: "1.94"
           components: clippy
+          cache: false
       - uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
         with:
           key: workspace
@@ -137,10 +137,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
-          toolchain: "1.94"
-          targets: i686-unknown-linux-gnu, armv7a-none-eabi
+          target: i686-unknown-linux-gnu, armv7a-none-eabi
+          cache: false
       - uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
         with:
           key: kernel

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -43,9 +43,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # nightly
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
           toolchain: nightly
+          cache: false
       - uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
         with:
           workspaces: fuzz

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -82,7 +82,9 @@ jobs:
         with:
           ref: ${{ env.ATTEST_REF }}
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          cache: false
       - uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
         with:
           key: release-attest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -41,7 +41,15 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false # PROJECT: security hardening — never expose token to steps
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      # WHY: previously dtolnay/rust-toolchain @ "# stable" floated to whatever
+      # Rust was current at run time. With no toolchain: input this fleet
+      # action instead installs the rust-toolchain.toml pin (1.94) -- the same
+      # version CI actually gates against, not an unpinned floor. Deliberate,
+      # not an oversight; same applies to the cargo-audit job below and
+      # release-please.yml's release-attest job.
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          cache: false
       - uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
         with:
           key: cargo-deny
@@ -54,7 +62,14 @@ jobs:
         # WHY (#586): 0.20 moved --config from the check subcommand to the
         # global position (`cargo-deny --config <path> check ...`, not
         # `check --config <path>`); scripts/security-scan.sh passes it there.
-        run: cargo install cargo-deny --locked --version ^0.20
+        #
+        # WHY prebuilt, not `cargo install` (kanon#2385): a source build
+        # couples cargo-deny's climbing MSRV to this repo's pinned toolchain.
+        # Exact version pinned deliberately -- a database-format bump must be
+        # a reviewed change, never an implicit floor from a caret range.
+        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        with:
+          tool: cargo-deny@0.20.2
       - name: cargo deny (all graphs)
         # WHY (#547): advisories/licenses/bans/sources over EVERY graph in
         # the lockfile manifest (workspace, kernel, fuzz) — one script and
@@ -72,12 +87,20 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          cache: false
       - uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2
         with:
           key: cargo-audit
       - name: Install cargo-audit
-        run: cargo install cargo-audit --locked --version ^0.22
+        # WHY prebuilt, not `cargo install` (kanon#2385): a source build
+        # couples cargo-audit's climbing MSRV to this repo's pinned toolchain.
+        # Exact version pinned deliberately -- a database-format bump must be
+        # a reviewed change, never an implicit floor from a caret range.
+        uses: taiki-e/install-action@1beb33eee6d086258184383af9a538940be190ed # v2.85.6
+        with:
+          tool: cargo-audit@0.22.2
       - name: cargo audit (all graphs)
         # WHY: -D unmaintained,unsound,yanked escalates those categories
         # to errors (default is warning only). Suppressions go through

--- a/.kanon-ci.toml
+++ b/.kanon-ci.toml
@@ -25,6 +25,9 @@
 stages = [
     "cargo fmt",
     "cargo check",
+    # WHY before "kernel build": a source-level grep that names the CAUSE of the
+    # link failure the next stage would otherwise report as undefined symbols.
+    "kernel build entrypoint",
     "kernel build",
     "kernel trust anchor",
     "kernel host tests",
@@ -60,6 +63,16 @@ timeout_secs = 300
 [stages."cargo check"]
 cmd = "cargo check --workspace --all-targets --locked --jobs 8"
 timeout_secs = 900
+
+# WHY (#546): env RUSTFLAGS REPLACES the rustflags in crates/thumos/.cargo/
+# config.toml rather than merging, so a kernel build that inherits the variable
+# loses the link script AND the -D warnings gate (#431). kernel-build.sh strips
+# it; this stage keeps that from being the only guarded site, because one
+# stripped invocation beside an unstripped one is a coincidence, not a guard.
+# Only the link loss is loud — a dropped warning gate ships green.
+[stages."kernel build entrypoint"]
+cmd = "scripts/check-kernel-build-entrypoint.sh"
+timeout_secs = 120
 
 # WHY (#546): the canonical build is scripts/kernel-build.sh — crates/thumos/
 # .cargo/config.toml pins target + link script + the -D warnings gate (#431).

--- a/scripts/check-kernel-build-entrypoint.sh
+++ b/scripts/check-kernel-build-entrypoint.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check-kernel-build-entrypoint.sh — the kernel is built in exactly one place.
+#
+# WHY: an env RUSTFLAGS REPLACES the rustflags in crates/thumos/.cargo/
+# config.toml rather than merging with them, so any kernel build inheriting the
+# variable loses both `-C link-arg=-Tlink.ld` and the `-D warnings` gate (#431).
+# Only the link loss is loud. A dropped warning gate ships a warning-carrying
+# kernel with every check still green, which is the drift kernel-build.sh (#546)
+# exists to kill — and a guard that holds at one site while a second site builds
+# unguarded is not a guard, it is a coincidence.
+#
+# The rule is deny-by-default: every `cargo build`/`cargo rustc` under scripts/
+# must either BE the entrypoint or be listed in ALLOWED below with a reason.
+# Matching the cargo call itself (not the kernel path next to it) is deliberate
+# — a build that reaches the kernel dir through a variable, a helper, or a
+# continued line is still caught.
+#
+# What this CANNOT see: a kernel build outside scripts/ (a workflow `run:` step
+# calling cargo directly, or a Makefile). Those are covered by review, not here.
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+ENTRYPOINT="scripts/kernel-build.sh"
+SELF="scripts/check-kernel-build-entrypoint.sh"
+
+# Substrings that mark a cargo build as NOT a kernel build. Each needs a reason.
+#   pylon-bridge: a host binary built from the root workspace, which declares no
+#   .cargo/config.toml rustflags — there is nothing for an env RUSTFLAGS to
+#   clobber, and `-D warnings` on the host build is wanted.
+ALLOWED=("--bin pylon-bridge")
+
+[[ -f "$ENTRYPOINT" ]] || { echo "FAIL: missing $ENTRYPOINT" >&2; exit 1; }
+
+# The entrypoint must still carry the guard and still build. Without these two
+# assertions the check passes while the thing it protects has been gutted.
+grep -q 'env -u RUSTFLAGS' "$ENTRYPOINT" || {
+    echo "FAIL: $ENTRYPOINT no longer strips RUSTFLAGS from the environment" >&2
+    echo "      That strip is the whole mechanism: env rustflags REPLACE the config's." >&2
+    exit 1
+}
+grep -qE '(^|[^#])(ARGS=\(build|cargo build)\b' "$ENTRYPOINT" || {
+    echo "FAIL: $ENTRYPOINT no longer runs a cargo build -- it is not an entrypoint" >&2
+    exit 1
+}
+
+# Refuse to pass vacuously: if the scan matches nothing, the pattern is wrong.
+scanned=$(find scripts -name '*.sh' -type f | wc -l)
+(( scanned >= 2 )) || {
+    echo "FAIL: scanned $scanned script(s) -- refusing to report a clean tree" >&2
+    exit 1
+}
+
+offenders=""
+while IFS= read -r hit; do
+    [[ -z "$hit" ]] && continue
+    [[ "$hit" == "$ENTRYPOINT":* ]] && continue
+    # WHY self-exclusion: this file describes the rule in prose and in its own
+    # failure messages, so it matches its own pattern. It invokes no cargo.
+    [[ "$hit" == "$SELF":* ]] && continue
+    # A comment ABOUT a kernel build is not a kernel build.
+    [[ "${hit#*:*:}" =~ ^[[:space:]]*# ]] && continue
+    allowed=0
+    for pattern in "${ALLOWED[@]}"; do
+        [[ "$hit" == *"$pattern"* ]] && { allowed=1; break; }
+    done
+    (( allowed )) || offenders+="$hit"$'\n'
+done < <(grep -rn --include='*.sh' -E '\bcargo[[:space:]]+(build|rustc)\b' scripts/ || true)
+
+if [[ -n "$offenders" ]]; then
+    echo "FAIL: cargo build outside $ENTRYPOINT (env RUSTFLAGS would replace the kernel's config rustflags):" >&2
+    printf '%s' "$offenders" >&2
+    echo "      Route it through $ENTRYPOINT, or add it to ALLOWED with a reason." >&2
+    exit 1
+fi
+
+echo "OK: kernel builds route through $ENTRYPOINT (scanned $scanned scripts)"

--- a/scripts/kernel-build.sh
+++ b/scripts/kernel-build.sh
@@ -8,18 +8,32 @@ set -euo pipefail
 # environment — env rustflags CLOBBER the config's and silently drop the
 # zero-warning gate (the live drift this script exists to kill).
 #
+# Usage: kernel-build.sh [feature[,feature...]]
+#
+# WHY this is the ONE place the kernel is built: an env RUSTFLAGS REPLACES the
+# config's rustflags rather than merging with them, so a kernel build that
+# inherits the variable loses BOTH the link script and the zero-warning gate.
+# Only the link loss is loud (undefined linker symbols); a dropped warning gate
+# ships silently. A single stripped invocation is the only shape that keeps that
+# true, and check-kernel-build-entrypoint.sh fails the gate if a second appears.
+#
 # WHY --locked (#757): crates/thumos keeps its own lockfile; without --locked
 # a manifest/lock disagreement here is silently resolved and rewritten
 # instead of failing the build.
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 KERNEL_DIR="${THUMOS_KERNEL_DIR:-$REPO_ROOT/crates/thumos}"
+FEATURES="${1:-}"
 
 rustup target list --installed 2>/dev/null | grep -q '^armv7a-none-eabi$' || {
     echo "FAIL: rust target armv7a-none-eabi not installed (rustup target add armv7a-none-eabi)" >&2
     exit 1
 }
+ARGS=(build --release --locked --jobs "${THUMOS_BUILD_JOBS:-8}")
+if [[ -n "$FEATURES" ]]; then
+    ARGS+=(--features "$FEATURES")
+fi
 # WHY the cd: cargo discovers .cargo/config.toml from the INVOCATION cwd, not
 # from --manifest-path's directory. Building from anywhere but the kernel dir
 # silently drops the armv7a target, the link script, and the -D warnings gate.
-(cd "$KERNEL_DIR" && env -u RUSTFLAGS cargo build --release --locked --jobs "${THUMOS_BUILD_JOBS:-8}")
+(cd "$KERNEL_DIR" && env -u RUSTFLAGS cargo "${ARGS[@]}")

--- a/scripts/witness/lib.sh
+++ b/scripts/witness/lib.sh
@@ -43,12 +43,16 @@ witness_deps() {
 }
 
 # build_kernel <feature-flags> — release cross-compile for the qemu board.
-# WHY --locked (#757): crates/thumos keeps its own lockfile; without --locked
-# a manifest/lock disagreement here is silently resolved and rewritten
-# instead of failing the build.
+#
+# WHY it delegates rather than calling cargo: kernel-build.sh is the one place
+# the kernel is built, because it strips RUSTFLAGS from the environment. An env
+# RUSTFLAGS REPLACES the rustflags in crates/thumos/.cargo/config.toml rather
+# than merging, so a direct cargo call here builds without the link script and
+# without the -D warnings gate whenever the caller's environment carries one.
+# The --target, --locked (#757) and jobs handling live there too.
 build_kernel() {
     local features="${1:-qemu}"
-    (cd "$KERNEL_DIR" && cargo build --release --target armv7a-none-eabi --locked --features "$features" --jobs "${THUMOS_BUILD_JOBS:-8}") \
+    "$REPO_ROOT/scripts/kernel-build.sh" "$features" \
         || { echo "FAIL: kernel build failed (features=$features)"; exit 1; }
 }
 


### PR DESCRIPTION
ci: install Rust the way the rest of the fleet does, and stop building audit tools from source

Two changes, both closing a divergence with a stated cause rather than a
preference.

**One PR installed Rust two different ways.** thumos's own jobs used
`dtolnay/rust-toolchain` while the shared `hybrid-gate.yml` it *calls* uses
`actions-rust-lang/setup-rust-toolchain`, as do harmonia, epistole, akroasis,
heurema, gnomon and logismos on the identical pin. hybrid-gate's own header
names the convention: the toolchain comes from `rust-toolchain.toml`, never
from workflow inputs. Seven sites across four files now match.

The explicit `toolchain: "1.94"` inputs are gone because the fleet action reads
`rust-toolchain.toml`, which already pins exactly that. `targets:` becomes
`target:` — the fleet action's key is singular, but it splits on commas
internally, so the kernel job's `i686-unknown-linux-gnu, armv7a-none-eabi`
value is unchanged. `cache: false` is set at every site because the fleet action
caches internally and thumos keeps its own separate `Swatinem/rust-cache` step;
that step is untouched, deliberately — its pin is the NEWEST of the four in the
fleet, so aligning it would mean going backwards.

**A real behaviour change, recorded rather than absorbed.** `release-please.yml`
and both `security.yml` jobs previously used a bare `# stable`, floating to
whatever Rust was current when the job ran. They now install the
`rust-toolchain.toml` pin. That is arguably more correct — it is the toolchain
CI actually gated against — but it IS a change, so there is a WHY comment at
the first site saying so.

`codeql.yml` deliberately keeps `dtolnay`: the shared reusable CodeQL workflow
uses the identical action for the same reason, since autobuild is a one-shot
compile with no cache to gain.

**cargo-deny and cargo-audit were compiled from source against a caret range.**
That contradicts a lesson the fleet already learned and wrote down — dot-github's
security workflow cites kanon#2385: install as a prebuilt binary, because a
source build couples the tool's climbing MSRV to the target repo's pinned
toolchain, and pin the exact version, because a database-format bump must be a
deliberate reviewed change and not an implicit floor. thumos is precisely the
MSRV-pinned shape that warns about (`channel = "1.94"`), and `^0.20` / `^0.22`
are literally the implicit floor.

Now `taiki-e/install-action` with `cargo-deny@0.20.2` and `cargo-audit@0.22.2` —
the exact versions those carets resolve to today, so this is a method change,
not a version bump. `scripts/security-scan.sh` and the job structure are
untouched: thumos deliberately scans three separate lockfile graphs, which the
single-graph fleet actions do not cover, and that difference has a stated reason
so it stays.

Worth recording because the plan said otherwise: dot-github does NOT install
cargo-deny through `taiki-e/install-action`. It uses
`EmbarkStudios/cargo-deny-action`, which bundles install-and-run into one step
and is therefore incompatible with the three-graph script. The action pin used
here is dot-github's own `taiki-e/install-action` SHA, which it applies to
cargo-audit and nextest — so the pin is fleet-standard even though the
tool pairing is new.

Verified before landing: every touched workflow parses; **no job `name:` field
changed anywhere**, confirmed by diffing the job-name lines against
`origin/main` — five required contexts key on those names and a rename would
strand every PR on a check that never reports.
