### PR TITLE
docs(usb): state MUSB register facts as prose instead of quoting vendor macros

### DIFF
--- a/crates/thumos/src/usb.rs
+++ b/crates/thumos/src/usb.rs
@@ -53,14 +53,15 @@ const REG_INTRRXE: usize = 0x08;
 const REG_INTRUSB: usize = 0x0A;
 /// USB interrupt enable mask (8-bit).
 const REG_INTRUSBE: usize = 0x0B;
-/// Current frame number (16-bit). Source: MT6739 vendor kernel
-/// `mtk_musb_reg.h`: `#define MUSB_FRAME 0x0C`.
+/// Current frame number (16-bit), the MUSB `FRAME` register at offset 0x0C.
+/// Cross-checked against the MT6739 vendor kernel's `mtk_musb_reg.h`.
 const REG_FRAME: usize = 0x0C;
 /// Endpoint index selector  -  selects which EP the indexed window (below)
-/// addresses (8-bit). Source: `mtk_musb_reg.h`: `#define MUSB_INDEX 0x0E`.
+/// addresses (8-bit) — the MUSB `INDEX` register at offset 0x0E, per
+/// `mtk_musb_reg.h`.
 const REG_INDEX: usize = 0x0E;
-/// Test mode control (8-bit). Source: `mtk_musb_reg.h`:
-/// `#define MUSB_TESTMODE 0x0F`.
+/// Test mode control (8-bit) — the MUSB `TESTMODE` register at offset 0x0F,
+/// per `mtk_musb_reg.h`.
 const REG_TESTMODE: usize = 0x0F;
 
 // ---------------------------------------------------------------------------
@@ -73,19 +74,23 @@ const REG_TESTMODE: usize = 0x0F;
 // REG_INDEX write for a DIFFERENT endpoint, by a write to REG_INDEX
 // selecting the intended endpoint -- addressing two endpoints without
 // re-indexing between them silently reads/writes the wrong endpoint's
-// state, not a fault. Source: MT6739 vendor kernel
-// `drivers/misc/mediatek/usb20/mtk_musb_reg.h`:
-//   #define MUSB_TXMAXP  0x00
-//   #define MUSB_TXCSR   0x02
-//   #define MUSB_CSR0    MUSB_TXCSR   /* Re-used for EP0 */
-//   #define MUSB_RXMAXP  0x04
-//   #define MUSB_RXCSR   0x06
-//   #define MUSB_RXCOUNT 0x08
-//   #define MUSB_COUNT0  MUSB_RXCOUNT /* Re-used for EP0 */
-//   #define MUSB_INDEXED_OFFSET(_epnum, _offset) (0x10 + (_offset))
-// cross-checked byte-identical against `musb_core.h`'s
-// `#define MUSB_EP_OFFSET MUSB_INDEXED_OFFSET` in both mirrors named in the
-// module doc comment above.
+// state, not a fault.
+//
+// Within the indexed window the offsets are: TX max-packet at 0x00, TX control and
+// status at 0x02, RX max-packet at 0x04, RX control and status at 0x06, and RX byte
+// count at 0x08. Endpoint 0 has no registers of its own — its control/status and byte
+// count are the TX-control and RX-count registers at 0x02 and 0x08 respectively,
+// reached through the same window with REG_INDEX selecting endpoint 0. The window
+// itself begins at 0x10 and an endpoint's register address does not depend on which
+// endpoint is selected, only on the offset — selection happens entirely through
+// REG_INDEX, which is what makes the ordering rule above load-bearing.
+//
+// These offsets are properties of the MUSB controller, cross-checked between the
+// MT6739 vendor kernel's `drivers/misc/mediatek/usb20/mtk_musb_reg.h` and mainline
+// Linux's own `musb_core.h`, which agree on the indexed-window layout across both
+// mirrors named in the module doc comment above. Stated here as prose rather than
+// reproduced as source: the numbers are facts about the silicon, while the upstream
+// file's macro spelling and its authors' inline remarks are theirs.
 // ---------------------------------------------------------------------------
 
 /// `EPx` TX max packet size (16-bit); valid for whichever endpoint
@@ -130,8 +135,8 @@ const REG_RXCOUNT: usize = 0x18;
 // Each endpoint has its OWN fixed 4-byte-aligned FIFO data register --
 // unlike the indexed window above, FIFO access does NOT depend on
 // REG_INDEX. Byte or word writes queue data INTO the FIFO; reads dequeue.
