### PR TITLE
docs(agents): AGENTS.md pointed at a standards directory this repo has never had

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,13 @@ For agent-native operations, prefer the `mcp__kanon__*` tool family. See
 
 ## Standards
 
-Read `crates/basanos/standards/STANDARDS.md` § Philosophy before writing code. Key principles:
-no workarounds, define once, reference everywhere, no shortcuts, no compromise on quality.
-Rust work also reads `crates/basanos/standards/RUST.md` before editing Rust code.
+The standards are not in this repository. CLAUDE.md § Standards names where they live; read them
+there. Restating the path here is what let it rot into `crates/basanos/standards/`, a directory
+thumos has never contained.
+
+Read `STANDARDS.md` § Philosophy before writing code, and `RUST.md` before editing Rust. Key
+principles: no workarounds, define once, reference everywhere, no shortcuts, no compromise on
+quality.
 
 ## Rules
 


### PR DESCRIPTION
`AGENTS.md` § Standards told agents to read
`crates/basanos/standards/STANDARDS.md` and `.../RUST.md`. Neither path
exists here — basanos lives in the kanon clone, which CLAUDE.md § Standards
names correctly on the same tree.

So an agent that follows AGENTS.md finds nothing, and then either skips the
standards entirely or reconstructs what it guesses they say. A pointer to a
missing file fails silently; nothing in CI reads AGENTS.md, so nothing
caught it.

The fix is a pointer rather than a corrected copy. Two files stating the
same path is what let one of them drift while the other stayed right, and
correcting the duplicate would leave that mechanism intact for next time.
AGENTS.md now names the sections to read and defers the location to
CLAUDE.md, which is the one place it belongs.