### PR TITLE
ci: fail when a fuzz target exercises code the kernel does not link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,14 @@ jobs:
         # only being caught (if at all) by the weekly fuzz.yml run against an
         # ephemeral runner that never commits the drift back.
         run: scripts/check-external-lockfile-versions.sh fuzz/Cargo.lock
+      - name: Fuzz target coverage check (#819)
+        # WHY (#819): the WPA, EAPOL and CCCI targets fuzz implementations the
+        # kernel does not link, so the shipped radio and modem-boundary parsers
+        # have no fuzz coverage while a green run reads as though they do. Graded
+        # per module, because one crate can have both a module that delegates
+        # into the shared core and one that does not. Fails on any gap not listed
+        # with its cause, and on any listed gap that has since been closed.
+        run: scripts/check-fuzz-target-coverage.sh
       - name: Kernel build entrypoint check (#546)
         # WHY it runs BEFORE the build: it is a source-level grep that names the
         # CAUSE of the failure the next steps would otherwise report as

--- a/.kanon-ci.toml
+++ b/.kanon-ci.toml
@@ -40,6 +40,7 @@ stages = [
     "llm issue refs",
     "kernel lockfile versions",
     "fuzz lockfile versions",
+    "fuzz target coverage",
     "target test ledger",
     "cargo clippy",
     "cargo nextest",
@@ -189,6 +190,16 @@ timeout_secs = 60
 [stages."fuzz lockfile versions"]
 cmd = "scripts/check-external-lockfile-versions.sh fuzz/Cargo.lock"
 timeout_secs = 60
+
+# WHY (#819): a fuzz target that imports a workspace crate the kernel does not
+# link certifies a path that never runs on a device — worse than no signal,
+# because a green fuzz run reads as coverage. Graded per MODULE: one crate can
+# have both a module that delegates into the shared core and one that does not.
+# The exemption table is a ratchet — an unlisted gap fails, and so does a listed
+# gap that has since been fixed.
+[stages."fuzz target coverage"]
+cmd = "scripts/check-fuzz-target-coverage.sh"
+timeout_secs = 120
 
 [stages."cargo clippy"]
 cmd = "cargo clippy --workspace --all-targets --locked --jobs 8 -- -D warnings"

--- a/scripts/check-fuzz-target-coverage.sh
+++ b/scripts/check-fuzz-target-coverage.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# check-fuzz-target-coverage.sh — #819. Every fuzz target must exercise code the
+# KERNEL links, and every known exception must be listed here with its cause.
+#
+# WHY: a fuzz target that imports a workspace crate the kernel does not link
+# certifies a code path that never runs on a device. That is worse than no
+# signal, because a green fuzz run reads as coverage. The protection was paid
+# for and landed on the wrong implementation.
+#
+# The test is per-MODULE, not per-crate. `fuzz_packet.rs` imports three modules
+# of one crate: `packet` delegates into asphaleia-core (which the kernel links)
+# and is genuinely covered, while `filter` and `rules` delegate to nothing. An
+# outer crate importing its own module name proves nothing on its own; whether
+# that module reaches the shared core is what decides it.
+#
+# The exemption table is a RATCHET, not a mute. A gap that is not listed fails.
+# A listed gap that is no longer a gap ALSO fails, so the table cannot rot into
+# a record of problems someone already fixed.
+#
+# What this CANNOT see: whether a module that references its core delegates the
+# specific function a target actually calls. It proves the module is wired to
+# shared code, not that every path through it is. Deeper coverage is the
+# convergence ledger's job (docs/convergence.toml), not this check's.
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+python3 - "$REPO_ROOT" <<'PYEOF'
+import glob
+import os
+import re
+import sys
+import tomllib
+
+root = sys.argv[1]
+
+# Known gaps: (crate, module) -> why it is not yet covered. Each must cite the
+# issue that will close it. Remove the row when the gap closes; the check fails
+# on a row that no longer describes a gap.
+EXEMPT = {
+    ("aither", "wpa"): "#819 — no aither-core exists; the kernel parses WPA in crates/thumos/src/wifi.rs",
+    ("aither", "eapol"): "#819 — no aither-core exists; the kernel parses EAPOL in crates/thumos/src/wifi.rs",
+    ("asphaleia", "filter"): "#819 — the kernel filters packets in crates/thumos/src/firewall.rs",
+    ("asphaleia", "rules"): "#819 — the kernel's rule evaluation lives in crates/thumos/src/firewall.rs",
+    ("klesis", "ccci"): "#819 — the kernel frames CCCI in crates/thumos/src/ccci.rs (its own CcciHeader)",
+}
+
+NOT_A_CRATE = {"libfuzzer_sys", "std", "core", "alloc", "crate", "self", "super"}
+
+
+def fail(msg):
+    print(f"FAIL: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+# The kernel is the authority on what ships. Read the -core crates it links.
+kernel_manifest = os.path.join(root, "crates", "thumos", "Cargo.toml")
+try:
+    with open(kernel_manifest, "rb") as fh:
+        kernel = tomllib.load(fh)
+except OSError as exc:
+    fail(f"cannot read the kernel manifest: {exc}")
+
+kernel_cores = {
+    name[: -len("-core")]
+    for name in kernel.get("dependencies", {})
+    if name.endswith("-core")
+}
+if not kernel_cores:
+    fail("the kernel declares no -core dependencies -- refusing to grade coverage against an empty set")
+
+targets = sorted(glob.glob(os.path.join(root, "fuzz", "fuzz_targets", "*.rs")))
+if not targets:
+    fail("no fuzz targets found -- refusing to report coverage over nothing")
+
+USE_RE = re.compile(r"^use\s+([a-z_][A-Za-z0-9_]*)::([A-Za-z_][A-Za-z0-9_]*)")
+
+
+def module_of(crate, segment):
+    """Resolve an imported path segment to the module that owns it."""
+    if segment[0].islower():
+        return segment
+    # A capitalised segment is a type re-exported at the crate root; find the
+    # module it is re-exported FROM, so the check grades the real owner.
+    lib = os.path.join(root, "crates", crate, "src", "lib.rs")
+    try:
+        text = open(lib, encoding="utf-8").read()
+    except OSError:
+        return None
+    m = re.search(rf"pub use\s+([a-z_][a-z0-9_]*)::(?:\w+::)*{re.escape(segment)}\b", text)
+    if m:
+        return m.group(1)
+    for path in glob.glob(os.path.join(root, "crates", crate, "src", "*.rs")):
+        body = open(path, encoding="utf-8").read()
+        if re.search(rf"pub\s+(?:struct|enum|type|trait)\s+{re.escape(segment)}\b", body):
+            return os.path.splitext(os.path.basename(path))[0]
+    return None
+
+
+def module_path(crate, module):
+    for candidate in (
+        os.path.join(root, "crates", crate, "src", f"{module}.rs"),
+        os.path.join(root, "crates", crate, "src", module, "mod.rs"),
+    ):
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+rows, gaps, resolved = [], set(), 0
+for target in targets:
+    name = os.path.basename(target)
+    seen = set()
+    for line in open(target, encoding="utf-8").read().splitlines():
+        m = USE_RE.match(line.strip())
+        if not m:
+            continue
+        crate, segment = m.group(1), m.group(2)
+        if crate in NOT_A_CRATE:
+            continue
+        module = module_of(crate, segment)
+        if module is None:
+            fail(f"{name}: cannot resolve `{crate}::{segment}` to a module -- the check would grade it blind")
+        if (crate, module) in seen:
+            continue
+        seen.add((crate, module))
+        resolved += 1
+
+        if crate not in kernel_cores:
+            rows.append((name, f"{crate}::{module}", "GAP", f"the kernel links no {crate}-core"))
+            gaps.add((crate, module))
+            continue
+        path = module_path(crate, module)
+        if path is None:
+            fail(f"{name}: `{crate}::{module}` names no module file -- cannot verify what it exercises")
+        refs = len(re.findall(rf"\b{crate}_core\b", open(path, encoding="utf-8").read()))
+        if refs:
+            rows.append((name, f"{crate}::{module}", "ok", f"{refs} {crate}_core ref(s)"))
+        else:
+            rows.append((name, f"{crate}::{module}", "GAP", f"no {crate}_core reference"))
+            gaps.add((crate, module))
+
+if not resolved:
+    fail("no crate imports resolved across any fuzz target -- the import pattern is wrong")
+
+width = max(len(r[1]) for r in rows)
+for target_name, path_label, verdict, why in rows:
+    mark = "ok  " if verdict == "ok" else "GAP "
+    print(f"  {mark} {target_name:<18} {path_label:<{width}}  {why}")
+
+unlisted = sorted(gaps - set(EXEMPT))
+stale = sorted(set(EXEMPT) - gaps)
+
+if unlisted:
+    print("", file=sys.stderr)
+    for crate, module in unlisted:
+        print(f"FAIL: {crate}::{module} is fuzzed but the kernel does not link it, and it is not a listed gap", file=sys.stderr)
+    print("      A fuzz target must exercise shipped code. Point it at the shared core,", file=sys.stderr)
+    print("      or add it to EXEMPT with the issue that will close it.", file=sys.stderr)
+
+if stale:
+    print("", file=sys.stderr)
+    for crate, module in stale:
+        print(f"FAIL: EXEMPT lists {crate}::{module}, but it is no longer a gap -- delete the row", file=sys.stderr)
+    print("      A stale exemption reports a problem that is already fixed.", file=sys.stderr)
+
+if unlisted or stale:
+    sys.exit(1)
+
+covered = sum(1 for r in rows if r[2] == "ok")
+print(f"OK: {covered}/{len(rows)} fuzzed modules exercise kernel-linked code; "
+      f"{len(gaps)} known gap(s) listed (see #819)")
+PYEOF


### PR DESCRIPTION
ci: fail when a fuzz target exercises code the kernel does not link

This is #819's second half — "a check enforces that so a future target cannot
silently be pointed at a non-shipped implementation." The extractions that close
the gaps themselves are separate work; this stops the class growing meanwhile and
makes the gap loud in CI instead of resident in an issue.

A fuzz target importing a workspace crate the kernel does not link certifies a
path that never runs on a device. That is worse than no signal, because a green
fuzz run reads as coverage — the effort was spent and the protection landed on
the wrong implementation.

**Graded per module, not per crate.** `fuzz_packet.rs` imports three modules of
one crate: `asphaleia::packet` delegates into asphaleia-core (which the kernel
links) and is genuinely covered, while `filter` and `rules` delegate to nothing.
An outer crate importing its own module name proves nothing on its own; whether
that module reaches the shared core is what decides it. The check resolves each
import to its owning module, including a type re-exported at the crate root
(`asphaleia::DnsBlocklist` -> `dns`), and refuses to grade an import it cannot
resolve rather than guessing.

Current state, which is the check's own output:

    ok   fuzz_at.rs      klesis::at          21 klesis_core ref(s)
    GAP  fuzz_ccci.rs    klesis::ccci        no klesis_core reference
    ok   fuzz_dns.rs     asphaleia::dns      12 asphaleia_core ref(s)
    GAP  fuzz_eapol.rs   aither::eapol       the kernel links no aither-core
    ok   fuzz_gsm7.rs    klesis::pdu         9 klesis_core ref(s)
    GAP  fuzz_packet.rs  asphaleia::filter   no asphaleia_core reference
    ok   fuzz_packet.rs  asphaleia::packet   9 asphaleia_core ref(s)
    GAP  fuzz_packet.rs  asphaleia::rules    no asphaleia_core reference
    ok   fuzz_pdu.rs     klesis::pdu         9 klesis_core ref(s)
    GAP  fuzz_wpa.rs     aither::eapol       the kernel links no aither-core
    GAP  fuzz_wpa.rs     aither::wpa         the kernel links no aither-core

**#819 undercounted its own finding, and measuring per module is what caught it.**
The issue's table clears all four klesis targets as fuzzing shipped code, citing
`klesis/src/pdu.rs`'s 9 core references. But `at`, `ccci` and `pdu` are different
modules: `at` has 21 references and `ccci` has **none**. The kernel frames CCCI
itself, with its own `CcciHeader` in `crates/thumos/src/ccci.rs`. So `fuzz_ccci`
is a third instance of the same shape, and on the boundary with the modem the
architecture explicitly treats as hostile. Generalising one module's measurement
to its crate is the error; the check cannot repeat it because it never reads a
crate as a unit.

**The exemption table is a ratchet, not a mute.** A gap that is not listed fails.
A listed gap that is no longer a gap ALSO fails, so the table cannot rot into a
record of problems someone already fixed — the same failure shape as an
unfulfilled `#[expect]`. Each row cites the issue that closes it.

Proven in all three directions before wiring: passes on the tree as it stands,
fails on an unlisted gap (dropping `klesis::ccci` from the table), and fails on a
stale exemption (claiming the covered `klesis::at` is a gap). It refuses to pass
vacuously — no targets, no resolved imports, or a kernel manifest declaring no
`-core` dependencies are each an error rather than a clean result.

What it cannot see, stated in its header: whether a module that references its
core delegates the specific function a target calls. It proves the module is
wired to shared code, not that every path through it is. That deeper question is
the convergence ledger's.

Scheduled in `.kanon-ci.toml` as well as defined — checked, not assumed — and
added to the required kernel job, which is the check both non-workspace graphs
already ride on.

Refs #819