-// MUSB auto-advances on each write. Source: MT6739 vendor kernel
-// `mtk_musb_reg.h`: `#define MUSB_FIFO_OFFSET(epnum) (0x20 + ((epnum) * 4))`.
+// MUSB auto-advances on each write. Each endpoint's FIFO sits at 0x20 plus four
+// bytes per endpoint number, per the MT6739 vendor kernel's `mtk_musb_reg.h`.
 // ---------------------------------------------------------------------------
 
 /// FIFO register offset for endpoint `epnum`, relative to `MUSB_BASE`.
@@ -1787,8 +1792,8 @@ mod tests {
 
     #[test]
     fn reg_fifo_matches_vendor_formula() {
-        // Source: MT6739 vendor kernel `mtk_musb_reg.h`:
-        // `#define MUSB_FIFO_OFFSET(epnum) (0x20 + ((epnum) * 4))`. This is
+        // Per the MT6739 vendor kernel's `mtk_musb_reg.h`, an endpoint's FIFO sits
+        // at 0x20 plus four bytes per endpoint number. This is
         // the one piece of address arithmetic in the MUSB map that DOES
         // depend on endpoint number -- unlike the indexed window above,
         // where endpoint selection happens via the value written to

--- a/crates/thumos/src/watchdog.rs
+++ b/crates/thumos/src/watchdog.rs
@@ -6,9 +6,9 @@
 //!
 //! Register map (base `0x1000_7000`). Cross-checked against mainline Linux's own
 //! `drivers/watchdog/mtk_wdt.c`, which carries the same base and the same restart
-//! key, and against several MediaTek vendor-kernel forks spanning MT6582, MT6739 and
+//! key, and against several `MediaTek` vendor-kernel forks spanning MT6582, MT6739 and
 //! MT8163 — the values are identical across all of them, which is what establishes
-//! them as properties of the SoC rather than one vendor's choice.
+//! them as properties of the `SoC` rather than one vendor's choice.
 //!
 //! WHY the citation is explicit here rather than "per BSP reference": every sibling
 //! driver in this crate names its source file and line, and this one named a category

--- a/crates/thumos/src/watchdog.rs
+++ b/crates/thumos/src/watchdog.rs
@@ -4,7 +4,17 @@
 //! stops petting it within the configured timeout. This provides a safety
 //! net against kernel hangs (infinite loops, deadlocks, interrupt starvation).
 //!
-//! Register map (base `0x1000_7000`, per MTK BSP reference):
+//! Register map (base `0x1000_7000`). Cross-checked against mainline Linux's own
+//! `drivers/watchdog/mtk_wdt.c`, which carries the same base and the same restart
+//! key, and against several MediaTek vendor-kernel forks spanning MT6582, MT6739 and
+//! MT8163 — the values are identical across all of them, which is what establishes
+//! them as properties of the SoC rather than one vendor's choice.
+//!
+//! WHY the citation is explicit here rather than "per BSP reference": every sibling
+//! driver in this crate names its source file and line, and this one named a category
+//! instead. A provenance audit could not verify the constants from this crate alone
+//! and flagged it — not because anything looked copied, but because an unverifiable
+//! claim and a false one are indistinguishable from the outside.
 //!
 //! | Offset | Register    | Description                              |
 //! |--------|-------------|------------------------------------------|

--- a/docs/GC9306-INIT.md
+++ b/docs/GC9306-INIT.md
@@ -116,7 +116,23 @@ The AGM M7 BSP configures `gc9306_dbi_c_qvgal`, indicating DBI (parallel) interf
 
 ## Sources
 
-Four independent driver implementations, all GPL-2.0 or Apache-2.0 licensed:
+Four independent driver implementations. **Their licenses differ and one is proprietary** — the
+per-source line below is authoritative, not this paragraph. An earlier version of this sentence said
+all four were GPL-2.0 or Apache-2.0, which contradicted the list directly beneath it and was wrong in
+the permissive direction about a source that grants no reuse rights at all.
+
+Why four are listed when only one is used: **independent convergence is the evidence**. Four unrelated
+vendors, on four unrelated host platforms, emitting the same command bytes is what establishes that the
+sequence is dictated by the GC9306 controller rather than authored by any of them — a hardware fact,
+not expression. The commands that are not GC9306-specific match the public MIPI DCS specification,
+reaching the same conclusion a second way.
+
+Where the sources genuinely **disagree** is the gamma table (0xF0–0xF5): three of the four differ, so
+those bytes are panel-tuning choices rather than device-mandated. The 36 bytes used here trace to
+source 1, LuatOS, which is MIT — permissive, requiring only that notice be kept, which naming it here
+does. **No bytes are taken from source 3**, and none may be: RDA Technologies' driver is proprietary
+and is cited purely as a convergence witness — evidence that a value is common across the ecosystem,
+never as something to copy from.
 
 1. **LuatOS** (`openLuat/luatos-soc-rtt`): `components/lcd/luat_lcd_gc9306.c`
    SPI driver for Air101/Air103 MCUs. MIT license.


### PR DESCRIPTION
## Finding

A copyleft-provenance audit run ahead of a fleet-wide relicense found one genuine piece of copied
expression in `crates/thumos`, and it is not where the audit expected.

`src/usb.rs:78-85` reproduced an eight-line block of the MT6739 vendor kernel's `mtk_musb_reg.h`
verbatim — its exact `#define` syntax, its macro identifiers, and two of its authors' inline remarks
(`/* Re-used for EP0 */`). Five further single-line macro quotes had the same shape at lines 57, 60,
63, 138 and 1795.

A comment is editorial prose, not a property of the silicon. Copying one is copying expression however
factual the register offsets around it are.

## Evidence

Everything else the audit examined is fact, and is established as such two independent ways rather
than asserted:

- **Convergence.** Four unrelated commercial driver authors, on four unrelated host platforms, emit
  identical command bytes for the GC9306; two independently-hosted vendor-kernel mirrors agree
  byte-for-byte on the USB MMIO base. Values that four independent implementations arrive at
  separately are dictated by the device.
- **Standards conformance.** The GC9306 sequence's non-device-specific commands match the public MIPI
  DCS specification, and the MUSB register layout matches decades-old ecosystem-wide mainline-Linux and
  u-boot naming rather than a MediaTek invention.

The gamma table (0xF0–0xF5) looked like the obvious candidate and is not the problem — though it IS the
one place discretion demonstrably exists, since three of the four sources disagree on the exact bytes.
The 36 bytes in use trace to LuatOS, which is MIT: permissive, requiring only that notice be kept.

## Why this matters

`crates/thumos` is separately licensed AGPL-3.0-only inside an otherwise PolyForm-Shield workspace, and
that carve-out was the last thing holding this repo out of a fleet-wide license posture. The blocker
turns out to be eight lines of comment rather than a driver rewrite.

The wider point is the one worth keeping: **copyright protects expression, not facts.** Register
addresses, MMIO bases and required command order are properties of hardware, and learning one by reading
GPL source then writing your own implementation creates nothing derivative. Applying the strict reading
to facts would have condemned five files and a driver rewrite that was never necessary. Applying the
loose reading to the comment block would have left a real copy in place.

## Desired correction

All quoted macro syntax is restated as prose. Every fact survives: TX max-packet 0x00, TX
control/status 0x02, RX max-packet 0x04, RX control/status 0x06, RX count 0x08, indexed window at 0x10,
per-endpoint FIFOs at 0x20 + 4·epnum, frame/index/testmode at 0x0C/0x0E/0x0F, and the endpoint-0
aliasing rule. What is gone is the upstream file's spelling.

Two documentation defects fixed alongside, both licensing misstatements:

- `docs/GC9306-INIT.md` claimed all four cited sources were "GPL-2.0 or Apache-2.0" while its own list
  directly beneath said MIT, GPL-2.0, **Proprietary (RDA Technologies)**, and Apache-2.0. Wrong in the
  permissive direction about a source granting no reuse rights at all. The header now defers to the
  per-source lines, explains that the four are cited as convergence *witnesses* rather than as material
  to copy from, and states outright that no bytes come from the proprietary one.
- `src/watchdog.rs` cited "per MTK BSP reference" — a category, not a source — while every sibling names
  a file and line. Its constants appear identically in mainline Linux's `drivers/watchdog/mtk_wdt.c` and
  in vendor forks across MT6582, MT6739 and MT8163, so this was never a copy. It was an unverifiable
  claim, and from outside the repo an unverifiable claim and a false one look the same.

`Done when:` no C macro syntax is quoted in `usb.rs`; every register offset it documented is still
documented; the GC9306 doc's license summary agrees with its own source list; and `watchdog.rs` names a
verifiable source like its siblings.

## Limits

This is an engineering determination from a read of the tree and its citations, not a legal opinion.
The fact/expression line is genuinely fuzzy for compiled artifacts like an init sequence, and the
threshold question of whether a short functional lookup table clears the originality bar at all is one
courts split on and a repo read cannot settle.
